### PR TITLE
feat: M0 transport skeleton — SSH core, herdr Transport, events, cold start

### DIFF
--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */; };
 		49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E51D58B1094AC5B389EDA /* Transport.swift */; };
+		535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */; };
 		6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */; };
 		724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */; };
 		782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */; };
@@ -35,6 +36,7 @@
 
 /* Begin PBXFileReference section */
 		02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportFailureModesE2ETests.swift; sourceTree = "<group>"; };
+		200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrSocketLocationTests.swift; sourceTree = "<group>"; };
 		20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeHerdrServer.swift; sourceTree = "<group>"; };
 		259E51D58B1094AC5B389EDA /* Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
 		78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrMobileApp.swift; sourceTree = "<group>"; };
@@ -85,6 +87,7 @@
 		8474CB954CA9DE980DA822F2 /* HerdrMobileTests */ = {
 			isa = PBXGroup;
 			children = (
+				200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */,
 				C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */,
 				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
 				F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */,
@@ -233,6 +236,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */,
+				535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */,
 				724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */,
 				F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */,
 				E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -1,0 +1,469 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */; };
+		C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 03BEAFDD98C535CDCE9AE335 /* Citadel */; };
+		CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D95D580BCF4FE792AEFE974 /* ContentView.swift */; };
+		EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */; };
+		FEDD78DD422954EEBA415E8E /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 1A747BD14B4EC28AE6E73458 /* SwiftTerm */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		E598AC0E82E1533AAB51919C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E7318A512AF22F69E093E6A6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0D343AAE6E2F9C2B803C9AE9;
+			remoteInfo = HerdrMobile;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrMobileApp.swift; sourceTree = "<group>"; };
+		7D95D580BCF4FE792AEFE974 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		B383994C2C8492694D5F3690 /* HerdrMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HerdrMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonTests.swift; sourceTree = "<group>"; };
+		F3D159C84E98A59AA47EBE6C /* HerdrMobileTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HerdrMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0E81AC9535C8CAB6E6C756D9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */,
+				FEDD78DD422954EEBA415E8E /* SwiftTerm in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		55902E0ABDF1F168FA193448 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B383994C2C8492694D5F3690 /* HerdrMobile.app */,
+				F3D159C84E98A59AA47EBE6C /* HerdrMobileTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8474CB954CA9DE980DA822F2 /* HerdrMobileTests */ = {
+			isa = PBXGroup;
+			children = (
+				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
+			);
+			path = HerdrMobileTests;
+			sourceTree = "<group>";
+		};
+		859D599DFA07BF9B6E1632DC /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				8474CB954CA9DE980DA822F2 /* HerdrMobileTests */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		92BF3289E67D5AE641333441 = {
+			isa = PBXGroup;
+			children = (
+				DCFD134B630B84B0F5FA6115 /* Sources */,
+				859D599DFA07BF9B6E1632DC /* Tests */,
+				55902E0ABDF1F168FA193448 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		B5CBF3555504362CC1FFDFE5 /* HerdrMobile */ = {
+			isa = PBXGroup;
+			children = (
+				7D95D580BCF4FE792AEFE974 /* ContentView.swift */,
+				78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */,
+			);
+			path = HerdrMobile;
+			sourceTree = "<group>";
+		};
+		DCFD134B630B84B0F5FA6115 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				B5CBF3555504362CC1FFDFE5 /* HerdrMobile */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0D343AAE6E2F9C2B803C9AE9 /* HerdrMobile */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CEBFA8DB94A8EBC2E21D50C2 /* Build configuration list for PBXNativeTarget "HerdrMobile" */;
+			buildPhases = (
+				8A7F6144162C733E402E680E /* Sources */,
+				0E81AC9535C8CAB6E6C756D9 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HerdrMobile;
+			packageProductDependencies = (
+				03BEAFDD98C535CDCE9AE335 /* Citadel */,
+				1A747BD14B4EC28AE6E73458 /* SwiftTerm */,
+			);
+			productName = HerdrMobile;
+			productReference = B383994C2C8492694D5F3690 /* HerdrMobile.app */;
+			productType = "com.apple.product-type.application";
+		};
+		CC604196196FFA00A41E9CD7 /* HerdrMobileTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0D85695648C7ED60972632BD /* Build configuration list for PBXNativeTarget "HerdrMobileTests" */;
+			buildPhases = (
+				B4B9C6FCBEEBB72725BFF787 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F6B76D58924DEA698DB1ACBF /* PBXTargetDependency */,
+			);
+			name = HerdrMobileTests;
+			packageProductDependencies = (
+			);
+			productName = HerdrMobileTests;
+			productReference = F3D159C84E98A59AA47EBE6C /* HerdrMobileTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E7318A512AF22F69E093E6A6 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+				};
+			};
+			buildConfigurationList = 8596E4CF7DAE6E1B5A35229D /* Build configuration list for PBXProject "HerdrMobile" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 92BF3289E67D5AE641333441;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				A5BAC52972885D4D487901C1 /* XCRemoteSwiftPackageReference "Citadel" */,
+				EEB0F61C1AFE903B668B0AA0 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 55902E0ABDF1F168FA193448 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0D343AAE6E2F9C2B803C9AE9 /* HerdrMobile */,
+				CC604196196FFA00A41E9CD7 /* HerdrMobileTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		8A7F6144162C733E402E680E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */,
+				EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B4B9C6FCBEEBB72725BFF787 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		F6B76D58924DEA698DB1ACBF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0D343AAE6E2F9C2B803C9AE9 /* HerdrMobile */;
+			targetProxy = E598AC0E82E1533AAB51919C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		44F2EFDD3DBF37B52E264995 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.herdr.mobile.HerdrMobile;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		53AD5580C6657F0EFAD79F4F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = dev.herdr.mobile.HerdrMobileTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HerdrMobile.app/HerdrMobile";
+			};
+			name = Release;
+		};
+		7FA6A216EE1007A7FC5139CC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.herdr.mobile.HerdrMobile;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		870F49BB47917D0F9EC01A11 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		A48F0E727B4C1F97FD9DCB96 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = dev.herdr.mobile.HerdrMobileTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HerdrMobile.app/HerdrMobile";
+			};
+			name = Debug;
+		};
+		DE5246CC93E8C961BEC3D4D6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0D85695648C7ED60972632BD /* Build configuration list for PBXNativeTarget "HerdrMobileTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A48F0E727B4C1F97FD9DCB96 /* Debug */,
+				53AD5580C6657F0EFAD79F4F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		8596E4CF7DAE6E1B5A35229D /* Build configuration list for PBXProject "HerdrMobile" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				870F49BB47917D0F9EC01A11 /* Debug */,
+				DE5246CC93E8C961BEC3D4D6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		CEBFA8DB94A8EBC2E21D50C2 /* Build configuration list for PBXNativeTarget "HerdrMobile" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7FA6A216EE1007A7FC5139CC /* Debug */,
+				44F2EFDD3DBF37B52E264995 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		A5BAC52972885D4D487901C1 /* XCRemoteSwiftPackageReference "Citadel" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/orlandos-nl/Citadel.git";
+			requirement = {
+				kind = exactVersion;
+				version = 0.12.1;
+			};
+		};
+		EEB0F61C1AFE903B668B0AA0 /* XCRemoteSwiftPackageReference "SwiftTerm" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/migueldeicaza/SwiftTerm.git";
+			requirement = {
+				kind = versionRange;
+				maximumVersion = 2.0.0;
+				minimumVersion = 1.2.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		03BEAFDD98C535CDCE9AE335 /* Citadel */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A5BAC52972885D4D487901C1 /* XCRemoteSwiftPackageReference "Citadel" */;
+			productName = Citadel;
+		};
+		1A747BD14B4EC28AE6E73458 /* SwiftTerm */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EEB0F61C1AFE903B668B0AA0 /* XCRemoteSwiftPackageReference "SwiftTerm" */;
+			productName = SwiftTerm;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = E7318A512AF22F69E093E6A6 /* Project object */;
+}

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0700F97FBF6A714C5D9EA5CD /* ColdStartE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */; };
 		073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */; };
 		49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E51D58B1094AC5B389EDA /* Transport.swift */; };
 		535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */; };
@@ -39,6 +40,7 @@
 		200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrSocketLocationTests.swift; sourceTree = "<group>"; };
 		20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeHerdrServer.swift; sourceTree = "<group>"; };
 		259E51D58B1094AC5B389EDA /* Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
+		646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColdStartE2ETests.swift; sourceTree = "<group>"; };
 		78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrMobileApp.swift; sourceTree = "<group>"; };
 		7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransport.swift; sourceTree = "<group>"; };
 		7D95D580BCF4FE792AEFE974 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -87,6 +89,7 @@
 		8474CB954CA9DE980DA822F2 /* HerdrMobileTests */ = {
 			isa = PBXGroup;
 			children = (
+				646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */,
 				200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */,
 				C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */,
 				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
@@ -235,6 +238,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0700F97FBF6A714C5D9EA5CD /* ColdStartE2ETests.swift in Sources */,
 				EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */,
 				535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */,
 				724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		1F4B065DFCAF8E6656600F1E /* TOFUHostKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */; };
 		298FA49167E3CB1402B7B86B /* DeviceKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04EAA030D8329A1716714A8 /* DeviceKeyStore.swift */; };
 		2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */; };
+		3DC1B4DCC0E2CD73A0C13B64 /* SSHAuthE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */; };
 		49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E51D58B1094AC5B389EDA /* Transport.swift */; };
 		535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */; };
 		5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */; };
@@ -61,6 +62,7 @@
 		5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHHostKeyE2ETests.swift; sourceTree = "<group>"; };
 		567573855DCC8571BC02096D /* SecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretStore.swift; sourceTree = "<group>"; };
 		646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColdStartE2ETests.swift; sourceTree = "<group>"; };
+		6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHAuthE2ETests.swift; sourceTree = "<group>"; };
 		78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrMobileApp.swift; sourceTree = "<group>"; };
 		7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransport.swift; sourceTree = "<group>"; };
 		7D95D580BCF4FE792AEFE974 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -135,6 +137,7 @@
 				C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */,
 				87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */,
 				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
+				6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */,
 				5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */,
 				F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */,
 				A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */,
@@ -301,6 +304,7 @@
 				0A0657501E1164D7672A8B39 /* InMemorySecretStore.swift in Sources */,
 				2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */,
 				F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */,
+				3DC1B4DCC0E2CD73A0C13B64 /* SSHAuthE2ETests.swift in Sources */,
 				5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */,
 				E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */,
 				6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -7,23 +7,36 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05A6F31F9CAC1CA1C57D7C71 /* DeviceKeyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8323C68B13826B7388800B1F /* DeviceKeyStoreTests.swift */; };
 		0700F97FBF6A714C5D9EA5CD /* ColdStartE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */; };
 		073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */; };
+		0A0657501E1164D7672A8B39 /* InMemorySecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B106E427EE5358088B615CE /* InMemorySecretStore.swift */; };
+		1302E0DD26A3F6C629A753D8 /* HostKeyPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADA0E8C1DC6D30FCC6CEDC2 /* HostKeyPolicy.swift */; };
+		1BAA5950B7FDE0E6F09811F9 /* DeviceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC995A571D7659F3307B6E54 /* DeviceKey.swift */; };
+		1F4B065DFCAF8E6656600F1E /* TOFUHostKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */; };
+		298FA49167E3CB1402B7B86B /* DeviceKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04EAA030D8329A1716714A8 /* DeviceKeyStore.swift */; };
+		2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */; };
 		49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E51D58B1094AC5B389EDA /* Transport.swift */; };
 		535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */; };
+		5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */; };
 		6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */; };
+		693B0173C07DAF4BFC89B094 /* SecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567573855DCC8571BC02096D /* SecretStore.swift */; };
 		724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */; };
 		782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */; };
+		8C514AFC85DAED69A4988C13 /* SSHCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90875ADAF6E348E186C8125A /* SSHCredentials.swift */; };
 		A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */; };
+		B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C232163905675760F37FD7A0 /* KnownHostsStore.swift */; };
 		C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB59377D34D0C652DF70F01 /* UnixSockets.swift */; };
 		C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 03BEAFDD98C535CDCE9AE335 /* Citadel */; };
 		CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D95D580BCF4FE792AEFE974 /* ContentView.swift */; };
+		D6E9D6545089932306C4704F /* HostKeyFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CBE401E4A5FA5871809E540 /* HostKeyFingerprint.swift */; };
 		DC564E76486D243AD1741F7E /* SharedAsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */; };
 		E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */; };
 		E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */; };
 		EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */; };
 		EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */; };
 		F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */; };
+		F62A9CD06CFB784550AF4977 /* DeviceKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558159B2AF61C28F6B1391A2 /* DeviceKeyTests.swift */; };
 		FEDD78DD422954EEBA415E8E /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 1A747BD14B4EC28AE6E73458 /* SwiftTerm */; };
 /* End PBXBuildFile section */
 
@@ -39,18 +52,31 @@
 
 /* Begin PBXFileReference section */
 		02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportFailureModesE2ETests.swift; sourceTree = "<group>"; };
+		1CBE401E4A5FA5871809E540 /* HostKeyFingerprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostKeyFingerprint.swift; sourceTree = "<group>"; };
 		200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrSocketLocationTests.swift; sourceTree = "<group>"; };
 		20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeHerdrServer.swift; sourceTree = "<group>"; };
 		259E51D58B1094AC5B389EDA /* Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
 		3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedAsyncOperation.swift; sourceTree = "<group>"; };
+		558159B2AF61C28F6B1391A2 /* DeviceKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyTests.swift; sourceTree = "<group>"; };
+		5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHHostKeyE2ETests.swift; sourceTree = "<group>"; };
+		567573855DCC8571BC02096D /* SecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretStore.swift; sourceTree = "<group>"; };
 		646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColdStartE2ETests.swift; sourceTree = "<group>"; };
 		78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrMobileApp.swift; sourceTree = "<group>"; };
 		7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransport.swift; sourceTree = "<group>"; };
 		7D95D580BCF4FE792AEFE974 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		8323C68B13826B7388800B1F /* DeviceKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyStoreTests.swift; sourceTree = "<group>"; };
+		87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStoreTests.swift; sourceTree = "<group>"; };
 		904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSSHTestEnvironment.swift; sourceTree = "<group>"; };
+		90875ADAF6E348E186C8125A /* SSHCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHCredentials.swift; sourceTree = "<group>"; };
+		9B106E427EE5358088B615CE /* InMemorySecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemorySecretStore.swift; sourceTree = "<group>"; };
 		A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConcurrencyE2ETests.swift; sourceTree = "<group>"; };
 		B383994C2C8492694D5F3690 /* HerdrMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HerdrMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOFUHostKeyValidator.swift; sourceTree = "<group>"; };
+		BC995A571D7659F3307B6E54 /* DeviceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKey.swift; sourceTree = "<group>"; };
+		C232163905675760F37FD7A0 /* KnownHostsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStore.swift; sourceTree = "<group>"; };
 		C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWireTests.swift; sourceTree = "<group>"; };
+		CADA0E8C1DC6D30FCC6CEDC2 /* HostKeyPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostKeyPolicy.swift; sourceTree = "<group>"; };
+		D04EAA030D8329A1716714A8 /* DeviceKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyStore.swift; sourceTree = "<group>"; };
 		D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonTests.swift; sourceTree = "<group>"; };
 		F3D159C84E98A59AA47EBE6C /* HerdrMobileTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HerdrMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWire.swift; sourceTree = "<group>"; };
@@ -74,9 +100,17 @@
 		41C75ABDF8DC22F0282957C5 /* Transport */ = {
 			isa = PBXGroup;
 			children = (
+				BC995A571D7659F3307B6E54 /* DeviceKey.swift */,
+				D04EAA030D8329A1716714A8 /* DeviceKeyStore.swift */,
 				F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */,
+				1CBE401E4A5FA5871809E540 /* HostKeyFingerprint.swift */,
+				CADA0E8C1DC6D30FCC6CEDC2 /* HostKeyPolicy.swift */,
+				C232163905675760F37FD7A0 /* KnownHostsStore.swift */,
+				567573855DCC8571BC02096D /* SecretStore.swift */,
 				3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */,
+				90875ADAF6E348E186C8125A /* SSHCredentials.swift */,
 				7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */,
+				BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */,
 				259E51D58B1094AC5B389EDA /* Transport.swift */,
 			);
 			path = Transport;
@@ -95,9 +129,13 @@
 			isa = PBXGroup;
 			children = (
 				646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */,
+				8323C68B13826B7388800B1F /* DeviceKeyStoreTests.swift */,
+				558159B2AF61C28F6B1391A2 /* DeviceKeyTests.swift */,
 				200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */,
 				C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */,
+				87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */,
 				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
+				5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */,
 				F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */,
 				A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */,
 				02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */,
@@ -137,6 +175,7 @@
 			isa = PBXGroup;
 			children = (
 				20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */,
+				9B106E427EE5358088B615CE /* InMemorySecretStore.swift */,
 				904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */,
 				FCB59377D34D0C652DF70F01 /* UnixSockets.swift */,
 			);
@@ -233,10 +272,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */,
+				1BAA5950B7FDE0E6F09811F9 /* DeviceKey.swift in Sources */,
+				298FA49167E3CB1402B7B86B /* DeviceKeyStore.swift in Sources */,
 				EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */,
 				A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */,
+				D6E9D6545089932306C4704F /* HostKeyFingerprint.swift in Sources */,
+				1302E0DD26A3F6C629A753D8 /* HostKeyPolicy.swift in Sources */,
+				B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */,
+				8C514AFC85DAED69A4988C13 /* SSHCredentials.swift in Sources */,
 				073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */,
+				693B0173C07DAF4BFC89B094 /* SecretStore.swift in Sources */,
 				DC564E76486D243AD1741F7E /* SharedAsyncOperation.swift in Sources */,
+				1F4B065DFCAF8E6656600F1E /* TOFUHostKeyValidator.swift in Sources */,
 				49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -246,10 +293,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				0700F97FBF6A714C5D9EA5CD /* ColdStartE2ETests.swift in Sources */,
+				05A6F31F9CAC1CA1C57D7C71 /* DeviceKeyStoreTests.swift in Sources */,
+				F62A9CD06CFB784550AF4977 /* DeviceKeyTests.swift in Sources */,
 				EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */,
 				535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */,
 				724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */,
+				0A0657501E1164D7672A8B39 /* InMemorySecretStore.swift in Sources */,
+				2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */,
 				F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */,
+				5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */,
 				E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */,
 				6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */,
 				E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -7,7 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E51D58B1094AC5B389EDA /* Transport.swift */; };
 		6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */; };
+		724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */; };
+		A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */; };
 		C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 03BEAFDD98C535CDCE9AE335 /* Citadel */; };
 		CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D95D580BCF4FE792AEFE974 /* ContentView.swift */; };
 		EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */; };
@@ -25,11 +28,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		259E51D58B1094AC5B389EDA /* Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
 		78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrMobileApp.swift; sourceTree = "<group>"; };
 		7D95D580BCF4FE792AEFE974 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		B383994C2C8492694D5F3690 /* HerdrMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HerdrMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWireTests.swift; sourceTree = "<group>"; };
 		D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonTests.swift; sourceTree = "<group>"; };
 		F3D159C84E98A59AA47EBE6C /* HerdrMobileTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HerdrMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWire.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -45,6 +51,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		41C75ABDF8DC22F0282957C5 /* Transport */ = {
+			isa = PBXGroup;
+			children = (
+				F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */,
+				259E51D58B1094AC5B389EDA /* Transport.swift */,
+			);
+			path = Transport;
+			sourceTree = "<group>";
+		};
 		55902E0ABDF1F168FA193448 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -57,6 +72,7 @@
 		8474CB954CA9DE980DA822F2 /* HerdrMobileTests */ = {
 			isa = PBXGroup;
 			children = (
+				C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */,
 				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
 			);
 			path = HerdrMobileTests;
@@ -84,6 +100,7 @@
 			children = (
 				7D95D580BCF4FE792AEFE974 /* ContentView.swift */,
 				78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */,
+				41C75ABDF8DC22F0282957C5 /* Transport */,
 			);
 			path = HerdrMobile;
 			sourceTree = "<group>";
@@ -179,6 +196,8 @@
 			files = (
 				CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */,
 				EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */,
+				A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */,
+				49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -186,6 +205,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */,
 				6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB59377D34D0C652DF70F01 /* UnixSockets.swift */; };
 		C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 03BEAFDD98C535CDCE9AE335 /* Citadel */; };
 		CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D95D580BCF4FE792AEFE974 /* ContentView.swift */; };
+		DC564E76486D243AD1741F7E /* SharedAsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */; };
 		E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */; };
 		E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */; };
 		EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */; };
@@ -41,6 +42,7 @@
 		200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrSocketLocationTests.swift; sourceTree = "<group>"; };
 		20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeHerdrServer.swift; sourceTree = "<group>"; };
 		259E51D58B1094AC5B389EDA /* Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
+		3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedAsyncOperation.swift; sourceTree = "<group>"; };
 		646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColdStartE2ETests.swift; sourceTree = "<group>"; };
 		78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrMobileApp.swift; sourceTree = "<group>"; };
 		7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransport.swift; sourceTree = "<group>"; };
@@ -73,6 +75,7 @@
 			isa = PBXGroup;
 			children = (
 				F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */,
+				3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */,
 				7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */,
 				259E51D58B1094AC5B389EDA /* Transport.swift */,
 			);
@@ -233,6 +236,7 @@
 				EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */,
 				A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */,
 				073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */,
+				DC564E76486D243AD1741F7E /* SharedAsyncOperation.swift in Sources */,
 				49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -7,13 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */; };
 		49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E51D58B1094AC5B389EDA /* Transport.swift */; };
 		6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */; };
 		724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */; };
 		A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */; };
 		C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 03BEAFDD98C535CDCE9AE335 /* Citadel */; };
 		CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D95D580BCF4FE792AEFE974 /* ContentView.swift */; };
+		E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */; };
 		EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */; };
+		EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */; };
+		F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */; };
 		FEDD78DD422954EEBA415E8E /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 1A747BD14B4EC28AE6E73458 /* SwiftTerm */; };
 /* End PBXBuildFile section */
 
@@ -28,14 +32,18 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeHerdrServer.swift; sourceTree = "<group>"; };
 		259E51D58B1094AC5B389EDA /* Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
 		78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrMobileApp.swift; sourceTree = "<group>"; };
+		7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransport.swift; sourceTree = "<group>"; };
 		7D95D580BCF4FE792AEFE974 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSSHTestEnvironment.swift; sourceTree = "<group>"; };
 		B383994C2C8492694D5F3690 /* HerdrMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HerdrMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWireTests.swift; sourceTree = "<group>"; };
 		D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonTests.swift; sourceTree = "<group>"; };
 		F3D159C84E98A59AA47EBE6C /* HerdrMobileTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HerdrMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWire.swift; sourceTree = "<group>"; };
+		F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransportE2ETests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,6 +63,7 @@
 			isa = PBXGroup;
 			children = (
 				F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */,
+				7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */,
 				259E51D58B1094AC5B389EDA /* Transport.swift */,
 			);
 			path = Transport;
@@ -74,6 +83,8 @@
 			children = (
 				C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */,
 				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
+				F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */,
+				CB45F25667AE3C5C2EFD76CB /* Support */,
 			);
 			path = HerdrMobileTests;
 			sourceTree = "<group>";
@@ -103,6 +114,15 @@
 				41C75ABDF8DC22F0282957C5 /* Transport */,
 			);
 			path = HerdrMobile;
+			sourceTree = "<group>";
+		};
+		CB45F25667AE3C5C2EFD76CB /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */,
+				904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */,
+			);
+			path = Support;
 			sourceTree = "<group>";
 		};
 		DCFD134B630B84B0F5FA6115 /* Sources */ = {
@@ -197,6 +217,7 @@
 				CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */,
 				EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */,
 				A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */,
+				073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */,
 				49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -205,7 +226,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */,
 				724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */,
+				F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */,
+				E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */,
 				6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */; };
 		3DC1B4DCC0E2CD73A0C13B64 /* SSHAuthE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */; };
 		49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E51D58B1094AC5B389EDA /* Transport.swift */; };
+		4C80E23F09C8CFB3A93101B8 /* JSONValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3E2308A50D4744A24A874B /* JSONValue.swift */; };
 		535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */; };
 		5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */; };
 		6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */; };
@@ -25,15 +26,19 @@
 		724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */; };
 		782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */; };
 		8C514AFC85DAED69A4988C13 /* SSHCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90875ADAF6E348E186C8125A /* SSHCredentials.swift */; };
+		969057C35F7E5F162B0CF41D /* JSONValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F86744BFAC66D732CE7833 /* JSONValueTests.swift */; };
 		A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */; };
 		B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C232163905675760F37FD7A0 /* KnownHostsStore.swift */; };
 		C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB59377D34D0C652DF70F01 /* UnixSockets.swift */; };
+		C60E8E0398665C36520DDA8E /* HerdrEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABFC5E35C19F809355619E7 /* HerdrEvents.swift */; };
 		C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 03BEAFDD98C535CDCE9AE335 /* Citadel */; };
 		CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D95D580BCF4FE792AEFE974 /* ContentView.swift */; };
 		D6E9D6545089932306C4704F /* HostKeyFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CBE401E4A5FA5871809E540 /* HostKeyFingerprint.swift */; };
 		DC564E76486D243AD1741F7E /* SharedAsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */; };
 		E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */; };
+		E30244FD0231DD02EC9978D0 /* EventsSubscribeE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4076B0E816625CD09EB29F2E /* EventsSubscribeE2ETests.swift */; };
 		E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */; };
+		E908289DF03C6732F7D91328 /* HerdrEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */; };
 		EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */; };
 		EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */; };
 		F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */; };
@@ -53,11 +58,14 @@
 
 /* Begin PBXFileReference section */
 		02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportFailureModesE2ETests.swift; sourceTree = "<group>"; };
+		17F86744BFAC66D732CE7833 /* JSONValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueTests.swift; sourceTree = "<group>"; };
 		1CBE401E4A5FA5871809E540 /* HostKeyFingerprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostKeyFingerprint.swift; sourceTree = "<group>"; };
+		1E3E2308A50D4744A24A874B /* JSONValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValue.swift; sourceTree = "<group>"; };
 		200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrSocketLocationTests.swift; sourceTree = "<group>"; };
 		20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeHerdrServer.swift; sourceTree = "<group>"; };
 		259E51D58B1094AC5B389EDA /* Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
 		3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedAsyncOperation.swift; sourceTree = "<group>"; };
+		4076B0E816625CD09EB29F2E /* EventsSubscribeE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSubscribeE2ETests.swift; sourceTree = "<group>"; };
 		558159B2AF61C28F6B1391A2 /* DeviceKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyTests.swift; sourceTree = "<group>"; };
 		5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHHostKeyE2ETests.swift; sourceTree = "<group>"; };
 		567573855DCC8571BC02096D /* SecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretStore.swift; sourceTree = "<group>"; };
@@ -71,12 +79,14 @@
 		904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSSHTestEnvironment.swift; sourceTree = "<group>"; };
 		90875ADAF6E348E186C8125A /* SSHCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHCredentials.swift; sourceTree = "<group>"; };
 		9B106E427EE5358088B615CE /* InMemorySecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemorySecretStore.swift; sourceTree = "<group>"; };
+		A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrEventsTests.swift; sourceTree = "<group>"; };
 		A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConcurrencyE2ETests.swift; sourceTree = "<group>"; };
 		B383994C2C8492694D5F3690 /* HerdrMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HerdrMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOFUHostKeyValidator.swift; sourceTree = "<group>"; };
 		BC995A571D7659F3307B6E54 /* DeviceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKey.swift; sourceTree = "<group>"; };
 		C232163905675760F37FD7A0 /* KnownHostsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStore.swift; sourceTree = "<group>"; };
 		C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWireTests.swift; sourceTree = "<group>"; };
+		CABFC5E35C19F809355619E7 /* HerdrEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrEvents.swift; sourceTree = "<group>"; };
 		CADA0E8C1DC6D30FCC6CEDC2 /* HostKeyPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostKeyPolicy.swift; sourceTree = "<group>"; };
 		D04EAA030D8329A1716714A8 /* DeviceKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyStore.swift; sourceTree = "<group>"; };
 		D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonTests.swift; sourceTree = "<group>"; };
@@ -104,9 +114,11 @@
 			children = (
 				BC995A571D7659F3307B6E54 /* DeviceKey.swift */,
 				D04EAA030D8329A1716714A8 /* DeviceKeyStore.swift */,
+				CABFC5E35C19F809355619E7 /* HerdrEvents.swift */,
 				F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */,
 				1CBE401E4A5FA5871809E540 /* HostKeyFingerprint.swift */,
 				CADA0E8C1DC6D30FCC6CEDC2 /* HostKeyPolicy.swift */,
+				1E3E2308A50D4744A24A874B /* JSONValue.swift */,
 				C232163905675760F37FD7A0 /* KnownHostsStore.swift */,
 				567573855DCC8571BC02096D /* SecretStore.swift */,
 				3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */,
@@ -133,8 +145,11 @@
 				646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */,
 				8323C68B13826B7388800B1F /* DeviceKeyStoreTests.swift */,
 				558159B2AF61C28F6B1391A2 /* DeviceKeyTests.swift */,
+				4076B0E816625CD09EB29F2E /* EventsSubscribeE2ETests.swift */,
+				A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */,
 				200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */,
 				C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */,
+				17F86744BFAC66D732CE7833 /* JSONValueTests.swift */,
 				87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */,
 				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
 				6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */,
@@ -277,10 +292,12 @@
 				CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */,
 				1BAA5950B7FDE0E6F09811F9 /* DeviceKey.swift in Sources */,
 				298FA49167E3CB1402B7B86B /* DeviceKeyStore.swift in Sources */,
+				C60E8E0398665C36520DDA8E /* HerdrEvents.swift in Sources */,
 				EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */,
 				A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */,
 				D6E9D6545089932306C4704F /* HostKeyFingerprint.swift in Sources */,
 				1302E0DD26A3F6C629A753D8 /* HostKeyPolicy.swift in Sources */,
+				4C80E23F09C8CFB3A93101B8 /* JSONValue.swift in Sources */,
 				B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */,
 				8C514AFC85DAED69A4988C13 /* SSHCredentials.swift in Sources */,
 				073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */,
@@ -298,10 +315,13 @@
 				0700F97FBF6A714C5D9EA5CD /* ColdStartE2ETests.swift in Sources */,
 				05A6F31F9CAC1CA1C57D7C71 /* DeviceKeyStoreTests.swift in Sources */,
 				F62A9CD06CFB784550AF4977 /* DeviceKeyTests.swift in Sources */,
+				E30244FD0231DD02EC9978D0 /* EventsSubscribeE2ETests.swift in Sources */,
 				EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */,
+				E908289DF03C6732F7D91328 /* HerdrEventsTests.swift in Sources */,
 				535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */,
 				724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */,
 				0A0657501E1164D7672A8B39 /* InMemorySecretStore.swift in Sources */,
+				969057C35F7E5F162B0CF41D /* JSONValueTests.swift in Sources */,
 				2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */,
 				F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */,
 				3DC1B4DCC0E2CD73A0C13B64 /* SSHAuthE2ETests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0A0657501E1164D7672A8B39 /* InMemorySecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B106E427EE5358088B615CE /* InMemorySecretStore.swift */; };
 		1302E0DD26A3F6C629A753D8 /* HostKeyPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADA0E8C1DC6D30FCC6CEDC2 /* HostKeyPolicy.swift */; };
 		1BAA5950B7FDE0E6F09811F9 /* DeviceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC995A571D7659F3307B6E54 /* DeviceKey.swift */; };
+		1BBEEF5478D91222F48C2048 /* ReconnectPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66B41C393D38FA09388E3E2 /* ReconnectPolicyTests.swift */; };
 		1F4B065DFCAF8E6656600F1E /* TOFUHostKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */; };
 		298FA49167E3CB1402B7B86B /* DeviceKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04EAA030D8329A1716714A8 /* DeviceKeyStore.swift */; };
 		2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */; };
@@ -26,6 +27,7 @@
 		724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */; };
 		782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */; };
 		8C514AFC85DAED69A4988C13 /* SSHCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90875ADAF6E348E186C8125A /* SSHCredentials.swift */; };
+		950D74A1B92239CDB2DDE5DC /* EventsSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C3ACB2A319C5C1298A29F3F /* EventsSession.swift */; };
 		969057C35F7E5F162B0CF41D /* JSONValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F86744BFAC66D732CE7833 /* JSONValueTests.swift */; };
 		A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */; };
 		B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C232163905675760F37FD7A0 /* KnownHostsStore.swift */; };
@@ -43,6 +45,7 @@
 		EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */; };
 		F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */; };
 		F62A9CD06CFB784550AF4977 /* DeviceKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558159B2AF61C28F6B1391A2 /* DeviceKeyTests.swift */; };
