### PR TITLE
feat: M1 follow-ups — bounded events buffering and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+# Headless build + test suite for every PR (User Story 12, refs #23).
+#
+# Runs the full XCTest suite on an iOS simulator. Kept deliberately minimal:
+# no signing certificates, no archive, no xcodegen. Simulator builds use free
+# ad-hoc signing ("Sign to Run Locally"), so no certificate or provisioning
+# profile is needed. We must NOT pass CODE_SIGNING_ALLOWED=NO: it strips the
+# app's signature and with it the keychain-access entitlement, which breaks the
+# tests that run against the real simulator keychain (errSecMissingEntitlement).
+#
+# Notes:
+# - The committed HerdrMobile.xcodeproj (project + shared HerdrMobile scheme)
+#   is the source of truth for CI. project.yml/xcodegen is a local convenience
+#   only; CI never regenerates the project.
+# - The sshd-dependent e2e suites gate on LocalSSHTestEnvironment.isAvailable
+#   (Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift): they probe
+#   for a local sshd, a socat binary, and a seeded Ed25519 key, and each test
+#   is annotated `.enabled(if: LocalSSHTestEnvironment.isAvailable)`. On a bare
+#   runner none of that exists, so those tests skip cleanly. We deliberately do
+#   NOT provision sshd here; the pure suite still runs.
+# - Wire-type codegen drift is checked against a committed schema snapshot
+#   (scripts/herdr-schema.json), captured from herdr 0.7.4 via
+#   `herdr api schema --json`. CI has no herdr binary, so `--schema` feeds the
+#   snapshot instead of shelling out. The snapshot also pins the exact schema
+#   version the generated types were built from.
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# One in-flight run per ref; a new push cancels the previous run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codegen-drift:
+    name: Wire-type codegen drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check generated wire types are up to date
+        run: scripts/generate-wire-types.py --check --schema scripts/herdr-schema.json
+
+  build-test:
+    name: Build & test (iOS Simulator)
+    # macos-26 ships Xcode 26.x and the iOS 26 simulator runtimes. Pinned
+    # rather than macos-latest for reproducibility.
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show Xcode and simulator versions
+        run: |
+          xcodebuild -version
+          xcrun simctl list runtimes
+
+      # OS=latest targets whatever iOS runtime the image currently ships, so a
+      # runtime-version bump on the runner image does not break the build. The
+      # app deployment target is iOS 18, which runs on newer simulator OSes.
+      - name: Build and test
+        run: |
+          xcodebuild test \
+            -project HerdrMobile.xcodeproj \
+            -scheme HerdrMobile \
+            -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		1F4B065DFCAF8E6656600F1E /* TOFUHostKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */; };
 		225ECBDC69A7785559BC4D20 /* AttachTerminalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97970F4D535CC80592333995 /* AttachTerminalStore.swift */; };
 		27C44B69FBE155A397F54B77 /* HostStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AECAD39A269D97DAB4ED194 /* HostStore.swift */; };
+		29832666B5E02B0D33453DB1 /* EventsSessionBufferingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641088A470B51F40C898830F /* EventsSessionBufferingTests.swift */; };
 		298FA49167E3CB1402B7B86B /* DeviceKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04EAA030D8329A1716714A8 /* DeviceKeyStore.swift */; };
 		2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */; };
 		2CE9115816E7CE945ABCF7A8 /* AgentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADF336771A3F757F2AD441D /* AgentDetailView.swift */; };
@@ -133,6 +134,7 @@
 		567573855DCC8571BC02096D /* SecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretStore.swift; sourceTree = "<group>"; };
 		597ACEE9D688E433B20108D7 /* TerminalScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalScreenView.swift; sourceTree = "<group>"; };
 		5ADF336771A3F757F2AD441D /* AgentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetailView.swift; sourceTree = "<group>"; };
+		641088A470B51F40C898830F /* EventsSessionBufferingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionBufferingTests.swift; sourceTree = "<group>"; };
 		6434D31A79422C0BAE80993F /* HostStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStoreTests.swift; sourceTree = "<group>"; };
 		646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColdStartE2ETests.swift; sourceTree = "<group>"; };
 		6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHAuthE2ETests.swift; sourceTree = "<group>"; };
@@ -277,6 +279,7 @@
 				079394F4C6AC8FE4D7B0779C /* ConsoleStoreTests.swift */,
 				8323C68B13826B7388800B1F /* DeviceKeyStoreTests.swift */,
 				558159B2AF61C28F6B1391A2 /* DeviceKeyTests.swift */,
+				641088A470B51F40C898830F /* EventsSessionBufferingTests.swift */,
 				9291334E33C85C7588F86281 /* EventsSessionE2ETests.swift */,
 				6CA5E9DDE1AB0F68F6EC56EB /* EventsSessionSubscriptionsTests.swift */,
 				4076B0E816625CD09EB29F2E /* EventsSubscribeE2ETests.swift */,
@@ -538,6 +541,7 @@
 				93851E040C292A16F5ECB10D /* ConsoleStoreTests.swift in Sources */,
 				05A6F31F9CAC1CA1C57D7C71 /* DeviceKeyStoreTests.swift in Sources */,
 				F62A9CD06CFB784550AF4977 /* DeviceKeyTests.swift in Sources */,
+				29832666B5E02B0D33453DB1 /* EventsSessionBufferingTests.swift in Sources */,
 				FE4ADC78CA6113FFFBCEC693 /* EventsSessionE2ETests.swift in Sources */,
 				033E8DCA2F64ABE6CA898758 /* EventsSessionSubscriptionsTests.swift in Sources */,
 				E30244FD0231DD02EC9978D0 /* EventsSubscribeE2ETests.swift in Sources */,

--- a/Sources/HerdrMobile/Console/ConsoleStore.swift
+++ b/Sources/HerdrMobile/Console/ConsoleStore.swift
@@ -9,7 +9,9 @@ import Observation
 /// snapshots, `pane.agent_status_changed` deltas mutate rows in place.
 /// Membership and context changes (agent detected, pane closed, workspace
 /// renamed, ...) re-snapshot the Host instead of patching state
-/// speculatively — one cheap RPC beats replicating herdr's tree logic.
+/// speculatively — one cheap RPC beats replicating herdr's tree logic. The
+/// drop marker a bounded events buffer emits under overflow (#22) rides the
+/// same path: lost deltas cost one re-snapshot, never corrupted state.
 ///
 /// Because `pane.agent_status_changed` subscribes per pane id, each snapshot
 /// also pushes the current pane set into the session via
@@ -296,7 +298,11 @@ final class ConsoleStore {
         .paneAgentDetected, .paneClosed, .paneExited,
         .workspaceRenamed, .workspaceMetadataUpdated, .workspaceClosed,
     ]
-    private static let resyncEventKinds = Set(membershipKinds.map(\.kind))
+    /// The membership kinds plus the local drop marker (#22): a bounded
+    /// event buffer that shed updates means the deltas are incomplete, so
+    /// the marker rides the same re-snapshot path membership changes do.
+    private static let resyncEventKinds =
+        Set(membershipKinds.map(\.kind)).union([HerdrEventKind.eventsDropped])
 
     /// One Host's Console subscription set: the global kinds plus a per-pane
     /// `pane.agent_status_changed` for every known Agent pane — the status