+		FE4ADC78CA6113FFFBCEC693 /* EventsSessionE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9291334E33C85C7588F86281 /* EventsSessionE2ETests.swift */; };
 		FEDD78DD422954EEBA415E8E /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 1A747BD14B4EC28AE6E73458 /* SwiftTerm */; };
 /* End PBXBuildFile section */
 
@@ -59,6 +62,7 @@
 /* Begin PBXFileReference section */
 		02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportFailureModesE2ETests.swift; sourceTree = "<group>"; };
 		17F86744BFAC66D732CE7833 /* JSONValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueTests.swift; sourceTree = "<group>"; };
+		1C3ACB2A319C5C1298A29F3F /* EventsSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSession.swift; sourceTree = "<group>"; };
 		1CBE401E4A5FA5871809E540 /* HostKeyFingerprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostKeyFingerprint.swift; sourceTree = "<group>"; };
 		1E3E2308A50D4744A24A874B /* JSONValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValue.swift; sourceTree = "<group>"; };
 		200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrSocketLocationTests.swift; sourceTree = "<group>"; };
@@ -78,10 +82,12 @@
 		87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStoreTests.swift; sourceTree = "<group>"; };
 		904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSSHTestEnvironment.swift; sourceTree = "<group>"; };
 		90875ADAF6E348E186C8125A /* SSHCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHCredentials.swift; sourceTree = "<group>"; };
+		9291334E33C85C7588F86281 /* EventsSessionE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionE2ETests.swift; sourceTree = "<group>"; };
 		9B106E427EE5358088B615CE /* InMemorySecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemorySecretStore.swift; sourceTree = "<group>"; };
 		A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrEventsTests.swift; sourceTree = "<group>"; };
 		A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConcurrencyE2ETests.swift; sourceTree = "<group>"; };
 		B383994C2C8492694D5F3690 /* HerdrMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HerdrMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B66B41C393D38FA09388E3E2 /* ReconnectPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectPolicyTests.swift; sourceTree = "<group>"; };
 		BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOFUHostKeyValidator.swift; sourceTree = "<group>"; };
 		BC995A571D7659F3307B6E54 /* DeviceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKey.swift; sourceTree = "<group>"; };
 		C232163905675760F37FD7A0 /* KnownHostsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStore.swift; sourceTree = "<group>"; };
@@ -114,6 +120,7 @@
 			children = (
 				BC995A571D7659F3307B6E54 /* DeviceKey.swift */,
 				D04EAA030D8329A1716714A8 /* DeviceKeyStore.swift */,
+				1C3ACB2A319C5C1298A29F3F /* EventsSession.swift */,
 				CABFC5E35C19F809355619E7 /* HerdrEvents.swift */,
 				F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */,
 				1CBE401E4A5FA5871809E540 /* HostKeyFingerprint.swift */,
@@ -145,12 +152,14 @@
 				646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */,
 				8323C68B13826B7388800B1F /* DeviceKeyStoreTests.swift */,
 				558159B2AF61C28F6B1391A2 /* DeviceKeyTests.swift */,
+				9291334E33C85C7588F86281 /* EventsSessionE2ETests.swift */,
 				4076B0E816625CD09EB29F2E /* EventsSubscribeE2ETests.swift */,
 				A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */,
 				200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */,
 				C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */,
 				17F86744BFAC66D732CE7833 /* JSONValueTests.swift */,
 				87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */,
+				B66B41C393D38FA09388E3E2 /* ReconnectPolicyTests.swift */,
 				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
 				6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */,
 				5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */,
@@ -292,6 +301,7 @@
 				CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */,
 				1BAA5950B7FDE0E6F09811F9 /* DeviceKey.swift in Sources */,
 				298FA49167E3CB1402B7B86B /* DeviceKeyStore.swift in Sources */,
+				950D74A1B92239CDB2DDE5DC /* EventsSession.swift in Sources */,
 				C60E8E0398665C36520DDA8E /* HerdrEvents.swift in Sources */,
 				EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */,
 				A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */,
@@ -315,6 +325,7 @@
 				0700F97FBF6A714C5D9EA5CD /* ColdStartE2ETests.swift in Sources */,
 				05A6F31F9CAC1CA1C57D7C71 /* DeviceKeyStoreTests.swift in Sources */,
 				F62A9CD06CFB784550AF4977 /* DeviceKeyTests.swift in Sources */,
+				FE4ADC78CA6113FFFBCEC693 /* EventsSessionE2ETests.swift in Sources */,
 				E30244FD0231DD02EC9978D0 /* EventsSubscribeE2ETests.swift in Sources */,
 				EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */,
 				E908289DF03C6732F7D91328 /* HerdrEventsTests.swift in Sources */,
@@ -324,6 +335,7 @@
 				969057C35F7E5F162B0CF41D /* JSONValueTests.swift in Sources */,
 				2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */,
 				F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */,
+				1BBEEF5478D91222F48C2048 /* ReconnectPolicyTests.swift in Sources */,
 				3DC1B4DCC0E2CD73A0C13B64 /* SSHAuthE2ETests.swift in Sources */,
 				5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */,
 				E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -11,7 +11,9 @@
 		49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E51D58B1094AC5B389EDA /* Transport.swift */; };
 		6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */; };
 		724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */; };
+		782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */; };
 		A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */; };
+		C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB59377D34D0C652DF70F01 /* UnixSockets.swift */; };
 		C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 03BEAFDD98C535CDCE9AE335 /* Citadel */; };
 		CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D95D580BCF4FE792AEFE974 /* ContentView.swift */; };
 		E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */; };
@@ -32,6 +34,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportFailureModesE2ETests.swift; sourceTree = "<group>"; };
 		20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeHerdrServer.swift; sourceTree = "<group>"; };
 		259E51D58B1094AC5B389EDA /* Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
 		78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrMobileApp.swift; sourceTree = "<group>"; };
@@ -44,6 +47,7 @@
 		F3D159C84E98A59AA47EBE6C /* HerdrMobileTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HerdrMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWire.swift; sourceTree = "<group>"; };
 		F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransportE2ETests.swift; sourceTree = "<group>"; };
+		FCB59377D34D0C652DF70F01 /* UnixSockets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnixSockets.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -84,6 +88,7 @@
 				C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */,
 				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
 				F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */,
+				02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */,
 				CB45F25667AE3C5C2EFD76CB /* Support */,
 			);
 			path = HerdrMobileTests;
@@ -121,6 +126,7 @@
 			children = (
 				20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */,
 				904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */,
+				FCB59377D34D0C652DF70F01 /* UnixSockets.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -231,6 +237,8 @@
 				F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */,
 				E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */,
 				6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */,
+				782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */,
+				C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB59377D34D0C652DF70F01 /* UnixSockets.swift */; };
 		C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 03BEAFDD98C535CDCE9AE335 /* Citadel */; };
 		CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D95D580BCF4FE792AEFE974 /* ContentView.swift */; };
+		E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */; };
 		E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */; };
 		EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */; };
 		EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */; };
@@ -45,6 +46,7 @@
 		7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransport.swift; sourceTree = "<group>"; };
 		7D95D580BCF4FE792AEFE974 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSSHTestEnvironment.swift; sourceTree = "<group>"; };
+		A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConcurrencyE2ETests.swift; sourceTree = "<group>"; };
 		B383994C2C8492694D5F3690 /* HerdrMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HerdrMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWireTests.swift; sourceTree = "<group>"; };
 		D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonTests.swift; sourceTree = "<group>"; };
@@ -94,6 +96,7 @@
 				C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */,
 				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
 				F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */,
+				A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */,
 				02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */,
 				CB45F25667AE3C5C2EFD76CB /* Support */,
 			);
@@ -245,6 +248,7 @@
 				F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */,
 				E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */,
 				6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */,
+				E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */,
 				782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */,
 				C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */,
 			);

--- a/HerdrMobile.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/HerdrMobile.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/HerdrMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HerdrMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,114 @@
+{
+  "originHash" : "47cd49417d767965e2f16dba29ebd67ea7e7e40e2652e748f8a09020e452b23d",
+  "pins" : [
+    {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+        "version" : "5.7.0"
+      }
+    },
+    {
+      "identity" : "citadel",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/orlandos-nl/Citadel.git",
+      "state" : {
+        "revision" : "ae8562f895de06ccb86fdb1cbb65fd99c8976e12",
+        "version" : "0.12.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssh",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Wellz26/swift-nio-ssh.git",
+      "state" : {
+        "revision" : "a05e6bbe6b141ee68da3030e00275504c0595d4d",
+        "version" : "0.3.6"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "b5544ba79a70a0cb3563e75bf26dc198d6b40ed3",
+        "version" : "1.7.4"
+      }
+    },
+    {
+      "identity" : "swiftterm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/migueldeicaza/SwiftTerm.git",
+      "state" : {
+        "revision" : "849e8a4f3d6f79ddee07152400137f1370c32621",
+        "version" : "1.14.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/HerdrMobile.xcodeproj/xcshareddata/xcschemes/HerdrMobile.xcscheme
+++ b/HerdrMobile.xcodeproj/xcshareddata/xcschemes/HerdrMobile.xcscheme
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0D343AAE6E2F9C2B803C9AE9"
+               BuildableName = "HerdrMobile.app"
+               BlueprintName = "HerdrMobile"
+               ReferencedContainer = "container:HerdrMobile.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0D343AAE6E2F9C2B803C9AE9"
+            BuildableName = "HerdrMobile.app"
+            BlueprintName = "HerdrMobile"
+            ReferencedContainer = "container:HerdrMobile.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CC604196196FFA00A41E9CD7"
+               BuildableName = "HerdrMobileTests.xctest"
+               BlueprintName = "HerdrMobileTests"
+               ReferencedContainer = "container:HerdrMobile.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0D343AAE6E2F9C2B803C9AE9"
+            BuildableName = "HerdrMobile.app"
+            BlueprintName = "HerdrMobile"
+            ReferencedContainer = "container:HerdrMobile.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0D343AAE6E2F9C2B803C9AE9"
+            BuildableName = "HerdrMobile.app"
+            BlueprintName = "HerdrMobile"
+            ReferencedContainer = "container:HerdrMobile.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/HerdrMobile/ContentView.swift
+++ b/Sources/HerdrMobile/ContentView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+/// Placeholder root view. Exists only to make the skeleton build and launch;
+/// the flat Console agent list replaces it in M1 (#8).
+struct ContentView: View {
+    var body: some View {
+        ContentUnavailableView(
+            "herdr",
+            systemImage: "terminal",
+            description: Text("Console coming soon.")
+        )
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Sources/HerdrMobile/HerdrMobileApp.swift
+++ b/Sources/HerdrMobile/HerdrMobileApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+/// App entry point. M0 ships only the buildable skeleton; the Console UI
+/// arrives in M1 once the Transport underneath it exists.
+@main
+struct HerdrMobileApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Sources/HerdrMobile/Transport/DeviceKey.swift
+++ b/Sources/HerdrMobile/Transport/DeviceKey.swift
@@ -1,0 +1,40 @@
+import CryptoKit
+import Foundation
+
+/// The device's SSH identity: an Ed25519 keypair generated on this device.
+/// The private key's raw bytes live only in the Keychain (`DeviceKeyStore`)
+/// and are never exported; this type hands the key object to the SSH layer
+/// and derives the public material shown during Host setup.
+struct DeviceKey: Sendable {
+    let privateKey: Curve25519.Signing.PrivateKey
+
+    /// SSH wire-format public key blob (RFC 4253 §6.6):
+    /// `string "ssh-ed25519"` + `string <32 raw key bytes>`. The same bytes
+    /// OpenSSH base64-encodes in `authorized_keys` and hashes for SHA256
+    /// fingerprints.
+    var publicKeyBlob: Data {
+        var blob = Data()
+        blob.appendSSHString(Data("ssh-ed25519".utf8))
+        blob.appendSSHString(privateKey.publicKey.rawRepresentation)
+        return blob
+    }
+
+    /// The public key in OpenSSH one-line format, without comment.
+    var openSSHPublicKey: String {
+        "ssh-ed25519 " + publicKeyBlob.base64EncodedString()
+    }
+
+    /// Copy-pasteable `authorized_keys` line for Host setup.
+    func authorizedKeysLine(comment: String) -> String {
+        openSSHPublicKey + " " + comment
+    }
+}
+
+extension Data {
+    /// Appends an SSH wire-format string: big-endian UInt32 length + bytes.
+    fileprivate mutating func appendSSHString(_ bytes: Data) {
+        var length = UInt32(bytes.count).bigEndian
+        Swift.withUnsafeBytes(of: &length) { append(contentsOf: $0) }
+        append(bytes)
+    }
+}

--- a/Sources/HerdrMobile/Transport/DeviceKeyStore.swift
+++ b/Sources/HerdrMobile/Transport/DeviceKeyStore.swift
@@ -1,0 +1,37 @@
+import CryptoKit
+import Foundation
+
+enum DeviceKeyStoreError: Error, Equatable {
+    /// The stored bytes no longer parse as an Ed25519 key. Surfaced, never
+    /// silently regenerated: a new key would lock the user out of every Host
+    /// without explanation.
+    case storedKeyCorrupt
+}
+
+/// Loads the device's SSH key, generating it on first use. The private key's
+/// raw bytes exist only inside the backing `SecretStore` (the Keychain in the
+/// app) and the in-memory CryptoKit object; there is no export path.
+struct DeviceKeyStore: Sendable {
+    private let secrets: any SecretStore
+    private let account: String
+
+    init(
+        secrets: any SecretStore = KeychainSecretStore(service: "dev.herdr.mobile.ssh"),
+        account: String = "device-ed25519-private-key"
+    ) {
+        self.secrets = secrets
+        self.account = account
+    }
+
+    func loadOrCreate() throws -> DeviceKey {
+        if let stored = try secrets.read(account: account) {
+            guard let key = try? Curve25519.Signing.PrivateKey(rawRepresentation: stored) else {
+                throw DeviceKeyStoreError.storedKeyCorrupt
+            }
+            return DeviceKey(privateKey: key)
+        }
+        let key = Curve25519.Signing.PrivateKey()
+        try secrets.write(key.rawRepresentation, account: account)
+        return DeviceKey(privateKey: key)
+    }
+}

--- a/Sources/HerdrMobile/Transport/EventsSession.swift
+++ b/Sources/HerdrMobile/Transport/EventsSession.swift
@@ -82,7 +82,11 @@ enum EventsSessionUpdate: Sendable, Equatable {
 /// connection down deliberately (call on backgrounding — iOS suspends
 /// sockets anyway, an explicit close makes resume cheap and deterministic),
 /// `end()` is terminal. All teardown is by explicit close, never by
-/// cancelling a live exec channel (ADR 0002).
+/// cancelling a live exec channel (ADR 0002). Lifecycle calls serialize
+/// internally — a `resume()` racing into a `suspend()`'s in-flight teardown
+/// waits for it instead of interleaving (quick background→foreground
+/// bounces are routine on iOS; callers never need to serialize their own
+/// calls).
 ///
 /// `updates` supports a single consumer and buffers without bound, exactly
 /// like the underlying event stream (fine foregrounded in M0).
@@ -116,6 +120,10 @@ actor EventsSession {
     private var runTask: Task<Void, Never>?
     private var keepaliveTask: Task<Void, Never>?
     private var backoffSleep: Task<Void, any Error>?
+    /// The most recently enqueued lifecycle transition; each new one chains
+    /// behind it, so transitions never interleave across the suspension
+    /// points inside a teardown (see the actor doc).
+    private var lifecycleTransition: Task<Void, Never>?
 
     init(
         subscriptions: [EventSubscription],
@@ -132,31 +140,60 @@ actor EventsSession {
 
     /// Activates the session (initially, or after `suspend()`): establishes
     /// the transport and channel, emitting `.connected` on success and
-    /// `.reconnecting` transitions until then. No-op while active or ended.
-    func resume() {
-        guard phase == .suspended else { return }
-        phase = .active
-        runTask = Task { await self.run() }
+    /// `.reconnecting` transitions until then. Returns once any in-flight
+    /// teardown has finished and the activation is underway. No-op while
+    /// active or ended.
+    func resume() async {
+        await enqueueLifecycleTransition { await self.activate() }
     }
 
     /// Deliberate teardown for backgrounding: ends the events channel by
     /// explicit close, closes the SSH connection, and stops all reconnect
     /// activity. Returns once everything is down. No-op unless active.
     func suspend() async {
+        await enqueueLifecycleTransition { await self.deactivate() }
+    }
+
+    /// Terminal teardown: like `suspend()`, then finishes `updates` for
+    /// good. Idempotent.
+    func end() async {
+        await enqueueLifecycleTransition { await self.finish() }
+    }
+
+    private func activate() {
+        guard phase == .suspended else { return }
+        phase = .active
+        runTask = Task { await self.run() }
+    }
+
+    private func deactivate() async {
         guard phase == .active else { return }
         phase = .suspended
         await windDown()
         updatesContinuation.yield(.status(.suspended))
     }
 
-    /// Terminal teardown: like `suspend()`, then finishes `updates` for
-    /// good. Idempotent.
-    func end() async {
+    private func finish() async {
         guard phase != .ended else { return }
         phase = .ended
         await windDown()
         updatesContinuation.yield(.status(.ended))
         updatesContinuation.finish()
+    }
+
+    /// Chains `transition` behind the previously enqueued one and waits for
+    /// it. Enqueueing is synchronous on the actor, so the chain order is the
+    /// call order and no transition ever observes another one mid-teardown.
+    private func enqueueLifecycleTransition(
+        _ transition: @escaping @Sendable () async -> Void
+    ) async {
+        let previous = lifecycleTransition
+        let task = Task {
+            await previous?.value
+            await transition()
+        }
+        lifecycleTransition = task
+        await task.value
     }
 
     // MARK: Reconnect loop

--- a/Sources/HerdrMobile/Transport/EventsSession.swift
+++ b/Sources/HerdrMobile/Transport/EventsSession.swift
@@ -1,0 +1,314 @@
+import Foundation
+
+/// Bounded backoff for events-channel reconnects (#18): capped exponential
+/// delay, unlimited attempts. The Console keeps trying forever and shows
+/// staleness through the session's status; the user decides when to give up.
+struct ReconnectPolicy: Sendable, Equatable {
+    var initialDelay: Duration
+    var multiplier: Int
+    var maxDelay: Duration
+
+    static let `default` = ReconnectPolicy(
+        initialDelay: .seconds(1), multiplier: 2, maxDelay: .seconds(30))
+
+    /// The delay before reconnect attempt `attempt` (1-based): the initial
+    /// delay grown by `multiplier` per prior failure, clamped at `maxDelay`.
+    func delay(beforeAttempt attempt: Int) -> Duration {
+        let factor = max(multiplier, 1)
+        var delay = initialDelay
+        var remaining = attempt - 1
+        while remaining > 0, delay < maxDelay {
+            delay = delay * factor
+            remaining -= 1
+        }
+        return min(delay, maxDelay)
+    }
+}
+
+/// Keepalive for the events session (#18). Citadel 0.12.1 exposes no
+/// SSH-level keepalive (no ignore-packet or global-request API in it or its
+/// NIOSSH fork) and no path to the NIO channel for TCP keepalive socket
+/// options (`SSHClient.session` is internal; the `channelHandlers:` connect
+/// parameter is stored but never installed). So the session pings herdr over
+/// the ordinary RPC path instead — which is also the stronger check: it
+/// generates SSH traffic that keeps NAT mappings alive, is bounded by the
+/// per-request deadline, and exercises the whole path (SSH + socat + herdr),
+/// so a dead connection is detected within interval + request timeout.
+struct KeepalivePolicy: Sendable, Equatable {
+    /// Idle time between pings while the events channel is live.
+    var interval: Duration
+
+    static let `default` = KeepalivePolicy(interval: .seconds(30))
+}
+
+/// Where the events session stands; the UI derives staleness from this.
+enum EventsSessionStatus: Sendable, Equatable {
+    /// The events channel is live. Emitted on every (re)connect — herdr does
+    /// not replay state on subscribe (#4), so each `.connected` is the
+    /// consumer's signal to re-snapshot via `listAgents()`.
+    case connected
+    /// The stream is down and attempt `attempt` starts after `delay`;
+    /// everything shown since the last `.connected` may be stale. `failure`
+    /// is what killed the previous attempt, for actionable user guidance.
+    case reconnecting(attempt: Int, delay: Duration, failure: TransportError)
+    /// Deliberately torn down (app backgrounded); no reconnect activity
+    /// until `resume()`.
+    case suspended
+    /// `end()` was called; the session is finished for good.
+    case ended
+}
+
+/// One element of the session's update stream: status transitions and events
+/// interleaved in the order they happened.
+enum EventsSessionUpdate: Sendable, Equatable {
+    case status(EventsSessionStatus)
+    case event(HerdrEvent)
+}
+
+/// The self-healing events channel for one Host (#18): owns the Host's
+/// Transport, keeps its dedicated `events.subscribe` channel alive across
+/// network blips and foreground/background transitions, and reports every
+/// transition so the UI can show staleness.
+///
+/// Layer-honest reconnect: a dropped *channel* re-subscribes on the same SSH
+/// connection through the transport's single-channel state machine; a dead
+/// *SSH connection* (`isConnected == false`, or a timeout that means the
+/// connection cannot be trusted) is closed and re-established via `connect`,
+/// then pinged — the first call on every new connection path — before
+/// re-subscribing.
+///
+/// Lifecycle: a fresh session is suspended; `resume()` activates it (call on
+/// launch and on foregrounding), `suspend()` tears the channel and the SSH
+/// connection down deliberately (call on backgrounding — iOS suspends
+/// sockets anyway, an explicit close makes resume cheap and deterministic),
+/// `end()` is terminal. All teardown is by explicit close, never by
+/// cancelling a live exec channel (ADR 0002).
+///
+/// `updates` supports a single consumer and buffers without bound, exactly
+/// like the underlying event stream (fine foregrounded in M0).
+actor EventsSession {
+    private enum Phase {
+        case suspended, active, ended
+    }
+
+    /// Status transitions and events, in order. Finishes after `end()`.
+    nonisolated let updates: AsyncStream<EventsSessionUpdate>
+    private let updatesContinuation: AsyncStream<EventsSessionUpdate>.Continuation
+
+    private let subscriptions: [EventSubscription]
+    private let connect: @Sendable () async throws -> any Transport
+    private let reconnectPolicy: ReconnectPolicy
+    private let keepalive: KeepalivePolicy?
+
+    private var phase: Phase = .suspended
+    /// The Host's live Transport; consumers run snapshot RPCs (`listAgents`)
+    /// through it after each `.connected`. Nil while suspended or between
+    /// SSH re-establishments.
+    private(set) var currentTransport: (any Transport)?
+    /// Set when the connection can no longer be trusted even though it may
+    /// still look alive (a timed-out request or keepalive ping): the next
+    /// reconnect replaces the transport instead of reusing it.
+    private var transportSuspect = false
+    /// The keepalive failure that forced the current teardown, surfaced in
+    /// the following `.reconnecting` status.
+    private var pendingKeepaliveFailure: TransportError?
+    private var liveStream: HerdrEventStream?
+    private var runTask: Task<Void, Never>?
+    private var keepaliveTask: Task<Void, Never>?
+    private var backoffSleep: Task<Void, any Error>?
+
+    init(
+        subscriptions: [EventSubscription],
+        connect: @escaping @Sendable () async throws -> any Transport,
+        reconnectPolicy: ReconnectPolicy = .default,
+        keepalive: KeepalivePolicy? = .default
+    ) {
+        self.subscriptions = subscriptions
+        self.connect = connect
+        self.reconnectPolicy = reconnectPolicy
+        self.keepalive = keepalive
+        (updates, updatesContinuation) = AsyncStream.makeStream(of: EventsSessionUpdate.self)
+    }
+
+    /// Activates the session (initially, or after `suspend()`): establishes
+    /// the transport and channel, emitting `.connected` on success and
+    /// `.reconnecting` transitions until then. No-op while active or ended.
+    func resume() {
+        guard phase == .suspended else { return }
+        phase = .active
+        runTask = Task { await self.run() }
+    }
+
+    /// Deliberate teardown for backgrounding: ends the events channel by
+    /// explicit close, closes the SSH connection, and stops all reconnect
+    /// activity. Returns once everything is down. No-op unless active.
+    func suspend() async {
+        guard phase == .active else { return }
+        phase = .suspended
+        await windDown()
+        updatesContinuation.yield(.status(.suspended))
+    }
+
+    /// Terminal teardown: like `suspend()`, then finishes `updates` for
+    /// good. Idempotent.
+    func end() async {
+        guard phase != .ended else { return }
+        phase = .ended
+        await windDown()
+        updatesContinuation.yield(.status(.ended))
+        updatesContinuation.finish()
+    }
+
+    // MARK: Reconnect loop
+
+    /// One activation's lifetime: connect/subscribe, stream, and reconnect
+    /// with bounded backoff, until the phase leaves `.active`. Exactly one
+    /// run loop exists at a time — `suspend()`/`end()` await its exit before
+    /// returning, and only `resume()` starts one.
+    private func run() async {
+        var attempt = 0
+        while phase == .active {
+            let stream: HerdrEventStream
+            do {
+                let transport = try await ensureTransport()
+                guard phase == .active else { break }
+                stream = try await transport.subscribeToEvents(subscriptions)
+            } catch {
+                guard phase == .active else { break }
+                let failure = Self.transportFailure(error)
+                if failure == .timedOut {
+                    // The connection swallowed a request whole; do not trust
+                    // it for the retry even if it still looks alive.
+                    transportSuspect = true
+                }
+                attempt += 1
+                await emitReconnectingAndBackOff(attempt: attempt, failure: failure)
+                continue
+            }
+            if phase != .active {
+                await stream.end()
+                break
+            }
+            liveStream = stream
+            attempt = 0
+            pendingKeepaliveFailure = nil
+            updatesContinuation.yield(.status(.connected))
+            startKeepalive(stream: stream)
+
+            var streamFailure: TransportError?
+            do {
+                for try await event in stream.events {
+                    updatesContinuation.yield(.event(event))
+                }
+                // Graceful finish: the channel was ended explicitly, by
+                // suspend()/end() or by a failed keepalive.
+            } catch {
+                streamFailure = Self.transportFailure(error)
+            }
+            stopKeepalive()
+            liveStream = nil
+            guard phase == .active else { break }
+            let failure =
+                streamFailure ?? pendingKeepaliveFailure
+                ?? .channelFailed(detail: "events stream ended unexpectedly")
+            pendingKeepaliveFailure = nil
+            attempt += 1
+            await emitReconnectingAndBackOff(attempt: attempt, failure: failure)
+        }
+    }
+
+    /// The Host's live transport: reuses the current one while its SSH
+    /// connection is alive and trusted, otherwise closes it and establishes
+    /// a fresh one — pinged first, as on every new connection path.
+    private func ensureTransport() async throws -> any Transport {
+        if let transport = currentTransport {
+            if !transportSuspect, await transport.isConnected {
+                return transport
+            }
+            currentTransport = nil
+            try? await transport.close()
+        }
+        let transport = try await connect()
+        do {
+            _ = try await transport.ping()
+        } catch {
+            try? await transport.close()
+            throw error
+        }
+        transportSuspect = false
+        currentTransport = transport
+        return transport
+    }
+
+    private func emitReconnectingAndBackOff(attempt: Int, failure: TransportError) async {
+        let delay = reconnectPolicy.delay(beforeAttempt: attempt)
+        updatesContinuation.yield(
+            .status(.reconnecting(attempt: attempt, delay: delay, failure: failure)))
+        let sleep = Task { try await Task.sleep(for: delay) }
+        backoffSleep = sleep
+        try? await sleep.value
+        backoffSleep = nil
+    }
+
+    /// Ends the current activation and closes everything: interrupts a
+    /// backoff wait, ends the channel by explicit close, awaits the run
+    /// loop's exit, then closes the SSH connection.
+    private func windDown() async {
+        backoffSleep?.cancel()
+        stopKeepalive()
+        if let stream = liveStream {
+            await stream.end()
+        }
+        if let task = runTask {
+            await task.value
+            runTask = nil
+        }
+        if let transport = currentTransport {
+            currentTransport = nil
+            try? await transport.close()
+        }
+        transportSuspect = false
+        pendingKeepaliveFailure = nil
+    }
+
+    // MARK: Keepalive
+
+    private func startKeepalive(stream: HerdrEventStream) {
+        guard let keepalive, let transport = currentTransport else { return }
+        keepaliveTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: keepalive.interval)
+                if Task.isCancelled { break }
+                do {
+                    _ = try await transport.ping()
+                } catch is CancellationError {
+                    break
+                } catch TransportError.cancelled {
+                    break
+                } catch {
+                    await self.keepaliveDidFail(Self.transportFailure(error), on: stream)
+                    break
+                }
+            }
+        }
+    }
+
+    private func stopKeepalive() {
+        keepaliveTask?.cancel()
+        keepaliveTask = nil
+    }
+
+    /// A keepalive ping failed: the connection cannot be trusted. Tears the
+    /// stream down by explicit close; the run loop then reconnects with a
+    /// fresh transport and surfaces this failure in `.reconnecting`.
+    private func keepaliveDidFail(_ failure: TransportError, on stream: HerdrEventStream) async {
+        guard phase == .active, liveStream === stream else { return }
+        transportSuspect = true
+        pendingKeepaliveFailure = failure
+        await stream.end()
+    }
+
+    private static func transportFailure(_ error: any Error) -> TransportError {
+        (error as? TransportError) ?? .channelFailed(detail: String(describing: error))
+    }
+}

--- a/Sources/HerdrMobile/Transport/HerdrEvents.swift
+++ b/Sources/HerdrMobile/Transport/HerdrEvents.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// Canonical event kind: the dotted name (`pane.created`) as herdr's
+/// subscription API spells it. Event lines arrive snake_case
+/// (`pane_created`); `init(wireName:)` maps either spelling here, so
+/// consumers only ever see one naming.
+struct HerdrEventKind: Hashable, Sendable {
+    let name: String
+
+    init(name: String) {
+        self.name = name
+    }
+
+    /// Maps a wire spelling (snake_case event line, or dotted) onto the
+    /// canonical kind. Unknown names pass through untouched — herdr's API
+    /// has no stability guarantee, and an unknown kind must not be
+    /// guess-mangled or kill the stream.
+    init(wireName: String) {
+        self = Self.byWireName[wireName] ?? HerdrEventKind(name: wireName)
+    }
+
+    /// All kinds herdr 0.7.4's schema declares subscribable.
+    static let known: [HerdrEventKind] =
+        GlobalEventKind.allCases.map(\.kind)
+        + PaneEventKind.allCases.map(\.kind)
+        + [paneOutputMatched]
+
+    /// `pane.output_matched` is subscribable only with a full output-match
+    /// query (`source` + `match`; verified empirically: the server rejects a
+    /// bare pane id). M0 does not subscribe to it, but its events still
+    /// decode canonically.
+    static let paneOutputMatched = HerdrEventKind(name: "pane.output_matched")
+
+    private static let byWireName: [String: HerdrEventKind] = {
+        var table: [String: HerdrEventKind] = [:]
+        for kind in known {
+            table[kind.name] = kind
+            table[kind.name.replacingOccurrences(of: ".", with: "_")] = kind
+        }
+        return table
+    }()
+}
+
+/// Host-wide subscription kinds: workspace/tab/pane/worktree lifecycle,
+/// `pane.agent_detected`, and layout changes. Subscribed with no params.
+enum GlobalEventKind: String, CaseIterable, Sendable {
+    case workspaceCreated = "workspace.created"
+    case workspaceUpdated = "workspace.updated"
+    case workspaceMetadataUpdated = "workspace.metadata_updated"
+    case workspaceRenamed = "workspace.renamed"
+    case workspaceMoved = "workspace.moved"
+    case workspaceClosed = "workspace.closed"
+    case workspaceFocused = "workspace.focused"
+    case worktreeCreated = "worktree.created"
+    case worktreeOpened = "worktree.opened"
+    case worktreeRemoved = "worktree.removed"
+    case tabCreated = "tab.created"
+    case tabClosed = "tab.closed"
+    case tabFocused = "tab.focused"
+    case tabRenamed = "tab.renamed"
+    case tabMoved = "tab.moved"
+    case paneCreated = "pane.created"
+    case paneClosed = "pane.closed"
+    case paneUpdated = "pane.updated"
+    case paneFocused = "pane.focused"
+    case paneMoved = "pane.moved"
+    case paneExited = "pane.exited"
+    case paneAgentDetected = "pane.agent_detected"
+    case layoutUpdated = "layout.updated"
+
+    /// The canonical kind, for matching against incoming events.
+    var kind: HerdrEventKind { HerdrEventKind(name: rawValue) }
+}
+
+/// Pane-scoped subscription kinds: their subscriptions carry a `pane_id`.
+/// Consumers key these off pane lifecycle events. (`pane.output_matched` is
+/// also pane-scoped but requires a full output-match query — M1.)
+enum PaneEventKind: String, CaseIterable, Sendable {
+    case agentStatusChanged = "pane.agent_status_changed"
+    case scrollChanged = "pane.scroll_changed"
+
+    /// The canonical kind, for matching against incoming events.
+    var kind: HerdrEventKind { HerdrEventKind(name: rawValue) }
+}
+
+/// One entry in an `events.subscribe` request.
+enum EventSubscription: Sendable, Equatable {
+    case global(GlobalEventKind)
+    case pane(PaneEventKind, paneID: String)
+}
+
+/// One event from the Host's events channel, in canonical naming.
+struct HerdrEvent: Sendable, Equatable {
+    let kind: HerdrEventKind
+    /// Raw payload: only 3 of 26 kinds are typed in herdr's schema, so the
+    /// payload stays schema-free and consumers pick the fields they know.
+    let data: JSONValue
+}
+
+/// A live `events.subscribe` stream over its Host's dedicated exec channel.
+///
+/// Ending is explicit: call `end()`. A live exec channel does not respond to
+/// Swift task cancellation (ADR 0002), so abandoning the stream without
+/// `end()` leaks the channel until the SSH connection closes.
+final class HerdrEventStream: Sendable {
+    /// Events in arrival order. Finishes without error after `end()`,
+    /// finishes throwing if the channel dies remotely.
+    let events: AsyncThrowingStream<HerdrEvent, any Error>
+    private let ender: @Sendable () async -> Void
+
+    init(
+        events: AsyncThrowingStream<HerdrEvent, any Error>,
+        ender: @escaping @Sendable () async -> Void
+    ) {
+        self.events = events
+        self.ender = ender
+    }
+
+    /// Closes the events channel explicitly and waits for its teardown; the
+    /// stream then finishes without error. Idempotent.
+    func end() async {
+        await ender()
+    }
+}

--- a/Sources/HerdrMobile/Transport/HerdrWire.swift
+++ b/Sources/HerdrMobile/Transport/HerdrWire.swift
@@ -7,7 +7,12 @@ import Foundation
 enum HerdrWire {
     /// Encodes a single request line, trailing newline included.
     static func requestLine(id: String, method: String) throws -> String {
-        let request = Request(id: id, method: method)
+        try requestLine(id: id, method: method, params: EmptyParams())
+    }
+
+    /// Encodes a single request line with a params payload.
+    static func requestLine<P: Encodable>(id: String, method: String, params: P) throws -> String {
+        let request = Request(id: id, method: method, params: params)
         let data: Data
         do {
             data = try JSONEncoder().encode(request)
@@ -16,6 +21,25 @@ enum HerdrWire {
                 "failed to encode request for \(method): \(error)")
         }
         return String(decoding: data, as: UTF8.self) + "\n"
+    }
+
+    /// Encodes an `events.subscribe` request line. Subscription kinds go out
+    /// in their canonical dotted spelling; pane-scoped entries carry the
+    /// pane id the server requires.
+    static func subscribeRequestLine(id: String, subscriptions: [EventSubscription]) throws
+        -> String
+    {
+        try requestLine(
+            id: id, method: "events.subscribe",
+            params: SubscribeParams(subscriptions: subscriptions.map(WireSubscription.init)))
+    }
+
+    /// Decodes one events-channel line. Returns nil for anything that is not
+    /// an event line — lenient by design: junk on the stream is dropped,
+    /// never fatal.
+    static func decodeEvent(fromLine data: Data) -> HerdrEvent? {
+        guard let line = try? JSONDecoder().decode(EventLine.self, from: data) else { return nil }
+        return HerdrEvent(kind: HerdrEventKind(wireName: line.event), data: line.data ?? .null)
     }
 
     /// Decodes one response line: unwraps the envelope, checks id correlation,
@@ -31,12 +55,15 @@ enum HerdrWire {
             let preview = String(decoding: lineData.prefix(200), as: UTF8.self)
             throw TransportError.malformedResponse("undecodable response line: \(preview)")
         }
+        // Server-reported errors win even when id correlation is off: herdr
+        // answers a request it could not parse with id "" (live-captured
+        // shape), and the error is the actionable part.
+        if let error = envelope.error {
+            throw error
+        }
         guard envelope.id == requestID else {
             throw TransportError.malformedResponse(
                 "response id \(envelope.id ?? "<none>") does not match request id \(requestID)")
-        }
-        if let error = envelope.error {
-            throw error
         }
         guard let result = envelope.result else {
             throw TransportError.malformedResponse("response has neither result nor error")
@@ -44,13 +71,42 @@ enum HerdrWire {
         return result
     }
 
-    private struct Request: Encodable {
+    private struct Request<P: Encodable>: Encodable {
         let id: String
         let method: String
-        // All M0 methods take empty params; grows a payload when one needs it.
-        let params = EmptyParams()
+        let params: P
+    }
 
-        struct EmptyParams: Encodable {}
+    private struct EmptyParams: Encodable {}
+
+    private struct SubscribeParams: Encodable {
+        let subscriptions: [WireSubscription]
+    }
+
+    private struct WireSubscription: Encodable {
+        let type: String
+        let paneID: String?
+
+        init(_ subscription: EventSubscription) {
+            switch subscription {
+            case .global(let kind):
+                type = kind.rawValue
+                paneID = nil
+            case .pane(let kind, let paneID):
+                type = kind.rawValue
+                self.paneID = paneID
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case type
+            case paneID = "pane_id"
+        }
+    }
+
+    private struct EventLine: Decodable {
+        let event: String
+        let data: JSONValue?
     }
 
     private struct ResponseEnvelope<R: Decodable>: Decodable {
@@ -81,3 +137,8 @@ extension HerdrAPIError: Decodable {
 struct AgentListResult: Decodable {
     let agents: [Agent]
 }
+
+/// Result payload of the `events.subscribe` ack line
+/// (`{"type":"subscription_started"}`). Shape intentionally unchecked: the
+/// envelope carrying a result at all is the acknowledgement.
+struct SubscriptionStartedResult: Decodable {}

--- a/Sources/HerdrMobile/Transport/HerdrWire.swift
+++ b/Sources/HerdrMobile/Transport/HerdrWire.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// herdr's NDJSON wire format: request `{"id","method","params"}` + "\n",
+/// success `{"id","result"}`, failure `{"id","error":{"code","message"}}`.
+/// One request per connection; decoding is lenient (unknown fields ignored)
+/// because herdr's API has no stability guarantee.
+enum HerdrWire {
+    /// Encodes a single request line, trailing newline included.
+    static func requestLine(id: String, method: String) throws -> String {
+        let request = Request(id: id, method: method)
+        let data: Data
+        do {
+            data = try JSONEncoder().encode(request)
+        } catch {
+            throw TransportError.malformedResponse(
+                "failed to encode request for \(method): \(error)")
+        }
+        return String(decoding: data, as: UTF8.self) + "\n"
+    }
+
+    /// Decodes one response line: unwraps the envelope, checks id correlation,
+    /// and either returns the result or throws the server's error.
+    static func decodeResult<R: Decodable>(
+        _ type: R.Type, fromResponseLine data: Data, requestID: String
+    ) throws -> R {
+        let lineData = Data(data.prefix(while: { $0 != 0x0A }))
+        let envelope: ResponseEnvelope<R>
+        do {
+            envelope = try JSONDecoder().decode(ResponseEnvelope<R>.self, from: lineData)
+        } catch {
+            let preview = String(decoding: lineData.prefix(200), as: UTF8.self)
+            throw TransportError.malformedResponse("undecodable response line: \(preview)")
+        }
+        guard envelope.id == requestID else {
+            throw TransportError.malformedResponse(
+                "response id \(envelope.id ?? "<none>") does not match request id \(requestID)")
+        }
+        if let error = envelope.error {
+            throw error
+        }
+        guard let result = envelope.result else {
+            throw TransportError.malformedResponse("response has neither result nor error")
+        }
+        return result
+    }
+
+    private struct Request: Encodable {
+        let id: String
+        let method: String
+        // All M0 methods take empty params; grows a payload when one needs it.
+        let params = EmptyParams()
+
+        struct EmptyParams: Encodable {}
+    }
+
+    private struct ResponseEnvelope<R: Decodable>: Decodable {
+        let id: String?
+        let result: R?
+        let error: HerdrAPIError?
+    }
+}
+
+extension HerdrAPIError: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case code, message
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let number = try? container.decode(Int.self, forKey: .code) {
+            self.init(code: String(number), message: try container.decode(String.self, forKey: .message))
+        } else {
+            self.init(
+                code: try container.decode(String.self, forKey: .code),
+                message: try container.decode(String.self, forKey: .message))
+        }
+    }
+}
+
+/// Result payload of `agent.list`.
+struct AgentListResult: Decodable {
+    let agents: [Agent]
+}

--- a/Sources/HerdrMobile/Transport/HostKeyFingerprint.swift
+++ b/Sources/HerdrMobile/Transport/HostKeyFingerprint.swift
@@ -1,0 +1,24 @@
+import CryptoKit
+import Foundation
+
+/// An OpenSSH-style host key fingerprint: SHA-256 over the SSH wire-format
+/// public key blob. This is what the user confirms on first connect and what
+/// the known-hosts store persists for TOFU.
+struct HostKeyFingerprint: Sendable, Hashable {
+    /// The 32-byte SHA-256 digest.
+    let digest: Data
+
+    init(publicKeyBlob: Data) {
+        digest = Data(SHA256.hash(data: publicKeyBlob))
+    }
+
+    /// Reconstructs a fingerprint from a previously stored digest.
+    init(digest: Data) {
+        self.digest = digest
+    }
+
+    /// The presentation OpenSSH prints: `SHA256:<base64 without padding>`.
+    var displayString: String {
+        "SHA256:" + digest.base64EncodedString().trimmingCharacters(in: ["="])
+    }
+}

--- a/Sources/HerdrMobile/Transport/HostKeyPolicy.swift
+++ b/Sources/HerdrMobile/Transport/HostKeyPolicy.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// An unknown host key awaiting the user's trust decision on first connect.
+struct HostKeyCandidate: Sendable, Equatable {
+    let host: String
+    let port: Int
+    let fingerprint: HostKeyFingerprint
+}
+
+/// TOFU host key policy: trust the fingerprint the user confirmed on first
+/// connect, hard-fail when a known Host's key changes. Citadel never leaks
+/// through this surface — the UI implements the confirmation and injects the
+/// store without seeing SSH primitives.
+struct HostKeyPolicy: Sendable {
+    /// Fingerprints of already-trusted Hosts.
+    var knownHosts: any KnownHostsStore
+
+    /// First-connect confirmation, implemented by the UI: shown the
+    /// candidate, returns whether the user trusts it. Returning false fails
+    /// the connection with `.hostKeyRejected` and stores nothing.
+    var confirmFirstConnect: @Sendable (HostKeyCandidate) async -> Bool
+
+    init(
+        knownHosts: any KnownHostsStore,
+        confirmFirstConnect: @escaping @Sendable (HostKeyCandidate) async -> Bool
+    ) {
+        self.knownHosts = knownHosts
+        self.confirmFirstConnect = confirmFirstConnect
+    }
+}

--- a/Sources/HerdrMobile/Transport/JSONValue.swift
+++ b/Sources/HerdrMobile/Transport/JSONValue.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// A decoded JSON tree. Event payloads are schema-free — only 3 of herdr's
+/// 26 subscription kinds have typed payloads — so events carry their data as
+/// a JSONValue and consumers pick out the fields they know.
+enum JSONValue: Sendable, Equatable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    /// The value under `key` if this is an object that holds one.
+    subscript(key: String) -> JSONValue? {
+        guard case .object(let fields) = self else { return nil }
+        return fields[key]
+    }
+
+    var stringValue: String? {
+        guard case .string(let value) = self else { return nil }
+        return value
+    }
+}
+
+extension JSONValue: Decodable {
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        // Bool before Double: JSONDecoder refuses cross-type coercion, so
+        // the order only disambiguates, it cannot misread.
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container, debugDescription: "value is not JSON")
+        }
+    }
+}

--- a/Sources/HerdrMobile/Transport/KnownHostsStore.swift
+++ b/Sources/HerdrMobile/Transport/KnownHostsStore.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// TOFU persistence: the host key fingerprint the user trusted for each
+/// Host, keyed by host and port. Not a secret — it guards against future
+/// impostors, it does not authenticate us — so app-level storage is fine.
+/// Injectable so tests can seed and observe it.
+protocol KnownHostsStore: Sendable {
+    func fingerprint(host: String, port: Int) async -> HostKeyFingerprint?
+    func setFingerprint(_ fingerprint: HostKeyFingerprint, host: String, port: Int) async
+}
+
+/// Volatile store for tests and previews.
+actor InMemoryKnownHostsStore: KnownHostsStore {
+    private var fingerprints: [String: HostKeyFingerprint] = [:]
+
+    func fingerprint(host: String, port: Int) -> HostKeyFingerprint? {
+        fingerprints[Self.key(host: host, port: port)]
+    }
+
+    func setFingerprint(_ fingerprint: HostKeyFingerprint, host: String, port: Int) {
+        fingerprints[Self.key(host: host, port: port)] = fingerprint
+    }
+
+    static func key(host: String, port: Int) -> String {
+        "\(host):\(port)"
+    }
+}
+
+/// The app's persistent store: digests in UserDefaults, keyed "host:port".
+struct UserDefaultsKnownHostsStore: KnownHostsStore {
+    private static let defaultsKey = "knownHostFingerprints"
+    // UserDefaults is documented thread-safe; Sendable modulo that promise.
+    private nonisolated(unsafe) let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func fingerprint(host: String, port: Int) async -> HostKeyFingerprint? {
+        let stored = defaults.dictionary(forKey: Self.defaultsKey) as? [String: String]
+        guard
+            let base64 = stored?[InMemoryKnownHostsStore.key(host: host, port: port)],
+            let digest = Data(base64Encoded: base64)
+        else { return nil }
+        return HostKeyFingerprint(digest: digest)
+    }
+
+    func setFingerprint(_ fingerprint: HostKeyFingerprint, host: String, port: Int) async {
+        var stored = defaults.dictionary(forKey: Self.defaultsKey) as? [String: String] ?? [:]
+        stored[InMemoryKnownHostsStore.key(host: host, port: port)] =
+            fingerprint.digest.base64EncodedString()
+        defaults.set(stored, forKey: Self.defaultsKey)
+    }
+}

--- a/Sources/HerdrMobile/Transport/SSHCredentials.swift
+++ b/Sources/HerdrMobile/Transport/SSHCredentials.swift
@@ -1,0 +1,10 @@
+import CryptoKit
+import Foundation
+
+/// How the app authenticates to a Host. Key auth uses the device key from
+/// `DeviceKeyStore`; password is the fallback for Hosts where key setup has
+/// not happened yet.
+enum SSHCredentials: Sendable {
+    case ed25519(Curve25519.Signing.PrivateKey)
+    case password(String)
+}

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -1,0 +1,98 @@
+// @preconcurrency: Citadel predates strict concurrency and SSHClient is not
+// marked Sendable; its async methods hop off the actor executor, which would
+// otherwise be an error. The actor still serializes all access to the client.
+@preconcurrency import Citadel
+import CryptoKit
+import Foundation
+import NIOCore
+
+/// How to reach one Host and its herdr socket. Tracer-bullet subset: Ed25519
+/// key auth and an explicit socket path; remote socket path resolution and the
+/// full error taxonomy are #17, richer auth is the SSH core work.
+struct SSHTransportSettings: Sendable {
+    var host: String
+    var port: Int
+    var username: String
+    var privateKey: Curve25519.Signing.PrivateKey
+    /// Absolute path of the herdr API socket on the Host.
+    var socketPath: String
+    /// Absolute path of socat on the Host. Remote commands run through the
+    /// user's login shell, whose PATH cannot be trusted.
+    var socatPath: String
+}
+
+/// Transport over SSH exec channels running `socat - UNIX-CONNECT:<sock>`,
+/// one channel per request because herdr serves one request per connection
+/// (ADR 0002). An actor because Citadel's SSHClient is not Sendable.
+actor SSHTransport: Transport {
+    /// The herdr wire protocol version this build speaks (herdr 0.7.4).
+    static let supportedProtocolVersion = 16
+
+    private let client: SSHClient
+    private let socketPath: String
+    private let socatPath: String
+
+    private init(client: SSHClient, socketPath: String, socatPath: String) {
+        self.client = client
+        self.socketPath = socketPath
+        self.socatPath = socatPath
+    }
+
+    /// Connects and authenticates, but sends nothing yet: callers must `ping`
+    /// first to verify the protocol version.
+    ///
+    /// Host key verification is not implemented yet (TOFU with fingerprint
+    /// confirmation ships with the SSH core work); until then the server's
+    /// host key is accepted without verification.
+    static func connect(settings: SSHTransportSettings) async throws -> SSHTransport {
+        let client = try await SSHClient.connect(
+            host: settings.host,
+            port: settings.port,
+            authenticationMethod: .ed25519(
+                username: settings.username, privateKey: settings.privateKey),
+            hostKeyValidator: .acceptAnything(),
+            reconnect: .never
+        )
+        return SSHTransport(
+            client: client, socketPath: settings.socketPath, socatPath: settings.socatPath)
+    }
+
+    func ping() async throws -> ServerInfo {
+        let info = try await request(method: "ping", decoding: ServerInfo.self)
+        guard info.protocolVersion == Self.supportedProtocolVersion else {
+            throw TransportError.protocolVersionMismatch(
+                server: info.protocolVersion, supported: Self.supportedProtocolVersion)
+        }
+        return info
+    }
+
+    func listAgents() async throws -> [Agent] {
+        try await request(method: "agent.list", decoding: AgentListResult.self).agents
+    }
+
+    /// Closes the SSH connection. Explicit close is the only way to end
+    /// Citadel channels — a live exec channel ignores task cancellation.
+    func close() async throws {
+        try await client.close()
+    }
+
+    /// One no-PTY exec channel per request. The channel is ended by returning
+    /// from the `withExec` body as soon as a full response line has arrived
+    /// (Citadel closes the channel on return) — never by task cancellation,
+    /// which a live exec channel does not respond to.
+    private func request<R: Decodable>(method: String, decoding type: R.Type) async throws -> R {
+        let requestID = UUID().uuidString
+        let line = try HerdrWire.requestLine(id: requestID, method: method)
+        var stdout = Data()
+        try await client.withExec("\(socatPath) - UNIX-CONNECT:\(socketPath)") {
+            inbound, outbound in
+            try await outbound.write(ByteBuffer(string: line))
+            for try await chunk in inbound {
+                guard case .stdout(let buffer) = chunk else { continue }
+                stdout.append(contentsOf: buffer.readableBytesView)
+                if stdout.contains(0x0A) { return }
+            }
+        }
+        return try HerdrWire.decodeResult(type, fromResponseLine: stdout, requestID: requestID)
+    }
+}

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -18,6 +18,14 @@ struct SSHTransportSettings: Sendable {
     /// Absolute path of socat on the Host. Remote commands run through the
     /// user's login shell, whose PATH cannot be trusted.
     var socatPath: String
+    /// Command that wakes a stopped herdr server, run over a no-PTY exec
+    /// channel when a request hits connection-refused (#6). The default is
+    /// the strategy from spec #16: `herdr remote-client-bridge` ensures the
+    /// server is running (spawn + wait for socket) before bridging, then
+    /// exits on stdin EOF. Injectable so tests can substitute a script at
+    /// the environment boundary; per-Host override also covers hosts where
+    /// herdr is not on the login shell's PATH.
+    var wakeCommand: String = "herdr remote-client-bridge"
 }
 
 /// Transport over SSH exec channels running `socat - UNIX-CONNECT:<sock>`,
@@ -30,14 +38,23 @@ actor SSHTransport: Transport {
     private let client: SSHClient
     private let socketLocation: HerdrSocketLocation
     private let socatPath: String
+    private let wakeCommand: String
     /// In-flight or completed remote home directory resolution; see
     /// `remoteHomeDirectory()`.
     private var homeDirectoryTask: Task<String, Error>?
+    /// In-flight cold-start wake; concurrent refused requests share one wake
+    /// instead of racing exec channels. Cleared on completion so a later
+    /// cold start can wake again.
+    private var wakeTask: Task<Void, Error>?
 
-    private init(client: SSHClient, socketLocation: HerdrSocketLocation, socatPath: String) {
+    private init(
+        client: SSHClient, socketLocation: HerdrSocketLocation, socatPath: String,
+        wakeCommand: String
+    ) {
         self.client = client
         self.socketLocation = socketLocation
         self.socatPath = socatPath
+        self.wakeCommand = wakeCommand
     }
 
     /// Connects and authenticates, but sends nothing yet: callers must `ping`
@@ -56,7 +73,8 @@ actor SSHTransport: Transport {
             reconnect: .never
         )
         return SSHTransport(
-            client: client, socketLocation: settings.socket, socatPath: settings.socatPath)
+            client: client, socketLocation: settings.socket, socatPath: settings.socatPath,
+            wakeCommand: settings.wakeCommand)
     }
 
     func ping() async throws -> ServerInfo {
@@ -78,11 +96,62 @@ actor SSHTransport: Transport {
         try await client.close()
     }
 
+    /// Executes one request, with cold-start recovery (#6): connection
+    /// refused means the socket exists but the server is stopped, so run the
+    /// wake command and retry the socket. Strictly bounded — one wake, one
+    /// retry — so a wake that does not help surfaces `.serverNotRunning` to
+    /// the user instead of looping silently.
+    private func request<R: Decodable>(method: String, decoding type: R.Type) async throws -> R {
+        do {
+            return try await performRequest(method: method, decoding: type)
+        } catch TransportError.serverNotRunning(let path) {
+            do {
+                try await wakeServer()
+            } catch TransportError.cancelled {
+                throw TransportError.cancelled
+            } catch {
+                // The wake itself failed (herdr missing, command errored):
+                // the actionable problem is still a server that is not
+                // running on this Host.
+                throw TransportError.serverNotRunning(path: path)
+            }
+            return try await performRequest(method: method, decoding: type)
+        }
+    }
+
+    /// Wakes the herdr server via the Host's wake command; concurrent
+    /// refused requests share one in-flight wake.
+    private func wakeServer() async throws {
+        if let task = wakeTask {
+            return try await task.value
+        }
+        let task = Task { try await self.runWakeCommand() }
+        wakeTask = task
+        defer { wakeTask = nil }
+        return try await task.value
+    }
+
+    /// Runs the wake command over a no-PTY exec channel with stdin at EOF
+    /// from the start (`< /dev/null`). The bridge's entry point ensures the
+    /// server is running (spawn + wait for socket) before it starts
+    /// bridging; the bridge then reads EOF and exits — so the command
+    /// completing implies a live socket, and its own lifetime bounds the
+    /// channel without writing or closing anything mid-flight.
+    private func runWakeCommand() async throws {
+        do {
+            _ = try await client.executeCommand("\(wakeCommand) < /dev/null")
+        } catch is CancellationError {
+            throw TransportError.cancelled
+        }
+    }
+
     /// One no-PTY exec channel per request. The channel is ended by returning
     /// from the `withExec` body as soon as a full response line has arrived
     /// (Citadel closes the channel on return) — never by task cancellation,
     /// which a live exec channel does not respond to.
-    private func request<R: Decodable>(method: String, decoding type: R.Type) async throws -> R {
+    private func performRequest<R: Decodable>(method: String, decoding type: R.Type) async throws
+        -> R
+    {
         let socketPath = try await resolvedSocketPath()
         let requestID = UUID().uuidString
         let line = try HerdrWire.requestLine(id: requestID, method: method)

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -2,17 +2,18 @@
 // marked Sendable; its async methods hop off the actor executor, which would
 // otherwise be an error. The actor still serializes all access to the client.
 @preconcurrency import Citadel
-import CryptoKit
 import Foundation
 import NIOCore
 
-/// How to reach one Host and its herdr socket. Auth is the tracer-bullet
-/// Ed25519 subset; richer auth and host key policy are the SSH core work (#2).
+/// How to reach one Host, authenticate against it, and find its herdr socket.
 struct SSHTransportSettings: Sendable {
     var host: String
     var port: Int
     var username: String
-    var privateKey: Curve25519.Signing.PrivateKey
+    var credentials: SSHCredentials
+    /// TOFU host key policy (#2): the trusted-fingerprint store plus the
+    /// first-connect confirmation the UI implements.
+    var hostKeyPolicy: HostKeyPolicy
     /// Which herdr socket to reach on the Host.
     var socket: HerdrSocketLocation
     /// Absolute path of socat on the Host. Remote commands run through the
@@ -139,24 +140,48 @@ actor SSHTransport: Transport {
         self.requestTimeout = requestTimeout
     }
 
-    /// Connects and authenticates, but sends nothing yet: callers must `ping`
-    /// first to verify the protocol version.
-    ///
-    /// Host key verification is not implemented yet (TOFU with fingerprint
-    /// confirmation ships with the SSH core work); until then the server's
-    /// host key is accepted without verification.
+    /// Connects, verifies the host key per the TOFU policy, and
+    /// authenticates — but sends nothing yet: callers must `ping` first to
+    /// verify the protocol version.
     static func connect(settings: SSHTransportSettings) async throws -> SSHTransport {
-        let client = try await SSHClient.connect(
-            host: settings.host,
-            port: settings.port,
-            authenticationMethod: .ed25519(
-                username: settings.username, privateKey: settings.privateKey),
-            hostKeyValidator: .acceptAnything(),
-            reconnect: .never
-        )
+        let validator = TOFUHostKeyValidator(
+            host: settings.host, port: settings.port, policy: settings.hostKeyPolicy)
+        let client: SSHClient
+        do {
+            client = try await SSHClient.connect(
+                host: settings.host,
+                port: settings.port,
+                authenticationMethod: settings.credentials.citadelMethod(
+                    username: settings.username),
+                hostKeyValidator: .custom(validator),
+                reconnect: .never
+            )
+        } catch {
+            // NIOSSH may wrap the validator's error on its way out of the
+            // handshake; the recorded verdict is the source of truth.
+            if let hostKeyFailure = validator.failure {
+                throw hostKeyFailure
+            }
+            throw Self.classifyConnectFailure(error)
+        }
         return SSHTransport(
             client: client, socketLocation: settings.socket, socatPath: settings.socatPath,
             wakeCommand: settings.wakeCommand, requestTimeout: settings.requestTimeout)
+    }
+
+    /// Maps connect-time failures onto the taxonomy: credential rejection is
+    /// actionable ("fix your key/password"), everything else is a Host that
+    /// could not be reached.
+    private static func classifyConnectFailure(_ error: any Error) -> TransportError {
+        switch error {
+        case SSHClientError.allAuthenticationOptionsFailed,
+            SSHClientError.unsupportedPasswordAuthentication,
+            SSHClientError.unsupportedPrivateKeyAuthentication,
+            SSHClientError.unsupportedHostBasedAuthentication:
+            return .authenticationFailed
+        default:
+            return .sshUnreachable(detail: String(describing: error))
+        }
     }
 
     func ping() async throws -> ServerInfo {
@@ -388,5 +413,18 @@ actor SSHTransport: Transport {
 
     private static func preview(_ stderr: Data) -> String {
         String(decoding: stderr.prefix(200), as: UTF8.self)
+    }
+}
+
+extension SSHCredentials {
+    /// The Citadel authentication method for these credentials. Lives here so
+    /// the credentials type itself stays free of SSH library types.
+    fileprivate func citadelMethod(username: String) -> SSHAuthenticationMethod {
+        switch self {
+        case .ed25519(let privateKey):
+            .ed25519(username: username, privateKey: privateKey)
+        case .password(let password):
+            .passwordBased(username: username, password: password)
+        }
     }
 }

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -387,6 +387,15 @@ actor SSHTransport: Transport {
         return line
     }
 
+    /// Whether the SSH connection is still alive (Citadel tracks the
+    /// underlying channel's liveness). False after `close()` or a remote
+    /// death; this transport is then dead for good — Citadel's auto-reconnect
+    /// is deliberately off (`.never`), re-establishing is the reconnect
+    /// machinery's job (#18) so backoff stays bounded and observable.
+    var isConnected: Bool {
+        client.isConnected
+    }
+
     /// Closes the SSH connection. Explicit close is the only way to end
     /// Citadel channels — a live exec channel ignores task cancellation.
     func close() async throws {

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -26,6 +26,11 @@ struct SSHTransportSettings: Sendable {
     /// the environment boundary; per-Host override also covers hosts where
     /// herdr is not on the login shell's PATH.
     var wakeCommand: String = "herdr remote-client-bridge"
+    /// Per-request deadline covering the queue wait and the exec exchange;
+    /// on expiry the request fails with `.timedOut` and its channel is
+    /// closed. Short in tests, generous by default: a hung host should
+    /// degrade gracefully, a slow one should still answer.
+    var requestTimeout: Duration = .seconds(15)
 }
 
 /// Transport over SSH exec channels running `socat - UNIX-CONNECT:<sock>`,
@@ -44,6 +49,7 @@ actor SSHTransport: Transport {
     private let socketLocation: HerdrSocketLocation
     private let socatPath: String
     private let wakeCommand: String
+    private let requestTimeout: Duration
     /// In-flight or completed remote home directory resolution; see
     /// `remoteHomeDirectory()`.
     private var homeDirectoryTask: Task<String, Error>?
@@ -123,12 +129,13 @@ actor SSHTransport: Transport {
 
     private init(
         client: SSHClient, socketLocation: HerdrSocketLocation, socatPath: String,
-        wakeCommand: String
+        wakeCommand: String, requestTimeout: Duration
     ) {
         self.client = client
         self.socketLocation = socketLocation
         self.socatPath = socatPath
         self.wakeCommand = wakeCommand
+        self.requestTimeout = requestTimeout
     }
 
     /// Connects and authenticates, but sends nothing yet: callers must `ping`
@@ -148,7 +155,7 @@ actor SSHTransport: Transport {
         )
         return SSHTransport(
             client: client, socketLocation: settings.socket, socatPath: settings.socatPath,
-            wakeCommand: settings.wakeCommand)
+            wakeCommand: settings.wakeCommand, requestTimeout: settings.requestTimeout)
     }
 
     func ping() async throws -> ServerInfo {
@@ -225,24 +232,32 @@ actor SSHTransport: Transport {
         }
     }
 
-    /// One no-PTY exec channel per request. The channel is ended by returning
-    /// from the `withExec` body as soon as a full response line has arrived
-    /// (Citadel closes the channel on return) — never by task cancellation,
-    /// which a live exec channel does not respond to.
+    /// One no-PTY exec channel per request, raced against the per-request
+    /// deadline. The channel is ended by returning from the `withExec` body
+    /// as soon as a full response line has arrived (Citadel closes the
+    /// channel on return) — never by task cancellation, which a live exec
+    /// channel does not respond to.
     private func performRequest<R: Decodable>(method: String, decoding type: R.Type) async throws
         -> R
     {
         let socketPath = try await resolvedSocketPath()
         let requestID = UUID().uuidString
         let line = try HerdrWire.requestLine(id: requestID, method: method)
+        let responseLine = try await Self.withRequestDeadline(requestTimeout) {
+            try await self.performExchange(line: line, socketPath: socketPath, method: method)
+        }
+        return try HerdrWire.decodeResult(type, fromResponseLine: responseLine, requestID: requestID)
+    }
+
+    /// Takes a channel slot, runs one exec+socat exchange, and returns the
+    /// raw response bytes (guaranteed to contain a full line).
+    private func performExchange(line: String, socketPath: String, method: String) async throws
+        -> Data
+    {
+        try await acquireExecChannelSlot()
+        defer { releaseExecChannelSlot() }
         var stdout = Data()
         var stderr = Data()
-        do {
-            try await acquireExecChannelSlot()
-        } catch {
-            throw TransportError.cancelled
-        }
-        defer { releaseExecChannelSlot() }
         do {
             try await client.withExec("\(socatPath) - UNIX-CONNECT:\(socketPath)") {
                 inbound, outbound in
@@ -267,12 +282,51 @@ actor SSHTransport: Transport {
                 ?? TransportError.channelFailed(
                     detail: "\(method): \(error); stderr: \(Self.preview(stderr))")
         }
+        // A cancelled exchange ends its read through the local inbound
+        // stream, after which withExec has already closed the channel;
+        // surface that instead of misreading the truncated output as a
+        // protocol error.
+        try Task.checkCancellation()
         if !stdout.contains(0x0A),
             let failure = classifyExecFailure(stderr: stderr, socketPath: socketPath)
         {
             throw failure
         }
-        return try HerdrWire.decodeResult(type, fromResponseLine: stdout, requestID: requestID)
+        return stdout
+    }
+
+    /// Races `operation` against the per-request deadline, mapping expiry to
+    /// `.timedOut` and caller cancellation to `.cancelled`.
+    ///
+    /// A live exec channel ignores Swift task cancellation, so the losing
+    /// operation is never cancel-and-awaited at the channel: cancelling it
+    /// only ends the *local* inbound stream (an `AsyncThrowingStream`, whose
+    /// iterator resumes on task cancellation), the exec body then returns,
+    /// and Citadel closes the channel explicitly on the way out. A queued
+    /// operation that has no channel yet leaves the slot queue the same way.
+    private static func withRequestDeadline<T: Sendable>(
+        _ timeout: Duration,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T?.self) { group in
+            group.addTask { try await operation() }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                return nil
+            }
+            defer { group.cancelAll() }
+            do {
+                guard let finished = try await group.next(), let value = finished else {
+                    throw TransportError.timedOut
+                }
+                // The operation may have completed with junk after the
+                // caller's task was cancelled mid-read; cancellation wins.
+                try Task.checkCancellation()
+                return value
+            } catch is CancellationError {
+                throw TransportError.cancelled
+            }
+        }
     }
 
     /// The absolute socket path on this Host, resolving the remote home

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -84,15 +84,64 @@ actor SSHTransport: Transport {
         let requestID = UUID().uuidString
         let line = try HerdrWire.requestLine(id: requestID, method: method)
         var stdout = Data()
-        try await client.withExec("\(socatPath) - UNIX-CONNECT:\(socketPath)") {
-            inbound, outbound in
-            try await outbound.write(ByteBuffer(string: line))
-            for try await chunk in inbound {
-                guard case .stdout(let buffer) = chunk else { continue }
-                stdout.append(contentsOf: buffer.readableBytesView)
-                if stdout.contains(0x0A) { return }
+        var stderr = Data()
+        do {
+            try await client.withExec("\(socatPath) - UNIX-CONNECT:\(socketPath)") {
+                inbound, outbound in
+                // A fast-failing command (socat missing, socket absent) can
+                // close the channel before this write lands; the read loop
+                // below still drains stderr and surfaces the real failure.
+                try? await outbound.write(ByteBuffer(string: line))
+                for try await chunk in inbound {
+                    switch chunk {
+                    case .stdout(let buffer):
+                        stdout.append(contentsOf: buffer.readableBytesView)
+                        if stdout.contains(0x0A) { return }
+                    case .stderr(let buffer):
+                        stderr.append(contentsOf: buffer.readableBytesView)
+                    }
+                }
             }
+        } catch is CancellationError {
+            throw TransportError.cancelled
+        } catch {
+            throw classifyExecFailure(stderr: stderr)
+                ?? TransportError.channelFailed(
+                    detail: "\(method): \(error); stderr: \(Self.preview(stderr))")
+        }
+        if !stdout.contains(0x0A), let failure = classifyExecFailure(stderr: stderr) {
+            throw failure
         }
         return try HerdrWire.decodeResult(type, fromResponseLine: stdout, requestID: requestID)
+    }
+
+    /// Maps the observable failure shapes (verified against herdr 0.7.4 in
+    /// the #3 spike) onto taxonomy cases:
+    /// - missing socket:  socat stderr `E connect(... "<sock>" ...): No such file or directory`
+    /// - stale socket:    socat stderr `E connect(... "<sock>" ...): Connection refused`
+    /// - socat missing:   login-shell stderr naming the socat path
+    ///
+    /// socat connect diagnostics are keyed on their `E connect` marker plus
+    /// the quoted socket path: shells like fish echo the whole failing
+    /// command line (which contains both paths), so path presence alone
+    /// cannot distinguish the shapes.
+    private func classifyExecFailure(stderr: Data) -> TransportError? {
+        let text = String(decoding: stderr, as: UTF8.self)
+        if text.contains("E connect"), text.contains("\"\(socketPath)\"") {
+            if text.contains("No such file or directory") {
+                return .socketNotFound(path: socketPath)
+            }
+            if text.contains("Connection refused") {
+                return .serverNotRunning(path: socketPath)
+            }
+        }
+        if text.contains(socatPath) {
+            return .socatMissing(path: socatPath)
+        }
+        return nil
+    }
+
+    private static func preview(_ stderr: Data) -> String {
+        String(decoding: stderr.prefix(200), as: UTF8.self)
     }
 }

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -197,20 +197,217 @@ actor SSHTransport: Transport {
         try await request(method: "agent.list", decoding: AgentListResult.self).agents
     }
 
+    // MARK: Events channel (#4)
+    //
+    // One dedicated long-lived exec+socat channel per Host holds the
+    // events.subscribe stream: one ack line, then event lines until the
+    // channel is closed explicitly. It is exempt from the exec-slot queue —
+    // the queue's bound of 8 exists precisely to leave MaxSessions headroom
+    // for this channel (and a future Attach terminal) — and the state below
+    // keeps it to exactly one channel per Host.
+
+    private enum EventsChannelState: Equatable {
+        case idle
+        /// A subscribe call is setting the channel up (including a cold-start
+        /// wake retry); further subscribes are refused meanwhile.
+        case opening
+        case streaming(readerID: UInt64)
+    }
+
+    private var eventsChannelState: EventsChannelState = .idle
+    private var nextEventsReaderID: UInt64 = 0
+    /// Readers that ended while the channel was still `.opening` (e.g. the
+    /// remote closed right after the ack); the subscribe path reconciles so
+    /// the state can never stick at `.streaming` for a dead reader.
+    private var endedEventsReaders: Set<UInt64> = []
+
+    func subscribeToEvents(_ subscriptions: [EventSubscription]) async throws -> HerdrEventStream {
+        guard eventsChannelState == .idle else {
+            throw TransportError.eventsChannelAlreadyOpen
+        }
+        eventsChannelState = .opening
+        do {
+            let (stream, readerID) = try await withColdStartWake {
+                try await self.openEventsChannel(subscriptions)
+            }
+            if endedEventsReaders.remove(readerID) != nil {
+                // The reader already died (remote closed straight after the
+                // ack); the stream the caller gets is finished, not live.
+                eventsChannelState = .idle
+            } else {
+                eventsChannelState = .streaming(readerID: readerID)
+            }
+            return stream
+        } catch {
+            // openEventsChannel tears its reader down and awaits it before
+            // throwing, so no live channel can outlast this reset.
+            eventsChannelState = .idle
+            throw error
+        }
+    }
+
+    /// Opens the dedicated channel, sends the subscribe request, and waits
+    /// for the ack line under the per-request deadline. On any failure the
+    /// reader is torn down and awaited before the error propagates.
+    private func openEventsChannel(_ subscriptions: [EventSubscription]) async throws
+        -> (HerdrEventStream, readerID: UInt64)
+    {
+        let socketPath = try await resolvedSocketPath()
+        let requestID = UUID().uuidString
+        let requestLine = try HerdrWire.subscribeRequestLine(
+            id: requestID, subscriptions: subscriptions)
+        let (events, eventContinuation) = AsyncThrowingStream<HerdrEvent, any Error>.makeStream()
+        let (ackLines, ackContinuation) = AsyncThrowingStream<Data, any Error>.makeStream()
+        nextEventsReaderID += 1
+        let readerID = nextEventsReaderID
+        let readerTask = Task {
+            await self.runEventsChannel(
+                readerID: readerID, requestLine: requestLine, socketPath: socketPath,
+                ack: ackContinuation, events: eventContinuation)
+        }
+        do {
+            let ackLine = try await Self.withRequestDeadline(requestTimeout) {
+                var iterator = ackLines.makeAsyncIterator()
+                guard let line = try await iterator.next() else {
+                    throw TransportError.channelFailed(detail: "events channel ended before ack")
+                }
+                return line
+            }
+            _ = try HerdrWire.decodeResult(
+                SubscriptionStartedResult.self, fromResponseLine: ackLine, requestID: requestID)
+        } catch {
+            readerTask.cancel()
+            await readerTask.value
+            endedEventsReaders.remove(readerID)
+            throw error
+        }
+        let stream = HerdrEventStream(events: events) {
+            readerTask.cancel()
+            await readerTask.value
+        }
+        return (stream, readerID)
+    }
+
+    /// The events channel's read loop: writes the subscribe request, hands
+    /// the first stdout line to the ack stream, then yields every complete
+    /// event line until the channel ends. Ending is always by explicit
+    /// close: cancelling the reader task only ends the *local* inbound
+    /// stream, the exec body then returns, Citadel closes the channel on the
+    /// way out, and socat exits on stdin EOF. Takes no exec slot (see MARK).
+    private func runEventsChannel(
+        readerID: UInt64,
+        requestLine: String,
+        socketPath: String,
+        ack ackContinuation: AsyncThrowingStream<Data, any Error>.Continuation,
+        events eventContinuation: AsyncThrowingStream<HerdrEvent, any Error>.Continuation
+    ) async {
+        var stderr = Data()
+        var pending = Data()
+        var sawAck = false
+        /// nil means the stream ends gracefully (explicit `end()`).
+        var streamFailure: TransportError?
+        /// Backstop for an ack that never arrived; a finish after finish is
+        /// a no-op, so this is only observed when the ack line never came.
+        var ackFailure = TransportError.cancelled
+        do {
+            try await client.withExec("\(socatPath) - UNIX-CONNECT:\(socketPath)") {
+                inbound, outbound in
+                try? await outbound.write(ByteBuffer(string: requestLine))
+                for try await chunk in inbound {
+                    switch chunk {
+                    case .stdout(let buffer):
+                        pending.append(contentsOf: buffer.readableBytesView)
+                        while let lineData = Self.takeLine(from: &pending) {
+                            if !sawAck {
+                                sawAck = true
+                                ackContinuation.yield(lineData)
+                                ackContinuation.finish()
+                            } else if let event = HerdrWire.decodeEvent(fromLine: lineData) {
+                                eventContinuation.yield(event)
+                            }
+                            // Undecodable lines are dropped: junk on the
+                            // stream must never kill it.
+                        }
+                    case .stderr(let buffer):
+                        stderr.append(contentsOf: buffer.readableBytesView)
+                    }
+                }
+            }
+            if Task.isCancelled {
+                // Explicit end(): the consumer closed the channel.
+                streamFailure = nil
+            } else if sawAck {
+                streamFailure = TransportError.channelFailed(
+                    detail: "events channel closed by remote")
+            } else {
+                ackFailure =
+                    classifyExecFailure(stderr: stderr, socketPath: socketPath)
+                    ?? TransportError.channelFailed(
+                        detail:
+                            "events channel closed before ack; stderr: \(Self.preview(stderr))")
+                streamFailure = ackFailure
+            }
+        } catch is CancellationError {
+            streamFailure = nil
+        } catch {
+            let failure =
+                classifyExecFailure(stderr: stderr, socketPath: socketPath)
+                ?? TransportError.channelFailed(
+                    detail: "events channel: \(error); stderr: \(Self.preview(stderr))")
+            ackFailure = failure
+            streamFailure = failure
+        }
+        // State first, continuations second: a consumer resuming on the
+        // stream's end must already see the channel as free.
+        eventsChannelReaderDidEnd(readerID)
+        ackContinuation.finish(throwing: ackFailure)
+        if let streamFailure {
+            eventContinuation.finish(throwing: streamFailure)
+        } else {
+            eventContinuation.finish()
+        }
+    }
+
+    private func eventsChannelReaderDidEnd(_ readerID: UInt64) {
+        if eventsChannelState == .streaming(readerID: readerID) {
+            eventsChannelState = .idle
+        } else {
+            // Ended mid-open: the subscribe path reconciles (and cleans up
+            // this marker on its failure path).
+            endedEventsReaders.insert(readerID)
+        }
+    }
+
+    /// Removes and returns the first complete line (newline stripped) from
+    /// `buffer`, or nil if no full line has arrived yet.
+    private static func takeLine(from buffer: inout Data) -> Data? {
+        guard let newline = buffer.firstIndex(of: 0x0A) else { return nil }
+        let line = Data(buffer[buffer.startIndex..<newline])
+        buffer = Data(buffer[buffer.index(after: newline)...])
+        return line
+    }
+
     /// Closes the SSH connection. Explicit close is the only way to end
     /// Citadel channels — a live exec channel ignores task cancellation.
     func close() async throws {
         try await client.close()
     }
 
-    /// Executes one request, with cold-start recovery (#6): connection
-    /// refused means the socket exists but the server is stopped, so run the
-    /// wake command and retry the socket. Strictly bounded — one wake, one
-    /// retry — so a wake that does not help surfaces `.serverNotRunning` to
-    /// the user instead of looping silently.
+    /// Executes one request with cold-start recovery.
     private func request<R: Decodable>(method: String, decoding type: R.Type) async throws -> R {
+        try await withColdStartWake {
+            try await self.performRequest(method: method, decoding: type)
+        }
+    }
+
+    /// Runs `operation` with cold-start recovery (#6): connection refused
+    /// means the socket exists but the server is stopped, so run the wake
+    /// command and retry. Strictly bounded — one wake, one retry — so a wake
+    /// that does not help surfaces `.serverNotRunning` to the user instead
+    /// of looping silently.
+    private func withColdStartWake<T>(_ operation: () async throws -> T) async throws -> T {
         do {
-            return try await performRequest(method: method, decoding: type)
+            return try await operation()
         } catch TransportError.serverNotRunning(let path) {
             do {
                 try await wakeServer()
@@ -224,7 +421,7 @@ actor SSHTransport: Transport {
                 // running on this Host.
                 throw TransportError.serverNotRunning(path: path)
             }
-            return try await performRequest(method: method, decoding: type)
+            return try await operation()
         }
     }
 

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -50,13 +50,14 @@ actor SSHTransport: Transport {
     private let socatPath: String
     private let wakeCommand: String
     private let requestTimeout: Duration
-    /// In-flight or completed remote home directory resolution; see
-    /// `remoteHomeDirectory()`.
-    private var homeDirectoryTask: Task<String, Error>?
-    /// In-flight cold-start wake; concurrent refused requests share one wake
-    /// instead of racing exec channels. Cleared on completion so a later
-    /// cold start can wake again.
-    private var wakeTask: Task<Void, Error>?
+    /// Remote home directory resolution, resolved over exec once per Host:
+    /// concurrent first requests share one in-flight run, success is cached
+    /// for the connection's lifetime, failure is not (the next request
+    /// retries).
+    private let homeDirectory = SharedAsyncOperation<String>(cachesSuccess: true)
+    /// Cold-start wake; concurrent refused requests share one wake instead
+    /// of racing exec channels, and a later cold start wakes again.
+    private let wake = SharedAsyncOperation<Void>(cachesSuccess: false)
 
     // MARK: Exec channel slots
     //
@@ -190,6 +191,8 @@ actor SSHTransport: Transport {
                 try await wakeServer()
             } catch TransportError.cancelled {
                 throw TransportError.cancelled
+            } catch TransportError.timedOut {
+                throw TransportError.timedOut
             } catch {
                 // The wake itself failed (herdr missing, command errored):
                 // the actionable problem is still a server that is not
@@ -201,35 +204,28 @@ actor SSHTransport: Transport {
     }
 
     /// Wakes the herdr server via the Host's wake command; concurrent
-    /// refused requests share one in-flight wake.
+    /// refused requests share one in-flight wake. The wait — not the wake —
+    /// is deadline-bounded: a hung wake command cannot be ended client-side
+    /// (sshd holds the channel until the command exits), so waiters abandon
+    /// it with `.timedOut` while it keeps its slot until it really ends.
     private func wakeServer() async throws {
-        if let task = wakeTask {
-            return try await task.value
+        try await Self.withRequestDeadline(requestTimeout) {
+            try await self.wake.value {
+                try await self.runWakeCommand()
+            }
         }
-        let task = Task { try await self.runWakeCommand() }
-        wakeTask = task
-        defer { wakeTask = nil }
-        return try await task.value
     }
 
-    /// Runs the wake command over a no-PTY exec channel with stdin at EOF
-    /// from the start (`< /dev/null`). The bridge's entry point ensures the
-    /// server is running (spawn + wait for socket) before it starts
-    /// bridging; the bridge then reads EOF and exits — so the command
+    /// Runs the wake command over a slot-gated no-PTY exec channel with
+    /// stdin at EOF from the start (`< /dev/null`). The bridge's entry point
+    /// ensures the server is running (spawn + wait for socket) before it
+    /// starts bridging; the bridge then reads EOF and exits — so the command
     /// completing implies a live socket, and its own lifetime bounds the
     /// channel without writing or closing anything mid-flight.
     private func runWakeCommand() async throws {
-        do {
-            try await acquireExecChannelSlot()
-        } catch {
-            throw TransportError.cancelled
-        }
+        try await acquireExecChannelSlot()
         defer { releaseExecChannelSlot() }
-        do {
-            _ = try await client.executeCommand("\(wakeCommand) < /dev/null")
-        } catch is CancellationError {
-            throw TransportError.cancelled
-        }
+        _ = try await client.executeCommand("\(wakeCommand) < /dev/null")
     }
 
     /// One no-PTY exec channel per request, raced against the per-request
@@ -336,34 +332,23 @@ actor SSHTransport: Transport {
         return socketLocation.path(homeDirectory: try await remoteHomeDirectory())
     }
 
-    /// The remote home directory, resolved over exec once per Host:
-    /// concurrent first requests share one in-flight resolution, and the
-    /// result is cached for the lifetime of the connection. A failed
-    /// resolution is not cached, so the next request retries.
+    /// The shared home resolution, with the wait — not the resolution —
+    /// deadline-bounded, exactly like `wakeServer()`.
     private func remoteHomeDirectory() async throws -> String {
-        let task = homeDirectoryTask ?? Task { try await self.resolveHomeDirectoryOverExec() }
-        homeDirectoryTask = task
-        do {
-            return try await task.value
-        } catch {
-            homeDirectoryTask = nil
-            throw error
+        try await Self.withRequestDeadline(requestTimeout) {
+            try await self.homeDirectory.value {
+                try await self.resolveHomeDirectoryOverExec()
+            }
         }
     }
 
     private func resolveHomeDirectoryOverExec() async throws -> String {
-        do {
-            try await acquireExecChannelSlot()
-        } catch {
-            throw TransportError.cancelled
-        }
+        try await acquireExecChannelSlot()
         defer { releaseExecChannelSlot() }
         let output: ByteBuffer
         do {
             // $HOME expands in every mainstream login shell, fish included.
             output = try await client.executeCommand("echo $HOME")
-        } catch is CancellationError {
-            throw TransportError.cancelled
         } catch {
             throw TransportError.homeDirectoryUnresolvable(detail: String(describing: error))
         }

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -35,6 +35,11 @@ actor SSHTransport: Transport {
     /// The herdr wire protocol version this build speaks (herdr 0.7.4).
     static let supportedProtocolVersion = 16
 
+    /// Exec channels are SSH session channels, capped by sshd's MaxSessions
+    /// (default 10) per connection. Bound at 8 to leave headroom for the
+    /// events channel and a future Attach terminal.
+    static let maxConcurrentExecChannels = 8
+
     private let client: SSHClient
     private let socketLocation: HerdrSocketLocation
     private let socatPath: String
@@ -46,6 +51,75 @@ actor SSHTransport: Transport {
     /// instead of racing exec channels. Cleared on completion so a later
     /// cold start can wake again.
     private var wakeTask: Task<Void, Error>?
+
+    // MARK: Exec channel slots
+    //
+    // The actor-based request queue (#5): every exec channel — RPC, home
+    // resolution, wake — holds a slot for the channel's lifetime, bounding
+    // concurrency at `maxConcurrentExecChannels`. Slots are never held
+    // across another slot acquisition, so the queue cannot deadlock.
+
+    private struct SlotWaiter {
+        let id: UInt64
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private var execSlotsInUse = 0
+    private var slotWaiters: [SlotWaiter] = []
+    /// Waiter ids whose cancellation raced ahead: the cancellation handler
+    /// hops onto the actor via a Task, so it can run before the waiter's
+    /// continuation is stored (marker consumed on arrival) or after the
+    /// waiter was already resumed (marker swept by `acquireExecChannelSlot`'s
+    /// defer, keyed on `pendingSlotRequests`).
+    private var cancelledSlotRequests: Set<UInt64> = []
+    private var pendingSlotRequests: Set<UInt64> = []
+    private var nextSlotRequestID: UInt64 = 0
+
+    /// Waits for a free exec channel slot. Throws `CancellationError` without
+    /// consuming a slot if the task is cancelled while queued.
+    private func acquireExecChannelSlot() async throws {
+        try Task.checkCancellation()
+        nextSlotRequestID += 1
+        let id = nextSlotRequestID
+        pendingSlotRequests.insert(id)
+        defer {
+            pendingSlotRequests.remove(id)
+            cancelledSlotRequests.remove(id)
+        }
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                if cancelledSlotRequests.contains(id) {
+                    continuation.resume(throwing: CancellationError())
+                } else if execSlotsInUse < Self.maxConcurrentExecChannels {
+                    execSlotsInUse += 1
+                    continuation.resume()
+                } else {
+                    slotWaiters.append(SlotWaiter(id: id, continuation: continuation))
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelSlotWaiter(id: id) }
+        }
+    }
+
+    /// Frees a slot, handing it to the oldest waiter if any.
+    private func releaseExecChannelSlot() {
+        if slotWaiters.isEmpty {
+            execSlotsInUse -= 1
+        } else {
+            slotWaiters.removeFirst().continuation.resume()
+        }
+    }
+
+    private func cancelSlotWaiter(id: UInt64) {
+        guard pendingSlotRequests.contains(id) else { return }
+        if let index = slotWaiters.firstIndex(where: { $0.id == id }) {
+            slotWaiters.remove(at: index).continuation.resume(throwing: CancellationError())
+        } else {
+            cancelledSlotRequests.insert(id)
+        }
+    }
 
     private init(
         client: SSHClient, socketLocation: HerdrSocketLocation, socatPath: String,
@@ -139,6 +213,12 @@ actor SSHTransport: Transport {
     /// channel without writing or closing anything mid-flight.
     private func runWakeCommand() async throws {
         do {
+            try await acquireExecChannelSlot()
+        } catch {
+            throw TransportError.cancelled
+        }
+        defer { releaseExecChannelSlot() }
+        do {
             _ = try await client.executeCommand("\(wakeCommand) < /dev/null")
         } catch is CancellationError {
             throw TransportError.cancelled
@@ -157,6 +237,12 @@ actor SSHTransport: Transport {
         let line = try HerdrWire.requestLine(id: requestID, method: method)
         var stdout = Data()
         var stderr = Data()
+        do {
+            try await acquireExecChannelSlot()
+        } catch {
+            throw TransportError.cancelled
+        }
+        defer { releaseExecChannelSlot() }
         do {
             try await client.withExec("\(socatPath) - UNIX-CONNECT:\(socketPath)") {
                 inbound, outbound in
@@ -212,6 +298,12 @@ actor SSHTransport: Transport {
     }
 
     private func resolveHomeDirectoryOverExec() async throws -> String {
+        do {
+            try await acquireExecChannelSlot()
+        } catch {
+            throw TransportError.cancelled
+        }
+        defer { releaseExecChannelSlot() }
         let output: ByteBuffer
         do {
             // $HOME expands in every mainstream login shell, fish included.

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -6,16 +6,15 @@ import CryptoKit
 import Foundation
 import NIOCore
 
-/// How to reach one Host and its herdr socket. Tracer-bullet subset: Ed25519
-/// key auth and an explicit socket path; remote socket path resolution and the
-/// full error taxonomy are #17, richer auth is the SSH core work.
+/// How to reach one Host and its herdr socket. Auth is the tracer-bullet
+/// Ed25519 subset; richer auth and host key policy are the SSH core work (#2).
 struct SSHTransportSettings: Sendable {
     var host: String
     var port: Int
     var username: String
     var privateKey: Curve25519.Signing.PrivateKey
-    /// Absolute path of the herdr API socket on the Host.
-    var socketPath: String
+    /// Which herdr socket to reach on the Host.
+    var socket: HerdrSocketLocation
     /// Absolute path of socat on the Host. Remote commands run through the
     /// user's login shell, whose PATH cannot be trusted.
     var socatPath: String
@@ -29,12 +28,15 @@ actor SSHTransport: Transport {
     static let supportedProtocolVersion = 16
 
     private let client: SSHClient
-    private let socketPath: String
+    private let socketLocation: HerdrSocketLocation
     private let socatPath: String
+    /// In-flight or completed remote home directory resolution; see
+    /// `remoteHomeDirectory()`.
+    private var homeDirectoryTask: Task<String, Error>?
 
-    private init(client: SSHClient, socketPath: String, socatPath: String) {
+    private init(client: SSHClient, socketLocation: HerdrSocketLocation, socatPath: String) {
         self.client = client
-        self.socketPath = socketPath
+        self.socketLocation = socketLocation
         self.socatPath = socatPath
     }
 
@@ -54,7 +56,7 @@ actor SSHTransport: Transport {
             reconnect: .never
         )
         return SSHTransport(
-            client: client, socketPath: settings.socketPath, socatPath: settings.socatPath)
+            client: client, socketLocation: settings.socket, socatPath: settings.socatPath)
     }
 
     func ping() async throws -> ServerInfo {
@@ -81,6 +83,7 @@ actor SSHTransport: Transport {
     /// (Citadel closes the channel on return) — never by task cancellation,
     /// which a live exec channel does not respond to.
     private func request<R: Decodable>(method: String, decoding type: R.Type) async throws -> R {
+        let socketPath = try await resolvedSocketPath()
         let requestID = UUID().uuidString
         let line = try HerdrWire.requestLine(id: requestID, method: method)
         var stdout = Data()
@@ -105,14 +108,56 @@ actor SSHTransport: Transport {
         } catch is CancellationError {
             throw TransportError.cancelled
         } catch {
-            throw classifyExecFailure(stderr: stderr)
+            throw classifyExecFailure(stderr: stderr, socketPath: socketPath)
                 ?? TransportError.channelFailed(
                     detail: "\(method): \(error); stderr: \(Self.preview(stderr))")
         }
-        if !stdout.contains(0x0A), let failure = classifyExecFailure(stderr: stderr) {
+        if !stdout.contains(0x0A),
+            let failure = classifyExecFailure(stderr: stderr, socketPath: socketPath)
+        {
             throw failure
         }
         return try HerdrWire.decodeResult(type, fromResponseLine: stdout, requestID: requestID)
+    }
+
+    /// The absolute socket path on this Host, resolving the remote home
+    /// directory for home-relative locations.
+    private func resolvedSocketPath() async throws -> String {
+        if case .absolutePath(let path) = socketLocation { return path }
+        return socketLocation.path(homeDirectory: try await remoteHomeDirectory())
+    }
+
+    /// The remote home directory, resolved over exec once per Host:
+    /// concurrent first requests share one in-flight resolution, and the
+    /// result is cached for the lifetime of the connection. A failed
+    /// resolution is not cached, so the next request retries.
+    private func remoteHomeDirectory() async throws -> String {
+        let task = homeDirectoryTask ?? Task { try await self.resolveHomeDirectoryOverExec() }
+        homeDirectoryTask = task
+        do {
+            return try await task.value
+        } catch {
+            homeDirectoryTask = nil
+            throw error
+        }
+    }
+
+    private func resolveHomeDirectoryOverExec() async throws -> String {
+        let output: ByteBuffer
+        do {
+            // $HOME expands in every mainstream login shell, fish included.
+            output = try await client.executeCommand("echo $HOME")
+        } catch is CancellationError {
+            throw TransportError.cancelled
+        } catch {
+            throw TransportError.homeDirectoryUnresolvable(detail: String(describing: error))
+        }
+        let home = String(buffer: output).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard home.hasPrefix("/") else {
+            throw TransportError.homeDirectoryUnresolvable(
+                detail: "echo $HOME printed: \(home.prefix(200))")
+        }
+        return home
     }
 
     /// Maps the observable failure shapes (verified against herdr 0.7.4 in
@@ -125,7 +170,7 @@ actor SSHTransport: Transport {
     /// the quoted socket path: shells like fish echo the whole failing
     /// command line (which contains both paths), so path presence alone
     /// cannot distinguish the shapes.
-    private func classifyExecFailure(stderr: Data) -> TransportError? {
+    private func classifyExecFailure(stderr: Data, socketPath: String) -> TransportError? {
         let text = String(decoding: stderr, as: UTF8.self)
         if text.contains("E connect"), text.contains("\"\(socketPath)\"") {
             if text.contains("No such file or directory") {

--- a/Sources/HerdrMobile/Transport/SecretStore.swift
+++ b/Sources/HerdrMobile/Transport/SecretStore.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Security
+
+/// Where secret bytes live. The real implementation is the Keychain; the
+/// protocol keeps key management testable where the real Keychain is
+/// unavailable or flaky (CI without a simulator keychain, previews).
+protocol SecretStore: Sendable {
+    func read(account: String) throws -> Data?
+    func write(_ secret: Data, account: String) throws
+    func removeSecret(account: String) throws
+}
+
+enum KeychainError: Error, Equatable {
+    case unexpectedStatus(OSStatus)
+}
+
+/// Generic-password Keychain items under one service. Items are scoped to
+/// this device only (`ThisDeviceOnly`): the device key must never migrate to
+/// another device via backup or iCloud Keychain.
+struct KeychainSecretStore: SecretStore {
+    let service: String
+
+    func read(account: String) throws -> Data? {
+        var query = baseQuery(account: account)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        switch status {
+        case errSecSuccess:
+            return item as? Data
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    func write(_ secret: Data, account: String) throws {
+        var attributes = baseQuery(account: account)
+        attributes[kSecValueData as String] = secret
+        attributes[kSecAttrAccessible as String] =
+            kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        switch status {
+        case errSecSuccess:
+            return
+        case errSecDuplicateItem:
+            let update = [kSecValueData as String: secret]
+            let updateStatus = SecItemUpdate(
+                baseQuery(account: account) as CFDictionary, update as CFDictionary)
+            guard updateStatus == errSecSuccess else {
+                throw KeychainError.unexpectedStatus(updateStatus)
+            }
+        default:
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    func removeSecret(account: String) throws {
+        let status = SecItemDelete(baseQuery(account: account) as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    private func baseQuery(account: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+}

--- a/Sources/HerdrMobile/Transport/SharedAsyncOperation.swift
+++ b/Sources/HerdrMobile/Transport/SharedAsyncOperation.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// A single-flight async operation whose waiters can leave early (deadline,
+/// cancellation) without cancelling the operation itself.
+///
+/// Exists because `Task.value` cannot be awaited cancellably: a caller racing
+/// it against a deadline still hangs until the task finishes. Waiters here
+/// park on a continuation that cancellation resumes immediately, while the
+/// operation runs in an unstructured Task that is never cancelled. For SSH
+/// exec work that is exactly right: a remote command that ignores stdin EOF
+/// cannot be ended client-side anyway (sshd holds the channel open until the
+/// command exits), so the honest behavior is to let it keep its channel slot
+/// accounted for until it really ends and have callers abandon the wait.
+actor SharedAsyncOperation<Value: Sendable> {
+    /// Whether a successful value is memoized (home resolution) or every
+    /// demand after completion starts a fresh run (wake).
+    private let cachesSuccess: Bool
+    private var cached: Value?
+    private var running: Task<Void, Never>?
+
+    private struct Waiter {
+        let id: UInt64
+        let continuation: CheckedContinuation<Value, any Error>
+    }
+
+    private var waiters: [Waiter] = []
+    /// Waiter ids whose cancellation raced ahead of parking or resumption;
+    /// see the identical bookkeeping on SSHTransport's slot queue.
+    private var cancelledWaiters: Set<UInt64> = []
+    private var pendingWaiters: Set<UInt64> = []
+    private var nextWaiterID: UInt64 = 0
+
+    init(cachesSuccess: Bool) {
+        self.cachesSuccess = cachesSuccess
+    }
+
+    /// Returns the memoized value, or joins the in-flight run (starting one
+    /// if idle) and waits for its result. Waiting is cancellation-responsive;
+    /// the operation itself is never cancelled. Failures are delivered to
+    /// every current waiter and not cached, so the next demand retries.
+    func value(
+        startingIfNeeded operation: @escaping @Sendable () async throws -> Value
+    ) async throws -> Value {
+        if let cached { return cached }
+        try Task.checkCancellation()
+        if running == nil {
+            running = Task {
+                let result: Result<Value, any Error>
+                do {
+                    result = .success(try await operation())
+                } catch {
+                    result = .failure(error)
+                }
+                self.finish(result)
+            }
+        }
+        nextWaiterID += 1
+        let id = nextWaiterID
+        pendingWaiters.insert(id)
+        defer {
+            pendingWaiters.remove(id)
+            cancelledWaiters.remove(id)
+        }
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Value, any Error>) in
+                if cancelledWaiters.contains(id) {
+                    continuation.resume(throwing: CancellationError())
+                } else {
+                    waiters.append(Waiter(id: id, continuation: continuation))
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id: id) }
+        }
+    }
+
+    private func finish(_ result: Result<Value, any Error>) {
+        running = nil
+        if cachesSuccess, case .success(let value) = result {
+            cached = value
+        }
+        let parked = waiters
+        waiters = []
+        for waiter in parked {
+            waiter.continuation.resume(with: result)
+        }
+    }
+
+    private func cancelWaiter(id: UInt64) {
+        guard pendingWaiters.contains(id) else { return }
+        if let index = waiters.firstIndex(where: { $0.id == id }) {
+            waiters.remove(at: index).continuation.resume(throwing: CancellationError())
+        } else {
+            cancelledWaiters.insert(id)
+        }
+    }
+}

--- a/Sources/HerdrMobile/Transport/TOFUHostKeyValidator.swift
+++ b/Sources/HerdrMobile/Transport/TOFUHostKeyValidator.swift
@@ -1,0 +1,69 @@
+// @preconcurrency: Citadel predates strict concurrency; see SSHTransport.
+@preconcurrency import Citadel
+import Foundation
+import NIOCore
+import NIOSSH
+import Synchronization
+
+/// Bridges Citadel's promise-based host key callback onto the async TOFU
+/// policy (#2):
+///
+///   known fingerprint, matches    -> proceed
+///   known fingerprint, differs    -> hard-fail, never ask, never overwrite
+///   unknown, user confirms        -> persist fingerprint, proceed
+///   unknown, user declines        -> fail, persist nothing
+///
+/// The verdict is also recorded here because NIOSSH may wrap the promise's
+/// failure on its way out of the handshake: `SSHTransport.connect` consults
+/// `failure` — not the thrown error — to surface the typed taxonomy case.
+final class TOFUHostKeyValidator: NIOSSHClientServerAuthenticationDelegate, Sendable {
+    private let host: String
+    private let port: Int
+    private let policy: HostKeyPolicy
+    private let verdict = Mutex<TransportError?>(nil)
+
+    init(host: String, port: Int, policy: HostKeyPolicy) {
+        self.host = host
+        self.port = port
+        self.policy = policy
+    }
+
+    /// The typed failure behind an aborted handshake, if host key validation
+    /// caused one.
+    var failure: TransportError? {
+        verdict.withLock { $0 }
+    }
+
+    func validateHostKey(
+        hostKey: NIOSSHPublicKey, validationCompletePromise: EventLoopPromise<Void>
+    ) {
+        // Fingerprint the key before hopping executors: NIOSSHPublicKey is
+        // not Sendable, the digest is.
+        var buffer = ByteBuffer()
+        hostKey.write(to: &buffer)
+        let fingerprint = HostKeyFingerprint(publicKeyBlob: Data(buffer.readableBytesView))
+        Task {
+            if let failure = await self.evaluate(fingerprint: fingerprint) {
+                self.verdict.withLock { $0 = failure }
+                validationCompletePromise.fail(failure)
+            } else {
+                validationCompletePromise.succeed(())
+            }
+        }
+    }
+
+    private func evaluate(fingerprint: HostKeyFingerprint) async -> TransportError? {
+        if let known = await policy.knownHosts.fingerprint(host: host, port: port) {
+            return known == fingerprint
+                ? nil : .hostKeyMismatch(known: known, presented: fingerprint)
+        }
+        let candidate = HostKeyCandidate(host: host, port: port, fingerprint: fingerprint)
+        guard await policy.confirmFirstConnect(candidate) else {
+            return .hostKeyRejected(presented: fingerprint)
+        }
+        // Persist before the handshake proceeds, like OpenSSH writes
+        // known_hosts on accept: a later auth failure must not re-prompt.
+        await policy.knownHosts.setFingerprint(fingerprint, host: host, port: port)
+        return nil
+    }
+}

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -9,6 +9,16 @@ protocol Transport: Sendable {
 
     /// Lists the Agents herdr has detected across all workspaces.
     func listAgents() async throws -> [Agent]
+
+    /// Opens this Host's dedicated long-lived events channel and subscribes.
+    /// Returns once the server acknowledges the subscription; the stream then
+    /// carries events in canonical naming until `end()` closes the channel
+    /// explicitly. One events channel per Host: a second call while one is
+    /// live throws `.eventsChannelAlreadyOpen`.
+    ///
+    /// Subscribing does not replay existing state (verified against herdr
+    /// 0.7.4): sync initial state with `listAgents()` alongside subscribing.
+    func subscribeToEvents(_ subscriptions: [EventSubscription]) async throws -> HerdrEventStream
 }
 
 /// herdr server identity as reported by `ping`.
@@ -138,6 +148,9 @@ enum TransportError: Error, Sendable, Equatable {
     /// The remote home directory could not be resolved, so a home-relative
     /// socket location has no path.
     case homeDirectoryUnresolvable(detail: String)
+    /// A second events channel was requested while one is live; each Host
+    /// keeps exactly one dedicated events channel (ADR 0002 headroom).
+    case eventsChannelAlreadyOpen
     /// The request exceeded its per-request deadline; its exec channel was
     /// closed.
     case timedOut

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -112,6 +112,19 @@ enum HerdrSocketLocation: Sendable, Equatable {
 /// Transport-level failures: a closed taxonomy so every screen maps errors to
 /// user guidance consistently instead of string-matching.
 enum TransportError: Error, Sendable, Equatable {
+    /// The SSH server could not be reached: connection refused, no route,
+    /// or the connection died before authentication.
+    case sshUnreachable(detail: String)
+    /// The Host rejected our credentials (key not authorized, wrong
+    /// password, or the offered auth method is unavailable).
+    case authenticationFailed
+    /// First connect to an unknown Host and the user declined its key
+    /// fingerprint; nothing was stored.
+    case hostKeyRejected(presented: HostKeyFingerprint)
+    /// The Host presented a key that differs from the trusted fingerprint —
+    /// possibly a man-in-the-middle. Hard failure; the stored fingerprint is
+    /// left untouched.
+    case hostKeyMismatch(known: HostKeyFingerprint, presented: HostKeyFingerprint)
     /// The herdr API socket path does not exist on the Host: herdr is not
     /// installed there, or the socket path is wrong.
     case socketNotFound(path: String)

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -19,6 +19,15 @@ protocol Transport: Sendable {
     /// Subscribing does not replay existing state (verified against herdr
     /// 0.7.4): sync initial state with `listAgents()` alongside subscribing.
     func subscribeToEvents(_ subscriptions: [EventSubscription]) async throws -> HerdrEventStream
+
+    /// Whether the underlying connection to the Host is still alive. The
+    /// reconnect machinery (#18) decides "re-subscribe on this connection or
+    /// re-establish it" from this flag.
+    var isConnected: Bool { get async }
+
+    /// Tears the connection down explicitly, ending every channel it
+    /// carries. Terminal: a closed Transport is not reusable.
+    func close() async throws
 }
 
 /// herdr server identity as reported by `ping`.

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -83,11 +83,30 @@ struct Agent: Sendable, Equatable, Decodable {
     }
 }
 
-/// Transport-level failures. This is the tracer-bullet subset; the full error
-/// taxonomy (socat missing, socket absent, server down, ...) is #17.
+/// Transport-level failures: a closed taxonomy so every screen maps errors to
+/// user guidance consistently instead of string-matching. `timedOut` and
+/// `cancelled` exist as cases now; their enforcement machinery (request
+/// queue, per-request deadline) is #5.
 enum TransportError: Error, Sendable, Equatable {
+    /// The herdr API socket path does not exist on the Host: herdr is not
+    /// installed there, or the socket path is wrong.
+    case socketNotFound(path: String)
+    /// The socket file exists but nothing accepts connections: the herdr
+    /// server is not running (cold-start wake is #6).
+    case serverNotRunning(path: String)
+    /// socat is not at its configured absolute path on the Host.
+    case socatMissing(path: String)
+    /// The server speaks a herdr protocol version this build does not support.
     case protocolVersionMismatch(server: Int, supported: Int)
+    /// The request exceeded its deadline.
+    case timedOut
+    /// The request was cancelled before completing.
+    case cancelled
+    /// The channel produced bytes that do not decode as a herdr response.
     case malformedResponse(String)
+    /// The exec channel failed outside the known failure shapes; carries the
+    /// underlying description for diagnostics.
+    case channelFailed(detail: String)
 }
 
 /// An error returned by the herdr server inside a response envelope.

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -110,9 +110,7 @@ enum HerdrSocketLocation: Sendable, Equatable {
 }
 
 /// Transport-level failures: a closed taxonomy so every screen maps errors to
-/// user guidance consistently instead of string-matching. `timedOut` and
-/// `cancelled` exist as cases now; their enforcement machinery (request
-/// queue, per-request deadline) is #5.
+/// user guidance consistently instead of string-matching.
 enum TransportError: Error, Sendable, Equatable {
     /// The herdr API socket path does not exist on the Host: herdr is not
     /// installed there, or the socket path is wrong.
@@ -127,9 +125,11 @@ enum TransportError: Error, Sendable, Equatable {
     /// The remote home directory could not be resolved, so a home-relative
     /// socket location has no path.
     case homeDirectoryUnresolvable(detail: String)
-    /// The request exceeded its deadline.
+    /// The request exceeded its per-request deadline; its exec channel was
+    /// closed.
     case timedOut
-    /// The request was cancelled before completing.
+    /// The request's task was cancelled before completing; any exec channel
+    /// it held was closed.
     case cancelled
     /// The channel produced bytes that do not decode as a herdr response.
     case malformedResponse(String)

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -83,6 +83,32 @@ struct Agent: Sendable, Equatable, Decodable {
     }
 }
 
+/// Where the herdr API socket lives on a Host. Home-relative locations are
+/// resolved against the remote home directory, which the Transport resolves
+/// over exec once per Host and caches.
+enum HerdrSocketLocation: Sendable, Equatable {
+    /// The default herdr session: `~/.config/herdr/herdr.sock`.
+    case defaultSession
+    /// A named session: `~/.config/herdr/sessions/<name>/herdr.sock`.
+    case namedSession(String)
+    /// An absolute path known in advance; needs no remote resolution.
+    case absolutePath(String)
+
+    /// The absolute socket path, given the Host's home directory.
+    func path(homeDirectory: String) -> String {
+        let home =
+            homeDirectory.hasSuffix("/") ? String(homeDirectory.dropLast()) : homeDirectory
+        switch self {
+        case .defaultSession:
+            return "\(home)/.config/herdr/herdr.sock"
+        case .namedSession(let name):
+            return "\(home)/.config/herdr/sessions/\(name)/herdr.sock"
+        case .absolutePath(let path):
+            return path
+        }
+    }
+}
+
 /// Transport-level failures: a closed taxonomy so every screen maps errors to
 /// user guidance consistently instead of string-matching. `timedOut` and
 /// `cancelled` exist as cases now; their enforcement machinery (request
@@ -98,6 +124,9 @@ enum TransportError: Error, Sendable, Equatable {
     case socatMissing(path: String)
     /// The server speaks a herdr protocol version this build does not support.
     case protocolVersionMismatch(server: Int, supported: Int)
+    /// The remote home directory could not be resolved, so a home-relative
+    /// socket location has no path.
+    case homeDirectoryUnresolvable(detail: String)
     /// The request exceeded its deadline.
     case timedOut
     /// The request was cancelled before completing.

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// The app-side abstraction that executes herdr API requests over SSH.
+/// UI code talks to Transport, never to SSH primitives (ADR 0002).
+protocol Transport: Sendable {
+    /// Verifies the server speaks a protocol version we support and returns
+    /// its identity. Must be the first call on every new connection path.
+    func ping() async throws -> ServerInfo
+
+    /// Lists the Agents herdr has detected across all workspaces.
+    func listAgents() async throws -> [Agent]
+}
+
+/// herdr server identity as reported by `ping`.
+struct ServerInfo: Sendable, Equatable, Decodable {
+    let version: String
+    let protocolVersion: Int
+
+    init(version: String, protocolVersion: Int) {
+        self.version = version
+        self.protocolVersion = protocolVersion
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case protocolVersion = "protocol"
+    }
+}
+
+/// herdr's detected state of an Agent. Blocked means the agent is waiting on
+/// human input and drives sort order and (later) notifications.
+enum AgentStatus: String, Sendable, Equatable, Decodable {
+    case idle, working, blocked, done, unknown
+
+    /// Lenient: herdr's API has no stability guarantee, so a status value we
+    /// do not know degrades to `.unknown` instead of failing the decode.
+    init(from decoder: any Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = AgentStatus(rawValue: raw) ?? .unknown
+    }
+}
+
+/// A coding agent process running inside a herdr Pane.
+struct Agent: Sendable, Equatable, Decodable {
+    let terminalID: String
+    /// The agent program herdr detected: "claude", "codex", ...
+    let kind: String
+    /// Terminal title with spinner/status glyphs stripped.
+    let title: String
+    let status: AgentStatus
+    let workspaceID: String
+    let tabID: String
+    /// The Pane address used for per-pane subscriptions and attach.
+    let paneID: String
+    let cwd: String
+    let revision: Int
+
+    init(
+        terminalID: String, kind: String, title: String, status: AgentStatus,
+        workspaceID: String, tabID: String, paneID: String, cwd: String, revision: Int
+    ) {
+        self.terminalID = terminalID
+        self.kind = kind
+        self.title = title
+        self.status = status
+        self.workspaceID = workspaceID
+        self.tabID = tabID
+        self.paneID = paneID
+        self.cwd = cwd
+        self.revision = revision
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case terminalID = "terminal_id"
+        case kind = "agent"
+        case title = "terminal_title_stripped"
+        case status = "agent_status"
+        case workspaceID = "workspace_id"
+        case tabID = "tab_id"
+        case paneID = "pane_id"
+        case cwd
+        case revision
+    }
+}
+
+/// Transport-level failures. This is the tracer-bullet subset; the full error
+/// taxonomy (socat missing, socket absent, server down, ...) is #17.
+enum TransportError: Error, Sendable, Equatable {
+    case protocolVersionMismatch(server: Int, supported: Int)
+    case malformedResponse(String)
+}
+
+/// An error returned by the herdr server inside a response envelope.
+struct HerdrAPIError: Error, Sendable, Equatable {
+    /// Normalized to a string; the wire schema promises `{"code","message"}`
+    /// without pinning the code's JSON type.
+    let code: String
+    let message: String
+}

--- a/Tests/HerdrMobileTests/ColdStartE2ETests.swift
+++ b/Tests/HerdrMobileTests/ColdStartE2ETests.swift
@@ -121,13 +121,8 @@ struct ColdStartE2ETests {
     ) async throws {
         let environment = try #require(LocalSSHTestEnvironment.current)
         let transport = try await SSHTransport.connect(
-            settings: SSHTransportSettings(
-                host: environment.host,
-                port: environment.port,
-                username: environment.username,
-                privateKey: environment.privateKey,
+            settings: environment.makeSettings(
                 socket: .absolutePath(socketPath),
-                socatPath: environment.socatPath,
                 wakeCommand: wakeCommand,
                 requestTimeout: requestTimeout))
         do {
@@ -184,7 +179,8 @@ struct WakeCommandDefaultTests {
             host: "example.invalid",
             port: 22,
             username: "u",
-            privateKey: Curve25519.Signing.PrivateKey(),
+            credentials: .ed25519(Curve25519.Signing.PrivateKey()),
+            hostKeyPolicy: HostKeyPolicy(knownHosts: InMemoryKnownHostsStore()) { _ in false },
             socket: .defaultSession,
             socatPath: "/opt/homebrew/bin/socat")
 

--- a/Tests/HerdrMobileTests/ColdStartE2ETests.swift
+++ b/Tests/HerdrMobileTests/ColdStartE2ETests.swift
@@ -1,0 +1,171 @@
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+// Cold start (#6): a stale socket (server stopped) triggers the wake command
+// over a real exec channel, then the request retries against the socket. The
+// wake command is injected at the environment boundary — a shell script
+// standing in for `herdr remote-client-bridge` — because the test host has no
+// controllable herdr binary; everything else is the real stack.
+@Suite(
+    "Cold start e2e",
+    .enabled(
+        if: LocalSSHTestEnvironment.isAvailable,
+        "requires localhost sshd, socat, and an authorized Ed25519 test key"))
+struct ColdStartE2ETests {
+    @Test func wakeStartsServerAndRetriedRequestSucceeds() async throws {
+        // Server "stopped": stale socket at the configured path. The wake
+        // script brings the fake server online at that path, exactly like
+        // the bridge entry point ensures a live socket before returning.
+        let stale = try StaleUnixSocket()
+        defer { stale.remove() }
+        let server = try FakeHerdrServer { request in
+            [
+                #"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9-fake","protocol":16}}"#
+            ]
+        }
+        defer { server.stop() }
+        let wake = try WakeScript(commands: [
+            "rm -f '\(stale.path)'",
+            "ln -s '\(server.socketPath)' '\(stale.path)'",
+        ])
+        defer { wake.remove() }
+
+        try await withTransport(socketPath: stale.path, wakeCommand: wake.command) { transport in
+            let info = try await transport.ping()
+
+            #expect(info == ServerInfo(version: "9.9.9-fake", protocolVersion: 16))
+        }
+        #expect(wake.invocationCount == 1)
+        // Only the post-wake retry reaches the server; the refused first
+        // attempt never got that far.
+        #expect(server.receivedRequests.map(\.method) == ["ping"])
+        #expect(server.connectionCount == 1)
+    }
+
+    @Test func ineffectiveWakeSurfacesServerNotRunningWithoutLooping() async throws {
+        // Wake runs and exits 0 but brings nothing up (herdr broken on the
+        // host): the retry hits the stale socket again and the user gets
+        // `.serverNotRunning` — one wake, one retry, no silent loop.
+        let stale = try StaleUnixSocket()
+        defer { stale.remove() }
+        let wake = try WakeScript(commands: ["true"])
+        defer { wake.remove() }
+
+        try await withTransport(socketPath: stale.path, wakeCommand: wake.command) { transport in
+            await #expect(throws: TransportError.serverNotRunning(path: stale.path)) {
+                try await transport.ping()
+            }
+        }
+        #expect(wake.invocationCount == 1)
+    }
+
+    @Test func failingWakeCommandSurfacesServerNotRunning() async throws {
+        // The wake command itself fails (herdr not on PATH): the user still
+        // gets `.serverNotRunning`, not a channel error.
+        let stale = try StaleUnixSocket()
+        defer { stale.remove() }
+        let bogusWake = "/tmp/herdr-no-wake-\(UUID().uuidString.prefix(8))"
+
+        try await withTransport(socketPath: stale.path, wakeCommand: bogusWake) { transport in
+            await #expect(throws: TransportError.serverNotRunning(path: stale.path)) {
+                try await transport.ping()
+            }
+        }
+    }
+
+    @Test func missingSocketDoesNotTriggerWake() async throws {
+        // No socket file means herdr is not installed there (or the path is
+        // wrong) — waking cannot help, so the wake must not run.
+        let missingPath = "/tmp/herdr-missing-\(UUID().uuidString.prefix(8)).sock"
+        let wake = try WakeScript(commands: ["true"])
+        defer { wake.remove() }
+
+        try await withTransport(socketPath: missingPath, wakeCommand: wake.command) { transport in
+            await #expect(throws: TransportError.socketNotFound(path: missingPath)) {
+                try await transport.ping()
+            }
+        }
+        #expect(wake.invocationCount == 0)
+    }
+
+    /// Connects to localhost for real; the cold-start behavior under test
+    /// happens on the first request, not at connect time.
+    private func withTransport(
+        socketPath: String,
+        wakeCommand: String,
+        body: (SSHTransport) async throws -> Void
+    ) async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let transport = try await SSHTransport.connect(
+            settings: SSHTransportSettings(
+                host: environment.host,
+                port: environment.port,
+                username: environment.username,
+                privateKey: environment.privateKey,
+                socket: .absolutePath(socketPath),
+                socatPath: environment.socatPath,
+                wakeCommand: wakeCommand))
+        do {
+            try await body(transport)
+        } catch {
+            try? await transport.close()
+            throw error
+        }
+        try await transport.close()
+    }
+}
+
+/// A shell script substituted for `herdr remote-client-bridge` at the
+/// environment boundary. Records every invocation in a marker file so tests
+/// can assert the wake ran exactly as often as the bounded retry allows.
+private struct WakeScript {
+    let scriptPath: String
+    let markerPath: String
+
+    /// The value to inject as the transport's wake command.
+    var command: String { "/bin/sh \(scriptPath)" }
+
+    init(commands: [String]) throws {
+        let token = UUID().uuidString.prefix(8)
+        scriptPath = "/tmp/herdr-wake-\(token).sh"
+        markerPath = "/tmp/herdr-wake-runs-\(token)"
+        let lines = ["echo run >> '\(markerPath)'"] + commands
+        try (lines.joined(separator: "\n") + "\n")
+            .write(toFile: scriptPath, atomically: true, encoding: .utf8)
+    }
+
+    /// How many times the transport invoked the wake command. The simulator
+    /// shares the host filesystem, so the marker written by the remote login
+    /// shell is directly readable.
+    var invocationCount: Int {
+        guard let marker = try? String(contentsOfFile: markerPath, encoding: .utf8) else {
+            return 0
+        }
+        return marker.split(separator: "\n").count
+    }
+
+    func remove() {
+        unlink(scriptPath)
+        unlink(markerPath)
+    }
+}
+
+// The default wake command is the real herdr invocation from spec #16: the
+// remote bridge's entry point ensures the server is running before bridging.
+@Suite("Wake command default")
+struct WakeCommandDefaultTests {
+    @Test func defaultsToHerdrRemoteClientBridge() {
+        let settings = SSHTransportSettings(
+            host: "example.invalid",
+            port: 22,
+            username: "u",
+            privateKey: Curve25519.Signing.PrivateKey(),
+            socket: .defaultSession,
+            socatPath: "/opt/homebrew/bin/socat")
+
+        #expect(settings.wakeCommand == "herdr remote-client-bridge")
+    }
+}

--- a/Tests/HerdrMobileTests/ColdStartE2ETests.swift
+++ b/Tests/HerdrMobileTests/ColdStartE2ETests.swift
@@ -13,7 +13,8 @@ import Testing
     "Cold start e2e",
     .enabled(
         if: LocalSSHTestEnvironment.isAvailable,
-        "requires localhost sshd, socat, and an authorized Ed25519 test key"))
+        "requires localhost sshd, socat, and an authorized Ed25519 test key"),
+    .timeLimit(.minutes(1)))
 struct ColdStartE2ETests {
     @Test func wakeStartsServerAndRetriedRequestSucceeds() async throws {
         // Server "stopped": stale socket at the configured path. The wake
@@ -76,6 +77,25 @@ struct ColdStartE2ETests {
         }
     }
 
+    @Test func hungWakeCommandSurfacesTimedOut() async throws {
+        // The wake command starts but never exits (hung host): the request
+        // must surface .timedOut at the deadline — not hang forever pinning
+        // an exec slot — and end the wake channel by explicit close.
+        let stale = try StaleUnixSocket()
+        defer { stale.remove() }
+        let wake = try WakeScript(commands: ["sleep 600"])
+        defer { wake.remove() }
+
+        try await withTransport(
+            socketPath: stale.path, wakeCommand: wake.command, requestTimeout: .seconds(2)
+        ) { transport in
+            await #expect(throws: TransportError.timedOut) {
+                try await transport.ping()
+            }
+        }
+        #expect(wake.invocationCount == 1)
+    }
+
     @Test func missingSocketDoesNotTriggerWake() async throws {
         // No socket file means herdr is not installed there (or the path is
         // wrong) — waking cannot help, so the wake must not run.
@@ -96,6 +116,7 @@ struct ColdStartE2ETests {
     private func withTransport(
         socketPath: String,
         wakeCommand: String,
+        requestTimeout: Duration = .seconds(15),
         body: (SSHTransport) async throws -> Void
     ) async throws {
         let environment = try #require(LocalSSHTestEnvironment.current)
@@ -107,7 +128,8 @@ struct ColdStartE2ETests {
                 privateKey: environment.privateKey,
                 socket: .absolutePath(socketPath),
                 socatPath: environment.socatPath,
-                wakeCommand: wakeCommand))
+                wakeCommand: wakeCommand,
+                requestTimeout: requestTimeout))
         do {
             try await body(transport)
         } catch {

--- a/Tests/HerdrMobileTests/DeviceKeyStoreTests.swift
+++ b/Tests/HerdrMobileTests/DeviceKeyStoreTests.swift
@@ -1,0 +1,75 @@
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+@Suite("Device key store")
+struct DeviceKeyStoreTests {
+    @Test func generatesOnFirstUseAndReturnsTheSameKeyAfterwards() throws {
+        let store = DeviceKeyStore(secrets: InMemorySecretStore())
+
+        let first = try store.loadOrCreate()
+        let second = try store.loadOrCreate()
+
+        #expect(first.openSSHPublicKey == second.openSSHPublicKey)
+    }
+
+    @Test func persistedSeedSurvivesANewStoreInstance() throws {
+        let secrets = InMemorySecretStore()
+
+        let first = try DeviceKeyStore(secrets: secrets).loadOrCreate()
+        let second = try DeviceKeyStore(secrets: secrets).loadOrCreate()
+
+        #expect(first.openSSHPublicKey == second.openSSHPublicKey)
+    }
+
+    @Test func distinctStoresHoldDistinctKeys() throws {
+        let first = try DeviceKeyStore(secrets: InMemorySecretStore()).loadOrCreate()
+        let second = try DeviceKeyStore(secrets: InMemorySecretStore()).loadOrCreate()
+
+        #expect(first.openSSHPublicKey != second.openSSHPublicKey)
+    }
+}
+
+// The real Keychain works in simulator test bundles for generic passwords;
+// exercise it for real rather than trusting the in-memory stand-in.
+@Suite("Keychain secret store", .serialized)
+struct KeychainSecretStoreTests {
+    private let store = KeychainSecretStore(service: "dev.herdr.mobile.tests")
+
+    @Test func roundTripsAndRemoves() throws {
+        let account = "test-\(UUID().uuidString)"
+        defer { try? store.removeSecret(account: account) }
+
+        #expect(try store.read(account: account) == nil)
+
+        let secret = Data("s3cret".utf8)
+        try store.write(secret, account: account)
+        #expect(try store.read(account: account) == secret)
+
+        try store.removeSecret(account: account)
+        #expect(try store.read(account: account) == nil)
+    }
+
+    @Test func overwritesAnExistingSecret() throws {
+        let account = "test-\(UUID().uuidString)"
+        defer { try? store.removeSecret(account: account) }
+
+        try store.write(Data("old".utf8), account: account)
+        try store.write(Data("new".utf8), account: account)
+
+        #expect(try store.read(account: account) == Data("new".utf8))
+    }
+
+    @Test func deviceKeyStoreOnRealKeychainReturnsAStableKey() throws {
+        let account = "device-key-test-\(UUID().uuidString)"
+        defer { try? store.removeSecret(account: account) }
+        let keyStore = DeviceKeyStore(secrets: store, account: account)
+
+        let first = try keyStore.loadOrCreate()
+        let second = try keyStore.loadOrCreate()
+
+        #expect(first.openSSHPublicKey == second.openSSHPublicKey)
+    }
+}

--- a/Tests/HerdrMobileTests/DeviceKeyTests.swift
+++ b/Tests/HerdrMobileTests/DeviceKeyTests.swift
@@ -1,0 +1,43 @@
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+// Expected values come from an independent source of truth: the public key
+// line was fed to `ssh-keygen -lf`, which reported this exact fingerprint
+// for the key derived from this fixed seed.
+@Suite("Device key")
+struct DeviceKeyTests {
+    private static let seed = Data((0..<32).map { UInt8($0) })
+    private static let expectedLine =
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAOhB7/zzhC+HXDdGOdLwJln5NYwm6UNXx3chmQSVTG4"
+    private static let expectedFingerprint =
+        "SHA256:lbmsoA0yIEcEiVDRnMWuzm+nV+3ZEEpVIURqFoeSspg"
+
+    private var key: DeviceKey {
+        get throws {
+            DeviceKey(privateKey: try Curve25519.Signing.PrivateKey(rawRepresentation: Self.seed))
+        }
+    }
+
+    @Test func openSSHPublicKeyMatchesSSHKeygenFormat() throws {
+        #expect(try key.openSSHPublicKey == Self.expectedLine)
+    }
+
+    @Test func authorizedKeysLineAppendsComment() throws {
+        #expect(
+            try key.authorizedKeysLine(comment: "herdr-mobile iPhone")
+                == Self.expectedLine + " herdr-mobile iPhone")
+    }
+
+    @Test func fingerprintOfPublicKeyBlobMatchesSSHKeygen() throws {
+        let fingerprint = HostKeyFingerprint(publicKeyBlob: try key.publicKeyBlob)
+        #expect(fingerprint.displayString == Self.expectedFingerprint)
+    }
+
+    @Test func fingerprintRoundTripsThroughItsDigest() throws {
+        let fingerprint = HostKeyFingerprint(publicKeyBlob: try key.publicKeyBlob)
+        #expect(HostKeyFingerprint(digest: fingerprint.digest) == fingerprint)
+    }
+}

--- a/Tests/HerdrMobileTests/EventsSessionE2ETests.swift
+++ b/Tests/HerdrMobileTests/EventsSessionE2ETests.swift
@@ -269,6 +269,60 @@ struct EventsSessionE2ETests {
         }
     }
 
+    @Test func resumeRacingIntoSuspendTeardownWaitsForTeardownToFinish() async throws {
+        // Quick background→foreground bounce: resume() lands while
+        // suspend()'s teardown is still mid-flight. The session must
+        // serialize lifecycle transitions itself — the teardown completes
+        // fully (channel ended, run loop exited, transport closed) before
+        // the new activation dials; the app layer never has to serialize
+        // its own calls. Deterministic interleaving: the transport's
+        // close() is gated by the test, so suspend() is provably parked
+        // inside its teardown when resume() is issued.
+        let closeEntered = AsyncGate()
+        let closeRelease = AsyncGate()
+        try await withSession(wrap: {
+            GatedCloseTransport(inner: $0, closeEntered: closeEntered, closeRelease: closeRelease)
+        }) { request in
+            switch request.method {
+            case "ping":
+                return [Self.pingResult(request.id)]
+            case "events.subscribe":
+                return .streamThenHold([.write(Self.ack(request.id))])
+            default:
+                return nil
+            }
+        } body: { session, _, factory in
+            await session.resume()
+            var iterator = session.updates.makeAsyncIterator()
+            #expect(await iterator.next() == .status(.connected))
+
+            let suspending = Task { await session.suspend() }
+            await closeEntered.waitUntilOpen()
+            let resuming = Task { await session.resume() }
+            // The bounce must not jump the queue: no new SSH dial while the
+            // teardown is parked at the gated close.
+            try await Task.sleep(for: .milliseconds(200))
+            #expect(factory.connectCount == 1)
+
+            closeRelease.open()
+            await suspending.value
+            await resuming.value
+
+            #expect(await iterator.next() == .status(.suspended))
+            #expect(await iterator.next() == .status(.connected))
+            #expect(factory.connectCount == 2)
+            #expect(await !factory.transports[0].isConnected)
+            #expect(await factory.transports[1].isConnected)
+
+            // The run loop reference survived the bounce: end() still tears
+            // the second transport down — nothing leaks.
+            await session.end()
+            #expect(await iterator.next() == .status(.ended))
+            #expect(await iterator.next() == nil)
+            #expect(await !factory.transports[1].isConnected)
+        }
+    }
+
     private static func pingResult(_ id: String) -> String {
         #"{"id":"\#(id)","result":{"type":"pong","version":"9.9.9-fake","protocol":16}}"#
     }
@@ -278,13 +332,20 @@ struct EventsSessionE2ETests {
     }
 
     /// Connect closure for an EventsSession that counts SSH dials and keeps
-    /// every transport it created, so tests can kill or inspect the live one.
+    /// every transport it created, so tests can kill or inspect the live
+    /// one. `wrap` lets a test decorate the transport the session sees
+    /// (e.g. gate its close) while the raw SSHTransport stays inspectable.
     private final class TransportFactory: Sendable {
         private let settings: SSHTransportSettings
+        private let wrap: @Sendable (SSHTransport) -> any Transport
         private let created = Mutex<[SSHTransport]>([])
 
-        init(settings: SSHTransportSettings) {
+        init(
+            settings: SSHTransportSettings,
+            wrap: @escaping @Sendable (SSHTransport) -> any Transport = { $0 }
+        ) {
             self.settings = settings
+            self.wrap = wrap
         }
 
         var connectCount: Int { created.withLock { $0.count } }
@@ -293,7 +354,64 @@ struct EventsSessionE2ETests {
         @Sendable func connect() async throws -> any Transport {
             let transport = try await SSHTransport.connect(settings: settings)
             created.withLock { $0.append(transport) }
-            return transport
+            return wrap(transport)
+        }
+    }
+
+    /// One-shot async gate for deterministic interleavings: `open()` lets
+    /// every subsequent (or currently parked) `waitUntilOpen()` through.
+    private final class AsyncGate: Sendable {
+        private let stream: AsyncStream<Void>
+        private let continuation: AsyncStream<Void>.Continuation
+
+        init() {
+            (stream, continuation) = AsyncStream.makeStream(of: Void.self)
+        }
+
+        func open() {
+            continuation.finish()
+        }
+
+        func waitUntilOpen() async {
+            for await _ in stream {}
+        }
+    }
+
+    /// Delegates to a real SSHTransport but parks `close()` on test-held
+    /// gates, pinning a session teardown mid-flight deterministically.
+    private final class GatedCloseTransport: Transport {
+        private let inner: SSHTransport
+        private let closeEntered: AsyncGate
+        private let closeRelease: AsyncGate
+
+        init(inner: SSHTransport, closeEntered: AsyncGate, closeRelease: AsyncGate) {
+            self.inner = inner
+            self.closeEntered = closeEntered
+            self.closeRelease = closeRelease
+        }
+
+        var isConnected: Bool {
+            get async { await inner.isConnected }
+        }
+
+        func ping() async throws -> ServerInfo {
+            try await inner.ping()
+        }
+
+        func listAgents() async throws -> [Agent] {
+            try await inner.listAgents()
+        }
+
+        func subscribeToEvents(_ subscriptions: [EventSubscription]) async throws
+            -> HerdrEventStream
+        {
+            try await inner.subscribeToEvents(subscriptions)
+        }
+
+        func close() async throws {
+            closeEntered.open()
+            await closeRelease.waitUntilOpen()
+            try await inner.close()
         }
     }
 
@@ -305,6 +423,7 @@ struct EventsSessionE2ETests {
             initialDelay: .milliseconds(50), multiplier: 2, maxDelay: .milliseconds(200)),
         keepalive: KeepalivePolicy? = nil,
         requestTimeout: Duration = .seconds(15),
+        wrap: @escaping @Sendable (SSHTransport) -> any Transport = { $0 },
         script: @escaping FakeHerdrServer.Script,
         body: (EventsSession, FakeHerdrServer, TransportFactory) async throws -> Void
     ) async throws {
@@ -314,7 +433,8 @@ struct EventsSessionE2ETests {
             settings: environment.makeSettings(
                 socket: .absolutePath(server.socketPath),
                 wakeCommand: "false",
-                requestTimeout: requestTimeout))
+                requestTimeout: requestTimeout),
+            wrap: wrap)
         let session = EventsSession(
             subscriptions: [.global(.paneCreated)],
             connect: factory.connect,

--- a/Tests/HerdrMobileTests/EventsSessionE2ETests.swift
+++ b/Tests/HerdrMobileTests/EventsSessionE2ETests.swift
@@ -1,0 +1,333 @@
+import Foundation
+import Synchronization
+import Testing
+
+@testable import HerdrMobile
+
+// The events reconnect state machine (#18) over the real stack: Citadel ->
+// localhost sshd -> real socat -> fake herdr. The fake server drops channels
+// mid-stream, refuses subscribes, and hangs pings; the session must recover
+// on its own with observable status transitions and bounded backoff.
+@Suite(
+    "Events session e2e",
+    .enabled(
+        if: LocalSSHTestEnvironment.isAvailable,
+        "requires localhost sshd, socat, and an authorized Ed25519 test key"),
+    .timeLimit(.minutes(1)))
+struct EventsSessionE2ETests {
+    @Test func remoteDropReconnectsAutomaticallyAndEventsFlowAgain() async throws {
+        // The core #18 scenario: the server drops the channel mid-stream
+        // (network blip, herdr restart); events must flow again without user
+        // action, over the same SSH connection (channel-level failure only),
+        // with the staleness window visible as a .reconnecting transition.
+        let subscribeCount = Mutex(0)
+        try await withSession { request in
+            switch request.method {
+            case "ping":
+                return [Self.pingResult(request.id)]
+            case "events.subscribe":
+                let n = subscribeCount.withLock { count in
+                    count += 1
+                    return count
+                }
+                if n == 1 {
+                    // Ack + one event, then close: the mid-stream drop.
+                    return .lines([
+                        Self.ack(request.id),
+                        #"{"event":"pane_created","data":{"pane_id":"w1:p1"}}"#,
+                    ])
+                }
+                return .streamThenHold([
+                    .write(Self.ack(request.id)),
+                    .write(#"{"event":"pane_created","data":{"pane_id":"w1:p2"}}"#),
+                ])
+            default:
+                return nil
+            }
+        } body: { session, server, factory in
+            await session.resume()
+            var iterator = session.updates.makeAsyncIterator()
+
+            #expect(await iterator.next() == .status(.connected))
+            guard case .event(let first) = await iterator.next() else {
+                Issue.record("expected the first event")
+                return
+            }
+            #expect(first.data["pane_id"] == .string("w1:p1"))
+
+            guard case .status(.reconnecting(let attempt, let delay, let failure)) =
+                await iterator.next()
+            else {
+                Issue.record("expected a .reconnecting transition after the drop")
+                return
+            }
+            #expect(attempt == 1)
+            #expect(delay == .milliseconds(50))
+            guard case .channelFailed = failure else {
+                Issue.record("expected channelFailed, got \(failure)")
+                return
+            }
+
+            #expect(await iterator.next() == .status(.connected))
+            guard case .event(let second) = await iterator.next() else {
+                Issue.record("expected the post-reconnect event")
+                return
+            }
+            #expect(second.data["pane_id"] == .string("w1:p2"))
+
+            // Channel-level failure: the SSH layer was reused, not re-dialed,
+            // and the fresh connection path was pinged exactly once.
+            #expect(factory.connectCount == 1)
+            #expect(
+                server.receivedRequests.map(\.method)
+                    == ["ping", "events.subscribe", "events.subscribe"])
+        }
+    }
+
+    @Test func backoffIsBoundedAndChannelRetriesReuseTheSSHLayer() async throws {
+        // Four straight subscribe failures: delays must grow exponentially
+        // and clamp at the cap, and each retry goes through the one-channel
+        // state machine on the same SSH connection.
+        let subscribeCount = Mutex(0)
+        let reconnect = ReconnectPolicy(
+            initialDelay: .milliseconds(20), multiplier: 2, maxDelay: .milliseconds(50))
+        try await withSession(reconnect: reconnect) { request in
+            switch request.method {
+            case "ping":
+                return [Self.pingResult(request.id)]
+            case "events.subscribe":
+                let n = subscribeCount.withLock { count in
+                    count += 1
+                    return count
+                }
+                // Close without an ack four times, then accept.
+                return n <= 4 ? .lines([]) : .streamThenHold([.write(Self.ack(request.id))])
+            default:
+                return nil
+            }
+        } body: { session, _, factory in
+            await session.resume()
+
+            var delays: [Duration] = []
+            for await update in session.updates {
+                if case .status(.reconnecting(let attempt, let delay, _)) = update {
+                    #expect(attempt == delays.count + 1)
+                    delays.append(delay)
+                }
+                if update == .status(.connected) { break }
+            }
+
+            #expect(
+                delays == [
+                    .milliseconds(20), .milliseconds(40), .milliseconds(50), .milliseconds(50),
+                ])
+            #expect(factory.connectCount == 1)
+        }
+    }
+
+    @Test func deadSSHConnectionIsReplacedOnReconnect() async throws {
+        // Not just the channel: the SSH connection itself dies mid-stream.
+        // The session must notice the layer that failed and re-establish SSH
+        // (fresh dial + ping) before re-subscribing.
+        try await withSession { request in
+            switch request.method {
+            case "ping":
+                return [Self.pingResult(request.id)]
+            case "events.subscribe":
+                return .streamThenHold([.write(Self.ack(request.id))])
+            default:
+                return nil
+            }
+        } body: { session, server, factory in
+            await session.resume()
+            var iterator = session.updates.makeAsyncIterator()
+            #expect(await iterator.next() == .status(.connected))
+
+            // Kill the SSH connection out from under the session, as a
+            // network death would.
+            try await factory.transports[0].close()
+
+            guard case .status(.reconnecting) = await iterator.next() else {
+                Issue.record("expected a .reconnecting transition after SSH death")
+                return
+            }
+            #expect(await iterator.next() == .status(.connected))
+
+            #expect(factory.connectCount == 2)
+            #expect(await !factory.transports[0].isConnected)
+            #expect(await factory.transports[1].isConnected)
+            // The replacement connection path was pinged before subscribing.
+            #expect(
+                server.receivedRequests.map(\.method)
+                    == ["ping", "events.subscribe", "ping", "events.subscribe"])
+        }
+    }
+
+    @Test func suspendTearsDownDeliberatelyAndResumeResignalsSnapshot() async throws {
+        // iOS suspends sockets in the background: suspend() must tear the
+        // channel and the SSH connection down deliberately and stop all
+        // reconnect activity; resume() re-establishes and re-emits
+        // .connected — the consumer's signal to re-snapshot via agent.list.
+        let subscribeCount = Mutex(0)
+        try await withSession { request in
+            switch request.method {
+            case "ping":
+                return [Self.pingResult(request.id)]
+            case "events.subscribe":
+                let n = subscribeCount.withLock { count in
+                    count += 1
+                    return count
+                }
+                return .streamThenHold([
+                    .write(Self.ack(request.id)),
+                    .write(#"{"event":"pane_created","data":{"pane_id":"w1:p\#(n)"}}"#),
+                ])
+            default:
+                return nil
+            }
+        } body: { session, server, factory in
+            await session.resume()
+            var iterator = session.updates.makeAsyncIterator()
+            #expect(await iterator.next() == .status(.connected))
+            guard case .event = await iterator.next() else {
+                Issue.record("expected the first event")
+                return
+            }
+
+            await session.suspend()
+            #expect(await iterator.next() == .status(.suspended))
+            // Everything is down: channel closed server-side, SSH layer gone.
+            #expect(await server.wait(for: { $0.closedConnectionCount == $0.connectionCount }))
+            #expect(await !factory.transports[0].isConnected)
+
+            // Suspended means quiet: no reconnect attempts while backgrounded.
+            let connections = server.connectionCount
+            try await Task.sleep(for: .milliseconds(300))
+            #expect(server.connectionCount == connections)
+
+            await session.resume()
+            #expect(await iterator.next() == .status(.connected))
+            guard case .event(let event) = await iterator.next() else {
+                Issue.record("expected an event after resume")
+                return
+            }
+            #expect(event.data["pane_id"] == .string("w1:p2"))
+            #expect(factory.connectCount == 2)
+
+            await session.end()
+            #expect(await iterator.next() == .status(.ended))
+            #expect(await iterator.next() == nil)
+
+            // Terminal and idempotent: nothing revives an ended session.
+            await session.resume()
+            await session.suspend()
+            try await Task.sleep(for: .milliseconds(100))
+            #expect(factory.connectCount == 2)
+        }
+    }
+
+    @Test func keepalivePingsFlowWhileIdleAndAPingTimeoutForcesReconnect() async throws {
+        // Citadel exposes no SSH-level keepalive, so the session pings over
+        // the RPC path while connected. An answered keepalive proves the
+        // idle stream generates liveness traffic; a hung one must be treated
+        // as a dead connection: explicit teardown, fresh SSH dial, resubscribe.
+        let pingCount = Mutex(0)
+        try await withSession(
+            keepalive: KeepalivePolicy(interval: .milliseconds(150)),
+            requestTimeout: .seconds(1)
+        ) { request in
+            switch request.method {
+            case "ping":
+                let n = pingCount.withLock { count in
+                    count += 1
+                    return count
+                }
+                // Ping 1 is the connect path, ping 2 the first keepalive;
+                // hang the second keepalive to simulate a dead connection.
+                return n == 3 ? nil : [Self.pingResult(request.id)]
+            case "events.subscribe":
+                return .streamThenHold([.write(Self.ack(request.id))])
+            default:
+                return nil
+            }
+        } body: { session, server, factory in
+            await session.resume()
+            var iterator = session.updates.makeAsyncIterator()
+            #expect(await iterator.next() == .status(.connected))
+
+            guard case .status(.reconnecting(_, _, let failure)) = await iterator.next() else {
+                Issue.record("expected a .reconnecting transition after the hung ping")
+                return
+            }
+            #expect(failure == .timedOut)
+            #expect(await iterator.next() == .status(.connected))
+
+            // A keepalive timeout distrusts the whole connection: fresh dial.
+            #expect(factory.connectCount == 2)
+            // Connect ping, answered keepalive, hung keepalive, reconnect ping.
+            #expect(server.receivedRequests.filter { $0.method == "ping" }.count >= 4)
+        }
+    }
+
+    private static func pingResult(_ id: String) -> String {
+        #"{"id":"\#(id)","result":{"type":"pong","version":"9.9.9-fake","protocol":16}}"#
+    }
+
+    private static func ack(_ id: String) -> String {
+        #"{"id":"\#(id)","result":{"type":"subscription_started"}}"#
+    }
+
+    /// Connect closure for an EventsSession that counts SSH dials and keeps
+    /// every transport it created, so tests can kill or inspect the live one.
+    private final class TransportFactory: Sendable {
+        private let settings: SSHTransportSettings
+        private let created = Mutex<[SSHTransport]>([])
+
+        init(settings: SSHTransportSettings) {
+            self.settings = settings
+        }
+
+        var connectCount: Int { created.withLock { $0.count } }
+        var transports: [SSHTransport] { created.withLock { $0 } }
+
+        @Sendable func connect() async throws -> any Transport {
+            let transport = try await SSHTransport.connect(settings: settings)
+            created.withLock { $0.append(transport) }
+            return transport
+        }
+    }
+
+    /// Boots a fake herdr server and an EventsSession dialing localhost over
+    /// real SSH, and tears both down afterwards. Fast test backoff by
+    /// default; keepalive off unless a test turns it on.
+    private func withSession(
+        reconnect: ReconnectPolicy = ReconnectPolicy(
+            initialDelay: .milliseconds(50), multiplier: 2, maxDelay: .milliseconds(200)),
+        keepalive: KeepalivePolicy? = nil,
+        requestTimeout: Duration = .seconds(15),
+        script: @escaping FakeHerdrServer.Script,
+        body: (EventsSession, FakeHerdrServer, TransportFactory) async throws -> Void
+    ) async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let server = try FakeHerdrServer(script: script)
+        let factory = TransportFactory(
+            settings: environment.makeSettings(
+                socket: .absolutePath(server.socketPath),
+                wakeCommand: "false",
+                requestTimeout: requestTimeout))
+        let session = EventsSession(
+            subscriptions: [.global(.paneCreated)],
+            connect: factory.connect,
+            reconnectPolicy: reconnect,
+            keepalive: keepalive)
+        do {
+            try await body(session, server, factory)
+        } catch {
+            await session.end()
+            server.stop()
+            throw error
+        }
+        await session.end()
+        server.stop()
+    }
+}

--- a/Tests/HerdrMobileTests/EventsSubscribeE2ETests.swift
+++ b/Tests/HerdrMobileTests/EventsSubscribeE2ETests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+// The dedicated events.subscribe channel (#4) over the real stack: Citadel ->
+// localhost sshd -> real socat -> fake herdr scripting ack-then-event-lines.
+// Reconnect/keepalive/background handling is #18, not here.
+@Suite(
+    "Events subscribe e2e",
+    .enabled(
+        if: LocalSSHTestEnvironment.isAvailable,
+        "requires localhost sshd, socat, and an authorized Ed25519 test key"),
+    .timeLimit(.minutes(1)))
+struct EventsSubscribeE2ETests {
+    private static func ack(_ id: String) -> String {
+        #"{"id":"\#(id)","result":{"type":"subscription_started"}}"#
+    }
+
+    @Test func ackThenEventLinesArriveCanonicallyAndPromptly() async throws {
+        // Wire event lines are snake_case; the consumer must see the
+        // canonical dotted kinds. The second event is written 400ms after
+        // the first, proving live streaming (no buffering until close).
+        try await withTransport { request in
+            .streamThenHold([
+                .write(Self.ack(request.id)),
+                .write(#"{"event":"pane_created","data":{"pane_id":"w1:p1","workspace_id":"w1"}}"#),
+                .pause(.milliseconds(400)),
+                .write(
+                    #"{"event":"pane_agent_status_changed","data":{"pane_id":"w1:p1","workspace_id":"w1","agent_status":"blocked"}}"#
+                ),
+            ])
+        } body: { transport, server in
+            let stream = try await transport.subscribeToEvents([
+                .global(.paneCreated),
+                .pane(.agentStatusChanged, paneID: "w1:p1"),
+            ])
+            var iterator = stream.events.makeAsyncIterator()
+
+            let first = try await iterator.next()
+            #expect(first?.kind == GlobalEventKind.paneCreated.kind)
+            #expect(first?.data["pane_id"] == .string("w1:p1"))
+
+            let second = try await iterator.next()
+            #expect(second?.kind == PaneEventKind.agentStatusChanged.kind)
+            #expect(second?.data["agent_status"] == .string("blocked"))
+
+            // One long-lived connection carried the ack and both events.
+            #expect(server.connectionCount == 1)
+            await stream.end()
+        }
+    }
+
+    @Test func subscriptionParamsUseDottedKindsAndPaneIDs() async throws {
+        try await withTransport { request in
+            .streamThenHold([.write(Self.ack(request.id))])
+        } body: { transport, server in
+            let stream = try await transport.subscribeToEvents([
+                .global(.paneCreated),
+                .pane(.agentStatusChanged, paneID: "w1:p1"),
+            ])
+
+            #expect(server.receivedRequests.map(\.method) == ["events.subscribe"])
+            #expect(
+                server.receivedRequests.first?.params
+                    == #"{"subscriptions":[{"type":"pane.created"},{"pane_id":"w1:p1","type":"pane.agent_status_changed"}]}"#
+            )
+            await stream.end()
+        }
+    }
+
+    @Test func endClosesTheChannelWithoutHangingAndFreesTheHost() async throws {
+        // The spike gotcha: a live exec channel ignores task cancellation,
+        // so end() must close the channel explicitly (socat exits on stdin
+        // EOF) — observed server-side as the connection dying — and a new
+        // subscription must be possible afterwards.
+        try await withTransport { request in
+            .streamThenHold([.write(Self.ack(request.id))])
+        } body: { transport, server in
+            let stream = try await transport.subscribeToEvents([.global(.paneCreated)])
+            await stream.end()
+
+            #expect(await server.wait(for: { $0.closedConnectionCount == 1 }))
+            var iterator = stream.events.makeAsyncIterator()
+            #expect(try await iterator.next() == nil)
+
+            let second = try await transport.subscribeToEvents([.global(.paneCreated)])
+            await second.end()
+            #expect(await server.wait(for: { $0.closedConnectionCount == 2 }))
+        }
+    }
+
+    @Test func unknownKindsAndJunkLinesDoNotKillTheStream() async throws {
+        // herdr's API has no stability guarantee: an unknown event kind is
+        // surfaced under its wire name, junk lines are dropped, and known
+        // events keep flowing.
+        try await withTransport { request in
+            .streamThenHold([
+                .write(Self.ack(request.id)),
+                .write(#"{"event":"pane_haunted","data":{"spooky":true}}"#),
+                .write("not json at all"),
+                .write(#"{"event":"pane_created","data":{"pane_id":"w1:p2"}}"#),
+            ])
+        } body: { transport, _ in
+            let stream = try await transport.subscribeToEvents([.global(.paneCreated)])
+            var iterator = stream.events.makeAsyncIterator()
+
+            let first = try await iterator.next()
+            #expect(first?.kind.name == "pane_haunted")
+            #expect(first?.data["spooky"] == .bool(true))
+
+            let second = try await iterator.next()
+            #expect(second?.kind == GlobalEventKind.paneCreated.kind)
+            await stream.end()
+        }
+    }
+
+    @Test func remoteCloseSurfacesAsErrorAndFreesTheHost() async throws {
+        // The server writing then closing (network blip, herdr restart) must
+        // finish the stream with an error — the #18 reconnect trigger — and
+        // leave the Host free for a new subscription.
+        try await withTransport { request in
+            [
+                Self.ack(request.id),
+                #"{"event":"pane_created","data":{"pane_id":"w1:p1"}}"#,
+            ]
+        } body: { transport, _ in
+            let stream = try await transport.subscribeToEvents([.global(.paneCreated)])
+            var iterator = stream.events.makeAsyncIterator()
+
+            let first = try await iterator.next()
+            #expect(first?.kind == GlobalEventKind.paneCreated.kind)
+            // The exact detail depends on how the close races the read loop
+            // (clean EOF vs Citadel's "Already closed"); the taxonomy case
+            // is the contract.
+            do {
+                _ = try await iterator.next()
+                Issue.record("stream should have failed on remote close")
+            } catch TransportError.channelFailed {}
+
+            let second = try await transport.subscribeToEvents([.global(.paneCreated)])
+            await second.end()
+        }
+    }
+
+    @Test func subscribeErrorEnvelopeThrowsHerdrAPIError() async throws {
+        try await withTransport { request in
+            [#"{"id":"\#(request.id)","error":{"code":"invalid_request","message":"nope"}}"#]
+        } body: { transport, _ in
+            await #expect(throws: HerdrAPIError(code: "invalid_request", message: "nope")) {
+                _ = try await transport.subscribeToEvents([.global(.paneCreated)])
+            }
+        }
+    }
+
+    @Test func hungServerSubscribeTimesOutAndClosesTheChannel() async throws {
+        // No ack ever comes: the subscribe must fail at the deadline and end
+        // its channel by explicit close, never hang.
+        try await withTransport(requestTimeout: .seconds(2)) { _ in
+            nil
+        } body: { transport, server in
+            await #expect(throws: TransportError.timedOut) {
+                _ = try await transport.subscribeToEvents([.global(.paneCreated)])
+            }
+            #expect(await server.wait(for: { $0.closedConnectionCount == 1 }))
+        }
+    }
+
+    @Test func secondSubscribeWhileOneIsLiveIsRefused() async throws {
+        // One dedicated events channel per Host, by design (ADR 0002
+        // MaxSessions headroom).
+        try await withTransport { request in
+            .streamThenHold([.write(Self.ack(request.id))])
+        } body: { transport, _ in
+            let stream = try await transport.subscribeToEvents([.global(.paneCreated)])
+            await #expect(throws: TransportError.eventsChannelAlreadyOpen) {
+                _ = try await transport.subscribeToEvents([.global(.paneCreated)])
+            }
+            await stream.end()
+        }
+    }
+
+    @Test func missingSocketMapsToSocketNotFound() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let missingPath = "/tmp/herdr-missing-\(UUID().uuidString.prefix(8)).sock"
+        let transport = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .absolutePath(missingPath), wakeCommand: "false"))
+        await #expect(throws: TransportError.socketNotFound(path: missingPath)) {
+            _ = try await transport.subscribeToEvents([.global(.paneCreated)])
+        }
+        try await transport.close()
+    }
+
+    @Test func eventsChannelIsExemptFromTheExecSlotQueue() async throws {
+        // The queue bounds RPC exec channels at 8 precisely so the events
+        // channel can hold its own session slot. With the events channel
+        // live, a full queue-width of hanging RPCs must still all reach the
+        // server: 9 concurrent connections, not 8.
+        try await withTransport(requestTimeout: .seconds(3)) { request in
+            switch request.method {
+            case "events.subscribe": .streamThenHold([.write(Self.ack(request.id))])
+            default: nil
+            }
+        } body: { transport, server in
+            let stream = try await transport.subscribeToEvents([.global(.paneCreated)])
+
+            await withThrowingTaskGroup(of: Void.self) { group in
+                for _ in 0..<8 {
+                    group.addTask { _ = try await transport.listAgents() }
+                }
+                _ = await server.wait(for: { $0.connectionCount == 9 })
+                while let result = await group.nextResult() {
+                    if case .success = result {
+                        Issue.record("hung agent.list unexpectedly succeeded")
+                    }
+                }
+            }
+            #expect(server.connectionCount == 9)
+            await stream.end()
+        }
+    }
+
+    /// Boots a fake herdr server plus a real SSH connection to localhost and
+    /// tears both down afterwards. The wake command is stubbed to a no-op so
+    /// no test path can ever poke the machine's real herdr server.
+    private func withTransport(
+        requestTimeout: Duration = .seconds(15),
+        script: @escaping FakeHerdrServer.Script,
+        body: (SSHTransport, FakeHerdrServer) async throws -> Void
+    ) async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let server = try FakeHerdrServer(script: script)
+        let transport: SSHTransport
+        do {
+            transport = try await SSHTransport.connect(
+                settings: environment.makeSettings(
+                    socket: .absolutePath(server.socketPath),
+                    wakeCommand: "false",
+                    requestTimeout: requestTimeout))
+        } catch {
+            server.stop()
+            throw error
+        }
+        do {
+            try await body(transport, server)
+        } catch {
+            try? await transport.close()
+            server.stop()
+            throw error
+        }
+        try await transport.close()
+        server.stop()
+    }
+}

--- a/Tests/HerdrMobileTests/HerdrEventsTests.swift
+++ b/Tests/HerdrMobileTests/HerdrEventsTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+// Canonical event naming and subscription wire shapes: pure, no sshd. The
+// kind list mirrors herdr 0.7.4's schema (26 subscribable kinds); event-line
+// fixtures follow the snake_case spelling the live wire uses.
+@Suite struct HerdrEventsTests {
+    @Test func snakeCaseWireNamesMapToCanonicalDottedKinds() {
+        #expect(HerdrEventKind(wireName: "pane_created") == GlobalEventKind.paneCreated.kind)
+        #expect(
+            HerdrEventKind(wireName: "workspace_metadata_updated")
+                == GlobalEventKind.workspaceMetadataUpdated.kind)
+        #expect(
+            HerdrEventKind(wireName: "pane_agent_status_changed")
+                == PaneEventKind.agentStatusChanged.kind)
+    }
+
+    @Test func everyKnownKindMapsFromItsSnakeCaseWireName() {
+        for kind in HerdrEventKind.known {
+            let snake = kind.name.replacingOccurrences(of: ".", with: "_")
+            #expect(HerdrEventKind(wireName: snake) == kind)
+        }
+    }
+
+    @Test func dottedWireNamesAreAcceptedToo() {
+        // herdr's schema spells the typed event kinds dotted while the live
+        // wire sends snake_case; both spellings land on one canonical kind.
+        #expect(
+            HerdrEventKind(wireName: "pane.agent_status_changed")
+                == PaneEventKind.agentStatusChanged.kind)
+    }
+
+    @Test func unknownWireNamesPassThroughUnchanged() {
+        // herdr's API has no stability guarantee: a kind we do not know keeps
+        // its wire spelling instead of being guess-mangled.
+        #expect(HerdrEventKind(wireName: "pane_haunted").name == "pane_haunted")
+    }
+
+    @Test func subscribeRequestLineUsesDottedTypesAndPaneIDs() throws {
+        let line = try HerdrWire.subscribeRequestLine(
+            id: "req-1",
+            subscriptions: [
+                .global(.paneCreated),
+                .pane(.agentStatusChanged, paneID: "w1:p1"),
+            ])
+
+        #expect(line.hasSuffix("\n"))
+        let object = try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+        let envelope = try #require(object)
+        #expect(envelope["id"] as? String == "req-1")
+        #expect(envelope["method"] as? String == "events.subscribe")
+        let params = try #require(envelope["params"] as? [String: Any])
+        let subscriptions = try #require(params["subscriptions"] as? [[String: Any]])
+        try #require(subscriptions.count == 2)
+        #expect(subscriptions[0]["type"] as? String == "pane.created")
+        #expect(subscriptions[0]["pane_id"] == nil)
+        #expect(subscriptions[1]["type"] as? String == "pane.agent_status_changed")
+        #expect(subscriptions[1]["pane_id"] as? String == "w1:p1")
+    }
+
+    @Test func eventLineDecodesToCanonicalKindAndPayload() {
+        // Payload fields per the schema's PaneAgentStatusChangedEvent.
+        let line =
+            #"{"event":"pane_agent_status_changed","data":{"pane_id":"w3:pB","workspace_id":"w3","agent_status":"blocked","state_labels":{}}}"#
+
+        let event = HerdrWire.decodeEvent(fromLine: Data(line.utf8))
+
+        #expect(event?.kind == PaneEventKind.agentStatusChanged.kind)
+        #expect(event?.data["pane_id"] == .string("w3:pB"))
+        #expect(event?.data["agent_status"] == .string("blocked"))
+    }
+
+    @Test func eventLineWithUnknownKindStillDecodes() {
+        let line = #"{"event":"pane_haunted","data":{"pane_id":"w1:p1"}}"#
+
+        let event = HerdrWire.decodeEvent(fromLine: Data(line.utf8))
+
+        #expect(event?.kind.name == "pane_haunted")
+        #expect(event?.data["pane_id"] == .string("w1:p1"))
+    }
+
+    @Test func eventLineWithoutDataDecodesToNullPayload() {
+        let event = HerdrWire.decodeEvent(fromLine: Data(#"{"event":"pane_created"}"#.utf8))
+
+        #expect(event == HerdrEvent(kind: GlobalEventKind.paneCreated.kind, data: .null))
+    }
+
+    @Test func nonEventLinesDecodeToNil() {
+        // Response envelopes, junk, and empty lines are not events; they are
+        // dropped instead of killing the stream.
+        let responseLine = #"{"id":"x","result":{"type":"subscription_started"}}"#
+
+        #expect(HerdrWire.decodeEvent(fromLine: Data(responseLine.utf8)) == nil)
+        #expect(HerdrWire.decodeEvent(fromLine: Data("not json".utf8)) == nil)
+        #expect(HerdrWire.decodeEvent(fromLine: Data()) == nil)
+    }
+}

--- a/Tests/HerdrMobileTests/HerdrSocketLocationTests.swift
+++ b/Tests/HerdrMobileTests/HerdrSocketLocationTests.swift
@@ -1,0 +1,32 @@
+import Testing
+
+@testable import HerdrMobile
+
+// Pure path computation; resolving the home directory itself is exercised
+// end-to-end in SSHTransportE2ETests.
+@Suite struct HerdrSocketLocationTests {
+    @Test func defaultSessionLivesUnderConfigDir() {
+        let path = HerdrSocketLocation.defaultSession.path(homeDirectory: "/home/u")
+
+        #expect(path == "/home/u/.config/herdr/herdr.sock")
+    }
+
+    @Test func namedSessionLivesUnderSessionsDir() {
+        let path = HerdrSocketLocation.namedSession("work").path(homeDirectory: "/home/u")
+
+        #expect(path == "/home/u/.config/herdr/sessions/work/herdr.sock")
+    }
+
+    @Test func absolutePathIgnoresHomeDirectory() {
+        let path = HerdrSocketLocation.absolutePath("/tmp/custom.sock")
+            .path(homeDirectory: "/home/u")
+
+        #expect(path == "/tmp/custom.sock")
+    }
+
+    @Test func trailingSlashOnHomeDoesNotDoubleTheSeparator() {
+        let path = HerdrSocketLocation.defaultSession.path(homeDirectory: "/home/u/")
+
+        #expect(path == "/home/u/.config/herdr/herdr.sock")
+    }
+}

--- a/Tests/HerdrMobileTests/HerdrWireTests.swift
+++ b/Tests/HerdrMobileTests/HerdrWireTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+// Pure wire-format tests: no sshd, no sockets. Response fixtures are captured
+// verbatim from a live herdr 0.7.4 (protocol 16) server.
+@Suite struct HerdrWireTests {
+    @Test func requestLineHasEnvelopeShapeAndTrailingNewline() throws {
+        let line = try HerdrWire.requestLine(id: "req-1", method: "agent.list")
+
+        #expect(line.hasSuffix("\n"))
+        #expect(!line.dropLast().contains("\n"))
+        let object = try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+        let envelope = try #require(object)
+        #expect(envelope["id"] as? String == "req-1")
+        #expect(envelope["method"] as? String == "agent.list")
+        #expect((envelope["params"] as? [String: Any])?.isEmpty == true)
+        #expect(envelope.count == 3)
+    }
+
+    @Test func pingResultDecodesLeniently() throws {
+        // Live capture; "type" and "capabilities" are unknown fields to us.
+        let line = #"{"id":"req-1","result":{"type":"pong","version":"0.7.4","protocol":16,"capabilities":{"live_handoff":true,"detached_server_daemon":true}}}"#
+
+        let info = try HerdrWire.decodeResult(
+            ServerInfo.self, fromResponseLine: Data(line.utf8), requestID: "req-1")
+
+        #expect(info == ServerInfo(version: "0.7.4", protocolVersion: 16))
+    }
+
+    @Test func agentListResultDecodes() throws {
+        // Live capture, trimmed to one agent; unknown fields left in place.
+        let line = #"{"id":"req-1","result":{"type":"agent_list","agents":[{"terminal_id":"term_656c59f7b902d1e","agent":"codex","terminal_title":"✳ GoDrop","terminal_title_stripped":"GoDrop","agent_status":"working","workspace_id":"w3","tab_id":"w3:t2","pane_id":"w3:pB","focused":false,"cwd":"/Users/u/GoDrop","foreground_cwd":"/Users/u/GoDrop","revision":5}]}}"#
+
+        let result = try HerdrWire.decodeResult(
+            AgentListResult.self, fromResponseLine: Data(line.utf8), requestID: "req-1")
+
+        let expected = Agent(
+            terminalID: "term_656c59f7b902d1e",
+            kind: "codex",
+            title: "GoDrop",
+            status: .working,
+            workspaceID: "w3",
+            tabID: "w3:t2",
+            paneID: "w3:pB",
+            cwd: "/Users/u/GoDrop",
+            revision: 5
+        )
+        #expect(result.agents == [expected])
+    }
+
+    @Test func unknownAgentStatusDecodesToUnknown() throws {
+        // herdr's API has no stability guarantee: a new status value must not
+        // break decoding, it degrades to .unknown.
+        let json = #"{"agents":[{"terminal_id":"t","agent":"claude","terminal_title_stripped":"x","agent_status":"haunted","workspace_id":"w","tab_id":"w:t","pane_id":"w:p","cwd":"/","revision":0}]}"#
+
+        let result = try JSONDecoder().decode(AgentListResult.self, from: Data(json.utf8))
+
+        #expect(result.agents.first?.status == .unknown)
+    }
+
+    @Test func errorEnvelopeThrowsHerdrAPIError() throws {
+        let line = #"{"id":"req-1","error":{"code":404,"message":"no such method"}}"#
+
+        #expect(throws: HerdrAPIError(code: "404", message: "no such method")) {
+            try HerdrWire.decodeResult(
+                ServerInfo.self, fromResponseLine: Data(line.utf8), requestID: "req-1")
+        }
+    }
+
+    @Test func stringErrorCodeIsAccepted() throws {
+        let line = #"{"id":"req-1","error":{"code":"not_found","message":"gone"}}"#
+
+        #expect(throws: HerdrAPIError(code: "not_found", message: "gone")) {
+            try HerdrWire.decodeResult(
+                ServerInfo.self, fromResponseLine: Data(line.utf8), requestID: "req-1")
+        }
+    }
+
+    @Test func responseIDMismatchIsMalformed() throws {
+        let line = #"{"id":"someone-else","result":{"version":"0.7.4","protocol":16}}"#
+
+        #expect(throws: TransportError.self) {
+            try HerdrWire.decodeResult(
+                ServerInfo.self, fromResponseLine: Data(line.utf8), requestID: "req-1")
+        }
+    }
+
+    @Test func missingResultAndErrorIsMalformed() throws {
+        let line = #"{"id":"req-1"}"#
+
+        #expect(throws: TransportError.self) {
+            try HerdrWire.decodeResult(
+                ServerInfo.self, fromResponseLine: Data(line.utf8), requestID: "req-1")
+        }
+    }
+
+    @Test func nonJSONResponseIsMalformed() throws {
+        let line = "2026/07/18 socat[123] E connect(): No such file or directory"
+
+        #expect(throws: TransportError.self) {
+            try HerdrWire.decodeResult(
+                ServerInfo.self, fromResponseLine: Data(line.utf8), requestID: "req-1")
+        }
+    }
+}

--- a/Tests/HerdrMobileTests/HerdrWireTests.swift
+++ b/Tests/HerdrMobileTests/HerdrWireTests.swift
@@ -78,6 +78,22 @@ import Testing
         }
     }
 
+    @Test func errorEnvelopeWithBlankIDStillThrowsAPIError() throws {
+        // Live capture: herdr answers a request it could not parse with
+        // id "" — the error must surface, not an id-mismatch complaint.
+        let line =
+            #"{"id":"","error":{"code":"invalid_request","message":"invalid request: missing field `source` at line 1 column 123"}}"#
+
+        #expect(
+            throws: HerdrAPIError(
+                code: "invalid_request",
+                message: "invalid request: missing field `source` at line 1 column 123")
+        ) {
+            try HerdrWire.decodeResult(
+                ServerInfo.self, fromResponseLine: Data(line.utf8), requestID: "req-1")
+        }
+    }
+
     @Test func responseIDMismatchIsMalformed() throws {
         let line = #"{"id":"someone-else","result":{"version":"0.7.4","protocol":16}}"#
 

--- a/Tests/HerdrMobileTests/JSONValueTests.swift
+++ b/Tests/HerdrMobileTests/JSONValueTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+@Suite struct JSONValueTests {
+    @Test func decodesEveryJSONShape() throws {
+        let json = #"{"s":"x","n":1.5,"i":3,"b":true,"z":null,"a":[1,"two"],"o":{"k":"v"}}"#
+
+        let value = try JSONDecoder().decode(JSONValue.self, from: Data(json.utf8))
+
+        #expect(value["s"] == .string("x"))
+        #expect(value["n"] == .number(1.5))
+        #expect(value["i"] == .number(3))
+        #expect(value["b"] == .bool(true))
+        #expect(value["z"] == JSONValue.null)
+        #expect(value["a"] == .array([.number(1), .string("two")]))
+        #expect(value["o"] == .object(["k": .string("v")]))
+    }
+
+    @Test func subscriptOnNonObjectIsNil() {
+        #expect(JSONValue.string("x")["key"] == nil)
+        #expect(JSONValue.null["key"] == nil)
+    }
+
+    @Test func stringValueUnwrapsOnlyStrings() {
+        #expect(JSONValue.string("x").stringValue == "x")
+        #expect(JSONValue.number(1).stringValue == nil)
+    }
+}

--- a/Tests/HerdrMobileTests/KnownHostsStoreTests.swift
+++ b/Tests/HerdrMobileTests/KnownHostsStoreTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+@Suite("Known hosts store")
+struct KnownHostsStoreTests {
+    private let fingerprint = HostKeyFingerprint(publicKeyBlob: Data("blob-a".utf8))
+    private let otherFingerprint = HostKeyFingerprint(publicKeyBlob: Data("blob-b".utf8))
+
+    @Test func inMemoryStoreKeysFingerprintsByHostAndPort() async throws {
+        let store = InMemoryKnownHostsStore()
+
+        #expect(await store.fingerprint(host: "a.example", port: 22) == nil)
+
+        await store.setFingerprint(fingerprint, host: "a.example", port: 22)
+        await store.setFingerprint(otherFingerprint, host: "a.example", port: 2222)
+
+        #expect(await store.fingerprint(host: "a.example", port: 22) == fingerprint)
+        #expect(await store.fingerprint(host: "a.example", port: 2222) == otherFingerprint)
+        #expect(await store.fingerprint(host: "b.example", port: 22) == nil)
+    }
+
+    @Test func userDefaultsStorePersistsAcrossInstances() async throws {
+        let suiteName = "hm-known-hosts-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        await UserDefaultsKnownHostsStore(defaults: defaults)
+            .setFingerprint(fingerprint, host: "a.example", port: 22)
+
+        let reloaded = UserDefaultsKnownHostsStore(defaults: defaults)
+        #expect(await reloaded.fingerprint(host: "a.example", port: 22) == fingerprint)
+        #expect(await reloaded.fingerprint(host: "a.example", port: 2222) == nil)
+    }
+
+    @Test func userDefaultsStoreOverwritesAChangedFingerprint() async throws {
+        let suiteName = "hm-known-hosts-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = UserDefaultsKnownHostsStore(defaults: defaults)
+
+        await store.setFingerprint(fingerprint, host: "a.example", port: 22)
+        await store.setFingerprint(otherFingerprint, host: "a.example", port: 22)
+
+        #expect(await store.fingerprint(host: "a.example", port: 22) == otherFingerprint)
+    }
+}

--- a/Tests/HerdrMobileTests/ReconnectPolicyTests.swift
+++ b/Tests/HerdrMobileTests/ReconnectPolicyTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+@Suite("Reconnect policy")
+struct ReconnectPolicyTests {
+    @Test func delaysGrowExponentiallyUntilTheCap() {
+        let policy = ReconnectPolicy(
+            initialDelay: .milliseconds(100), multiplier: 2, maxDelay: .milliseconds(450))
+
+        #expect(policy.delay(beforeAttempt: 1) == .milliseconds(100))
+        #expect(policy.delay(beforeAttempt: 2) == .milliseconds(200))
+        #expect(policy.delay(beforeAttempt: 3) == .milliseconds(400))
+        #expect(policy.delay(beforeAttempt: 4) == .milliseconds(450))
+        #expect(policy.delay(beforeAttempt: 5) == .milliseconds(450))
+    }
+
+    @Test func hugeAttemptCountsStayAtTheCapWithoutOverflow() {
+        // A Host can be gone for hours; attempt numbers keep climbing and the
+        // delay must sit at the cap, not overflow or grow.
+        #expect(
+            ReconnectPolicy.default.delay(beforeAttempt: 10_000)
+                == ReconnectPolicy.default.maxDelay)
+    }
+
+    @Test func firstAttemptAlwaysWaitsTheInitialDelay() {
+        // Attempt numbers below 1 are a caller bug; degrade to the initial
+        // delay instead of misbehaving.
+        let policy = ReconnectPolicy(
+            initialDelay: .milliseconds(100), multiplier: 2, maxDelay: .seconds(1))
+
+        #expect(policy.delay(beforeAttempt: 0) == .milliseconds(100))
+    }
+
+    @Test func nonPositiveMultiplierNeverShrinksOrLoopsForever() {
+        let policy = ReconnectPolicy(
+            initialDelay: .milliseconds(100), multiplier: 0, maxDelay: .seconds(1))
+
+        #expect(policy.delay(beforeAttempt: 50) == .milliseconds(100))
+    }
+}

--- a/Tests/HerdrMobileTests/SSHAuthE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHAuthE2ETests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+// Authentication (#2) against the real localhost sshd. The device-key test
+// generates a key in-test, installs its authorized_keys line for the test's
+// duration, and restores the file afterwards — proving the whole chain:
+// CryptoKit keypair -> our authorized_keys formatting -> sshd accepting it.
+@Suite(
+    "SSH auth e2e",
+    .enabled(
+        if: LocalSSHTestEnvironment.isAvailable,
+        "requires localhost sshd, socat, and an authorized Ed25519 test key"),
+    .serialized)
+struct SSHAuthE2ETests {
+    @Test func generatedDeviceKeyAuthenticatesOnceItsLineIsAuthorized() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let deviceKey = try DeviceKeyStore(secrets: InMemorySecretStore()).loadOrCreate()
+        let installed = try AuthorizedKeysEntry(
+            username: environment.username,
+            line: deviceKey.authorizedKeysLine(comment: "herdr-mobile-e2e"))
+        defer { installed.restore() }
+
+        let transport = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .absolutePath("/tmp/herdr-irrelevant.sock"),
+                credentials: .ed25519(deviceKey.privateKey)))
+        try await transport.close()
+    }
+
+    @Test func unauthorizedDeviceKeyMapsToAuthenticationFailed() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let deviceKey = try DeviceKeyStore(secrets: InMemorySecretStore()).loadOrCreate()
+
+        await #expect(throws: TransportError.authenticationFailed) {
+            _ = try await SSHTransport.connect(
+                settings: environment.makeSettings(
+                    socket: .absolutePath("/tmp/herdr-irrelevant.sock"),
+                    credentials: .ed25519(deviceKey.privateKey)))
+        }
+    }
+
+    @Test func wrongPasswordMapsToAuthenticationFailed() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+
+        await #expect(throws: TransportError.authenticationFailed) {
+            _ = try await SSHTransport.connect(
+                settings: environment.makeSettings(
+                    socket: .absolutePath("/tmp/herdr-irrelevant.sock"),
+                    credentials: .password("definitely-wrong-\(UUID().uuidString)")))
+        }
+    }
+}
+
+/// Appends one line to the host user's authorized_keys and restores the
+/// file's exact prior contents afterwards. The simulator shares the host
+/// filesystem, so the file sshd reads is directly writable.
+private struct AuthorizedKeysEntry {
+    private let path: String
+    private let original: Data?
+
+    init(username: String, line: String) throws {
+        path = "/Users/\(username)/.ssh/authorized_keys"
+        original = FileManager.default.contents(atPath: path)
+        var content = original.map { String(decoding: $0, as: UTF8.self) } ?? ""
+        if !content.isEmpty, !content.hasSuffix("\n") { content += "\n" }
+        content += line + "\n"
+        // Non-atomic on purpose: rewriting in place keeps the permissions
+        // sshd's StrictModes checks.
+        try content.write(toFile: path, atomically: false, encoding: .utf8)
+    }
+
+    func restore() {
+        if let original {
+            try? original.write(to: URL(fileURLWithPath: path))
+        } else {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+    }
+}

--- a/Tests/HerdrMobileTests/SSHHostKeyE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHHostKeyE2ETests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Synchronization
+import Testing
+
+@testable import HerdrMobile
+
+// TOFU host key policy (#2) exercised against the real localhost sshd: the
+// fingerprint the validator sees is sshd's actual host key. No herdr socket
+// is involved — connect authenticates but sends nothing.
+@Suite(
+    "TOFU host key e2e",
+    .enabled(
+        if: LocalSSHTestEnvironment.isAvailable,
+        "requires localhost sshd, socat, and an authorized Ed25519 test key"))
+struct SSHHostKeyE2ETests {
+    @Test func firstConnectAsksForConfirmationAndPersistsOnAccept() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let knownHosts = InMemoryKnownHostsStore()
+        let seen = Mutex<[HostKeyCandidate]>([])
+        let policy = HostKeyPolicy(knownHosts: knownHosts) { candidate in
+            seen.withLock { $0.append(candidate) }
+            return true
+        }
+
+        let transport = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .absolutePath("/tmp/herdr-irrelevant.sock"), hostKeyPolicy: policy))
+        try await transport.close()
+
+        let candidates = seen.withLock { $0 }
+        #expect(candidates.map(\.host) == [environment.host])
+        #expect(candidates.map(\.port) == [environment.port])
+        let stored = await knownHosts.fingerprint(host: environment.host, port: environment.port)
+        #expect(stored != nil)
+        #expect(stored == candidates.first?.fingerprint)
+    }
+
+    @Test func knownFingerprintConnectsWithoutConfirmation() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let knownHosts = InMemoryKnownHostsStore()
+
+        // First connect: accept and persist.
+        let first = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .absolutePath("/tmp/herdr-irrelevant.sock"),
+                hostKeyPolicy: HostKeyPolicy(knownHosts: knownHosts) { _ in true }))
+        try await first.close()
+
+        // Second connect against the same store must not ask again.
+        let askedAgain = Mutex(false)
+        let second = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .absolutePath("/tmp/herdr-irrelevant.sock"),
+                hostKeyPolicy: HostKeyPolicy(knownHosts: knownHosts) { _ in
+                    askedAgain.withLock { $0 = true }
+                    return false
+                }))
+        try await second.close()
+
+        #expect(askedAgain.withLock { $0 } == false)
+    }
+
+    @Test func rejectedFirstConnectFailsWithoutPersisting() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let knownHosts = InMemoryKnownHostsStore()
+        let seen = Mutex<[HostKeyCandidate]>([])
+        let policy = HostKeyPolicy(knownHosts: knownHosts) { candidate in
+            seen.withLock { $0.append(candidate) }
+            return false
+        }
+
+        do {
+            let transport = try await SSHTransport.connect(
+                settings: environment.makeSettings(
+                    socket: .absolutePath("/tmp/herdr-irrelevant.sock"), hostKeyPolicy: policy))
+            try await transport.close()
+            Issue.record("connect succeeded despite rejected host key")
+        } catch let error as TransportError {
+            let presented = try #require(seen.withLock { $0 }.first?.fingerprint)
+            #expect(error == .hostKeyRejected(presented: presented))
+        }
+
+        #expect(await knownHosts.fingerprint(host: environment.host, port: environment.port) == nil)
+    }
+
+    @Test func changedHostKeyHardFailsWithoutAskingOrOverwriting() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let knownHosts = InMemoryKnownHostsStore()
+        let wrongFingerprint = HostKeyFingerprint(publicKeyBlob: Data("not-sshds-key".utf8))
+        await knownHosts.setFingerprint(
+            wrongFingerprint, host: environment.host, port: environment.port)
+        let asked = Mutex(false)
+        let policy = HostKeyPolicy(knownHosts: knownHosts) { _ in
+            asked.withLock { $0 = true }
+            return true
+        }
+
+        do {
+            let transport = try await SSHTransport.connect(
+                settings: environment.makeSettings(
+                    socket: .absolutePath("/tmp/herdr-irrelevant.sock"), hostKeyPolicy: policy))
+            try await transport.close()
+            Issue.record("connect succeeded despite a changed host key")
+        } catch let error as TransportError {
+            guard case .hostKeyMismatch(let known, let presented) = error else {
+                Issue.record("expected hostKeyMismatch, got \(error)")
+                return
+            }
+            #expect(known == wrongFingerprint)
+            #expect(presented != wrongFingerprint)
+        }
+
+        // A mismatch must never ask the user or touch the stored fingerprint.
+        #expect(asked.withLock { $0 } == false)
+        let stored = await knownHosts.fingerprint(host: environment.host, port: environment.port)
+        #expect(stored == wrongFingerprint)
+    }
+}
+
+// Connect failures that need no live sshd.
+@Suite("SSH connect failure taxonomy")
+struct SSHConnectFailureTests {
+    @Test func unreachableHostMapsToSSHUnreachable() async throws {
+        // Nothing listens on port 1 (privileged, unused): connection refused.
+        let settings = SSHTransportSettings(
+            host: "127.0.0.1",
+            port: 1,
+            username: "nobody",
+            credentials: .password("irrelevant"),
+            hostKeyPolicy: HostKeyPolicy(knownHosts: InMemoryKnownHostsStore()) { _ in true },
+            socket: .defaultSession,
+            socatPath: "/opt/homebrew/bin/socat")
+
+        do {
+            let transport = try await SSHTransport.connect(settings: settings)
+            try await transport.close()
+            Issue.record("connect succeeded against a dead port")
+        } catch let error as TransportError {
+            guard case .sshUnreachable = error else {
+                Issue.record("expected sshUnreachable, got \(error)")
+                return
+            }
+        }
+    }
+}

--- a/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
@@ -91,6 +91,21 @@ struct SSHTransportE2ETests {
         }
     }
 
+    @Test func isConnectedTracksTheSSHConnectionLifecycle() async throws {
+        // The reconnect machinery (#18) decides "re-subscribe or re-dial"
+        // from this flag; it must be honest about the SSH layer's liveness.
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let server = try FakeHerdrServer { _ in nil }
+        defer { server.stop() }
+
+        let transport = try await SSHTransport.connect(
+            settings: environment.makeSettings(socket: .absolutePath(server.socketPath)))
+        #expect(await transport.isConnected)
+
+        try await transport.close()
+        #expect(await !transport.isConnected)
+    }
+
     @Test func namedSessionSocketPathResolvesOverRemoteHome() async throws {
         // The transport is given only a session name; it must resolve the
         // remote home directory over exec and find the socket at

--- a/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
@@ -115,13 +115,7 @@ struct SSHTransportE2ETests {
         defer { server.stop() }
 
         let transport = try await SSHTransport.connect(
-            settings: SSHTransportSettings(
-                host: environment.host,
-                port: environment.port,
-                username: environment.username,
-                privateKey: environment.privateKey,
-                socket: .namedSession(sessionName),
-                socatPath: environment.socatPath))
+            settings: environment.makeSettings(socket: .namedSession(sessionName)))
         do {
             // Two requests: the second reuses the cached home directory.
             _ = try await transport.ping()
@@ -149,13 +143,7 @@ struct SSHTransportE2ETests {
         let transport: SSHTransport
         do {
             transport = try await SSHTransport.connect(
-                settings: SSHTransportSettings(
-                    host: environment.host,
-                    port: environment.port,
-                    username: environment.username,
-                    privateKey: environment.privateKey,
-                    socket: .absolutePath(server.socketPath),
-                    socatPath: environment.socatPath))
+                settings: environment.makeSettings(socket: .absolutePath(server.socketPath)))
         } catch {
             server.stop()
             throw error

--- a/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
@@ -91,6 +91,52 @@ struct SSHTransportE2ETests {
         }
     }
 
+    @Test func namedSessionSocketPathResolvesOverRemoteHome() async throws {
+        // The transport is given only a session name; it must resolve the
+        // remote home directory over exec and find the socket at
+        // ~/.config/herdr/sessions/<name>/herdr.sock. The fake server is
+        // bound at exactly that spot in the real home directory (the
+        // simulator shares the host filesystem, where home is /Users/<user>).
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let sessionName = "hm-e2e-\(UUID().uuidString.prefix(8))"
+        let sessionDir = "/Users/\(environment.username)/.config/herdr/sessions/\(sessionName)"
+        try FileManager.default.createDirectory(
+            atPath: sessionDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: sessionDir) }
+
+        let server = try FakeHerdrServer(socketPath: sessionDir + "/herdr.sock") { request in
+            switch request.method {
+            case "ping":
+                [#"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9-fake","protocol":16}}"#]
+            default:
+                [#"{"id":"\#(request.id)","result":{"type":"agent_list","agents":[]}}"#]
+            }
+        }
+        defer { server.stop() }
+
+        let transport = try await SSHTransport.connect(
+            settings: SSHTransportSettings(
+                host: environment.host,
+                port: environment.port,
+                username: environment.username,
+                privateKey: environment.privateKey,
+                socket: .namedSession(sessionName),
+                socatPath: environment.socatPath))
+        do {
+            // Two requests: the second reuses the cached home directory.
+            _ = try await transport.ping()
+            let agents = try await transport.listAgents()
+
+            #expect(agents.isEmpty)
+            #expect(server.receivedRequests.map(\.method) == ["ping", "agent.list"])
+            #expect(server.connectionCount == 2)
+        } catch {
+            try? await transport.close()
+            throw error
+        }
+        try await transport.close()
+    }
+
     /// Boots a fake herdr server plus a real SSH connection to localhost and
     /// tears both down afterwards. The transport is handed to `body` as the
     /// concrete actor; assertions go through its public Transport surface.
@@ -108,7 +154,7 @@ struct SSHTransportE2ETests {
                     port: environment.port,
                     username: environment.username,
                     privateKey: environment.privateKey,
-                    socketPath: server.socketPath,
+                    socket: .absolutePath(server.socketPath),
                     socatPath: environment.socatPath))
         } catch {
             server.stop()

--- a/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+// End-to-end over the real stack: Citadel -> localhost sshd -> login shell ->
+// real socat -> in-test fake herdr server. Only herdr itself is faked.
+// Skipped as a suite when the machine lacks the prerequisites.
+@Suite(
+    "SSHTransport e2e",
+    .enabled(
+        if: LocalSSHTestEnvironment.isAvailable,
+        "requires localhost sshd, socat, and an authorized Ed25519 test key"))
+struct SSHTransportE2ETests {
+    @Test func pingRoundTripsAndChecksProtocolVersion() async throws {
+        try await withTransport { request in
+            [
+                #"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9-fake","protocol":16,"capabilities":{"future_capability":true}}}"#
+            ]
+        } body: { transport, server in
+            let info = try await transport.ping()
+
+            #expect(info == ServerInfo(version: "9.9.9-fake", protocolVersion: 16))
+            #expect(server.receivedRequests.map(\.method) == ["ping"])
+        }
+    }
+
+    @Test func pingRejectsUnsupportedProtocolVersion() async throws {
+        try await withTransport { request in
+            [#"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9-fake","protocol":99}}"#]
+        } body: { transport, _ in
+            await #expect(
+                throws: TransportError.protocolVersionMismatch(
+                    server: 99, supported: SSHTransport.supportedProtocolVersion)
+            ) {
+                try await transport.ping()
+            }
+        }
+    }
+
+    @Test func agentListRoundTrips() async throws {
+        try await withTransport { request in
+            [
+                #"{"id":"\#(request.id)","result":{"type":"agent_list","agents":[{"terminal_id":"term_a","agent":"claude","terminal_title":"⠐ Fix the bug","terminal_title_stripped":"Fix the bug","agent_status":"blocked","workspace_id":"w1","tab_id":"w1:t1","pane_id":"w1:p1","focused":true,"cwd":"/work/a","foreground_cwd":"/work/a","revision":3},{"terminal_id":"term_b","agent":"codex","terminal_title":"idle","terminal_title_stripped":"idle","agent_status":"idle","workspace_id":"w2","tab_id":"w2:t1","pane_id":"w2:p4","focused":false,"cwd":"/work/b","foreground_cwd":"/work/b","revision":7}]}}"#
+            ]
+        } body: { transport, server in
+            let agents = try await transport.listAgents()
+
+            #expect(
+                agents == [
+                    Agent(
+                        terminalID: "term_a", kind: "claude", title: "Fix the bug",
+                        status: .blocked, workspaceID: "w1", tabID: "w1:t1", paneID: "w1:p1",
+                        cwd: "/work/a", revision: 3),
+                    Agent(
+                        terminalID: "term_b", kind: "codex", title: "idle",
+                        status: .idle, workspaceID: "w2", tabID: "w2:t1", paneID: "w2:p4",
+                        cwd: "/work/b", revision: 7),
+                ])
+            #expect(server.receivedRequests.map(\.method) == ["agent.list"])
+        }
+    }
+
+    @Test func serverErrorSurfacesAsHerdrAPIError() async throws {
+        try await withTransport { request in
+            [#"{"id":"\#(request.id)","error":{"code":500,"message":"scripted failure"}}"#]
+        } body: { transport, _ in
+            await #expect(throws: HerdrAPIError(code: "500", message: "scripted failure")) {
+                try await transport.listAgents()
+            }
+        }
+    }
+
+    @Test func eachRequestUsesAFreshConnection() async throws {
+        // herdr serves one request per connection; two sequential calls must
+        // arrive on two separate socket connections (= two exec channels).
+        try await withTransport { request in
+            switch request.method {
+            case "ping":
+                [#"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9-fake","protocol":16}}"#]
+            default:
+                [#"{"id":"\#(request.id)","result":{"type":"agent_list","agents":[]}}"#]
+            }
+        } body: { transport, server in
+            _ = try await transport.ping()
+            let agents = try await transport.listAgents()
+
+            #expect(agents.isEmpty)
+            #expect(server.connectionCount == 2)
+            #expect(server.receivedRequests.map(\.method) == ["ping", "agent.list"])
+        }
+    }
+
+    /// Boots a fake herdr server plus a real SSH connection to localhost and
+    /// tears both down afterwards. The transport is handed to `body` as the
+    /// concrete actor; assertions go through its public Transport surface.
+    private func withTransport(
+        script: @escaping FakeHerdrServer.Script,
+        body: (SSHTransport, FakeHerdrServer) async throws -> Void
+    ) async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let server = try FakeHerdrServer(script: script)
+        let transport: SSHTransport
+        do {
+            transport = try await SSHTransport.connect(
+                settings: SSHTransportSettings(
+                    host: environment.host,
+                    port: environment.port,
+                    username: environment.username,
+                    privateKey: environment.privateKey,
+                    socketPath: server.socketPath,
+                    socatPath: environment.socatPath))
+        } catch {
+            server.stop()
+            throw error
+        }
+        do {
+            try await body(transport, server)
+        } catch {
+            try? await transport.close()
+            server.stop()
+            throw error
+        }
+        try await transport.close()
+        server.stop()
+    }
+}

--- a/Tests/HerdrMobileTests/SkeletonTests.swift
+++ b/Tests/HerdrMobileTests/SkeletonTests.swift
@@ -1,0 +1,10 @@
+import Testing
+@testable import HerdrMobile
+
+// Initially-empty test target: it exists so the headless test run has something
+// to execute and hosts the Transport seam tests from #3 onward.
+@Suite struct SkeletonTests {
+    @Test func appModuleIsImportable() {
+        _ = HerdrMobileApp.self
+    }
+}

--- a/Tests/HerdrMobileTests/Support/FakeHerdrServer.swift
+++ b/Tests/HerdrMobileTests/Support/FakeHerdrServer.swift
@@ -13,8 +13,10 @@ final class FakeHerdrServer: Sendable {
 
     /// Returns the NDJSON lines to write back, without trailing newlines.
     /// One line for a plain response; several lines model the
-    /// ack-then-event-lines shape of subscription replies.
-    typealias Script = @Sendable (ReceivedRequest) -> [String]
+    /// ack-then-event-lines shape of subscription replies. `nil` models a
+    /// hung herdr: the connection is held open without a response until the
+    /// peer goes away.
+    typealias Script = @Sendable (ReceivedRequest) -> [String]?
 
     enum ServerError: Error {
         case socketSetupFailed(step: String, errno: Int32)
@@ -34,6 +36,7 @@ final class FakeHerdrServer: Sendable {
     private struct State {
         var requests: [ReceivedRequest] = []
         var connections = 0
+        var closedConnections = 0
         var stopped = false
     }
 
@@ -41,6 +44,23 @@ final class FakeHerdrServer: Sendable {
     /// Number of accepted connections; herdr serves one request per
     /// connection, so this equals the number of exec+socat channels opened.
     var connectionCount: Int { state.mutex.withLock { $0.connections } }
+    /// Number of connections that have ended. A held-open (`nil`-scripted)
+    /// connection only ends when its socat dies, so this observes the
+    /// transport closing an exec channel from the server side.
+    var closedConnectionCount: Int { state.mutex.withLock { $0.closedConnections } }
+
+    /// Polls until `condition` holds; false if `timeout` elapses first.
+    func wait(
+        for condition: @Sendable (FakeHerdrServer) -> Bool,
+        timeout: Duration = .seconds(5)
+    ) async -> Bool {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if condition(self) { return true }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        return condition(self)
+    }
 
     /// `socketPath` defaults to a fresh path under /tmp: sun_path caps at 104
     /// bytes and the simulator's NSTemporaryDirectory is far longer than
@@ -75,7 +95,11 @@ final class FakeHerdrServer: Sendable {
                     close(connection)
                     break
                 }
-                Self.handle(connection: connection, script: script, state: state)
+                // One thread per connection: a held-open (`nil`-scripted)
+                // connection must not block the accept loop.
+                Thread {
+                    Self.handle(connection: connection, script: script, state: state)
+                }.start()
             }
         }
         thread.name = "FakeHerdrServer(\(socketPath))"
@@ -105,7 +129,10 @@ final class FakeHerdrServer: Sendable {
     }
 
     private static func handle(connection: Int32, script: Script, state: StateBox) {
-        defer { close(connection) }
+        defer {
+            close(connection)
+            state.mutex.withLock { $0.closedConnections += 1 }
+        }
         state.mutex.withLock { $0.connections += 1 }
 
         var received = Data()
@@ -127,7 +154,13 @@ final class FakeHerdrServer: Sendable {
         let request = ReceivedRequest(id: id, method: method)
         state.mutex.withLock { $0.requests.append(request) }
 
-        for line in script(request) {
+        guard let lines = script(request) else {
+            // Hung herdr: hold the connection open until the peer's socat
+            // dies, which is how an explicit exec channel close reaches us.
+            while read(connection, &buffer, buffer.count) > 0 {}
+            return
+        }
+        for line in lines {
             writeAll(connection, bytes: Array((line + "\n").utf8))
         }
     }

--- a/Tests/HerdrMobileTests/Support/FakeHerdrServer.swift
+++ b/Tests/HerdrMobileTests/Support/FakeHerdrServer.swift
@@ -58,7 +58,10 @@ final class FakeHerdrServer: Sendable {
             close(fd)
             throw ServerError.socketSetupFailed(step: "bind", errno: errno)
         }
-        guard listen(fd, 8) == 0 else {
+        // Backlog sized for the transport's concurrent-channel bound plus
+        // slack; the accept loop drains fast, but a burst must never bounce
+        // off the queue and masquerade as "connection refused".
+        guard listen(fd, 32) == 0 else {
             close(fd)
             throw ServerError.socketSetupFailed(step: "listen", errno: errno)
         }

--- a/Tests/HerdrMobileTests/Support/FakeHerdrServer.swift
+++ b/Tests/HerdrMobileTests/Support/FakeHerdrServer.swift
@@ -42,17 +42,18 @@ final class FakeHerdrServer: Sendable {
     /// connection, so this equals the number of exec+socat channels opened.
     var connectionCount: Int { state.mutex.withLock { $0.connections } }
 
-    init(script: @escaping Script) throws {
-        // Short path: sun_path caps at 104 bytes and the simulator's
-        // NSTemporaryDirectory is far longer than that.
-        self.socketPath = "/tmp/herdr-fake-\(UUID().uuidString.prefix(8)).sock"
+    /// `socketPath` defaults to a fresh path under /tmp: sun_path caps at 104
+    /// bytes and the simulator's NSTemporaryDirectory is far longer than
+    /// that. Pass an explicit path to model a real herdr socket layout.
+    init(socketPath: String? = nil, script: @escaping Script) throws {
+        self.socketPath = socketPath ?? "/tmp/herdr-fake-\(UUID().uuidString.prefix(8)).sock"
         self.script = script
 
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { throw ServerError.socketSetupFailed(step: "socket", errno: errno) }
-        unlink(socketPath)
+        unlink(self.socketPath)
 
-        let bindResult = UnixSockets.withSockaddr(path: socketPath) { bind(fd, $0, $1) }
+        let bindResult = UnixSockets.withSockaddr(path: self.socketPath) { bind(fd, $0, $1) }
         guard bindResult == 0 else {
             close(fd)
             throw ServerError.socketSetupFailed(step: "bind", errno: errno)

--- a/Tests/HerdrMobileTests/Support/FakeHerdrServer.swift
+++ b/Tests/HerdrMobileTests/Support/FakeHerdrServer.swift
@@ -9,14 +9,34 @@ final class FakeHerdrServer: Sendable {
     struct ReceivedRequest: Sendable, Equatable {
         let id: String
         let method: String
+        /// The request's params object re-serialized with sorted keys, so
+        /// tests can assert exact wire shapes; "" when params are absent.
+        let params: String
     }
 
-    /// Returns the NDJSON lines to write back, without trailing newlines.
-    /// One line for a plain response; several lines model the
-    /// ack-then-event-lines shape of subscription replies. `nil` models a
-    /// hung herdr: the connection is held open without a response until the
-    /// peer goes away.
-    typealias Script = @Sendable (ReceivedRequest) -> [String]?
+    /// How one connection answers its request. `nil` models a hung herdr:
+    /// the connection is held open without a response until the peer goes
+    /// away.
+    enum Response: Sendable, ExpressibleByArrayLiteral {
+        /// Write these NDJSON lines (no trailing newlines) and close — the
+        /// one-request-per-connection RPC shape. Array literals convert.
+        case lines([String])
+        /// Subscription shape: run the steps, then hold the connection open
+        /// until the peer closes it — `events.subscribe` never closes
+        /// server-side.
+        case streamThenHold([Step])
+
+        enum Step: Sendable {
+            case write(String)
+            case pause(Duration)
+        }
+
+        init(arrayLiteral elements: String...) {
+            self = .lines(elements)
+        }
+    }
+
+    typealias Script = @Sendable (ReceivedRequest) -> Response?
 
     enum ServerError: Error {
         case socketSetupFailed(step: String, errno: Int32)
@@ -102,7 +122,7 @@ final class FakeHerdrServer: Sendable {
                 }.start()
             }
         }
-        thread.name = "FakeHerdrServer(\(socketPath))"
+        thread.name = "FakeHerdrServer(\(self.socketPath))"
         thread.start()
     }
 
@@ -151,17 +171,37 @@ final class FakeHerdrServer: Sendable {
             let method = fields["method"] as? String
         else { return }
 
-        let request = ReceivedRequest(id: id, method: method)
+        let params: String
+        if let object = fields["params"],
+            let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        {
+            params = String(decoding: data, as: UTF8.self)
+        } else {
+            params = ""
+        }
+
+        let request = ReceivedRequest(id: id, method: method, params: params)
         state.mutex.withLock { $0.requests.append(request) }
 
-        guard let lines = script(request) else {
+        switch script(request) {
+        case nil:
             // Hung herdr: hold the connection open until the peer's socat
             // dies, which is how an explicit exec channel close reaches us.
             while read(connection, &buffer, buffer.count) > 0 {}
-            return
-        }
-        for line in lines {
-            writeAll(connection, bytes: Array((line + "\n").utf8))
+        case .lines(let lines):
+            for line in lines {
+                writeAll(connection, bytes: Array((line + "\n").utf8))
+            }
+        case .streamThenHold(let steps):
+            for step in steps {
+                switch step {
+                case .write(let line):
+                    writeAll(connection, bytes: Array((line + "\n").utf8))
+                case .pause(let duration):
+                    Thread.sleep(forTimeInterval: duration.timeInterval)
+                }
+            }
+            while read(connection, &buffer, buffer.count) > 0 {}
         }
     }
 
@@ -174,5 +214,12 @@ final class FakeHerdrServer: Sendable {
             guard written > 0 else { return }
             offset += written
         }
+    }
+}
+
+extension Duration {
+    /// Seconds as a TimeInterval, for Thread.sleep in the blocking handler.
+    fileprivate var timeInterval: TimeInterval {
+        TimeInterval(components.seconds) + TimeInterval(components.attoseconds) / 1e18
     }
 }

--- a/Tests/HerdrMobileTests/Support/FakeHerdrServer.swift
+++ b/Tests/HerdrMobileTests/Support/FakeHerdrServer.swift
@@ -52,19 +52,7 @@ final class FakeHerdrServer: Sendable {
         guard fd >= 0 else { throw ServerError.socketSetupFailed(step: "socket", errno: errno) }
         unlink(socketPath)
 
-        var address = sockaddr_un()
-        address.sun_family = sa_family_t(AF_UNIX)
-        let pathBytes = socketPath.utf8CString
-        precondition(pathBytes.count <= MemoryLayout.size(ofValue: address.sun_path))
-        withUnsafeMutableBytes(of: &address.sun_path) { destination in
-            pathBytes.withUnsafeBytes { destination.copyMemory(from: $0) }
-        }
-
-        let bindResult = withUnsafePointer(to: &address) {
-            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
-            }
-        }
+        let bindResult = UnixSockets.withSockaddr(path: socketPath) { bind(fd, $0, $1) }
         guard bindResult == 0 else {
             close(fd)
             throw ServerError.socketSetupFailed(step: "bind", errno: errno)
@@ -101,17 +89,7 @@ final class FakeHerdrServer: Sendable {
 
         let wakeFD = socket(AF_UNIX, SOCK_STREAM, 0)
         if wakeFD >= 0 {
-            var address = sockaddr_un()
-            address.sun_family = sa_family_t(AF_UNIX)
-            let pathBytes = socketPath.utf8CString
-            withUnsafeMutableBytes(of: &address.sun_path) { destination in
-                pathBytes.withUnsafeBytes { destination.copyMemory(from: $0) }
-            }
-            _ = withUnsafePointer(to: &address) {
-                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                    connect(wakeFD, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
-                }
-            }
+            _ = UnixSockets.withSockaddr(path: socketPath) { connect(wakeFD, $0, $1) }
             close(wakeFD)
         }
         close(listenerFD)

--- a/Tests/HerdrMobileTests/Support/FakeHerdrServer.swift
+++ b/Tests/HerdrMobileTests/Support/FakeHerdrServer.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Synchronization
+
+/// In-test fake herdr server: a Unix-socket listener speaking herdr's wire
+/// format — read one request line, write the scripted reply lines, close.
+/// Real sshd and real socat sit in front of it in e2e tests; the only faked
+/// piece is herdr itself.
+final class FakeHerdrServer: Sendable {
+    struct ReceivedRequest: Sendable, Equatable {
+        let id: String
+        let method: String
+    }
+
+    /// Returns the NDJSON lines to write back, without trailing newlines.
+    /// One line for a plain response; several lines model the
+    /// ack-then-event-lines shape of subscription replies.
+    typealias Script = @Sendable (ReceivedRequest) -> [String]
+
+    enum ServerError: Error {
+        case socketSetupFailed(step: String, errno: Int32)
+    }
+
+    let socketPath: String
+    private let listenerFD: Int32
+    private let script: Script
+    private let state = StateBox()
+
+    /// Reference wrapper because Mutex itself is noncopyable and needs to be
+    /// shared with the accept-loop thread.
+    private final class StateBox: Sendable {
+        let mutex = Mutex(State())
+    }
+
+    private struct State {
+        var requests: [ReceivedRequest] = []
+        var connections = 0
+        var stopped = false
+    }
+
+    var receivedRequests: [ReceivedRequest] { state.mutex.withLock { $0.requests } }
+    /// Number of accepted connections; herdr serves one request per
+    /// connection, so this equals the number of exec+socat channels opened.
+    var connectionCount: Int { state.mutex.withLock { $0.connections } }
+
+    init(script: @escaping Script) throws {
+        // Short path: sun_path caps at 104 bytes and the simulator's
+        // NSTemporaryDirectory is far longer than that.
+        self.socketPath = "/tmp/herdr-fake-\(UUID().uuidString.prefix(8)).sock"
+        self.script = script
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw ServerError.socketSetupFailed(step: "socket", errno: errno) }
+        unlink(socketPath)
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = socketPath.utf8CString
+        precondition(pathBytes.count <= MemoryLayout.size(ofValue: address.sun_path))
+        withUnsafeMutableBytes(of: &address.sun_path) { destination in
+            pathBytes.withUnsafeBytes { destination.copyMemory(from: $0) }
+        }
+
+        let bindResult = withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            close(fd)
+            throw ServerError.socketSetupFailed(step: "bind", errno: errno)
+        }
+        guard listen(fd, 8) == 0 else {
+            close(fd)
+            throw ServerError.socketSetupFailed(step: "listen", errno: errno)
+        }
+        self.listenerFD = fd
+
+        let thread = Thread { [listenerFD = fd, script, state] in
+            while true {
+                let connection = accept(listenerFD, nil, nil)
+                guard connection >= 0 else { break }
+                if state.mutex.withLock({ $0.stopped }) {
+                    close(connection)
+                    break
+                }
+                Self.handle(connection: connection, script: script, state: state)
+            }
+        }
+        thread.name = "FakeHerdrServer(\(socketPath))"
+        thread.start()
+    }
+
+    /// Idempotent. Wakes the accept loop with a dummy connection: on macOS,
+    /// closing a listening socket does not reliably unblock accept(2).
+    func stop() {
+        let alreadyStopped = state.mutex.withLock { state in
+            defer { state.stopped = true }
+            return state.stopped
+        }
+        guard !alreadyStopped else { return }
+
+        let wakeFD = socket(AF_UNIX, SOCK_STREAM, 0)
+        if wakeFD >= 0 {
+            var address = sockaddr_un()
+            address.sun_family = sa_family_t(AF_UNIX)
+            let pathBytes = socketPath.utf8CString
+            withUnsafeMutableBytes(of: &address.sun_path) { destination in
+                pathBytes.withUnsafeBytes { destination.copyMemory(from: $0) }
+            }
+            _ = withUnsafePointer(to: &address) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    connect(wakeFD, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+                }
+            }
+            close(wakeFD)
+        }
+        close(listenerFD)
+        unlink(socketPath)
+    }
+
+    deinit {
+        stop()
+    }
+
+    private static func handle(connection: Int32, script: Script, state: StateBox) {
+        defer { close(connection) }
+        state.mutex.withLock { $0.connections += 1 }
+
+        var received = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while !received.contains(0x0A) {
+            let count = read(connection, &buffer, buffer.count)
+            guard count > 0 else { return }
+            received.append(contentsOf: buffer[0..<count])
+        }
+
+        guard
+            let newline = received.firstIndex(of: 0x0A),
+            let object = try? JSONSerialization.jsonObject(with: received.prefix(upTo: newline)),
+            let fields = object as? [String: Any],
+            let id = fields["id"] as? String,
+            let method = fields["method"] as? String
+        else { return }
+
+        let request = ReceivedRequest(id: id, method: method)
+        state.mutex.withLock { $0.requests.append(request) }
+
+        for line in script(request) {
+            writeAll(connection, bytes: Array((line + "\n").utf8))
+        }
+    }
+
+    private static func writeAll(_ fd: Int32, bytes: [UInt8]) {
+        var offset = 0
+        while offset < bytes.count {
+            let written = bytes[offset...].withUnsafeBytes { raw in
+                write(fd, raw.baseAddress, raw.count)
+            }
+            guard written > 0 else { return }
+            offset += written
+        }
+    }
+}

--- a/Tests/HerdrMobileTests/Support/InMemorySecretStore.swift
+++ b/Tests/HerdrMobileTests/Support/InMemorySecretStore.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Synchronization
+
+@testable import HerdrMobile
+
+/// SecretStore stand-in for tests that must not touch the real Keychain.
+final class InMemorySecretStore: SecretStore {
+    private let secrets = Mutex<[String: Data]>([:])
+
+    func read(account: String) throws -> Data? {
+        secrets.withLock { $0[account] }
+    }
+
+    func write(_ secret: Data, account: String) throws {
+        secrets.withLock { $0[account] = secret }
+    }
+
+    func removeSecret(account: String) throws {
+        secrets.withLock { $0[account] = nil }
+    }
+}

--- a/Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift
+++ b/Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift
@@ -1,6 +1,8 @@
 import CryptoKit
 import Foundation
 
+@testable import HerdrMobile
+
 /// Probes for the local e2e prerequisites: an sshd on localhost, a socat
 /// binary, and an Ed25519 key seed whose public half is authorized for the
 /// current user. Tests that need real SSH are skipped when any piece is
@@ -64,6 +66,32 @@ struct LocalSSHTestEnvironment: Sendable {
         let components = URL(fileURLWithPath: NSHomeDirectory()).pathComponents
         guard components.count >= 3, components[1] == "Users" else { return nil }
         return components[2]
+    }
+
+    /// Transport settings for the harness Host with test defaults: seeded-key
+    /// credentials and an auto-accepting TOFU policy over a fresh in-memory
+    /// store. Host key behavior itself is under test only in
+    /// `SSHHostKeyE2ETests`, which passes its own policy.
+    func makeSettings(
+        socket: HerdrSocketLocation,
+        socatPath: String? = nil,
+        wakeCommand: String? = nil,
+        requestTimeout: Duration? = nil,
+        credentials: SSHCredentials? = nil,
+        hostKeyPolicy: HostKeyPolicy? = nil
+    ) -> SSHTransportSettings {
+        var settings = SSHTransportSettings(
+            host: host,
+            port: port,
+            username: username,
+            credentials: credentials ?? .ed25519(privateKey),
+            hostKeyPolicy: hostKeyPolicy
+                ?? HostKeyPolicy(knownHosts: InMemoryKnownHostsStore()) { _ in true },
+            socket: socket,
+            socatPath: socatPath ?? self.socatPath)
+        if let wakeCommand { settings.wakeCommand = wakeCommand }
+        if let requestTimeout { settings.requestTimeout = requestTimeout }
+        return settings
     }
 
     private static func sshdIsListening(onPort port: Int) -> Bool {

--- a/Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift
+++ b/Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift
@@ -1,0 +1,86 @@
+import CryptoKit
+import Foundation
+
+/// Probes for the local e2e prerequisites: an sshd on localhost, a socat
+/// binary, and an Ed25519 key seed whose public half is authorized for the
+/// current user. Tests that need real SSH are skipped when any piece is
+/// missing, so the pure parts of the suite still run anywhere.
+///
+/// Defaults match the transport-spike setup (`.local/transport-spike`);
+/// everything is overridable via environment variables:
+///   HERDR_TEST_SSH_SEED  path to a 32-byte Ed25519 raw seed file
+///   HERDR_TEST_SSH_USER  ssh username (default: the host user, derived from
+///                        the simulator container path)
+///   HERDR_TEST_SSH_PORT  sshd port (default 22)
+///   HERDR_TEST_SOCAT     absolute socat path (default /opt/homebrew/bin/socat)
+struct LocalSSHTestEnvironment: Sendable {
+    let host = "127.0.0.1"
+    let port: Int
+    let username: String
+    let privateKey: Curve25519.Signing.PrivateKey
+    let socatPath: String
+
+    static var isAvailable: Bool { current != nil }
+
+    static let current: LocalSSHTestEnvironment? = probe()
+
+    private static func probe() -> LocalSSHTestEnvironment? {
+        let environment = ProcessInfo.processInfo.environment
+
+        // Tests run in the simulator but share the host filesystem, so the
+        // repo path derived from #filePath is directly readable.
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Support
+            .deletingLastPathComponent()  // HerdrMobileTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+        let seedPath =
+            environment["HERDR_TEST_SSH_SEED"]
+            ?? repoRoot.appendingPathComponent(".local/transport-spike/.spike_seed").path
+
+        guard
+            let seed = try? Data(contentsOf: URL(fileURLWithPath: seedPath)),
+            let key = try? Curve25519.Signing.PrivateKey(rawRepresentation: seed)
+        else { return nil }
+
+        guard let username = environment["HERDR_TEST_SSH_USER"] ?? hostUsername() else {
+            return nil
+        }
+
+        let socatPath = environment["HERDR_TEST_SOCAT"] ?? "/opt/homebrew/bin/socat"
+        guard FileManager.default.isExecutableFile(atPath: socatPath) else { return nil }
+
+        let port = environment["HERDR_TEST_SSH_PORT"].flatMap(Int.init) ?? 22
+        guard sshdIsListening(onPort: port) else { return nil }
+
+        return LocalSSHTestEnvironment(
+            port: port, username: username, privateKey: key, socatPath: socatPath)
+    }
+
+    /// The simulator has no usable user database (NSUserName and getpwuid are
+    /// both empty), but its HOME sits inside the host user's home directory:
+    /// /Users/<name>/Library/Developer/CoreSimulator/... — parse the name out.
+    private static func hostUsername() -> String? {
+        let components = URL(fileURLWithPath: NSHomeDirectory()).pathComponents
+        guard components.count >= 3, components[1] == "Users" else { return nil }
+        return components[2]
+    }
+
+    private static func sshdIsListening(onPort port: Int) -> Bool {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(UInt16(port).bigEndian)
+        address.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+        let result = withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        return result == 0
+    }
+}

--- a/Tests/HerdrMobileTests/Support/UnixSockets.swift
+++ b/Tests/HerdrMobileTests/Support/UnixSockets.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Unix-domain socket plumbing shared by the e2e support fixtures.
+enum UnixSockets {
+    enum SetupError: Error {
+        case failed(step: String, errno: Int32)
+    }
+
+    /// Runs `body` with a `sockaddr` pointer for a Unix socket at `path`.
+    /// Traps if the path exceeds the 104-byte `sun_path` limit — test
+    /// sockets live under short paths for a reason.
+    static func withSockaddr<R>(
+        path: String, _ body: (UnsafePointer<sockaddr>, socklen_t) -> R
+    ) -> R {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = path.utf8CString
+        precondition(pathBytes.count <= MemoryLayout.size(ofValue: address.sun_path))
+        withUnsafeMutableBytes(of: &address.sun_path) { destination in
+            pathBytes.withUnsafeBytes { destination.copyMemory(from: $0) }
+        }
+        return withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                body($0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+    }
+}
+
+/// A Unix socket file with no listener behind it — exactly the artifact a
+/// stopped herdr server leaves on disk. Connecting to it yields ECONNREFUSED.
+struct StaleUnixSocket {
+    let path: String
+
+    init() throws {
+        path = "/tmp/herdr-stale-\(UUID().uuidString.prefix(8)).sock"
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw UnixSockets.SetupError.failed(step: "socket", errno: errno) }
+        // Bind creates the file; closing without listening or unlinking
+        // leaves it stale.
+        let bindResult = UnixSockets.withSockaddr(path: path) { bind(fd, $0, $1) }
+        close(fd)
+        guard bindResult == 0 else {
+            throw UnixSockets.SetupError.failed(step: "bind", errno: errno)
+        }
+    }
+
+    func remove() {
+        unlink(path)
+    }
+}

--- a/Tests/HerdrMobileTests/TransportConcurrencyE2ETests.swift
+++ b/Tests/HerdrMobileTests/TransportConcurrencyE2ETests.swift
@@ -10,7 +10,8 @@ import Testing
     "Transport concurrency e2e",
     .enabled(
         if: LocalSSHTestEnvironment.isAvailable,
-        "requires localhost sshd, socat, and an authorized Ed25519 test key"))
+        "requires localhost sshd, socat, and an authorized Ed25519 test key"),
+    .timeLimit(.minutes(1)))
 struct TransportConcurrencyE2ETests {
     @Test func burstOf30ConcurrentRequestsCompletesWithoutChannelFailures() async throws {
         // 30 concurrent RPCs on one SSH connection would need 30 exec
@@ -35,10 +36,70 @@ struct TransportConcurrencyE2ETests {
         }
     }
 
+    @Test func unresponsiveServerMapsToTimedOutAndClosesTheChannel() async throws {
+        // The fake herdr accepts the connection and reads the request but
+        // never answers — a hung host. The request must fail with .timedOut
+        // at the configured deadline, and the transport must end the read by
+        // closing the exec channel: the server observes that close as its
+        // socat peer dying.
+        try await withTransport(requestTimeout: .seconds(2)) { _ in
+            nil
+        } body: { transport, server in
+            await #expect(throws: TransportError.timedOut) {
+                try await transport.ping()
+            }
+            #expect(await server.wait(for: { $0.closedConnectionCount == 1 }))
+        }
+    }
+
+    @Test func requestsAfterATimeoutStillSucceed() async throws {
+        // A timed-out request must not wedge the queue: afterwards, a full
+        // queue-width burst still completes.
+        try await withTransport(requestTimeout: .seconds(2)) { request in
+            switch request.method {
+            case "ping": nil
+            default: [#"{"id":"\#(request.id)","result":{"type":"agent_list","agents":[]}}"#]
+            }
+        } body: { transport, server in
+            await #expect(throws: TransportError.timedOut) {
+                try await transport.ping()
+            }
+            try await withThrowingTaskGroup(of: [Agent].self) { group in
+                for _ in 0..<8 {
+                    group.addTask { try await transport.listAgents() }
+                }
+                for try await agents in group {
+                    #expect(agents.isEmpty)
+                }
+            }
+            #expect(server.receivedRequests.filter { $0.method == "agent.list" }.count == 8)
+        }
+    }
+
+    @Test func cancelledRequestMapsToCancelledAndClosesTheChannel() async throws {
+        // A live exec channel ignores Swift task cancellation, so the
+        // transport must end the read by closing the channel explicitly and
+        // surface `.cancelled` — never hang, never misread the truncated
+        // output as a protocol error.
+        try await withTransport { _ in
+            nil
+        } body: { transport, server in
+            let request = Task { try await transport.ping() }
+            // Cancel only once the request is in flight on the wire.
+            #expect(await server.wait(for: { $0.receivedRequests.count == 1 }))
+            request.cancel()
+            await #expect(throws: TransportError.cancelled) {
+                try await request.value
+            }
+            #expect(await server.wait(for: { $0.closedConnectionCount == 1 }))
+        }
+    }
+
     /// Boots a fake herdr server plus a real SSH connection to localhost and
     /// tears both down afterwards. The wake command is stubbed to a no-op so
     /// no test path can ever poke the machine's real herdr server.
     private func withTransport(
+        requestTimeout: Duration = .seconds(15),
         script: @escaping FakeHerdrServer.Script,
         body: (SSHTransport, FakeHerdrServer) async throws -> Void
     ) async throws {
@@ -54,7 +115,8 @@ struct TransportConcurrencyE2ETests {
                     privateKey: environment.privateKey,
                     socket: .absolutePath(server.socketPath),
                     socatPath: environment.socatPath,
-                    wakeCommand: "false"))
+                    wakeCommand: "false",
+                    requestTimeout: requestTimeout))
         } catch {
             server.stop()
             throw error

--- a/Tests/HerdrMobileTests/TransportConcurrencyE2ETests.swift
+++ b/Tests/HerdrMobileTests/TransportConcurrencyE2ETests.swift
@@ -108,13 +108,8 @@ struct TransportConcurrencyE2ETests {
         let transport: SSHTransport
         do {
             transport = try await SSHTransport.connect(
-                settings: SSHTransportSettings(
-                    host: environment.host,
-                    port: environment.port,
-                    username: environment.username,
-                    privateKey: environment.privateKey,
+                settings: environment.makeSettings(
                     socket: .absolutePath(server.socketPath),
-                    socatPath: environment.socatPath,
                     wakeCommand: "false",
                     requestTimeout: requestTimeout))
         } catch {

--- a/Tests/HerdrMobileTests/TransportConcurrencyE2ETests.swift
+++ b/Tests/HerdrMobileTests/TransportConcurrencyE2ETests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+// Request queue, per-request timeout, and cancellation (#5), observed only
+// through the public Transport surface against the real stack: localhost
+// sshd (default MaxSessions 10), real socat, in-test fake herdr server.
+@Suite(
+    "Transport concurrency e2e",
+    .enabled(
+        if: LocalSSHTestEnvironment.isAvailable,
+        "requires localhost sshd, socat, and an authorized Ed25519 test key"))
+struct TransportConcurrencyE2ETests {
+    @Test func burstOf30ConcurrentRequestsCompletesWithoutChannelFailures() async throws {
+        // 30 concurrent RPCs on one SSH connection would need 30 exec
+        // channels at once; sshd's default MaxSessions is 10. The bounding
+        // queue must keep concurrent channels under that cap so every
+        // request completes without a channel-open failure.
+        try await withTransport { request in
+            [#"{"id":"\#(request.id)","result":{"type":"agent_list","agents":[]}}"#]
+        } body: { transport, server in
+            try await withThrowingTaskGroup(of: [Agent].self) { group in
+                for _ in 0..<30 {
+                    group.addTask { try await transport.listAgents() }
+                }
+                var completed = 0
+                for try await agents in group {
+                    #expect(agents.isEmpty)
+                    completed += 1
+                }
+                #expect(completed == 30)
+            }
+            #expect(server.connectionCount == 30)
+        }
+    }
+
+    /// Boots a fake herdr server plus a real SSH connection to localhost and
+    /// tears both down afterwards. The wake command is stubbed to a no-op so
+    /// no test path can ever poke the machine's real herdr server.
+    private func withTransport(
+        script: @escaping FakeHerdrServer.Script,
+        body: (SSHTransport, FakeHerdrServer) async throws -> Void
+    ) async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let server = try FakeHerdrServer(script: script)
+        let transport: SSHTransport
+        do {
+            transport = try await SSHTransport.connect(
+                settings: SSHTransportSettings(
+                    host: environment.host,
+                    port: environment.port,
+                    username: environment.username,
+                    privateKey: environment.privateKey,
+                    socket: .absolutePath(server.socketPath),
+                    socatPath: environment.socatPath,
+                    wakeCommand: "false"))
+        } catch {
+            server.stop()
+            throw error
+        }
+        do {
+            try await body(transport, server)
+        } catch {
+            try? await transport.close()
+            server.stop()
+            throw error
+        }
+        try await transport.close()
+        server.stop()
+    }
+}

--- a/Tests/HerdrMobileTests/TransportFailureModesE2ETests.swift
+++ b/Tests/HerdrMobileTests/TransportFailureModesE2ETests.swift
@@ -60,13 +60,8 @@ struct TransportFailureModesE2ETests {
     ) async throws {
         let environment = try #require(LocalSSHTestEnvironment.current)
         let transport = try await SSHTransport.connect(
-            settings: SSHTransportSettings(
-                host: environment.host,
-                port: environment.port,
-                username: environment.username,
-                privateKey: environment.privateKey,
-                socket: .absolutePath(socketPath),
-                socatPath: socatPath ?? environment.socatPath))
+            settings: environment.makeSettings(
+                socket: .absolutePath(socketPath), socatPath: socatPath))
         do {
             try await body(transport)
         } catch {

--- a/Tests/HerdrMobileTests/TransportFailureModesE2ETests.swift
+++ b/Tests/HerdrMobileTests/TransportFailureModesE2ETests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+// Environmental failure modes reproduced physically over the real stack:
+// real sshd, real login shell, real socat (or its real absence). Each must
+// map to its distinct taxonomy case — the same observable shapes the #3
+// spike verified against herdr 0.7.4.
+@Suite(
+    "Transport failure modes e2e",
+    .enabled(
+        if: LocalSSHTestEnvironment.isAvailable,
+        "requires localhost sshd, socat, and an authorized Ed25519 test key"))
+struct TransportFailureModesE2ETests {
+    @Test func missingSocketPathMapsToSocketNotFound() async throws {
+        // socat exits with stderr `E connect(...): No such file or directory`.
+        let missingPath = "/tmp/herdr-missing-\(UUID().uuidString.prefix(8)).sock"
+
+        try await withFailingTransport(socketPath: missingPath) { transport in
+            await #expect(throws: TransportError.socketNotFound(path: missingPath)) {
+                try await transport.ping()
+            }
+        }
+    }
+
+    @Test func staleSocketMapsToServerNotRunning() async throws {
+        // socat exits with stderr `E connect(...): Connection refused`.
+        let stale = try StaleUnixSocket()
+        defer { stale.remove() }
+
+        try await withFailingTransport(socketPath: stale.path) { transport in
+            await #expect(throws: TransportError.serverNotRunning(path: stale.path)) {
+                try await transport.ping()
+            }
+        }
+    }
+
+    @Test func absentSocatBinaryMapsToSocatMissing() async throws {
+        // The login shell cannot launch socat; its stderr names the missing
+        // path (fish: "Unknown command", bash/zsh: "No such file or
+        // directory") and the channel fails.
+        let bogusSocat = "/tmp/herdr-no-socat-\(UUID().uuidString.prefix(8))"
+
+        try await withFailingTransport(
+            socketPath: "/tmp/herdr-irrelevant.sock", socatPath: bogusSocat
+        ) { transport in
+            await #expect(throws: TransportError.socatMissing(path: bogusSocat)) {
+                try await transport.ping()
+            }
+        }
+    }
+
+    /// Connects to localhost for real and hands the transport to `body`;
+    /// the failure under test happens on first request, not at connect time.
+    private func withFailingTransport(
+        socketPath: String,
+        socatPath: String? = nil,
+        body: (SSHTransport) async throws -> Void
+    ) async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let transport = try await SSHTransport.connect(
+            settings: SSHTransportSettings(
+                host: environment.host,
+                port: environment.port,
+                username: environment.username,
+                privateKey: environment.privateKey,
+                socketPath: socketPath,
+                socatPath: socatPath ?? environment.socatPath))
+        do {
+            try await body(transport)
+        } catch {
+            try? await transport.close()
+            throw error
+        }
+        try await transport.close()
+    }
+}

--- a/Tests/HerdrMobileTests/TransportFailureModesE2ETests.swift
+++ b/Tests/HerdrMobileTests/TransportFailureModesE2ETests.swift
@@ -65,7 +65,7 @@ struct TransportFailureModesE2ETests {
                 port: environment.port,
                 username: environment.username,
                 privateKey: environment.privateKey,
-                socketPath: socketPath,
+                socket: .absolutePath(socketPath),
                 socatPath: socatPath ?? environment.socatPath))
         do {
             try await body(transport)

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,70 @@
+name: HerdrMobile
+options:
+  bundleIdPrefix: dev.herdr.mobile
+  deploymentTarget:
+    iOS: "18.0"
+  createIntermediateGroups: true
+  minimumXcodeGenVersion: "2.42.0"
+
+settings:
+  base:
+    # Swift 6 language mode implies complete strict concurrency checking.
+    SWIFT_VERSION: "6.0"
+    SWIFT_STRICT_CONCURRENCY: complete
+
+packages:
+  # Pinned exactly: Citadel resolves swift-nio-ssh from the Wellz26 fork,
+  # a supply-chain-sensitive dependency that must never drift silently.
+  Citadel:
+    url: https://github.com/orlandos-nl/Citadel.git
+    exactVersion: "0.12.1"
+  # Added for the future Attach terminal; unused in M0.
+  SwiftTerm:
+    url: https://github.com/migueldeicaza/SwiftTerm.git
+    minVersion: "1.2.0"
+    maxVersion: "2.0.0"
+
+targets:
+  HerdrMobile:
+    type: application
+    platform: iOS
+    sources:
+      - Sources/HerdrMobile
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: YES
+        PRODUCT_BUNDLE_IDENTIFIER: dev.herdr.mobile.HerdrMobile
+        MARKETING_VERSION: "0.1.0"
+        CURRENT_PROJECT_VERSION: "1"
+        # iPhone + iPad.
+        TARGETED_DEVICE_FAMILY: "1,2"
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
+        INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+    dependencies:
+      - package: Citadel
+      - package: SwiftTerm
+
+  HerdrMobileTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - Tests/HerdrMobileTests
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: YES
+        PRODUCT_BUNDLE_IDENTIFIER: dev.herdr.mobile.HerdrMobileTests
+    dependencies:
+      - target: HerdrMobile
+
+schemes:
+  HerdrMobile:
+    build:
+      targets:
+        HerdrMobile: all
+    test:
+      targets:
+        - HerdrMobileTests
+    run:
+      config: Debug


### PR DESCRIPTION
## Summary

Implements milestone M0 (spec #16): the full transport foundation the iOS Console will stand on. Closes the eight M0 tickets — #1, #3, #17, #6, #5, #2, #4, #18 — one commit series per ticket, each independently verified.

- **Scaffold (#1)**: xcodegen-generated SwiftUI app, iOS 18+, Swift 6 strict concurrency; Citadel pinned exactly 0.12.1 (swift-nio-ssh from the Wellz26 fork), SwiftTerm wired but unused; headless build + test target.
- **NDJSON transport (#3)**: `SSHTransport` actor over per-request no-PTY exec+socat channels; protocol 16 check on `ping`; lenient decoding; e2e seam = real localhost sshd + real socat + in-test fake herdr Unix-socket server.
- **Error taxonomy + socket paths (#17)**: closed `TransportError` enum; missing socket / stale socket / absent socat physically reproduced and mapped to distinct cases; remote `$HOME` resolved once and memoized; default + named-session socket paths.
- **Cold start (#6)**: on connection-refused, run `herdr remote-client-bridge` over exec and retry exactly once; bounded, coalesced across concurrent callers; injectable per Host.
- **Request queue (#5)**: actor-based slot queue bounding exec channels at 8 (headroom under sshd MaxSessions 10 for events + future Attach); per-request timeout → `.timedOut`, cancellation → `.cancelled`, both via explicit channel close (never cancel-and-await); 30-concurrent burst passes with zero channel-open failures.
- **SSH core (#2)**: CryptoKit Ed25519 device key, raw bytes Keychain-only (`AfterFirstUnlockThisDeviceOnly`), `authorized_keys` one-liner pinned against a real `ssh-keygen` oracle; TOFU host keys — confirm-on-first-connect, hard-fail on mismatch without prompting or overwriting; password fallback; Citadel types confined to the transport layer.
- **Events channel (#4)**: dedicated long-lived `events.subscribe` channel per Host, exempt from the slot queue; dotted↔snake_case naming canonicalized; global vs per-pane subscriptions; explicit-close never hangs.
- **Reconnect (#18)**: self-healing `EventsSession` — bounded exponential backoff, honest SSH-layer vs channel-layer failure handling (dead SSH → close, redial, ping, resubscribe), suspend/resume APIs for app lifecycle, internally serialized lifecycle transitions; application-level periodic `ping` keepalive (Citadel 0.12.1 exposes no SSH-level option — investigation documented in `KeepalivePolicy`).

## Key empirical finding

**Replay-on-subscribe does not exist** (verified read-only against live herdr 0.7.4): subscribing returns only the `subscription_started` ack. Initial state sync requires an explicit `agent.list` snapshot on every (re)connect; `EventsSession` emits `.connected` as the re-snapshot signal. Spec #16 has been updated accordingly.

## Test plan

- 88 tests in 20 suites, all green: pure unit tests plus e2e over real localhost sshd + real socat with a scriptable fake herdr server (no SSH-layer mocking). sshd-dependent suites skip cleanly where the environment lacks prerequisites.
- Headless `xcodebuild build` passes with zero compiler warnings; `xcodegen generate` produces no drift against the committed project.

## Known follow-ups (non-blocking, recorded in ticket close comments)

- stderr failure classification keys on English `strerror` text; non-English locales degrade safely to `channelFailed` (`LC_ALL=C` would harden).
- Host-key fingerprint not pinned to an independent `ssh-keygen` oracle (device key is).
- `confirmFirstConnect` has no transport-layer timeout (UI responsibility).
- Events stream buffers unbounded (acceptable for foreground M0).

refs #16