--- a/Sources/HerdrMobile/Transport/EventsSession.swift
+++ b/Sources/HerdrMobile/Transport/EventsSession.swift
@@ -88,8 +88,15 @@ enum EventsSessionUpdate: Sendable, Equatable {
 /// bounces are routine on iOS; callers never need to serialize their own
 /// calls).
 ///
-/// `updates` supports a single consumer and buffers without bound, exactly
-/// like the underlying event stream (fine foregrounded in M0).
+/// `updates` supports a single consumer and buffers at most
+/// `updatesBufferLimit` updates (#22): under overflow the oldest are shed
+/// and an `.event(.eventsDropped)` marker is yielded in their place (see
+/// `HerdrEvent.eventsDropped` for the delivery guarantee), so the consumer
+/// always learns it must resync instead of trusting incomplete deltas.
+/// Statuses can be shed too — they are state, not edges, so the newest one
+/// wins: terminal transitions (`.suspended`, `.ended`) are always the last
+/// thing yielded and therefore survive, and a shed `.connected`'s resync
+/// duty is covered by the marker.
 actor EventsSession {
     private enum Phase {
         case suspended, active, ended
@@ -98,6 +105,10 @@ actor EventsSession {
     /// Status transitions and events, in order. Finishes after `end()`.
     nonisolated let updates: AsyncStream<EventsSessionUpdate>
     private let updatesContinuation: AsyncStream<EventsSessionUpdate>.Continuation
+    /// How many updates the bounded buffer has shed so far. Every shed
+    /// update is covered by a marker (see `yieldUpdate`), so this is
+    /// observability for diagnostics and tests, not a consumer signal.
+    private(set) var droppedUpdateCount = 0
 
     private var subscriptions: [EventSubscription]
     private let connect: @Sendable () async throws -> any Transport
@@ -134,13 +145,19 @@ actor EventsSession {
         subscriptions: [EventSubscription],
         connect: @escaping @Sendable () async throws -> any Transport,
         reconnectPolicy: ReconnectPolicy = .default,
-        keepalive: KeepalivePolicy? = .default
+        keepalive: KeepalivePolicy? = .default,
+        updatesBufferLimit: Int = HerdrEventStream.bufferLimit
     ) {
         self.subscriptions = subscriptions
         self.connect = connect
         self.reconnectPolicy = reconnectPolicy
         self.keepalive = keepalive
-        (updates, updatesContinuation) = AsyncStream.makeStream(of: EventsSessionUpdate.self)
+        // Bounded (#22): dropping is safe because every drop is surfaced
+        // through `yieldUpdate`'s marker; see the actor doc for the policy
+        // and HerdrEventStream.bufferLimit for the sizing rationale.
+        (updates, updatesContinuation) = AsyncStream.makeStream(
+            of: EventsSessionUpdate.self,
+            bufferingPolicy: .bufferingNewest(updatesBufferLimit))
     }
 
     /// Activates the session (initially, or after `suspend()`): establishes
@@ -191,15 +208,28 @@ actor EventsSession {
         guard phase == .active else { return }
         phase = .suspended
         await windDown()
-        updatesContinuation.yield(.status(.suspended))
+        yieldUpdate(.status(.suspended))
     }
 
     private func finish() async {
         guard phase != .ended else { return }
         phase = .ended
         await windDown()
-        updatesContinuation.yield(.status(.ended))
+        yieldUpdate(.status(.ended))
         updatesContinuation.finish()
+    }
+
+    /// The single gate every update leaves through: yields it and, when the
+    /// bounded buffer sheds something to make room, follows up with the drop
+    /// marker. One marker covers every update shed before it; a marker that
+    /// is later shed itself lands right back here and is re-armed (see
+    /// `HerdrEvent.eventsDropped`).
+    private func yieldUpdate(_ update: EventsSessionUpdate) {
+        guard case .dropped = updatesContinuation.yield(update) else { return }
+        droppedUpdateCount += 1
+        if case .dropped = updatesContinuation.yield(.event(.eventsDropped)) {
+            droppedUpdateCount += 1
+        }
     }
 
     /// Chains `transition` behind the previously enqueued one and waits for
@@ -250,13 +280,13 @@ actor EventsSession {
             liveStream = stream
             attempt = 0
             pendingKeepaliveFailure = nil
-            updatesContinuation.yield(.status(.connected))
+            yieldUpdate(.status(.connected))
             startKeepalive(stream: stream)
 
             var streamFailure: TransportError?
             do {
                 for try await event in stream.events {
-                    updatesContinuation.yield(.event(event))
+                    yieldUpdate(.event(event))
                 }
                 // Graceful finish: the channel was ended explicitly, by
                 // suspend()/end() or by a failed keepalive.
@@ -308,8 +338,7 @@ actor EventsSession {
 
     private func emitReconnectingAndBackOff(attempt: Int, failure: TransportError) async {
         let delay = reconnectPolicy.delay(beforeAttempt: attempt)
-        updatesContinuation.yield(
-            .status(.reconnecting(attempt: attempt, delay: delay, failure: failure)))
+        yieldUpdate(.status(.reconnecting(attempt: attempt, delay: delay, failure: failure)))
         let sleep = Task { try await Task.sleep(for: delay) }
         backoffSleep = sleep
         try? await sleep.value

--- a/Sources/HerdrMobile/Transport/HerdrEvents.swift
+++ b/Sources/HerdrMobile/Transport/HerdrEvents.swift
@@ -89,6 +89,14 @@ enum EventSubscription: Sendable, Equatable {
     case pane(PaneEventKind, paneID: String)
 }
 
+extension HerdrEventKind {
+    /// Synthetic, local-only kind (#22): stands in for updates a bounded
+    /// event buffer shed under overflow. Never sent by herdr and not
+    /// subscribable (deliberately absent from `known`). Consumers treat it
+    /// like a membership event — re-snapshot, because deltas may be missing.
+    static let eventsDropped = HerdrEventKind(name: "local.events_dropped")
+}
+
 /// One event from the Host's events channel, in canonical naming.
 struct HerdrEvent: Sendable, Equatable {
     let kind: HerdrEventKind
@@ -97,12 +105,34 @@ struct HerdrEvent: Sendable, Equatable {
     let data: JSONValue
 }
 
+extension HerdrEvent {
+    /// The drop marker (#22), yielded in place of updates a bounded buffer
+    /// shed. Snapshot-then-delta (spec #20) makes dropping events safe
+    /// exactly when the consumer learns it happened — this event is how it
+    /// learns. AsyncStream's `.bufferingNewest` drops silently, so producers
+    /// inspect every yield's result and follow any `.dropped` with this
+    /// marker: bufferingNewest guarantees the marker itself lands, and if a
+    /// later flood sheds the marker too, that shed surfaces as another
+    /// `.dropped` result and re-arms it — a consumer that eventually drains
+    /// always sees a marker newer than everything it lost.
+    static let eventsDropped = HerdrEvent(kind: .eventsDropped, data: .null)
+}
+
 /// A live `events.subscribe` stream over its Host's dedicated exec channel.
 ///
 /// Ending is explicit: call `end()`. A live exec channel does not respond to
 /// Swift task cancellation (ADR 0002), so abandoning the stream without
 /// `end()` leaks the channel until the SSH connection closes.
 final class HerdrEventStream: Sendable {
+    /// Buffer bound for the event delivery path (#22), sized for stall
+    /// absorption, not history: events are single JSON lines (hundreds of
+    /// bytes), and bursts are pane-churn or status-flap scale — tens of
+    /// events — so 256 rides out a multi-second consumer stall at a few
+    /// hundred KB worst case. Anything beyond that means the consumer is
+    /// badly behind, and one snapshot resync (the designed recovery for
+    /// dropped events) beats replaying a stale backlog.
+    static let bufferLimit = 256
+
     /// Events in arrival order. Finishes without error after `end()`,
     /// finishes throwing if the channel dies remotely.
     let events: AsyncThrowingStream<HerdrEvent, any Error>

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -307,8 +307,17 @@ actor SSHTransport: Transport {
         let requestID = UUID().uuidString
         let requestLine = try HerdrWire.subscribeRequestLine(
             id: requestID, subscriptions: subscriptions)
-        let (events, eventContinuation) = AsyncThrowingStream<HerdrEvent, any Error>.makeStream()
-        let (ackLines, ackContinuation) = AsyncThrowingStream<Data, any Error>.makeStream()
+        // Bounded event-path buffering (#22): under overflow the oldest
+        // event is shed and the loss surfaces as a drop marker (see the
+        // yield in runEventsChannel); the events session forwards it and
+        // the Console resyncs from a snapshot. Sizing rationale lives on
+        // HerdrEventStream.bufferLimit.
+        let (events, eventContinuation) = AsyncThrowingStream<HerdrEvent, any Error>.makeStream(
+            bufferingPolicy: .bufferingNewest(HerdrEventStream.bufferLimit))
+        // Carries exactly one ack line and is finished right after it; one
+        // slot is all it can ever hold.
+        let (ackLines, ackContinuation) = AsyncThrowingStream<Data, any Error>.makeStream(
+            bufferingPolicy: .bufferingNewest(1))
         nextEventsReaderID += 1
         let readerID = nextEventsReaderID
         let readerTask = Task {
@@ -374,7 +383,15 @@ actor SSHTransport: Transport {
                                 ackContinuation.yield(lineData)
                                 ackContinuation.finish()
                             } else if let event = HerdrWire.decodeEvent(fromLine: lineData) {
-                                eventContinuation.yield(event)
+                                if case .dropped = eventContinuation.yield(event) {
+                                    // The bounded buffer shed its oldest
+                                    // event; one marker covers everything
+                                    // shed before it, and a marker the
+                                    // flood later sheds lands right back
+                                    // here and is re-armed (see
+                                    // HerdrEvent.eventsDropped).
+                                    _ = eventContinuation.yield(.eventsDropped)
+                                }
                             }
                             // Undecodable lines are dropped: junk on the
                             // stream must never kill it.
@@ -454,7 +471,13 @@ actor SSHTransport: Transport {
         }
         let command = Self.observeChannelCommand(
             observeCommand: observeCommand, request: request)
-        let (frames, continuation) = AsyncThrowingStream<TerminalFrame, any Error>.makeStream()
+        // Bounded like the events path (#22): a shed frame leaves a hole in
+        // the `seq` counter, and the observe consumer already treats any
+        // seq gap as "re-observe for a fresh full repaint" — local drops
+        // recover exactly like wire-level frame loss, no extra signal
+        // needed.
+        let (frames, continuation) = AsyncThrowingStream<TerminalFrame, any Error>.makeStream(
+            bufferingPolicy: .bufferingNewest(HerdrEventStream.bufferLimit))
         nextTerminalReaderID += 1
         let readerID = nextTerminalReaderID
         let readerTask = Task {
@@ -579,7 +602,15 @@ actor SSHTransport: Transport {
         }
         let bootstrapLine = try Self.attachBootstrapLine(
             attachCommand: attachCommand, request: request)
+        // Deliberately unbounded (#22): raw PTY bytes have no framing, no
+        // seq, and no snapshot to resync from, so a shed chunk would corrupt
+        // the escape stream for the rest of the session. Volume is
+        // interactive TUI output bounded by SSH channel flow control, and
+        // the consumer is a synchronous terminal feed.
         let (output, outputContinuation) = AsyncThrowingStream<Data, any Error>.makeStream()
+        // Deliberately unbounded (#22): keystrokes and resizes arrive at
+        // human rate, and silently shedding input would type the wrong
+        // thing; the writer task drains it for the channel's whole life.
         let (input, inputContinuation) = AsyncStream<TerminalAttachInput>.makeStream()
         nextTerminalReaderID += 1
         let readerID = nextTerminalReaderID

--- a/Tests/HerdrMobileTests/ConsoleStoreTests.swift
+++ b/Tests/HerdrMobileTests/ConsoleStoreTests.swift
@@ -200,6 +200,63 @@ struct ConsoleStoreTests {
         store.setHosts([])
     }
 
+    @Test func forcedEventOverflowConvergesViaTheDropMarkerResync() async throws {
+        // The #22 acceptance criterion: force the bounded events buffer to
+        // overflow and prove the Console converges anyway. The server state
+        // changes with no membership event — only ignorable noise — so the
+        // drop marker's resync is the one path to the new snapshot.
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: .fixture(agents: [.fixture(paneID: "w1:p1", status: .idle)]))
+        let box = SessionBox()
+        let store = ConsoleStore { _, subscriptions in
+            let session = EventsSession(
+                subscriptions: subscriptions,
+                connect: { transport },
+                reconnectPolicy: Self.fastPolicy,
+                keepalive: nil,
+                updatesBufferLimit: 2)
+            Task { await box.set(session) }
+            return session
+        }
+
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the initial agent should arrive") { store.agents.count == 1 }
+        // Let the connect→snapshot→resubscribe→re-snapshot cycle settle, so
+        // no in-flight resync can fetch the updated snapshot by accident.
+        try await waitUntil("the pane subscription should be live") {
+            await transport.capturedSubscriptions.last?
+                .contains(.pane(.agentStatusChanged, paneID: "w1:p1")) == true
+        }
+        try await waitUntil("the post-resubscribe resync should settle") {
+            await transport.snapshotFetchCount >= 2
+        }
+        let session = try #require(await box.session)
+
+        await transport.setSnapshot(
+            .fixture(agents: [
+                .fixture(paneID: "w1:p1", status: .idle),
+                .fixture(paneID: "w1:p9", status: .blocked),
+            ]))
+        // Flood with events the Console ignores until the bounded buffer
+        // demonstrably sheds updates.
+        try await waitUntil("the bounded buffer should shed updates") {
+            for _ in 0..<50 {
+                await transport.emit(
+                    HerdrEvent(kind: PaneEventKind.scrollChanged.kind, data: .object([:])))
+            }
+            return await session.droppedUpdateCount > 0
+        }
+
+        try await waitUntil("the marker resync should surface the pane changed during the gap") {
+            store.agents.map(\.agent.paneID) == ["w1:p9", "w1:p1"]
+        }
+        #expect(store.agents.first?.agent.status == .blocked)
+
+        store.setHosts([])
+    }
+
     @Test func membershipEventTriggersAResnapshot() async throws {
         let host = Host.fixture()
         let transport = ScriptedTransport(
@@ -445,5 +502,15 @@ struct ConsoleStoreTests {
         }
 
         store.setHosts([])
+    }
+}
+
+/// Captures the session a store's factory built, so overflow tests can
+/// observe its drop diagnostics.
+private actor SessionBox {
+    private(set) var session: EventsSession?
+
+    func set(_ session: EventsSession) {
+        self.session = session
     }
 }

--- a/Tests/HerdrMobileTests/EventsSessionBufferingTests.swift
+++ b/Tests/HerdrMobileTests/EventsSessionBufferingTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+/// Bounded buffering on the events path (#22): `EventsSession.updates` sheds
+/// the oldest updates under overflow, and every shed update is covered by an
+/// `.event(.eventsDropped)` marker so the consumer knows to resync — the
+/// snapshot-then-delta contract makes dropping safe exactly when the
+/// consumer learns about it.
+@Suite("Events session buffering")
+struct EventsSessionBufferingTests {
+    private func makeSession(transport: ScriptedTransport, bufferLimit: Int) -> EventsSession {
+        EventsSession(
+            subscriptions: [.global(.paneAgentDetected)],
+            connect: { transport },
+            reconnectPolicy: ReconnectPolicy(
+                initialDelay: .milliseconds(10), multiplier: 2, maxDelay: .milliseconds(50)),
+            keepalive: nil,
+            updatesBufferLimit: bufferLimit)
+    }
+
+    /// Polls until `condition` holds, yielding so the session's tasks progress.
+    private func waitUntil(
+        _ comment: Comment, timeout: Duration = .seconds(5),
+        condition: () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if await condition() { break }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await condition(), comment)
+    }
+
+    private func workingEvent(_ index: Int) -> HerdrEvent {
+        .agentStatusChanged(paneID: "w1:p\(index)", status: .working)
+    }
+
+    @Test func overflowShedsTheOldestAndSurfacesTheDropMarker() async throws {
+        let transport = ScriptedTransport()
+        let session = makeSession(transport: transport, bufferLimit: 3)
+        await session.resume()
+        try await waitUntil("the events channel should come up") {
+            await transport.capturedSubscriptions.count == 1
+        }
+
+        // Nobody consumes `updates` yet: 11 yields into a 3-slot buffer must
+        // shed the oldest update — the `.connected` status — and record it.
+        for index in 1...10 {
+            await transport.emit(workingEvent(index))
+        }
+        try await waitUntil("the bounded buffer should shed updates") {
+            await session.droppedUpdateCount > 0
+        }
+
+        let collector = UpdateCollector()
+        let consumeTask = Task {
+            for await update in session.updates {
+                await collector.append(update)
+            }
+        }
+        try await waitUntil("the newest event and the drop marker should be delivered") {
+            let sawMarker = await collector.contains(.event(.eventsDropped))
+            let sawNewest = await collector.contains(.event(workingEvent(10)))
+            return sawMarker && sawNewest
+        }
+        // The shed `.connected` is gone for good; the marker stands in for
+        // it, telling the consumer to resync instead of trusting the deltas.
+        #expect(await !collector.contains(.status(.connected)))
+
+        await session.end()
+        await consumeTask.value
+    }
+
+    @Test func underTheLimitEveryUpdateArrivesInOrderWithNoMarker() async throws {
+        let transport = ScriptedTransport()
+        let session = makeSession(transport: transport, bufferLimit: 8)
+        var updates = session.updates.makeAsyncIterator()
+
+        await session.resume()
+        #expect(await updates.next() == .status(.connected))
+        for index in 1...3 {
+            await transport.emit(workingEvent(index))
+        }
+        for index in 1...3 {
+            #expect(await updates.next() == .event(workingEvent(index)))
+        }
+        #expect(await session.droppedUpdateCount == 0)
+
+        await session.end()
+    }
+
+    @Test func suspendedStatusSurvivesAnOverflowingBuffer() async throws {
+        // Lifecycle statuses are yielded last on their transitions, and
+        // bufferingNewest keeps the newest: an overflow must never eat the
+        // `.suspended` the consumer's state machine depends on.
+        let transport = ScriptedTransport()
+        let session = makeSession(transport: transport, bufferLimit: 2)
+        await session.resume()
+        try await waitUntil("the events channel should come up") {
+            await transport.capturedSubscriptions.count == 1
+        }
+
+        for index in 1...10 {
+            await transport.emit(workingEvent(index))
+        }
+        try await waitUntil("the bounded buffer should shed updates") {
+            await session.droppedUpdateCount > 0
+        }
+        await session.suspend()
+
+        let collector = UpdateCollector()
+        let consumeTask = Task {
+            for await update in session.updates {
+                await collector.append(update)
+            }
+        }
+        try await waitUntil("the suspended status and the drop marker should be delivered") {
+            let sawSuspended = await collector.contains(.status(.suspended))
+            let sawMarker = await collector.contains(.event(.eventsDropped))
+            return sawSuspended && sawMarker
+        }
+
+        await session.end()
+        await consumeTask.value
+    }
+}
+
+/// Collects a session's updates so tests can poll for delivery.
+private actor UpdateCollector {
+    private var updates: [EventsSessionUpdate] = []
+
+    func append(_ update: EventsSessionUpdate) {
+        updates.append(update)
+    }
+
+    func contains(_ update: EventsSessionUpdate) -> Bool {
+        updates.contains(update)
+    }
+}

--- a/scripts/herdr-schema.json
+++ b/scripts/herdr-schema.json
@@ -1,0 +1,9353 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "protocol": 16,
+  "schema_version": 1,
+  "schemas": {
+    "error_response": {
+      "$defs": {
+        "ErrorBody": {
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "error": {
+          "$ref": "#/schemas/error_response/$defs/ErrorBody"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "error"
+      ],
+      "title": "ErrorResponse",
+      "type": "object"
+    },
+    "event": {
+      "$defs": {
+        "AgentSessionInfo": {
+          "properties": {
+            "agent": {
+              "type": "string"
+            },
+            "kind": {
+              "$ref": "#/schemas/event/$defs/AgentSessionRefKind"
+            },
+            "source": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "agent",
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        "AgentSessionRefKind": {
+          "enum": [
+            "id",
+            "path"
+          ],
+          "type": "string"
+        },
+        "AgentStatus": {
+          "enum": [
+            "idle",
+            "working",
+            "blocked",
+            "done",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "EventData": {
+          "oneOf": [
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace_created",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/event/$defs/WorkspaceInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace_updated",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/event/$defs/WorkspaceInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace_metadata_updated",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/event/$defs/WorkspaceInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace_closed",
+                  "type": "string"
+                },
+                "workspace": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/event/$defs/WorkspaceInfo"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "workspace_renamed",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "workspace_id",
+                "label"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "insert_index": {
+                  "format": "uint",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": {
+                  "const": "workspace_moved",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                },
+                "workspaces": {
+                  "items": {
+                    "$ref": "#/schemas/event/$defs/WorkspaceInfo"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "type",
+                "workspace_id",
+                "insert_index",
+                "workspaces"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace_focused",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "worktree_created",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/event/$defs/WorkspaceInfo"
+                },
+                "worktree": {
+                  "$ref": "#/schemas/event/$defs/WorktreeInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace",
+                "worktree"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "already_open": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "const": "worktree_opened",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/event/$defs/WorkspaceInfo"
+                },
+                "worktree": {
+                  "$ref": "#/schemas/event/$defs/WorktreeInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace",
+                "worktree",
+                "already_open"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "forced": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "const": "worktree_removed",
+                  "type": "string"
+                },
+                "workspace": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/event/$defs/WorkspaceInfo"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "workspace_id": {
+                  "type": "string"
+                },
+                "worktree": {
+                  "$ref": "#/schemas/event/$defs/WorktreeInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace_id",
+                "worktree",
+                "forced"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "tab": {
+                  "$ref": "#/schemas/event/$defs/TabInfo"
+                },
+                "type": {
+                  "const": "tab_created",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "tab"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "tab_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "tab_closed",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "tab_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "tab_renamed",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id",
+                "label"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "insert_index": {
+                  "format": "uint",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "tab_id": {
+                  "type": "string"
+                },
+                "tabs": {
+                  "items": {
+                    "$ref": "#/schemas/event/$defs/TabInfo"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "tab_moved",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id",
+                "insert_index",
+                "tabs"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "tab_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "tab_focused",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane": {
+                  "$ref": "#/schemas/event/$defs/PaneInfo"
+                },
+                "type": {
+                  "const": "pane_created",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "pane_closed",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane": {
+                  "$ref": "#/schemas/event/$defs/PaneInfo"
+                },
+                "type": {
+                  "const": "pane_updated",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "pane_focused",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "closed_tab_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "closed_workspace_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "created_tab": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/event/$defs/TabInfo"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "created_workspace": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/event/$defs/WorkspaceInfo"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "pane": {
+                  "$ref": "#/schemas/event/$defs/PaneInfo"
+                },
+                "previous_pane_id": {
+                  "type": "string"
+                },
+                "previous_tab_id": {
+                  "type": "string"
+                },
+                "previous_workspace_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "pane_moved",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "previous_pane_id",
+                "previous_workspace_id",
+                "previous_tab_id",
+                "pane"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane_id": {
+                  "type": "string"
+                },
+                "revision": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": {
+                  "const": "pane_output_changed",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id",
+                "revision"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "pane_exited",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "agent": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "pane_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "pane_agent_detected",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "agent": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "agent_status": {
+                  "$ref": "#/schemas/event/$defs/AgentStatus"
+                },
+                "display_agent": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "pane_id": {
+                  "type": "string"
+                },
+                "state_labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "title": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "const": "pane_agent_status_changed",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id",
+                "agent_status"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "layout": {
+                  "$ref": "#/schemas/event/$defs/PaneLayoutSnapshot"
+                },
+                "type": {
+                  "const": "layout_updated",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "layout"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "EventKind": {
+          "enum": [
+            "workspace_created",
+            "workspace_updated",
+            "workspace_metadata_updated",
+            "workspace_closed",
+            "workspace_renamed",
+            "workspace_moved",
+            "workspace_focused",
+            "worktree_created",
+            "worktree_opened",
+            "worktree_removed",
+            "tab_created",
+            "tab_closed",
+            "tab_renamed",
+            "tab_moved",
+            "tab_focused",
+            "pane_created",
+            "pane_closed",
+            "pane_updated",
+            "pane_focused",
+            "pane_moved",
+            "pane_output_changed",
+            "pane_exited",
+            "pane_agent_detected",
+            "pane_agent_status_changed",
+            "layout_updated"
+          ],
+          "type": "string"
+        },
+        "PaneInfo": {
+          "properties": {
+            "agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "agent_session": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/event/$defs/AgentSessionInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "agent_status": {
+              "$ref": "#/schemas/event/$defs/AgentStatus"
+            },
+            "cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "display_agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focused": {
+              "type": "boolean"
+            },
+            "foreground_cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "revision": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "scroll": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/event/$defs/PaneScrollInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "state_labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "tab_id": {
+              "type": "string"
+            },
+            "terminal_id": {
+              "type": "string"
+            },
+            "terminal_title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "terminal_title_stripped": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tokens": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "maxProperties": 32,
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9_-]{1,32}$"
+              },
+              "type": "object"
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "terminal_id",
+            "workspace_id",
+            "tab_id",
+            "focused",
+            "agent_status",
+            "revision"
+          ],
+          "type": "object"
+        },
+        "PaneLayoutPane": {
+          "properties": {
+            "focused": {
+              "type": "boolean"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "rect": {
+              "$ref": "#/schemas/event/$defs/PaneLayoutRect"
+            }
+          },
+          "required": [
+            "pane_id",
+            "focused",
+            "rect"
+          ],
+          "type": "object"
+        },
+        "PaneLayoutRect": {
+          "properties": {
+            "height": {
+              "format": "uint16",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "width": {
+              "format": "uint16",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "x": {
+              "format": "uint16",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "y": {
+              "format": "uint16",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "width",
+            "height"
+          ],
+          "type": "object"
+        },
+        "PaneLayoutSnapshot": {
+          "properties": {
+            "area": {
+              "$ref": "#/schemas/event/$defs/PaneLayoutRect"
+            },
+            "focused_pane_id": {
+              "type": "string"
+            },
+            "panes": {
+              "items": {
+                "$ref": "#/schemas/event/$defs/PaneLayoutPane"
+              },
+              "type": "array"
+            },
+            "splits": {
+              "items": {
+                "$ref": "#/schemas/event/$defs/PaneLayoutSplit"
+              },
+              "type": "array"
+            },
+            "tab_id": {
+              "type": "string"
+            },
+            "workspace_id": {
+              "type": "string"
+            },
+            "zoomed": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "workspace_id",
+            "tab_id",
+            "zoomed",
+            "area",
+            "focused_pane_id",
+            "panes",
+            "splits"
+          ],
+          "type": "object"
+        },
+        "PaneLayoutSplit": {
+          "properties": {
+            "direction": {
+              "$ref": "#/schemas/event/$defs/SplitDirection"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ratio": {
+              "format": "float",
+              "type": "number"
+            },
+            "rect": {
+              "$ref": "#/schemas/event/$defs/PaneLayoutRect"
+            }
+          },
+          "required": [
+            "id",
+            "direction",
+            "ratio",
+            "rect"
+          ],
+          "type": "object"
+        },
+        "PaneScrollInfo": {
+          "properties": {
+            "max_offset_from_bottom": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "offset_from_bottom": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "viewport_rows": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "offset_from_bottom",
+            "max_offset_from_bottom",
+            "viewport_rows"
+          ],
+          "type": "object"
+        },
+        "SplitDirection": {
+          "enum": [
+            "right",
+            "down"
+          ],
+          "type": "string"
+        },
+        "TabInfo": {
+          "properties": {
+            "agent_status": {
+              "$ref": "#/schemas/event/$defs/AgentStatus"
+            },
+            "focused": {
+              "type": "boolean"
+            },
+            "label": {
+              "type": "string"
+            },
+            "number": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pane_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tab_id": {
+              "type": "string"
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "tab_id",
+            "workspace_id",
+            "number",
+            "label",
+            "focused",
+            "pane_count",
+            "agent_status"
+          ],
+          "type": "object"
+        },
+        "WorkspaceInfo": {
+          "properties": {
+            "active_tab_id": {
+              "type": "string"
+            },
+            "agent_status": {
+              "$ref": "#/schemas/event/$defs/AgentStatus"
+            },
+            "focused": {
+              "type": "boolean"
+            },
+            "label": {
+              "type": "string"
+            },
+            "number": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pane_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tab_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tokens": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "maxProperties": 32,
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9_-]{1,32}$"
+              },
+              "type": "object"
+            },
+            "workspace_id": {
+              "type": "string"
+            },
+            "worktree": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/event/$defs/WorkspaceWorktreeInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "workspace_id",
+            "number",
+            "label",
+            "focused",
+            "pane_count",
+            "tab_count",
+            "active_tab_id",
+            "agent_status"
+          ],
+          "type": "object"
+        },
+        "WorkspaceWorktreeInfo": {
+          "properties": {
+            "checkout_path": {
+              "type": "string"
+            },
+            "is_linked_worktree": {
+              "type": "boolean"
+            },
+            "repo_key": {
+              "type": "string"
+            },
+            "repo_name": {
+              "type": "string"
+            },
+            "repo_root": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "repo_key",
+            "repo_name",
+            "repo_root",
+            "checkout_path",
+            "is_linked_worktree"
+          ],
+          "type": "object"
+        },
+        "WorktreeInfo": {
+          "properties": {
+            "branch": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "is_bare": {
+              "type": "boolean"
+            },
+            "is_detached": {
+              "type": "boolean"
+            },
+            "is_linked_worktree": {
+              "type": "boolean"
+            },
+            "is_prunable": {
+              "type": "boolean"
+            },
+            "label": {
+              "type": "string"
+            },
+            "open_workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "is_bare",
+            "is_detached",
+            "is_prunable",
+            "is_linked_worktree",
+            "label"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "data": {
+          "$ref": "#/schemas/event/$defs/EventData"
+        },
+        "event": {
+          "$ref": "#/schemas/event/$defs/EventKind"
+        }
+      },
+      "required": [
+        "event",
+        "data"
+      ],
+      "title": "EventEnvelope",
+      "type": "object"
+    },
+    "request": {
+      "$defs": {
+        "AgentReadParams": {
+          "properties": {
+            "format": {
+              "$ref": "#/schemas/request/$defs/ReadFormat",
+              "default": "text"
+            },
+            "lines": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "source": {
+              "$ref": "#/schemas/request/$defs/ReadSource"
+            },
+            "strip_ansi": {
+              "default": true,
+              "type": "boolean"
+            },
+            "target": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "target",
+            "source"
+          ],
+          "type": "object"
+        },
+        "AgentRenameParams": {
+          "properties": {
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "target": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "target"
+          ],
+          "type": "object"
+        },
+        "AgentSendParams": {
+          "properties": {
+            "target": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "target",
+            "text"
+          ],
+          "type": "object"
+        },
+        "AgentStartParams": {
+          "properties": {
+            "argv": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "env": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "focus": {
+              "default": false,
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "split": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/SplitDirection"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "tab_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "name",
+            "argv"
+          ],
+          "type": "object"
+        },
+        "AgentStatus": {
+          "enum": [
+            "idle",
+            "working",
+            "blocked",
+            "done",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "AgentTarget": {
+          "properties": {
+            "target": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "target"
+          ],
+          "type": "object"
+        },
+        "ClientWindowTitleSetParams": {
+          "properties": {
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "title"
+          ],
+          "type": "object"
+        },
+        "EmptyParams": {
+          "type": "object"
+        },
+        "EventMatch": {
+          "oneOf": [
+            {
+              "properties": {
+                "event": {
+                  "const": "workspace_created",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "event"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "workspace_updated",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "workspace_closed",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "workspace_renamed",
+                  "type": "string"
+                },
+                "label": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "workspace_moved",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "workspace_focused",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "tab_created",
+                  "type": "string"
+                },
+                "tab_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "workspace_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "event"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "tab_closed",
+                  "type": "string"
+                },
+                "tab_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "tab_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "tab_renamed",
+                  "type": "string"
+                },
+                "label": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "tab_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "tab_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "tab_moved",
+                  "type": "string"
+                },
+                "tab_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "tab_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "tab_focused",
+                  "type": "string"
+                },
+                "tab_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "tab_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "pane_created",
+                  "type": "string"
+                },
+                "pane_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "workspace_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "event"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "pane_closed",
+                  "type": "string"
+                },
+                "pane_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "pane_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "pane_focused",
+                  "type": "string"
+                },
+                "pane_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "pane_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "pane_moved",
+                  "type": "string"
+                },
+                "pane_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "pane_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "pane_output_changed",
+                  "type": "string"
+                },
+                "min_revision": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "pane_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "pane_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "const": "pane_exited",
+                  "type": "string"
+                },
+                "pane_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "pane_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "agent": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "event": {
+                  "const": "pane_agent_detected",
+                  "type": "string"
+                },
+                "pane_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "pane_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "agent_status": {
+                  "$ref": "#/schemas/request/$defs/AgentStatus"
+                },
+                "event": {
+                  "const": "pane_agent_status_changed",
+                  "type": "string"
+                },
+                "pane_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event",
+                "pane_id",
+                "agent_status"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "EventsSubscribeParams": {
+          "properties": {
+            "subscriptions": {
+              "items": {
+                "$ref": "#/schemas/request/$defs/Subscription"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "subscriptions"
+          ],
+          "type": "object"
+        },
+        "EventsWaitParams": {
+          "properties": {
+            "match_event": {
+              "$ref": "#/schemas/request/$defs/EventMatch"
+            },
+            "timeout_ms": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "match_event"
+          ],
+          "type": "object"
+        },
+        "IntegrationInstallParams": {
+          "properties": {
+            "target": {
+              "$ref": "#/schemas/request/$defs/IntegrationTarget"
+            }
+          },
+          "required": [
+            "target"
+          ],
+          "type": "object"
+        },
+        "IntegrationTarget": {
+          "enum": [
+            "pi",
+            "omp",
+            "claude",
+            "codex",
+            "copilot",
+            "devin",
+            "droid",
+            "kimi",
+            "opencode",
+            "kilo",
+            "hermes",
+            "qodercli",
+            "cursor",
+            "mastracode"
+          ],
+          "type": "string"
+        },
+        "IntegrationUninstallParams": {
+          "properties": {
+            "target": {
+              "$ref": "#/schemas/request/$defs/IntegrationTarget"
+            }
+          },
+          "required": [
+            "target"
+          ],
+          "type": "object"
+        },
+        "LayoutApplyParams": {
+          "properties": {
+            "focus": {
+              "default": false,
+              "type": "boolean"
+            },
+            "root": {
+              "$ref": "#/schemas/request/$defs/LayoutNode"
+            },
+            "tab_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tab_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "root"
+          ],
+          "type": "object"
+        },
+        "LayoutExportParams": {
+          "properties": {
+            "pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tab_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "LayoutNode": {
+          "oneOf": [
+            {
+              "properties": {
+                "command": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "cwd": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "env": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "label": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "pane_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "const": "pane",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "direction": {
+                  "$ref": "#/schemas/request/$defs/SplitDirection"
+                },
+                "first": {
+                  "$ref": "#/schemas/request/$defs/LayoutNode"
+                },
+                "ratio": {
+                  "format": "float",
+                  "type": "number"
+                },
+                "second": {
+                  "$ref": "#/schemas/request/$defs/LayoutNode"
+                },
+                "type": {
+                  "const": "split",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "direction",
+                "ratio",
+                "first",
+                "second"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "LayoutSetSplitRatioParams": {
+          "properties": {
+            "pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "path": {
+              "items": {
+                "type": "boolean"
+              },
+              "type": "array"
+            },
+            "ratio": {
+              "format": "float",
+              "type": "number"
+            },
+            "tab_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "path",
+            "ratio"
+          ],
+          "type": "object"
+        },
+        "NotificationShowParams": {
+          "properties": {
+            "body": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "position": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/ToastHerdrPosition"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "sound": {
+              "$ref": "#/schemas/request/$defs/NotificationShowSound"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "title"
+          ],
+          "type": "object"
+        },
+        "NotificationShowSound": {
+          "enum": [
+            "none",
+            "done",
+            "request"
+          ],
+          "type": "string"
+        },
+        "OutputMatch": {
+          "oneOf": [
+            {
+              "properties": {
+                "type": {
+                  "const": "substring",
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "regex",
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "value"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "PaneAgentState": {
+          "enum": [
+            "idle",
+            "working",
+            "blocked",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "PaneClearAgentAuthorityParams": {
+          "properties": {
+            "pane_id": {
+              "type": "string"
+            },
+            "seq": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "pane_id"
+          ],
+          "type": "object"
+        },
+        "PaneCurrentParams": {
+          "properties": {
+            "caller_pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "PaneDirection": {
+          "enum": [
+            "left",
+            "right",
+            "up",
+            "down"
+          ],
+          "type": "string"
+        },
+        "PaneEdgesParams": {
+          "properties": {
+            "pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "PaneFocusDirectionParams": {
+          "properties": {
+            "direction": {
+              "$ref": "#/schemas/request/$defs/PaneDirection"
+            },
+            "pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "direction"
+          ],
+          "type": "object"
+        },
+        "PaneGraphicsClearParams": {
+          "properties": {
+            "pane_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id"
+          ],
+          "type": "object"
+        },
+        "PaneGraphicsFormat": {
+          "enum": [
+            "png",
+            "rgb",
+            "rgba"
+          ],
+          "type": "string"
+        },
+        "PaneGraphicsPlacementParams": {
+          "properties": {
+            "grid_cols": {
+              "default": 0,
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "grid_rows": {
+              "default": 0,
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "viewport_col": {
+              "default": 0,
+              "format": "int32",
+              "type": "integer"
+            },
+            "viewport_row": {
+              "default": 0,
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "PaneGraphicsSetParams": {
+          "properties": {
+            "data_base64": {
+              "default": "",
+              "type": "string"
+            },
+            "format": {
+              "$ref": "#/schemas/request/$defs/PaneGraphicsFormat"
+            },
+            "image_height": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "image_width": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "placement": {
+              "$ref": "#/schemas/request/$defs/PaneGraphicsPlacementParams",
+              "default": {
+                "grid_cols": 0,
+                "grid_rows": 0,
+                "viewport_col": 0,
+                "viewport_row": 0
+              }
+            }
+          },
+          "required": [
+            "pane_id",
+            "format",
+            "image_width",
+            "image_height"
+          ],
+          "type": "object"
+        },
+        "PaneLayoutParams": {
+          "properties": {
+            "pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "PaneListParams": {
+          "properties": {
+            "workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "PaneMoveDestination": {
+          "oneOf": [
+            {
+              "properties": {
+                "ratio": {
+                  "format": "float",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "split": {
+                  "$ref": "#/schemas/request/$defs/SplitDirection"
+                },
+                "tab_id": {
+                  "type": "string"
+                },
+                "target_pane_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "const": "tab",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "tab_id",
+                "split"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "label": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "const": "new_tab",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "label": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "tab_label": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "const": "new_workspace",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "PaneMoveParams": {
+          "properties": {
+            "destination": {
+              "$ref": "#/schemas/request/$defs/PaneMoveDestination"
+            },
+            "focus": {
+              "default": false,
+              "type": "boolean"
+            },
+            "pane_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "destination"
+          ],
+          "type": "object"
+        },
+        "PaneNeighborParams": {
+          "properties": {
+            "direction": {
+              "$ref": "#/schemas/request/$defs/PaneDirection"
+            },
+            "pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "direction"
+          ],
+          "type": "object"
+        },
+        "PaneProcessInfoParams": {
+          "properties": {
+            "pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "PaneReadParams": {
+          "properties": {
+            "format": {
+              "$ref": "#/schemas/request/$defs/ReadFormat",
+              "default": "text"
+            },
+            "lines": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "source": {
+              "$ref": "#/schemas/request/$defs/ReadSource"
+            },
+            "strip_ansi": {
+              "default": true,
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "pane_id",
+            "source"
+          ],
+          "type": "object"
+        },
+        "PaneReleaseAgentParams": {
+          "properties": {
+            "agent": {
+              "type": "string"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "seq": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "source",
+            "agent"
+          ],
+          "type": "object"
+        },
+        "PaneRenameParams": {
+          "properties": {
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pane_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id"
+          ],
+          "type": "object"
+        },
+        "PaneReportAgentParams": {
+          "properties": {
+            "agent": {
+              "type": "string"
+            },
+            "agent_session_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "agent_session_path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "message": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "seq": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "source": {
+              "type": "string"
+            },
+            "state": {
+              "$ref": "#/schemas/request/$defs/PaneAgentState"
+            }
+          },
+          "required": [
+            "pane_id",
+            "source",
+            "agent",
+            "state"
+          ],
+          "type": "object"
+        },
+        "PaneReportAgentSessionParams": {
+          "properties": {
+            "agent": {
+              "type": "string"
+            },
+            "agent_session_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "agent_session_path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "seq": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "session_start_source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "source",
+            "agent"
+          ],
+          "type": "object"
+        },
+        "PaneReportMetadataParams": {
+          "properties": {
+            "agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "applies_to_source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "clear_display_agent": {
+              "default": false,
+              "type": "boolean"
+            },
+            "clear_state_labels": {
+              "default": false,
+              "type": "boolean"
+            },
+            "clear_title": {
+              "default": false,
+              "type": "boolean"
+            },
+            "display_agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "seq": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "source": {
+              "type": "string"
+            },
+            "state_labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tokens": {
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "maxProperties": 16,
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9_-]{1,32}$"
+              },
+              "type": "object"
+            },
+            "ttl_ms": {
+              "format": "uint64",
+              "maximum": 86400000,
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "pane_id",
+            "source"
+          ],
+          "type": "object"
+        },
+        "PaneResizeParams": {
+          "properties": {
+            "amount": {
+              "format": "float",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "direction": {
+              "$ref": "#/schemas/request/$defs/PaneDirection"
+            },
+            "pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "direction"
+          ],
+          "type": "object"
+        },
+        "PaneSendInputParams": {
+          "properties": {
+            "keys": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id"
+          ],
+          "type": "object"
+        },
+        "PaneSendKeysParams": {
+          "properties": {
+            "keys": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "pane_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "keys"
+          ],
+          "type": "object"
+        },
+        "PaneSendTextParams": {
+          "properties": {
+            "pane_id": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "text"
+          ],
+          "type": "object"
+        },
+        "PaneSplitParams": {
+          "properties": {
+            "cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "direction": {
+              "$ref": "#/schemas/request/$defs/SplitDirection"
+            },
+            "env": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "focus": {
+              "default": false,
+              "type": "boolean"
+            },
+            "ratio": {
+              "format": "float",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "target_pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "direction"
+          ],
+          "type": "object"
+        },
+        "PaneSwapParams": {
+          "properties": {
+            "direction": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/PaneDirection"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source_pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "target_pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "PaneTarget": {
+          "properties": {
+            "pane_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id"
+          ],
+          "type": "object"
+        },
+        "PaneWaitForOutputParams": {
+          "properties": {
+            "lines": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "match": {
+              "$ref": "#/schemas/request/$defs/OutputMatch"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "source": {
+              "$ref": "#/schemas/request/$defs/ReadSource"
+            },
+            "strip_ansi": {
+              "default": true,
+              "type": "boolean"
+            },
+            "timeout_ms": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "pane_id",
+            "source",
+            "match"
+          ],
+          "type": "object"
+        },
+        "PaneZoomMode": {
+          "enum": [
+            "toggle",
+            "on",
+            "off"
+          ],
+          "type": "string"
+        },
+        "PaneZoomParams": {
+          "properties": {
+            "mode": {
+              "$ref": "#/schemas/request/$defs/PaneZoomMode",
+              "default": "toggle"
+            },
+            "pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "PingParams": {
+          "type": "object"
+        },
+        "PluginActionInvokeParams": {
+          "properties": {
+            "action_id": {
+              "type": "string"
+            },
+            "context": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/PluginInvocationContext"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "plugin_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "action_id"
+          ],
+          "type": "object"
+        },
+        "PluginActionListParams": {
+          "properties": {
+            "plugin_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "PluginInvocationContext": {
+          "properties": {
+            "clicked_url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "correlation_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focused_pane_agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focused_pane_cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focused_pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focused_pane_status": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/AgentStatus"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "invocation_source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "link_handler_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "selected_text": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tab_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tab_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "worktree": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/WorkspaceWorktreeInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "PluginLinkParams": {
+          "properties": {
+            "enabled": {
+              "default": true,
+              "type": "boolean"
+            },
+            "path": {
+              "type": "string"
+            },
+            "source": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/PluginSourceInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "path"
+          ],
+          "type": "object"
+        },
+        "PluginListParams": {
+          "properties": {
+            "plugin_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "PluginLogListParams": {
+          "properties": {
+            "limit": {
+              "format": "uint",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "plugin_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "PluginPaneCloseParams": {
+          "properties": {
+            "pane_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id"
+          ],
+          "type": "object"
+        },
+        "PluginPaneFocusParams": {
+          "properties": {
+            "pane_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id"
+          ],
+          "type": "object"
+        },
+        "PluginPaneOpenParams": {
+          "properties": {
+            "cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "direction": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/SplitDirection"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "entrypoint": {
+              "type": "string"
+            },
+            "env": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "focus": {
+              "default": false,
+              "type": "boolean"
+            },
+            "height": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/PopupSize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "placement": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/PluginPanePlacement"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "plugin_id": {
+              "type": "string"
+            },
+            "target_pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "width": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/request/$defs/PopupSize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "plugin_id",
+            "entrypoint"
+          ],
+          "type": "object"
+        },
+        "PluginPanePlacement": {
+          "enum": [
+            "overlay",
+            "popup",
+            "split",
+            "tab",
+            "zoomed"
+          ],
+          "type": "string"
+        },
+        "PluginSetEnabledParams": {
+          "properties": {
+            "plugin_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "plugin_id"
+          ],
+          "type": "object"
+        },
+        "PluginSourceInfo": {
+          "properties": {
+            "installed_unix_ms": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "kind": {
+              "$ref": "#/schemas/request/$defs/PluginSourceKind",
+              "default": "local"
+            },
+            "managed_path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "owner": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "repo": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "requested_ref": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "resolved_commit": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "subdir": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "PluginSourceKind": {
+          "enum": [
+            "local",
+            "github"
+          ],
+          "type": "string"
+        },
+        "PluginUnlinkParams": {
+          "properties": {
+            "plugin_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "plugin_id"
+          ],
+          "type": "object"
+        },
+        "PopupSize": {
+          "oneOf": [
+            {
+              "description": "Outer popup size in terminal cells, including the border.",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "description": "Outer popup size as a percentage of the terminal area, for example 80%.",
+              "pattern": "^(100|[1-9][0-9]?)%$",
+              "type": "string"
+            }
+          ]
+        },
+        "ReadFormat": {
+          "enum": [
+            "text",
+            "ansi"
+          ],
+          "type": "string"
+        },
+        "ReadSource": {
+          "enum": [
+            "visible",
+            "recent",
+            "recent_unwrapped",
+            "detection"
+          ],
+          "type": "string"
+        },
+        "ServerLiveHandoffParams": {
+          "properties": {
+            "expected_protocol": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "expected_version": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "import_exe": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "SplitDirection": {
+          "enum": [
+            "right",
+            "down"
+          ],
+          "type": "string"
+        },
+        "Subscription": {
+          "oneOf": [
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace.created",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace.updated",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace.metadata_updated",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace.renamed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace.moved",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace.closed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace.focused",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "worktree.created",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "worktree.opened",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "worktree.removed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "tab.created",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "tab.closed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "tab.focused",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "tab.renamed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "tab.moved",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "pane.created",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "pane.closed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "pane.updated",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "pane.focused",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "pane.moved",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "pane.exited",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "pane.agent_detected",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "lines": {
+                  "format": "uint32",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "match": {
+                  "$ref": "#/schemas/request/$defs/OutputMatch"
+                },
+                "pane_id": {
+                  "type": "string"
+                },
+                "source": {
+                  "$ref": "#/schemas/request/$defs/ReadSource"
+                },
+                "strip_ansi": {
+                  "default": true,
+                  "type": "boolean"
+                },
+                "type": {
+                  "const": "pane.output_matched",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "source",
+                "match"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "agent_status": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/request/$defs/AgentStatus"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "pane_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "pane.agent_status_changed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "pane.scroll_changed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "layout.updated",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "TabCreateParams": {
+          "properties": {
+            "cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "env": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "focus": {
+              "default": false,
+              "type": "boolean"
+            },
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "TabListParams": {
+          "properties": {
+            "workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "TabMoveParams": {
+          "properties": {
+            "insert_index": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tab_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "tab_id",
+            "insert_index"
+          ],
+          "type": "object"
+        },
+        "TabRenameParams": {
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "tab_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "tab_id",
+            "label"
+          ],
+          "type": "object"
+        },
+        "TabTarget": {
+          "properties": {
+            "tab_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "tab_id"
+          ],
+          "type": "object"
+        },
+        "ToastHerdrPosition": {
+          "enum": [
+            "top-left",
+            "top-right",
+            "bottom-left",
+            "bottom-right"
+          ],
+          "type": "string"
+        },
+        "WorkspaceCreateParams": {
+          "properties": {
+            "cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "env": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "focus": {
+              "default": false,
+              "type": "boolean"
+            },
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "WorkspaceMoveParams": {
+          "properties": {
+            "insert_index": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "workspace_id",
+            "insert_index"
+          ],
+          "type": "object"
+        },
+        "WorkspaceRenameParams": {
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "workspace_id",
+            "label"
+          ],
+          "type": "object"
+        },
+        "WorkspaceReportMetadataParams": {
+          "properties": {
+            "seq": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "source": {
+              "type": "string"
+            },
+            "tokens": {
+              "additionalProperties": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "maxProperties": 16,
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9_-]{1,32}$"
+              },
+              "type": "object"
+            },
+            "ttl_ms": {
+              "format": "uint64",
+              "maximum": 86400000,
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "workspace_id",
+            "source",
+            "tokens"
+          ],
+          "type": "object"
+        },
+        "WorkspaceTarget": {
+          "properties": {
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "workspace_id"
+          ],
+          "type": "object"
+        },
+        "WorkspaceWorktreeInfo": {
+          "properties": {
+            "checkout_path": {
+              "type": "string"
+            },
+            "is_linked_worktree": {
+              "type": "boolean"
+            },
+            "repo_key": {
+              "type": "string"
+            },
+            "repo_name": {
+              "type": "string"
+            },
+            "repo_root": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "repo_key",
+            "repo_name",
+            "repo_root",
+            "checkout_path",
+            "is_linked_worktree"
+          ],
+          "type": "object"
+        },
+        "WorktreeCreateParams": {
+          "properties": {
+            "base": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "branch": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focus": {
+              "default": false,
+              "type": "boolean"
+            },
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "WorktreeListParams": {
+          "properties": {
+            "cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "WorktreeOpenParams": {
+          "properties": {
+            "branch": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focus": {
+              "default": false,
+              "type": "boolean"
+            },
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "WorktreeRemoveParams": {
+          "properties": {
+            "force": {
+              "default": false,
+              "type": "boolean"
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "workspace_id"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "oneOf": [
+        {
+          "properties": {
+            "method": {
+              "const": "ping",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PingParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "server.stop",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/EmptyParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "server.live_handoff",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/ServerLiveHandoffParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "server.reload_config",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/EmptyParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "server.agent_manifests",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/EmptyParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "server.reload_agent_manifests",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/EmptyParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "notification.show",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/NotificationShowParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "client.window_title.set",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/ClientWindowTitleSetParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "client.window_title.clear",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/EmptyParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "session.snapshot",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/EmptyParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "workspace.create",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/WorkspaceCreateParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "workspace.list",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/EmptyParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "workspace.get",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/WorkspaceTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "workspace.focus",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/WorkspaceTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "workspace.rename",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/WorkspaceRenameParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "workspace.move",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/WorkspaceMoveParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "workspace.report_metadata",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/WorkspaceReportMetadataParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "workspace.close",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/WorkspaceTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "worktree.list",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/WorktreeListParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "worktree.create",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/WorktreeCreateParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "worktree.open",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/WorktreeOpenParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "worktree.remove",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/WorktreeRemoveParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "tab.create",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/TabCreateParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "tab.list",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/TabListParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "tab.get",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/TabTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "tab.focus",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/TabTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "tab.rename",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/TabRenameParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "tab.move",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/TabMoveParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "tab.close",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/TabTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "agent.list",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/EmptyParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "agent.get",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/AgentTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "agent.read",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/AgentReadParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "agent.explain",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/AgentTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "agent.send",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/AgentSendParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "agent.rename",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/AgentRenameParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "agent.focus",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/AgentTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "agent.start",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/AgentStartParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.split",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneSplitParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.swap",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneSwapParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.move",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneMoveParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.zoom",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneZoomParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.layout",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneLayoutParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.process_info",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneProcessInfoParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "layout.export",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/LayoutExportParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "layout.apply",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/LayoutApplyParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "layout.set_split_ratio",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/LayoutSetSplitRatioParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.neighbor",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneNeighborParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.edges",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneEdgesParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.focus_direction",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneFocusDirectionParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.resize",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneResizeParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.list",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneListParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.current",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneCurrentParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.get",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.focus",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.rename",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneRenameParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.send_text",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneSendTextParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.send_keys",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneSendKeysParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.send_input",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneSendInputParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.read",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneReadParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.graphics.set",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneGraphicsSetParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.graphics.clear",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneGraphicsClearParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.graphics.info",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.report_agent",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneReportAgentParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.report_agent_session",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneReportAgentSessionParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.report_metadata",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneReportMetadataParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.clear_agent_authority",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneClearAgentAuthorityParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.release_agent",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneReleaseAgentParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.close",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneTarget"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "popup.close",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/EmptyParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "events.subscribe",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/EventsSubscribeParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "events.wait",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/EventsWaitParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "pane.wait_for_output",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PaneWaitForOutputParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "integration.install",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/IntegrationInstallParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "integration.uninstall",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/IntegrationUninstallParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "plugin.link",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PluginLinkParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "plugin.list",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PluginListParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "plugin.unlink",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PluginUnlinkParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "plugin.enable",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PluginSetEnabledParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "plugin.disable",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PluginSetEnabledParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "plugin.action.list",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PluginActionListParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "plugin.action.invoke",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PluginActionInvokeParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "plugin.log.list",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PluginLogListParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "plugin.pane.open",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PluginPaneOpenParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "plugin.pane.focus",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PluginPaneFocusParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "plugin.pane.close",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/PluginPaneCloseParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "Request",
+      "type": "object"
+    },
+    "subscription_event": {
+      "$defs": {
+        "AgentStatus": {
+          "enum": [
+            "idle",
+            "working",
+            "blocked",
+            "done",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "PaneAgentStatusChangedEvent": {
+          "properties": {
+            "agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "agent_status": {
+              "$ref": "#/schemas/subscription_event/$defs/AgentStatus"
+            },
+            "display_agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "state_labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "workspace_id",
+            "agent_status"
+          ],
+          "type": "object"
+        },
+        "PaneOutputMatchedEvent": {
+          "properties": {
+            "matched_line": {
+              "type": "string"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "read": {
+              "$ref": "#/schemas/subscription_event/$defs/PaneReadResult"
+            }
+          },
+          "required": [
+            "pane_id",
+            "matched_line",
+            "read"
+          ],
+          "type": "object"
+        },
+        "PaneReadResult": {
+          "properties": {
+            "format": {
+              "$ref": "#/schemas/subscription_event/$defs/ReadFormat"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "revision": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "source": {
+              "$ref": "#/schemas/subscription_event/$defs/ReadSource"
+            },
+            "tab_id": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            },
+            "truncated": {
+              "type": "boolean"
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "workspace_id",
+            "tab_id",
+            "source",
+            "format",
+            "text",
+            "revision",
+            "truncated"
+          ],
+          "type": "object"
+        },
+        "PaneScrollChangedEvent": {
+          "properties": {
+            "pane_id": {
+              "type": "string"
+            },
+            "scroll": {
+              "$ref": "#/schemas/subscription_event/$defs/PaneScrollInfo"
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "workspace_id",
+            "scroll"
+          ],
+          "type": "object"
+        },
+        "PaneScrollInfo": {
+          "properties": {
+            "max_offset_from_bottom": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "offset_from_bottom": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "viewport_rows": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "offset_from_bottom",
+            "max_offset_from_bottom",
+            "viewport_rows"
+          ],
+          "type": "object"
+        },
+        "ReadFormat": {
+          "enum": [
+            "text",
+            "ansi"
+          ],
+          "type": "string"
+        },
+        "ReadSource": {
+          "enum": [
+            "visible",
+            "recent",
+            "recent_unwrapped",
+            "detection"
+          ],
+          "type": "string"
+        },
+        "SubscriptionEventData": {
+          "anyOf": [
+            {
+              "$ref": "#/schemas/subscription_event/$defs/PaneOutputMatchedEvent"
+            },
+            {
+              "$ref": "#/schemas/subscription_event/$defs/PaneAgentStatusChangedEvent"
+            },
+            {
+              "$ref": "#/schemas/subscription_event/$defs/PaneScrollChangedEvent"
+            }
+          ]
+        },
+        "SubscriptionEventKind": {
+          "enum": [
+            "pane.output_matched",
+            "pane.agent_status_changed",
+            "pane.scroll_changed"
+          ],
+          "type": "string"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "data": {
+          "$ref": "#/schemas/subscription_event/$defs/SubscriptionEventData"
+        },
+        "event": {
+          "$ref": "#/schemas/subscription_event/$defs/SubscriptionEventKind"
+        }
+      },
+      "required": [
+        "event",
+        "data"
+      ],
+      "title": "SubscriptionEventEnvelope",
+      "type": "object"
+    },
+    "success_response": {
+      "$defs": {
+        "AgentInfo": {
+          "properties": {
+            "agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "agent_session": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/AgentSessionInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "agent_status": {
+              "$ref": "#/schemas/success_response/$defs/AgentStatus"
+            },
+            "cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "display_agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focused": {
+              "type": "boolean"
+            },
+            "foreground_cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "revision": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "screen_detection_skipped": {
+              "type": "boolean"
+            },
+            "state_labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "tab_id": {
+              "type": "string"
+            },
+            "terminal_id": {
+              "type": "string"
+            },
+            "terminal_title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "terminal_title_stripped": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tokens": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "maxProperties": 32,
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9_-]{1,32}$"
+              },
+              "type": "object"
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "terminal_id",
+            "agent_status",
+            "workspace_id",
+            "tab_id",
+            "pane_id",
+            "focused",
+            "revision"
+          ],
+          "type": "object"
+        },
+        "AgentManifestInfo": {
+          "properties": {
+            "active_version": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "agent": {
+              "type": "string"
+            },
+            "cached_remote_version": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "local_override_shadowing_remote": {
+              "type": "boolean"
+            },
+            "remote_last_checked_unix": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "remote_update_error": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "remote_update_result": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": "string"
+            },
+            "source_kind": {
+              "type": "string"
+            },
+            "warning": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "agent",
+            "source",
+            "source_kind",
+            "local_override_shadowing_remote"
+          ],
+          "type": "object"
+        },
+        "AgentSessionInfo": {
+          "properties": {
+            "agent": {
+              "type": "string"
+            },
+            "kind": {
+              "$ref": "#/schemas/success_response/$defs/AgentSessionRefKind"
+            },
+            "source": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "agent",
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        "AgentSessionRefKind": {
+          "enum": [
+            "id",
+            "path"
+          ],
+          "type": "string"
+        },
+        "AgentStatus": {
+          "enum": [
+            "idle",
+            "working",
+            "blocked",
+            "done",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "ClientWindowTitleReason": {
+          "enum": [
+            "set",
+            "cleared",
+            "no_foreground_client"
+          ],
+          "type": "string"
+        },
+        "ConfigReloadStatus": {
+          "enum": [
+            "applied",
+            "partial",
+            "failed"
+          ],
+          "type": "string"
+        },
+        "EventData": {
+          "oneOf": [
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace_created",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace_updated",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace_metadata_updated",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace_closed",
+                  "type": "string"
+                },
+                "workspace": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "workspace_renamed",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "workspace_id",
+                "label"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "insert_index": {
+                  "format": "uint",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": {
+                  "const": "workspace_moved",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                },
+                "workspaces": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "type",
+                "workspace_id",
+                "insert_index",
+                "workspaces"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace_focused",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "worktree_created",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                },
+                "worktree": {
+                  "$ref": "#/schemas/success_response/$defs/WorktreeInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace",
+                "worktree"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "already_open": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "const": "worktree_opened",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                },
+                "worktree": {
+                  "$ref": "#/schemas/success_response/$defs/WorktreeInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace",
+                "worktree",
+                "already_open"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "forced": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "const": "worktree_removed",
+                  "type": "string"
+                },
+                "workspace": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "workspace_id": {
+                  "type": "string"
+                },
+                "worktree": {
+                  "$ref": "#/schemas/success_response/$defs/WorktreeInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace_id",
+                "worktree",
+                "forced"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "tab": {
+                  "$ref": "#/schemas/success_response/$defs/TabInfo"
+                },
+                "type": {
+                  "const": "tab_created",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "tab"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "tab_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "tab_closed",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "tab_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "tab_renamed",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id",
+                "label"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "insert_index": {
+                  "format": "uint",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "tab_id": {
+                  "type": "string"
+                },
+                "tabs": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/TabInfo"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "tab_moved",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id",
+                "insert_index",
+                "tabs"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "tab_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "tab_focused",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "tab_id",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane": {
+                  "$ref": "#/schemas/success_response/$defs/PaneInfo"
+                },
+                "type": {
+                  "const": "pane_created",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "pane_closed",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane": {
+                  "$ref": "#/schemas/success_response/$defs/PaneInfo"
+                },
+                "type": {
+                  "const": "pane_updated",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "pane_focused",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "closed_tab_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "closed_workspace_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "created_tab": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/success_response/$defs/TabInfo"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "created_workspace": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "pane": {
+                  "$ref": "#/schemas/success_response/$defs/PaneInfo"
+                },
+                "previous_pane_id": {
+                  "type": "string"
+                },
+                "previous_tab_id": {
+                  "type": "string"
+                },
+                "previous_workspace_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "pane_moved",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "previous_pane_id",
+                "previous_workspace_id",
+                "previous_tab_id",
+                "pane"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane_id": {
+                  "type": "string"
+                },
+                "revision": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": {
+                  "const": "pane_output_changed",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id",
+                "revision"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "pane_exited",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "agent": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "pane_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "pane_agent_detected",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "agent": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "agent_status": {
+                  "$ref": "#/schemas/success_response/$defs/AgentStatus"
+                },
+                "display_agent": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "pane_id": {
+                  "type": "string"
+                },
+                "state_labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "title": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "const": "pane_agent_status_changed",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "workspace_id",
+                "agent_status"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "layout": {
+                  "$ref": "#/schemas/success_response/$defs/PaneLayoutSnapshot"
+                },
+                "type": {
+                  "const": "layout_updated",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "layout"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "EventEnvelope": {
+          "properties": {
+            "data": {
+              "$ref": "#/schemas/success_response/$defs/EventData"
+            },
+            "event": {
+              "$ref": "#/schemas/success_response/$defs/EventKind"
+            }
+          },
+          "required": [
+            "event",
+            "data"
+          ],
+          "type": "object"
+        },
+        "EventKind": {
+          "enum": [
+            "workspace_created",
+            "workspace_updated",
+            "workspace_metadata_updated",
+            "workspace_closed",
+            "workspace_renamed",
+            "workspace_moved",
+            "workspace_focused",
+            "worktree_created",
+            "worktree_opened",
+            "worktree_removed",
+            "tab_created",
+            "tab_closed",
+            "tab_renamed",
+            "tab_moved",
+            "tab_focused",
+            "pane_created",
+            "pane_closed",
+            "pane_updated",
+            "pane_focused",
+            "pane_moved",
+            "pane_output_changed",
+            "pane_exited",
+            "pane_agent_detected",
+            "pane_agent_status_changed",
+            "layout_updated"
+          ],
+          "type": "string"
+        },
+        "InstalledPluginInfo": {
+          "properties": {
+            "actions": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginManifestAction"
+              },
+              "type": "array"
+            },
+            "build": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginManifestBuild"
+              },
+              "type": "array"
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "events": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginManifestEventHook"
+              },
+              "type": "array"
+            },
+            "link_handlers": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginManifestLinkHandler"
+              },
+              "type": "array"
+            },
+            "manifest_path": {
+              "type": "string"
+            },
+            "min_herdr_version": {
+              "default": "",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "panes": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginManifestPane"
+              },
+              "type": "array"
+            },
+            "platforms": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginPlatform"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "plugin_id": {
+              "type": "string"
+            },
+            "plugin_root": {
+              "type": "string"
+            },
+            "source": {
+              "$ref": "#/schemas/success_response/$defs/PluginSourceInfo",
+              "default": {
+                "kind": "local"
+              }
+            },
+            "version": {
+              "type": "string"
+            },
+            "warnings": {
+              "description": "Warnings collected at link time or on registry load (e.g. unknown event names,\nmissing manifest file). Non-fatal — the entry is kept and surfaced by plugin.list.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "plugin_id",
+            "name",
+            "version",
+            "manifest_path",
+            "plugin_root",
+            "enabled"
+          ],
+          "type": "object"
+        },
+        "IntegrationInstallResult": {
+          "properties": {
+            "messages": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "messages"
+          ],
+          "type": "object"
+        },
+        "IntegrationTarget": {
+          "enum": [
+            "pi",
+            "omp",
+            "claude",
+            "codex",
+            "copilot",
+            "devin",
+            "droid",
+            "kimi",
+            "opencode",
+            "kilo",
+            "hermes",
+            "qodercli",
+            "cursor",
+            "mastracode"
+          ],
+          "type": "string"
+        },
+        "IntegrationUninstallResult": {
+          "properties": {
+            "messages": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "messages"
+          ],
+          "type": "object"
+        },
+        "LayoutDescription": {
+          "properties": {
+            "focused_pane_id": {
+              "type": "string"
+            },
+            "root": {
+              "$ref": "#/schemas/success_response/$defs/LayoutNode"
+            },
+            "tab_id": {
+              "type": "string"
+            },
+            "workspace_id": {
+              "type": "string"
+            },
+            "zoomed": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "workspace_id",
+            "tab_id",
+            "zoomed",
+            "focused_pane_id",
+            "root"
+          ],
+          "type": "object"
+        },
+        "LayoutNode": {
+          "oneOf": [
+            {
+              "properties": {
+                "command": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                },
+                "cwd": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "env": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "label": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "pane_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "const": "pane",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "direction": {
+                  "$ref": "#/schemas/success_response/$defs/SplitDirection"
+                },
+                "first": {
+                  "$ref": "#/schemas/success_response/$defs/LayoutNode"
+                },
+                "ratio": {
+                  "format": "float",
+                  "type": "number"
+                },
+                "second": {
+                  "$ref": "#/schemas/success_response/$defs/LayoutNode"
+                },
+                "type": {
+                  "const": "split",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "direction",
+                "ratio",
+                "first",
+                "second"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "NotificationShowReason": {
+          "enum": [
+            "shown",
+            "disabled",
+            "rate_limited",
+            "no_foreground_client",
+            "busy"
+          ],
+          "type": "string"
+        },
+        "PaneDirection": {
+          "enum": [
+            "left",
+            "right",
+            "up",
+            "down"
+          ],
+          "type": "string"
+        },
+        "PaneEdgesResult": {
+          "properties": {
+            "down": {
+              "type": "boolean"
+            },
+            "layout": {
+              "$ref": "#/schemas/success_response/$defs/PaneLayoutSnapshot"
+            },
+            "left": {
+              "type": "boolean"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "right": {
+              "type": "boolean"
+            },
+            "up": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "pane_id",
+            "left",
+            "right",
+            "up",
+            "down",
+            "layout"
+          ],
+          "type": "object"
+        },
+        "PaneFocusDirectionReason": {
+          "enum": [
+            "no_neighbor"
+          ],
+          "type": "string"
+        },
+        "PaneFocusDirectionResult": {
+          "properties": {
+            "changed": {
+              "type": "boolean"
+            },
+            "focused_pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "layout": {
+              "$ref": "#/schemas/success_response/$defs/PaneLayoutSnapshot"
+            },
+            "reason": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/PaneFocusDirectionReason"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "source_pane_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "changed",
+            "source_pane_id",
+            "layout"
+          ],
+          "type": "object"
+        },
+        "PaneInfo": {
+          "properties": {
+            "agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "agent_session": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/AgentSessionInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "agent_status": {
+              "$ref": "#/schemas/success_response/$defs/AgentStatus"
+            },
+            "cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "display_agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focused": {
+              "type": "boolean"
+            },
+            "foreground_cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "revision": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "scroll": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/PaneScrollInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "state_labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "tab_id": {
+              "type": "string"
+            },
+            "terminal_id": {
+              "type": "string"
+            },
+            "terminal_title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "terminal_title_stripped": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tokens": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "maxProperties": 32,
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9_-]{1,32}$"
+              },
+              "type": "object"
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "terminal_id",
+            "workspace_id",
+            "tab_id",
+            "focused",
+            "agent_status",
+            "revision"
+          ],
+          "type": "object"
+        },
+        "PaneLayoutPane": {
+          "properties": {
+            "focused": {
+              "type": "boolean"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "rect": {
+              "$ref": "#/schemas/success_response/$defs/PaneLayoutRect"
+            }
+          },
+          "required": [
+            "pane_id",
+            "focused",
+            "rect"
+          ],
+          "type": "object"
+        },
+        "PaneLayoutRect": {
+          "properties": {
+            "height": {
+              "format": "uint16",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "width": {
+              "format": "uint16",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "x": {
+              "format": "uint16",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "y": {
+              "format": "uint16",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "width",
+            "height"
+          ],
+          "type": "object"
+        },
+        "PaneLayoutSnapshot": {
+          "properties": {
+            "area": {
+              "$ref": "#/schemas/success_response/$defs/PaneLayoutRect"
+            },
+            "focused_pane_id": {
+              "type": "string"
+            },
+            "panes": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PaneLayoutPane"
+              },
+              "type": "array"
+            },
+            "splits": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PaneLayoutSplit"
+              },
+              "type": "array"
+            },
+            "tab_id": {
+              "type": "string"
+            },
+            "workspace_id": {
+              "type": "string"
+            },
+            "zoomed": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "workspace_id",
+            "tab_id",
+            "zoomed",
+            "area",
+            "focused_pane_id",
+            "panes",
+            "splits"
+          ],
+          "type": "object"
+        },
+        "PaneLayoutSplit": {
+          "properties": {
+            "direction": {
+              "$ref": "#/schemas/success_response/$defs/SplitDirection"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ratio": {
+              "format": "float",
+              "type": "number"
+            },
+            "rect": {
+              "$ref": "#/schemas/success_response/$defs/PaneLayoutRect"
+            }
+          },
+          "required": [
+            "id",
+            "direction",
+            "ratio",
+            "rect"
+          ],
+          "type": "object"
+        },
+        "PaneMoveReason": {
+          "enum": [
+            "same_tab",
+            "zoomed_tab"
+          ],
+          "type": "string"
+        },
+        "PaneMoveResult": {
+          "properties": {
+            "changed": {
+              "type": "boolean"
+            },
+            "closed_tab_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "closed_workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "created_tab": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/TabInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "created_workspace": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "focused_pane_id": {
+              "type": "string"
+            },
+            "pane": {
+              "$ref": "#/schemas/success_response/$defs/PaneInfo"
+            },
+            "previous_pane_id": {
+              "type": "string"
+            },
+            "previous_tab_id": {
+              "type": "string"
+            },
+            "previous_workspace_id": {
+              "type": "string"
+            },
+            "reason": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/PaneMoveReason"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "source_layout": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/PaneLayoutSnapshot"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "target_layout": {
+              "$ref": "#/schemas/success_response/$defs/PaneLayoutSnapshot"
+            }
+          },
+          "required": [
+            "changed",
+            "previous_pane_id",
+            "previous_workspace_id",
+            "previous_tab_id",
+            "pane",
+            "target_layout",
+            "focused_pane_id"
+          ],
+          "type": "object"
+        },
+        "PaneNeighborResult": {
+          "properties": {
+            "direction": {
+              "$ref": "#/schemas/success_response/$defs/PaneDirection"
+            },
+            "layout": {
+              "$ref": "#/schemas/success_response/$defs/PaneLayoutSnapshot"
+            },
+            "neighbor_pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pane_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "direction",
+            "layout"
+          ],
+          "type": "object"
+        },
+        "PaneProcessInfo": {
+          "properties": {
+            "foreground_process_group_id": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "foreground_processes": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PaneProcessInfoProcess"
+              },
+              "type": "array"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "shell_pid": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "tty": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "pane_id"
+          ],
+          "type": "object"
+        },
+        "PaneProcessInfoProcess": {
+          "properties": {
+            "argv": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "argv0": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cmdline": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "pid": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "pid",
+            "name"
+          ],
+          "type": "object"
+        },
+        "PaneReadResult": {
+          "properties": {
+            "format": {
+              "$ref": "#/schemas/success_response/$defs/ReadFormat"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "revision": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "source": {
+              "$ref": "#/schemas/success_response/$defs/ReadSource"
+            },
+            "tab_id": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            },
+            "truncated": {
+              "type": "boolean"
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "pane_id",
+            "workspace_id",
+            "tab_id",
+            "source",
+            "format",
+            "text",
+            "revision",
+            "truncated"
+          ],
+          "type": "object"
+        },
+        "PaneResizeReason": {
+          "enum": [
+            "unchanged"
+          ],
+          "type": "string"
+        },
+        "PaneResizeResult": {
+          "properties": {
+            "changed": {
+              "type": "boolean"
+            },
+            "focused_pane_id": {
+              "type": "string"
+            },
+            "layout": {
+              "$ref": "#/schemas/success_response/$defs/PaneLayoutSnapshot"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "reason": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/PaneResizeReason"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "changed",
+            "pane_id",
+            "focused_pane_id",
+            "layout"
+          ],
+          "type": "object"
+        },
+        "PaneScrollInfo": {
+          "properties": {
+            "max_offset_from_bottom": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "offset_from_bottom": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "viewport_rows": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "offset_from_bottom",
+            "max_offset_from_bottom",
+            "viewport_rows"
+          ],
+          "type": "object"
+        },
+        "PaneSwapReason": {
+          "enum": [
+            "no_neighbor",
+            "same_pane",
+            "not_found",
+            "cross_tab"
+          ],
+          "type": "string"
+        },
+        "PaneSwapResult": {
+          "properties": {
+            "changed": {
+              "type": "boolean"
+            },
+            "focused_pane_id": {
+              "type": "string"
+            },
+            "layout": {
+              "$ref": "#/schemas/success_response/$defs/PaneLayoutSnapshot"
+            },
+            "reason": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/PaneSwapReason"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "source_pane_id": {
+              "type": "string"
+            },
+            "target_pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "changed",
+            "source_pane_id",
+            "focused_pane_id",
+            "layout"
+          ],
+          "type": "object"
+        },
+        "PaneZoomReason": {
+          "enum": [
+            "single_pane",
+            "already_zoomed",
+            "already_unzoomed"
+          ],
+          "type": "string"
+        },
+        "PaneZoomResult": {
+          "properties": {
+            "changed": {
+              "type": "boolean"
+            },
+            "focus_changed": {
+              "type": "boolean"
+            },
+            "focused_pane_id": {
+              "type": "string"
+            },
+            "layout": {
+              "$ref": "#/schemas/success_response/$defs/PaneLayoutSnapshot"
+            },
+            "pane_id": {
+              "type": "string"
+            },
+            "reason": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/PaneZoomReason"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "zoom_changed": {
+              "type": "boolean"
+            },
+            "zoomed": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "changed",
+            "zoom_changed",
+            "focus_changed",
+            "pane_id",
+            "focused_pane_id",
+            "zoomed",
+            "layout"
+          ],
+          "type": "object"
+        },
+        "PluginActionContext": {
+          "enum": [
+            "global",
+            "workspace",
+            "tab",
+            "pane",
+            "selection"
+          ],
+          "type": "string"
+        },
+        "PluginActionInfo": {
+          "properties": {
+            "action_id": {
+              "type": "string"
+            },
+            "command": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "contexts": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginActionContext"
+              },
+              "type": "array"
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "platforms": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginPlatform"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "plugin_id": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "plugin_id",
+            "action_id",
+            "title",
+            "command"
+          ],
+          "type": "object"
+        },
+        "PluginCommandLogInfo": {
+          "properties": {
+            "action_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "command": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "error": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "event": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "exit_code": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "finished_unix_ms": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "log_id": {
+              "type": "string"
+            },
+            "plugin_id": {
+              "type": "string"
+            },
+            "started_unix_ms": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "status": {
+              "$ref": "#/schemas/success_response/$defs/PluginCommandStatus"
+            },
+            "stderr": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "stdout": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "log_id",
+            "plugin_id",
+            "command",
+            "status",
+            "started_unix_ms"
+          ],
+          "type": "object"
+        },
+        "PluginCommandStatus": {
+          "enum": [
+            "running",
+            "succeeded",
+            "failed"
+          ],
+          "type": "string"
+        },
+        "PluginInvocationContext": {
+          "properties": {
+            "clicked_url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "correlation_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focused_pane_agent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focused_pane_cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focused_pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focused_pane_status": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/AgentStatus"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "invocation_source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "link_handler_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "selected_text": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tab_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tab_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_cwd": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "worktree": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/WorkspaceWorktreeInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "PluginManifestAction": {
+          "properties": {
+            "command": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "contexts": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginActionContext"
+              },
+              "type": "array"
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "platforms": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginPlatform"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "title",
+            "command"
+          ],
+          "type": "object"
+        },
+        "PluginManifestBuild": {
+          "properties": {
+            "command": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "platforms": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginPlatform"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "command"
+          ],
+          "type": "object"
+        },
+        "PluginManifestEventHook": {
+          "properties": {
+            "command": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "on": {
+              "type": "string"
+            },
+            "platforms": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginPlatform"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "on",
+            "command"
+          ],
+          "type": "object"
+        },
+        "PluginManifestLinkHandler": {
+          "properties": {
+            "action": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "pattern": {
+              "type": "string"
+            },
+            "platforms": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginPlatform"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "title",
+            "pattern",
+            "action"
+          ],
+          "type": "object"
+        },
+        "PluginManifestPane": {
+          "properties": {
+            "command": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "height": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/PopupSize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "placement": {
+              "$ref": "#/schemas/success_response/$defs/PluginPanePlacement",
+              "default": "overlay"
+            },
+            "platforms": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PluginPlatform"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "title": {
+              "type": "string"
+            },
+            "width": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/PopupSize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "title",
+            "command"
+          ],
+          "type": "object"
+        },
+        "PluginPaneInfo": {
+          "properties": {
+            "entrypoint": {
+              "type": "string"
+            },
+            "pane": {
+              "$ref": "#/schemas/success_response/$defs/PaneInfo"
+            },
+            "plugin_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "plugin_id",
+            "entrypoint",
+            "pane"
+          ],
+          "type": "object"
+        },
+        "PluginPanePlacement": {
+          "enum": [
+            "overlay",
+            "popup",
+            "split",
+            "tab",
+            "zoomed"
+          ],
+          "type": "string"
+        },
+        "PluginPlatform": {
+          "enum": [
+            "linux",
+            "macos",
+            "windows"
+          ],
+          "type": "string"
+        },
+        "PluginSourceInfo": {
+          "properties": {
+            "installed_unix_ms": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "kind": {
+              "$ref": "#/schemas/success_response/$defs/PluginSourceKind",
+              "default": "local"
+            },
+            "managed_path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "owner": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "repo": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "requested_ref": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "resolved_commit": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "subdir": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "PluginSourceKind": {
+          "enum": [
+            "local",
+            "github"
+          ],
+          "type": "string"
+        },
+        "PopupSize": {
+          "oneOf": [
+            {
+              "description": "Outer popup size in terminal cells, including the border.",
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "description": "Outer popup size as a percentage of the terminal area, for example 80%.",
+              "pattern": "^(100|[1-9][0-9]?)%$",
+              "type": "string"
+            }
+          ]
+        },
+        "ReadFormat": {
+          "enum": [
+            "text",
+            "ansi"
+          ],
+          "type": "string"
+        },
+        "ReadSource": {
+          "enum": [
+            "visible",
+            "recent",
+            "recent_unwrapped",
+            "detection"
+          ],
+          "type": "string"
+        },
+        "ResponseResult": {
+          "oneOf": [
+            {
+              "properties": {
+                "capabilities": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/schemas/success_response/$defs/ServerCapabilities"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "protocol": {
+                  "format": "uint32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": {
+                  "const": "pong",
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "version",
+                "protocol"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "snapshot": {
+                  "$ref": "#/schemas/success_response/$defs/SessionSnapshot"
+                },
+                "type": {
+                  "const": "session_snapshot",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "snapshot"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace_info",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "root_pane": {
+                  "$ref": "#/schemas/success_response/$defs/PaneInfo"
+                },
+                "tab": {
+                  "$ref": "#/schemas/success_response/$defs/TabInfo"
+                },
+                "type": {
+                  "const": "workspace_created",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace",
+                "tab",
+                "root_pane"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "workspace_list",
+                  "type": "string"
+                },
+                "workspaces": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "type",
+                "workspaces"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "source": {
+                  "$ref": "#/schemas/success_response/$defs/WorktreeSourceInfo"
+                },
+                "type": {
+                  "const": "worktree_list",
+                  "type": "string"
+                },
+                "worktrees": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/WorktreeInfo"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "type",
+                "source",
+                "worktrees"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "root_pane": {
+                  "$ref": "#/schemas/success_response/$defs/PaneInfo"
+                },
+                "tab": {
+                  "$ref": "#/schemas/success_response/$defs/TabInfo"
+                },
+                "type": {
+                  "const": "worktree_created",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                },
+                "worktree": {
+                  "$ref": "#/schemas/success_response/$defs/WorktreeInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace",
+                "tab",
+                "root_pane",
+                "worktree"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "already_open": {
+                  "type": "boolean"
+                },
+                "root_pane": {
+                  "$ref": "#/schemas/success_response/$defs/PaneInfo"
+                },
+                "tab": {
+                  "$ref": "#/schemas/success_response/$defs/TabInfo"
+                },
+                "type": {
+                  "const": "worktree_opened",
+                  "type": "string"
+                },
+                "workspace": {
+                  "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                },
+                "worktree": {
+                  "$ref": "#/schemas/success_response/$defs/WorktreeInfo"
+                }
+              },
+              "required": [
+                "type",
+                "workspace",
+                "tab",
+                "root_pane",
+                "worktree",
+                "already_open"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "forced": {
+                  "type": "boolean"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "worktree_removed",
+                  "type": "string"
+                },
+                "workspace_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "workspace_id",
+                "path",
+                "forced"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "tab": {
+                  "$ref": "#/schemas/success_response/$defs/TabInfo"
+                },
+                "type": {
+                  "const": "tab_info",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "tab"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "root_pane": {
+                  "$ref": "#/schemas/success_response/$defs/PaneInfo"
+                },
+                "tab": {
+                  "$ref": "#/schemas/success_response/$defs/TabInfo"
+                },
+                "type": {
+                  "const": "tab_created",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "tab",
+                "root_pane"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "tabs": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/TabInfo"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "tab_list",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "tabs"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "agent": {
+                  "$ref": "#/schemas/success_response/$defs/AgentInfo"
+                },
+                "type": {
+                  "const": "agent_info",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "agent"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "agent": {
+                  "$ref": "#/schemas/success_response/$defs/AgentInfo"
+                },
+                "argv": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "agent_started",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "agent",
+                "argv"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "agents": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/AgentInfo"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "agent_list",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "agents"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane": {
+                  "$ref": "#/schemas/success_response/$defs/PaneInfo"
+                },
+                "type": {
+                  "const": "pane_info",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "panes": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/PaneInfo"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "pane_list",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "panes"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane": {
+                  "$ref": "#/schemas/success_response/$defs/PaneInfo"
+                },
+                "type": {
+                  "const": "pane_current",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "swap": {
+                  "$ref": "#/schemas/success_response/$defs/PaneSwapResult"
+                },
+                "type": {
+                  "const": "pane_swap",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "swap"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "move_result": {
+                  "$ref": "#/schemas/success_response/$defs/PaneMoveResult"
+                },
+                "type": {
+                  "const": "pane_move",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "move_result"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "pane_zoom",
+                  "type": "string"
+                },
+                "zoom": {
+                  "$ref": "#/schemas/success_response/$defs/PaneZoomResult"
+                }
+              },
+              "required": [
+                "type",
+                "zoom"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "layout": {
+                  "$ref": "#/schemas/success_response/$defs/PaneLayoutSnapshot"
+                },
+                "type": {
+                  "const": "pane_layout",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "layout"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "process_info": {
+                  "$ref": "#/schemas/success_response/$defs/PaneProcessInfo"
+                },
+                "type": {
+                  "const": "pane_process_info",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "process_info"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "layout": {
+                  "$ref": "#/schemas/success_response/$defs/LayoutDescription"
+                },
+                "type": {
+                  "const": "layout_export",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "layout"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "layout": {
+                  "$ref": "#/schemas/success_response/$defs/LayoutDescription"
+                },
+                "type": {
+                  "const": "layout_apply",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "layout"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "layout": {
+                  "$ref": "#/schemas/success_response/$defs/LayoutDescription"
+                },
+                "type": {
+                  "const": "layout_split_ratio_set",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "layout"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "neighbor": {
+                  "$ref": "#/schemas/success_response/$defs/PaneNeighborResult"
+                },
+                "type": {
+                  "const": "pane_neighbor",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "neighbor"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "edges": {
+                  "$ref": "#/schemas/success_response/$defs/PaneEdgesResult"
+                },
+                "type": {
+                  "const": "pane_edges",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "edges"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "focus": {
+                  "$ref": "#/schemas/success_response/$defs/PaneFocusDirectionResult"
+                },
+                "type": {
+                  "const": "pane_focus_direction",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "focus"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "resize": {
+                  "$ref": "#/schemas/success_response/$defs/PaneResizeResult"
+                },
+                "type": {
+                  "const": "pane_resize",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "resize"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "read": {
+                  "$ref": "#/schemas/success_response/$defs/PaneReadResult"
+                },
+                "type": {
+                  "const": "pane_read",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "read"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "cell_height_px": {
+                  "format": "uint32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "cell_width_px": {
+                  "format": "uint32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": {
+                  "const": "pane_graphics_info",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "cell_width_px",
+                "cell_height_px"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "explain": true,
+                "type": {
+                  "const": "agent_explain",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "explain"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "subscription_started",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "event": {
+                  "$ref": "#/schemas/success_response/$defs/EventEnvelope"
+                },
+                "type": {
+                  "const": "wait_matched",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "event"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "matched_line": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "pane_id": {
+                  "type": "string"
+                },
+                "read": {
+                  "$ref": "#/schemas/success_response/$defs/PaneReadResult"
+                },
+                "revision": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": {
+                  "const": "output_matched",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id",
+                "revision",
+                "read"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "reason": {
+                  "$ref": "#/schemas/success_response/$defs/NotificationShowReason"
+                },
+                "shown": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "const": "notification_show",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "shown",
+                "reason"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "changed": {
+                  "type": "boolean"
+                },
+                "reason": {
+                  "$ref": "#/schemas/success_response/$defs/ClientWindowTitleReason"
+                },
+                "type": {
+                  "const": "client_window_title",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "changed",
+                "reason"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "details": {
+                  "$ref": "#/schemas/success_response/$defs/IntegrationInstallResult"
+                },
+                "target": {
+                  "$ref": "#/schemas/success_response/$defs/IntegrationTarget"
+                },
+                "type": {
+                  "const": "integration_install",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "target",
+                "details"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "details": {
+                  "$ref": "#/schemas/success_response/$defs/IntegrationUninstallResult"
+                },
+                "target": {
+                  "$ref": "#/schemas/success_response/$defs/IntegrationTarget"
+                },
+                "type": {
+                  "const": "integration_uninstall",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "target",
+                "details"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "manifests": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/AgentManifestInfo"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "agent_manifest_reload",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "manifests"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "last_check_unix": {
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "last_result": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "manifests": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/AgentManifestInfo"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "agent_manifest_status",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "manifests"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "plugin": {
+                  "$ref": "#/schemas/success_response/$defs/InstalledPluginInfo"
+                },
+                "type": {
+                  "const": "plugin_linked",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "plugin"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "plugins": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/InstalledPluginInfo"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "plugin_list",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "plugins"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "plugin_id": {
+                  "type": "string"
+                },
+                "removed": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "const": "plugin_unlinked",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "plugin_id",
+                "removed"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "plugin": {
+                  "$ref": "#/schemas/success_response/$defs/InstalledPluginInfo"
+                },
+                "type": {
+                  "const": "plugin_enabled",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "plugin"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "plugin": {
+                  "$ref": "#/schemas/success_response/$defs/InstalledPluginInfo"
+                },
+                "type": {
+                  "const": "plugin_disabled",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "plugin"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "actions": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/PluginActionInfo"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "plugin_action_list",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "actions"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "action": {
+                  "$ref": "#/schemas/success_response/$defs/PluginActionInfo"
+                },
+                "context": {
+                  "$ref": "#/schemas/success_response/$defs/PluginInvocationContext"
+                },
+                "log": {
+                  "$ref": "#/schemas/success_response/$defs/PluginCommandLogInfo"
+                },
+                "type": {
+                  "const": "plugin_action_invoked",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "action",
+                "context",
+                "log"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "logs": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/PluginCommandLogInfo"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "const": "plugin_log_list",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "logs"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "plugin_pane": {
+                  "$ref": "#/schemas/success_response/$defs/PluginPaneInfo"
+                },
+                "type": {
+                  "const": "plugin_pane_opened",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "plugin_pane"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "plugin_pane": {
+                  "$ref": "#/schemas/success_response/$defs/PluginPaneInfo"
+                },
+                "type": {
+                  "const": "plugin_pane_focused",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "plugin_pane"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pane_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "const": "plugin_pane_closed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "pane_id"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "diagnostics": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "status": {
+                  "$ref": "#/schemas/success_response/$defs/ConfigReloadStatus"
+                },
+                "type": {
+                  "const": "config_reload",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "status",
+                "diagnostics"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "ok",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "ServerCapabilities": {
+          "properties": {
+            "detached_server_daemon": {
+              "default": false,
+              "type": "boolean"
+            },
+            "live_handoff": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "live_handoff"
+          ],
+          "type": "object"
+        },
+        "SessionSnapshot": {
+          "properties": {
+            "agents": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/AgentInfo"
+              },
+              "type": "array"
+            },
+            "focused_pane_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focused_tab_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "focused_workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "layouts": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PaneLayoutSnapshot"
+              },
+              "type": "array"
+            },
+            "panes": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/PaneInfo"
+              },
+              "type": "array"
+            },
+            "protocol": {
+              "format": "uint32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tabs": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/TabInfo"
+              },
+              "type": "array"
+            },
+            "version": {
+              "type": "string"
+            },
+            "workspaces": {
+              "items": {
+                "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "version",
+            "protocol",
+            "workspaces",
+            "tabs",
+            "panes",
+            "layouts",
+            "agents"
+          ],
+          "type": "object"
+        },
+        "SplitDirection": {
+          "enum": [
+            "right",
+            "down"
+          ],
+          "type": "string"
+        },
+        "TabInfo": {
+          "properties": {
+            "agent_status": {
+              "$ref": "#/schemas/success_response/$defs/AgentStatus"
+            },
+            "focused": {
+              "type": "boolean"
+            },
+            "label": {
+              "type": "string"
+            },
+            "number": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pane_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tab_id": {
+              "type": "string"
+            },
+            "workspace_id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "tab_id",
+            "workspace_id",
+            "number",
+            "label",
+            "focused",
+            "pane_count",
+            "agent_status"
+          ],
+          "type": "object"
+        },
+        "WorkspaceInfo": {
+          "properties": {
+            "active_tab_id": {
+              "type": "string"
+            },
+            "agent_status": {
+              "$ref": "#/schemas/success_response/$defs/AgentStatus"
+            },
+            "focused": {
+              "type": "boolean"
+            },
+            "label": {
+              "type": "string"
+            },
+            "number": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "pane_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tab_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "tokens": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "maxProperties": 32,
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9_-]{1,32}$"
+              },
+              "type": "object"
+            },
+            "workspace_id": {
+              "type": "string"
+            },
+            "worktree": {
+              "anyOf": [
+                {
+                  "$ref": "#/schemas/success_response/$defs/WorkspaceWorktreeInfo"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "workspace_id",
+            "number",
+            "label",
+            "focused",
+            "pane_count",
+            "tab_count",
+            "active_tab_id",
+            "agent_status"
+          ],
+          "type": "object"
+        },
+        "WorkspaceWorktreeInfo": {
+          "properties": {
+            "checkout_path": {
+              "type": "string"
+            },
+            "is_linked_worktree": {
+              "type": "boolean"
+            },
+            "repo_key": {
+              "type": "string"
+            },
+            "repo_name": {
+              "type": "string"
+            },
+            "repo_root": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "repo_key",
+            "repo_name",
+            "repo_root",
+            "checkout_path",
+            "is_linked_worktree"
+          ],
+          "type": "object"
+        },
+        "WorktreeInfo": {
+          "properties": {
+            "branch": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "is_bare": {
+              "type": "boolean"
+            },
+            "is_detached": {
+              "type": "boolean"
+            },
+            "is_linked_worktree": {
+              "type": "boolean"
+            },
+            "is_prunable": {
+              "type": "boolean"
+            },
+            "label": {
+              "type": "string"
+            },
+            "open_workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "is_bare",
+            "is_detached",
+            "is_prunable",
+            "is_linked_worktree",
+            "label"
+          ],
+          "type": "object"
+        },
+        "WorktreeSourceInfo": {
+          "properties": {
+            "repo_key": {
+              "type": "string"
+            },
+            "repo_name": {
+              "type": "string"
+            },
+            "repo_root": {
+              "type": "string"
+            },
+            "source_checkout_path": {
+              "type": "string"
+            },
+            "source_workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "repo_key",
+            "repo_name",
+            "repo_root",
+            "source_checkout_path"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/schemas/success_response/$defs/ResponseResult"
+        }
+      },
+      "required": [
+        "id",
+        "result"
+      ],
+      "title": "SuccessResponse",
+      "type": "object"
+    }
+  },
+  "title": "Herdr API"
+}


### PR DESCRIPTION
Closes out the two M1 spec items that had no child ticket: the bounded events-stream buffering (#22, a binding decision in spec #20, flagged since M0) and the CI workflow (#23, User Story 12). Per-ticket verification details are in the closing comments on each issue.

## Bounded events buffering (#22)

- `EventsSession.updates` and the transport event stream move from unbounded AsyncStreams to `.bufferingNewest(256)` (rationale documented at the constant).
- Drops surface via a synthetic `local.events_dropped` marker: whenever a yield reports an eviction, the producer re-yields a marker. The compensation loop provably converges even when the marker itself is evicted, so a drop can never go unsignaled. Lifecycle updates (`.suspended`/`.ended`) always survive by yield ordering.
- `ConsoleStore` treats the marker as a resync trigger through the existing snapshot-then-delta machinery — no new sync path. Convergence is proven by a test that forces a real overflow (injected limit, observed drop count) where the marker is the only possible resync route.
- Other stream sites audited: ack stream bounded to 1; observe frame stream bounded (local frame drops create a seq gap, which the store's existing gap-recovery already handles); attach PTY streams deliberately stay unbounded with a written justification (raw terminal bytes are not resyncable).
- The serialized lifecycle-transition machinery (847b5cb) is untouched.

## CI (#23)

- `.github/workflows/ci.yml`, two jobs on `pull_request` + push to `main`:
  - codegen drift check on ubuntu against a committed schema snapshot (`scripts/herdr-schema.json`, captured from herdr 0.7.4 / protocol 16) — CI needs no herdr binary;
  - full headless `xcodebuild test` on macos-26 (iPhone 17 simulator, OS=latest). sshd-dependent e2e suites skip cleanly on bare runners via `LocalSSHTestEnvironment.isAvailable`.
- Dispatcher verification caught a real bug pre-merge: `CODE_SIGNING_ALLOWED=NO` strips the simulator keychain entitlement and fails the real-Keychain tests with -34018. Removed after an A/B confirmation; the workflow header comment warns against reintroducing it.

## Test evidence

Full suite with the exact CI command: **234 tests / 38 suites green** locally (incl. real-sshd e2e). `actionlint` clean. `generate-wire-types.py --check --schema scripts/herdr-schema.json` reports no drift. This PR's first CI run doubles as the workflow's live validation.

With this merged, every child ticket of spec #20 is closed (#15 was resolved as a deferral decision; follow-up issues #24–#27 are tracked separately).

refs #20