### PR TITLE
fix(console): improve replies and observe history

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,7 +25,9 @@ The native dashboard surface: the flat, status-sorted list of Agents across Host
 _Avoid_: dashboard, home
 
 **Observe**:
-Read-only live view of an Agent's terminal output. Never sends input.
+Read-only live view of an Agent's terminal output. It temporarily claims a
+non-takeover herdr control session so the Agent's PTY matches the phone
+geometry, but never sends terminal input; replies and keys use native controls.
 _Avoid_: watch, monitor, preview
 
 **Attach**:

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -35,12 +35,26 @@ struct AgentDetailView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            TerminalScreenView(feed: store.feed) { cols, rows in
-                store.viewDidResize(cols: cols, rows: rows)
-            }
+            TerminalScreenView(
+                feed: store.feed,
+                onSizeChanged: { cols, rows in
+                    store.viewDidResize(cols: cols, rows: rows)
+                },
+                onLoadEarlier: { store.loadEarlier() })
             // Keyed on the store: resuming Observe after Attach mints a
             // fresh store, whose feed must get a freshly attached view.
             .id(ObjectIdentifier(store))
+            .overlay(alignment: .top) {
+                if store.isLoadingEarlier {
+                    ProgressView()
+                        .controlSize(.small)
+                        .padding(8)
+                        .background(.thinMaterial, in: Capsule())
+                        .padding(.top, 8)
+                        .accessibilityLabel("Loading earlier output")
+                        .allowsHitTesting(false)
+                }
+            }
             .overlay { statusOverlay }
 
             AgentInputBar(store: input)

--- a/Sources/HerdrMobile/Console/AgentInputBar.swift
+++ b/Sources/HerdrMobile/Console/AgentInputBar.swift
@@ -27,6 +27,10 @@ struct AgentInputBar: View {
                     .lineLimit(1...5)
                     .focused($messageFocused)
                     .submitLabel(.send)
+                    .onSubmit {
+                        messageFocused = false
+                        Task { await store.sendDraft() }
+                    }
 
                 Button {
                     messageFocused = false

--- a/Sources/HerdrMobile/Console/AgentInputStore.swift
+++ b/Sources/HerdrMobile/Console/AgentInputStore.swift
@@ -63,9 +63,10 @@ enum QuickKey: String, CaseIterable, Identifiable, Sendable {
 }
 
 /// The Agent detail screen's input pipeline (#10): a message box that sends
-/// typed replies via `agent.send`, and a quick-key bar that sends control
-/// keys via `pane.send_keys`. This is the User Story 6 surface — answering a
-/// Blocked agent from native controls, never entering Attach.
+/// typed replies and Enter atomically via `pane.send_input`, and a quick-key
+/// bar that sends control keys via `pane.send_keys`. This is the User Story
+/// 6 surface — answering a Blocked agent from native controls, never entering
+/// Attach.
 ///
 /// Kept separate from `ObserveTerminalStore`, which is deliberately read-only
 /// (CONTEXT.md): Observe never sends input, so the send path lives here.
@@ -93,7 +94,7 @@ final class AgentInputStore {
     /// hop, leaving a window the second tap slips through.
     private var isSendingDraft = false
 
-    /// The Agent's pane id — the target for both `agent.send` and
+    /// The Agent's pane id — the target for both `pane.send_input` and
     /// `pane.send_keys`.
     private let target: String
     /// The Host's current transport, re-queried per send: the events session
@@ -111,8 +112,8 @@ final class AgentInputStore {
         !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    /// Sends the composed message via `agent.send`, clearing the box on
-    /// success. Whitespace-only drafts are ignored.
+    /// Writes the composed message and presses Enter in one RPC, clearing the
+    /// box on success. Whitespace-only drafts are ignored.
     func sendDraft() async {
         guard !isSendingDraft else { return }
         let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -120,7 +121,8 @@ final class AgentInputStore {
         isSendingDraft = true
         defer { isSendingDraft = false }
         let sent = await run { transport in
-            try await transport.sendToAgent(AgentSendParams(target: target, text: text))
+            try await transport.sendInput(
+                PaneSendInputParams(paneID: target, keys: ["enter"], text: text))
         }
         if sent {
             draft = ""

--- a/Sources/HerdrMobile/Console/AttachTerminalView.swift
+++ b/Sources/HerdrMobile/Console/AttachTerminalView.swift
@@ -18,6 +18,7 @@ struct AttachTerminalView: View {
         NavigationStack {
             TerminalScreenView(
                 feed: store.feed,
+                style: .attach,
                 allowsInput: true,
                 onSizeChanged: { cols, rows in store.viewDidResize(cols: cols, rows: rows) },
                 onSend: { keystrokes in store.send(keystrokes) }

--- a/Sources/HerdrMobile/Console/ObserveTerminalStore.swift
+++ b/Sources/HerdrMobile/Console/ObserveTerminalStore.swift
@@ -4,8 +4,10 @@ import Observation
 /// The Agent detail screen's Observe pipeline (#9): render the Pane's logical
 /// transcript from `pane.read --format ansi --source recent-unwrapped`, then
 /// use the terminal stream as a low-latency change signal. Each coalesced
-/// refresh replaces the local SwiftTerm screen, where long PC-width lines can
-/// wrap to the phone instead of being cropped by a narrow server-side frame.
+/// refresh removes the remote TUI's input chrome, then replaces the local
+/// SwiftTerm screen, where long PC-width output can wrap to the phone instead
+/// of being cropped by a narrow server-side frame. Input belongs exclusively
+/// to the native `AgentInputBar` below Observe.
 ///
 /// The store is driven by the terminal view's geometry: nothing starts until
 /// the first size report (the observe command needs cols/rows), and a
@@ -234,7 +236,7 @@ final class ObserveTerminalStore {
         guard !stopRequested else { return false }
         // pane.read joins lines with bare newlines; a raw-mode terminal
         // needs CR+LF or the lines stair-step.
-        let normalized = read.text
+        let normalized = Self.outputOnlyTranscript(read.text)
             .replacingOccurrences(of: "\r\n", with: "\n")
             .replacingOccurrences(of: "\n", with: "\r\n")
         var bytes = Data()
@@ -247,6 +249,87 @@ final class ObserveTerminalStore {
         feed.write(bytes)
         hasLoadedTranscript = true
         return true
+    }
+
+    /// herdr exposes terminal rows, not an agent-output-only stream. Remove
+    /// the final interactive prompt and its footer while retaining earlier
+    /// prompts from the conversation history. ANSI is preserved for the
+    /// retained output; a plain-text projection is used only to find chrome.
+    private static func outputOnlyTranscript(_ transcript: String) -> String {
+        var lines = transcript.components(separatedBy: "\n")
+        guard
+            let inputStart = lines.lastIndex(where: { line in
+                let plain = terminalPlainText(line).trimmingCharacters(in: .whitespaces)
+                return plain == "›" || plain.hasPrefix("› ")
+                    || plain == "❯" || plain.hasPrefix("❯ ")
+            })
+        else { return transcript }
+
+        lines.removeSubrange(inputStart...)
+        trimTrailingBlankLines(&lines)
+        if let last = lines.last {
+            let status = terminalPlainText(last).trimmingCharacters(in: .whitespaces)
+            if status.hasPrefix("• Working (") || status.hasPrefix("• Worked for ") {
+                lines.removeLast()
+                trimTrailingBlankLines(&lines)
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func trimTrailingBlankLines(_ lines: inout [String]) {
+        while let last = lines.last,
+            terminalPlainText(last).trimmingCharacters(in: .whitespaces).isEmpty
+        {
+            lines.removeLast()
+        }
+    }
+
+    /// Removes CSI/OSC control sequences for matching only. The original ANSI
+    /// line remains untouched when it is kept in the transcript.
+    private static func terminalPlainText(_ line: String) -> String {
+        let scalars = Array(line.unicodeScalars)
+        var result = String.UnicodeScalarView()
+        var index = 0
+        while index < scalars.count {
+            guard scalars[index].value == 0x1B else {
+                if scalars[index].value != 0x0D {
+                    result.append(scalars[index])
+                }
+                index += 1
+                continue
+            }
+
+            index += 1
+            guard index < scalars.count else { break }
+            switch scalars[index].value {
+            case 0x5B:  // CSI: ESC [ ... final-byte
+                index += 1
+                while index < scalars.count {
+                    let value = scalars[index].value
+                    index += 1
+                    if (0x40...0x7E).contains(value) { break }
+                }
+            case 0x5D:  // OSC: ESC ] ... BEL or ST
+                index += 1
+                while index < scalars.count {
+                    if scalars[index].value == 0x07 {
+                        index += 1
+                        break
+                    }
+                    if scalars[index].value == 0x1B, index + 1 < scalars.count,
+                        scalars[index + 1].value == 0x5C
+                    {
+                        index += 2
+                        break
+                    }
+                    index += 1
+                }
+            default:
+                index += 1
+            }
+        }
+        return String(result)
     }
 
     private static func message(for error: any Error) -> String {

--- a/Sources/HerdrMobile/Console/ObserveTerminalStore.swift
+++ b/Sources/HerdrMobile/Console/ObserveTerminalStore.swift
@@ -59,6 +59,7 @@ final class ObserveTerminalStore {
     private var historyLoadTask: Task<Void, Never>?
     private var transcriptLineLimit = ObserveTerminalStore.initialTranscriptLines
     private var loadedTranscriptLineLimit = 0
+    private var latestTranscript: String?
 
     init(
         target: String, transcriptRefreshInterval: Duration = .milliseconds(150),
@@ -299,11 +300,19 @@ final class ObserveTerminalStore {
         let expandsHistory = replacing && loadedTranscriptLineLimit > 0
             && requestedLines > loadedTranscriptLineLimit
         loadedTranscriptLineLimit = max(loadedTranscriptLineLimit, requestedLines)
-        canLoadEarlier = requestedLines < Self.maximumTranscriptLines
-            && Self.logicalLineCount(read.text) >= requestedLines
+        let transcript = Self.outputOnlyTranscript(read.text)
+        if expandsHistory {
+            canLoadEarlier = requestedLines < Self.maximumTranscriptLines
+                && latestTranscript.map {
+                    Self.addsEarlierHistory(transcript, than: $0)
+                } ?? true
+        } else if requestedLines >= Self.maximumTranscriptLines {
+            canLoadEarlier = false
+        }
+        latestTranscript = transcript
         // pane.read joins lines with bare newlines; a raw-mode terminal
         // needs CR+LF or the lines stair-step.
-        let normalized = Self.outputOnlyTranscript(read.text)
+        let normalized = transcript
             .replacingOccurrences(of: "\r\n", with: "\n")
             .replacingOccurrences(of: "\n", with: "\r\n")
         var bytes = Data()
@@ -322,9 +331,19 @@ final class ObserveTerminalStore {
         return true
     }
 
-    private static func logicalLineCount(_ transcript: String) -> Int {
-        guard !transcript.isEmpty else { return 0 }
-        return transcript.components(separatedBy: "\n").count
+    private static func addsEarlierHistory(_ transcript: String, than previous: String) -> Bool {
+        guard !previous.isEmpty, transcript != previous else { return false }
+        let previousLines = previous.components(separatedBy: "\n").map(terminalPlainText)
+        let transcriptLines = transcript.components(separatedBy: "\n").map(terminalPlainText)
+        let signature = Array(previousLines.prefix(8))
+        guard !signature.isEmpty, transcriptLines.count >= signature.count else { return false }
+
+        for start in 0...(transcriptLines.count - signature.count) {
+            if transcriptLines[start..<(start + signature.count)].elementsEqual(signature) {
+                return start > 0
+            }
+        }
+        return false
     }
 
     /// herdr exposes terminal rows, not an agent-output-only stream. Remove

--- a/Sources/HerdrMobile/Console/ObserveTerminalStore.swift
+++ b/Sources/HerdrMobile/Console/ObserveTerminalStore.swift
@@ -17,6 +17,10 @@ import Observation
 @MainActor
 @Observable
 final class ObserveTerminalStore {
+    private static let initialTranscriptLines = 80
+    private static let transcriptPageLines = 200
+    private static let maximumTranscriptLines = 1_000
+
     enum Status: Equatable {
         /// Waiting for the terminal view's first layout to report cols/rows.
         case waitingForSize
@@ -31,6 +35,8 @@ final class ObserveTerminalStore {
     }
 
     private(set) var status: Status = .waitingForSize
+    private(set) var isLoadingEarlier = false
+    private(set) var canLoadEarlier = true
     /// The byte pipe the terminal view consumes.
     let feed = TerminalByteFeed()
 
@@ -50,6 +56,9 @@ final class ObserveTerminalStore {
     private var runTask: Task<Void, Never>?
     private var transcriptRefreshTask: Task<Void, Never>?
     private var transcriptRefreshPending = false
+    private var historyLoadTask: Task<Void, Never>?
+    private var transcriptLineLimit = ObserveTerminalStore.initialTranscriptLines
+    private var loadedTranscriptLineLimit = 0
 
     init(
         target: String, transcriptRefreshInterval: Duration = .milliseconds(150),
@@ -90,6 +99,7 @@ final class ObserveTerminalStore {
         stopRequested = true
         transcriptRefreshPending = false
         transcriptRefreshTask?.cancel()
+        historyLoadTask?.cancel()
         if let stream = liveStream {
             await stream.end()
         }
@@ -99,7 +109,52 @@ final class ObserveTerminalStore {
         if let task = transcriptRefreshTask {
             await task.value
         }
+        if let task = historyLoadTask {
+            await task.value
+        }
         status = .stopped
+    }
+
+    /// Expands the recent-unwrapped window when the terminal reaches the top.
+    /// herdr 0.7.4 has no offset pagination and caps reads at 1,000 lines, so
+    /// each accepted pull grows the window by one page until that boundary or
+    /// the beginning of retained history is reached.
+    @discardableResult
+    func loadEarlier() -> Bool {
+        guard case .live = status else { return false }
+        guard hasLoadedTranscript, canLoadEarlier, !isLoadingEarlier else { return false }
+        guard transcriptLineLimit < Self.maximumTranscriptLines else {
+            canLoadEarlier = false
+            return false
+        }
+
+        let previousLimit = transcriptLineLimit
+        let requestedLimit = min(
+            Self.maximumTranscriptLines, previousLimit + Self.transcriptPageLines)
+        transcriptLineLimit = requestedLimit
+        isLoadingEarlier = true
+        historyLoadTask = Task {
+            await self.runHistoryLoad(previousLimit: previousLimit, requestedLimit: requestedLimit)
+        }
+        return true
+    }
+
+    private func runHistoryLoad(previousLimit: Int, requestedLimit: Int) async {
+        let succeeded: Bool
+        if let transport = await transport() {
+            succeeded = await refreshTranscript(
+                transport: transport, replacing: true, requestedLines: requestedLimit)
+        } else {
+            succeeded = false
+        }
+
+        if !succeeded, loadedTranscriptLineLimit < requestedLimit,
+            transcriptLineLimit == requestedLimit
+        {
+            transcriptLineLimit = previousLimit
+        }
+        isLoadingEarlier = false
+        historyLoadTask = nil
     }
 
     private func start() {
@@ -227,12 +282,25 @@ final class ObserveTerminalStore {
     /// Reads and renders the complete logical transcript. Failure is not
     /// fatal: the stream remains live and a later frame retries the read.
     @discardableResult
-    private func refreshTranscript(transport: any Transport, replacing: Bool) async -> Bool {
+    private func refreshTranscript(
+        transport: any Transport, replacing: Bool, requestedLines: Int? = nil
+    ) async -> Bool {
+        let requestedLines = requestedLines ?? transcriptLineLimit
         guard
             let read = try? await transport.readPane(
-                PaneReadParams(paneID: target, source: .recentUnwrapped, format: .ansi))
+                PaneReadParams(
+                    paneID: target, source: .recentUnwrapped, format: .ansi,
+                    lines: requestedLines))
         else { return false }
         guard !stopRequested else { return false }
+        // An older in-flight read must not replace a larger history window
+        // accepted by a later pull-to-load request.
+        guard requestedLines >= transcriptLineLimit else { return false }
+        let expandsHistory = replacing && loadedTranscriptLineLimit > 0
+            && requestedLines > loadedTranscriptLineLimit
+        loadedTranscriptLineLimit = max(loadedTranscriptLineLimit, requestedLines)
+        canLoadEarlier = requestedLines < Self.maximumTranscriptLines
+            && Self.logicalLineCount(read.text) >= requestedLines
         // pane.read joins lines with bare newlines; a raw-mode terminal
         // needs CR+LF or the lines stair-step.
         let normalized = Self.outputOnlyTranscript(read.text)
@@ -245,9 +313,18 @@ final class ObserveTerminalStore {
             bytes.append(Data("\u{1B}[3J\u{1B}[2J\u{1B}[H".utf8))
         }
         bytes.append(Data(normalized.utf8))
-        feed.write(bytes)
+        if expandsHistory {
+            feed.writeHistorySnapshot(bytes)
+        } else {
+            feed.write(bytes)
+        }
         hasLoadedTranscript = true
         return true
+    }
+
+    private static func logicalLineCount(_ transcript: String) -> Int {
+        guard !transcript.isEmpty else { return 0 }
+        return transcript.components(separatedBy: "\n").count
     }
 
     /// herdr exposes terminal rows, not an agent-output-only stream. Remove

--- a/Sources/HerdrMobile/Console/ObserveTerminalStore.swift
+++ b/Sources/HerdrMobile/Console/ObserveTerminalStore.swift
@@ -1,16 +1,16 @@
 import Foundation
 import Observation
 
-/// The Agent detail screen's Observe pipeline (#9): backfill scrollback with
-/// `pane.read --format ansi --source recent`, then live-follow the Pane over
-/// the Host's terminal channel, feeding decoded bytes to the terminal view
-/// through a `TerminalByteFeed`.
+/// The Agent detail screen's Observe pipeline (#9): render the Pane's logical
+/// transcript from `pane.read --format ansi --source recent-unwrapped`, then
+/// use the terminal stream as a low-latency change signal. Each coalesced
+/// refresh replaces the local SwiftTerm screen, where long PC-width lines can
+/// wrap to the phone instead of being cropped by a narrow server-side frame.
 ///
 /// The store is driven by the terminal view's geometry: nothing starts until
 /// the first size report (the observe command needs cols/rows), and a
-/// changed size restarts the live-follow — the server renders frames for
-/// exactly one geometry, and every fresh stream opens with a full repaint,
-/// which is also how sequence gaps recover. Observe is read-only
+/// changed size restarts the live-follow. Sequence gaps also restart the
+/// stream so future change signals remain trustworthy. Observe is read-only
 /// (CONTEXT.md): no input path exists here.
 @MainActor
 @Observable
@@ -36,17 +36,25 @@ final class ObserveTerminalStore {
     /// The Host's current transport, re-queried per (re)start: the events
     /// session underneath may have reconnected onto a fresh one.
     private let transport: @Sendable () async -> (any Transport)?
+    private let transcriptRefreshInterval: Duration
 
     private var cols: Int?
     private var rows: Int?
-    private var didBackfill = false
+    private var didLoadInitialTranscript = false
+    private var hasLoadedTranscript = false
     private var stopRequested = false
     private var restartRequested = false
     private var liveStream: TerminalFrameStream?
     private var runTask: Task<Void, Never>?
+    private var transcriptRefreshTask: Task<Void, Never>?
+    private var transcriptRefreshPending = false
 
-    init(target: String, transport: @escaping @Sendable () async -> (any Transport)?) {
+    init(
+        target: String, transcriptRefreshInterval: Duration = .milliseconds(150),
+        transport: @escaping @Sendable () async -> (any Transport)?
+    ) {
         self.target = target
+        self.transcriptRefreshInterval = transcriptRefreshInterval
         self.transport = transport
     }
 
@@ -78,10 +86,15 @@ final class ObserveTerminalStore {
     /// the detail screen creates a fresh store per visit.
     func stop() async {
         stopRequested = true
+        transcriptRefreshPending = false
+        transcriptRefreshTask?.cancel()
         if let stream = liveStream {
             await stream.end()
         }
         if let task = runTask {
+            await task.value
+        }
+        if let task = transcriptRefreshTask {
             await task.value
         }
         status = .stopped
@@ -109,8 +122,9 @@ final class ObserveTerminalStore {
                 status = .failed("The Host is not connected.")
                 return
             }
-            if !didBackfill {
-                await backfillScrollback(transport: transport)
+            if !didLoadInitialTranscript {
+                didLoadInitialTranscript = true
+                _ = await refreshTranscript(transport: transport, replacing: false)
                 if stopRequested { return }
             }
             // The stream below opens with the latest geometry, satisfying
@@ -152,7 +166,16 @@ final class ObserveTerminalStore {
                         break
                     }
                     lastSeq = frame.seq
-                    feed.write(frame.bytes)
+                    // The server renders this frame at the requested mobile
+                    // width by cropping an already-laid-out PC terminal. Use
+                    // it as a change signal, then fetch logical lines that
+                    // SwiftTerm can wrap locally.
+                    if !hasLoadedTranscript {
+                        // Degrade to the raw frame while pane.read is failing;
+                        // the next successful transcript refresh replaces it.
+                        feed.write(frame.bytes)
+                    }
+                    requestTranscriptRefresh(transport: transport)
                 }
             } catch {
                 failure = error
@@ -176,21 +199,54 @@ final class ObserveTerminalStore {
         }
     }
 
-    /// Scrollback backfill, once per store: the observe stream's first full
-    /// frame repaints the visible screen, so only history needs fetching.
-    /// Failure is not fatal — live output alone beats no terminal at all.
-    private func backfillScrollback(transport: any Transport) async {
-        didBackfill = true
+    /// Coalesces frame bursts into one immediate read plus at most one read
+    /// per interval. The pending bit guarantees a final refresh after output
+    /// becomes quiet without opening one SSH request per frame.
+    private func requestTranscriptRefresh(transport: any Transport) {
+        transcriptRefreshPending = true
+        guard transcriptRefreshTask == nil else { return }
+        transcriptRefreshTask = Task {
+            await self.runTranscriptRefreshes(transport: transport)
+        }
+    }
+
+    private func runTranscriptRefreshes(transport: any Transport) async {
+        defer { transcriptRefreshTask = nil }
+        while !Task.isCancelled, !stopRequested, transcriptRefreshPending {
+            transcriptRefreshPending = false
+            _ = await refreshTranscript(transport: transport, replacing: true)
+            do {
+                try await Task.sleep(for: transcriptRefreshInterval)
+            } catch {
+                return
+            }
+        }
+    }
+
+    /// Reads and renders the complete logical transcript. Failure is not
+    /// fatal: the stream remains live and a later frame retries the read.
+    @discardableResult
+    private func refreshTranscript(transport: any Transport, replacing: Bool) async -> Bool {
         guard
             let read = try? await transport.readPane(
-                PaneReadParams(paneID: target, source: .recent, format: .ansi))
-        else { return }
+                PaneReadParams(paneID: target, source: .recentUnwrapped, format: .ansi))
+        else { return false }
+        guard !stopRequested else { return false }
         // pane.read joins lines with bare newlines; a raw-mode terminal
         // needs CR+LF or the lines stair-step.
         let normalized = read.text
             .replacingOccurrences(of: "\r\n", with: "\n")
             .replacingOccurrences(of: "\n", with: "\r\n")
-        feed.write(Data(normalized.utf8))
+        var bytes = Data()
+        if replacing {
+            // Clear scrollback and the visible screen before painting the
+            // latest snapshot, otherwise every refresh duplicates history.
+            bytes.append(Data("\u{1B}[3J\u{1B}[2J\u{1B}[H".utf8))
+        }
+        bytes.append(Data(normalized.utf8))
+        feed.write(bytes)
+        hasLoadedTranscript = true
+        return true
     }
 
     private static func message(for error: any Error) -> String {

--- a/Sources/HerdrMobile/Console/ObserveTerminalStore.swift
+++ b/Sources/HerdrMobile/Console/ObserveTerminalStore.swift
@@ -5,9 +5,9 @@ import Observation
 /// transcript from `pane.read --format ansi --source recent-unwrapped`, then
 /// use the terminal stream as a low-latency change signal. Each coalesced
 /// refresh removes the remote TUI's input chrome, then replaces the local
-/// SwiftTerm screen, where long PC-width output can wrap to the phone instead
-/// of being cropped by a narrow server-side frame. Input belongs exclusively
-/// to the native `AgentInputBar` below Observe.
+/// SwiftTerm screen. The transport applies the phone geometry to the Agent's
+/// PTY, but input belongs exclusively to the native `AgentInputBar` below
+/// Observe.
 ///
 /// The store is driven by the terminal view's geometry: nothing starts until
 /// the first size report (the observe command needs cols/rows), and a
@@ -168,10 +168,9 @@ final class ObserveTerminalStore {
                         break
                     }
                     lastSeq = frame.seq
-                    // The server renders this frame at the requested mobile
-                    // width by cropping an already-laid-out PC terminal. Use
-                    // it as a change signal, then fetch logical lines that
-                    // SwiftTerm can wrap locally.
+                    // The server renders this frame after applying the mobile
+                    // width to the Agent's PTY. Use it as a change signal,
+                    // then fetch complete logical lines for local rendering.
                     if !hasLoadedTranscript {
                         // Degrade to the raw frame while pane.read is failing;
                         // the next successful transcript refresh replaces it.

--- a/Sources/HerdrMobile/Terminal/TerminalByteFeed.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalByteFeed.swift
@@ -7,26 +7,51 @@ import Foundation
 /// and Attach (#11), which differ only in whether an input path exists.
 @MainActor
 final class TerminalByteFeed {
-    private var sink: ((Data) -> Void)?
-    private var buffered = Data()
+    enum Delivery {
+        case bytes(Data)
+        case historySnapshot(Data)
+
+        var data: Data {
+            switch self {
+            case .bytes(let data), .historySnapshot(let data):
+                data
+            }
+        }
+    }
+
+    private var sink: ((Delivery) -> Void)?
+    private var buffered: [Delivery] = []
 
     /// Registers the consumer, flushing anything buffered. Later attaches
     /// replace the sink (a representable view can be remade by SwiftUI).
     func attach(_ sink: @escaping (Data) -> Void) {
+        attachDeliveries { sink($0.data) }
+    }
+
+    func attachDeliveries(_ sink: @escaping (Delivery) -> Void) {
         self.sink = sink
-        if !buffered.isEmpty {
-            let pending = buffered
-            buffered = Data()
-            sink(pending)
+        let pending = buffered
+        buffered.removeAll(keepingCapacity: true)
+        for delivery in pending {
+            sink(delivery)
         }
     }
 
     func write(_ data: Data) {
+        deliver(.bytes(data))
+    }
+
+    func writeHistorySnapshot(_ data: Data) {
+        deliver(.historySnapshot(data))
+    }
+
+    private func deliver(_ delivery: Delivery) {
+        let data = delivery.data
         guard !data.isEmpty else { return }
         if let sink {
-            sink(data)
+            sink(delivery)
         } else {
-            buffered.append(data)
+            buffered.append(delivery)
         }
     }
 }

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -5,7 +5,7 @@ import UIKit
 /// Presentation-specific terminal typography. Observe prioritizes fitting a
 /// useful amount of a desktop transcript on a phone; Attach keeps SwiftTerm's
 /// default size for interactive use.
-enum TerminalScreenStyle {
+enum TerminalScreenStyle: Equatable {
     case observe
     case attach
 
@@ -29,6 +29,7 @@ struct TerminalScreenView: UIViewRepresentable {
     var style: TerminalScreenStyle = .observe
     var allowsInput = false
     var onSizeChanged: ((_ cols: Int, _ rows: Int) -> Void)?
+    var onLoadEarlier: (() -> Bool)?
     /// Keystrokes the terminal wants sent to the remote; nil (Observe)
     /// discards them — this surface never sends input (CONTEXT.md).
     var onSend: ((Data) -> Void)?
@@ -36,12 +37,20 @@ struct TerminalScreenView: UIViewRepresentable {
     func makeUIView(context: Context) -> SizeReportingTerminalView {
         let view = SizeReportingTerminalView(frame: .zero, font: style.font)
         view.allowsInput = allowsInput
+        if style == .observe {
+            // herdr exposes up to 1,000 logical lines. Phone-width wrapping
+            // can turn those into several thousand terminal rows.
+            view.changeScrollback(5_000)
+        }
         view.terminalDelegate = context.coordinator
         view.onSizeReport = { [weak coordinator = context.coordinator] cols, rows in
             coordinator?.onSizeChanged?(cols, rows)
         }
-        feed.attach { [weak view] data in
-            view?.consume(data)
+        view.onLoadEarlier = { [weak coordinator = context.coordinator] in
+            coordinator?.onLoadEarlier?() ?? false
+        }
+        feed.attachDeliveries { [weak view] delivery in
+            view?.consume(delivery)
         }
         return view
     }
@@ -49,11 +58,13 @@ struct TerminalScreenView: UIViewRepresentable {
     func updateUIView(_ view: SizeReportingTerminalView, context: Context) {
         view.allowsInput = allowsInput
         context.coordinator.onSizeChanged = onSizeChanged
+        context.coordinator.onLoadEarlier = onLoadEarlier
         context.coordinator.onSend = onSend
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onSizeChanged: onSizeChanged, onSend: onSend)
+        Coordinator(
+            onSizeChanged: onSizeChanged, onLoadEarlier: onLoadEarlier, onSend: onSend)
     }
 
     /// SwiftTerm's delegate protocol is not actor-annotated but the view
@@ -63,10 +74,15 @@ struct TerminalScreenView: UIViewRepresentable {
     @MainActor
     final class Coordinator: TerminalViewDelegate {
         var onSizeChanged: ((Int, Int) -> Void)?
+        var onLoadEarlier: (() -> Bool)?
         var onSend: ((Data) -> Void)?
 
-        init(onSizeChanged: ((Int, Int) -> Void)?, onSend: ((Data) -> Void)?) {
+        init(
+            onSizeChanged: ((Int, Int) -> Void)?, onLoadEarlier: (() -> Bool)? = nil,
+            onSend: ((Data) -> Void)?
+        ) {
             self.onSizeChanged = onSizeChanged
+            self.onLoadEarlier = onLoadEarlier
             self.onSend = onSend
         }
 
@@ -106,11 +122,19 @@ final class SizeReportingTerminalView: TerminalView {
         }
     }
     var onSizeReport: ((_ cols: Int, _ rows: Int) -> Void)?
+    var onLoadEarlier: (() -> Bool)?
     private var lastReported: (cols: Int, rows: Int)?
     private var defersScrollerUpdates = false
     private var pendingReadOnlySnapshot: Data?
     private var appliesReadOnlySnapshot = false
     private var browsesHistory = false
+    private var requestedEarlierAtTop = false
+
+    private struct ViewportAnchor {
+        let signature: [String]
+        let row: Int
+        let totalRows: Int
+    }
 
     /// Feeds one transport delivery as an atomic visual update. Observe
     /// replaces its entire snapshot in one delivery; SwiftTerm otherwise
@@ -118,17 +142,33 @@ final class SizeReportingTerminalView: TerminalView {
     /// indicator collapse and grow. While the user browses history, keep only
     /// the latest snapshot pending and apply it on returning to the bottom.
     /// Attach keeps SwiftTerm's normal incremental behavior.
-    func consume(_ data: Data) {
+    func consume(_ delivery: TerminalByteFeed.Delivery) {
+        let data = delivery.data
         guard !data.isEmpty else { return }
         guard !allowsInput else {
             feed(byteArray: ArraySlice([UInt8](data)))
             return
         }
+
+        if case .historySnapshot = delivery {
+            let anchor = captureViewportAnchor()
+            pendingReadOnlySnapshot = nil
+            applyReadOnlySnapshot(data)
+            restoreViewportAnchor(anchor)
+            requestedEarlierAtTop = false
+            browsesHistory = !isAtBottom
+            return
+        }
+
         if browsesHistory, !appliesReadOnlySnapshot {
             pendingReadOnlySnapshot = data
             return
         }
 
+        applyReadOnlySnapshot(data)
+    }
+
+    private func applyReadOnlySnapshot(_ data: Data) {
         let terminal = getTerminal()
         appliesReadOnlySnapshot = true
         defersScrollerUpdates = true
@@ -136,6 +176,47 @@ final class SizeReportingTerminalView: TerminalView {
         defersScrollerUpdates = false
         super.scrolled(source: terminal, yDisp: terminal.getTopVisibleRow())
         appliesReadOnlySnapshot = false
+    }
+
+    private func captureViewportAnchor() -> ViewportAnchor? {
+        let terminal = getTerminal()
+        let row = terminal.getTopVisibleRow()
+        let signature = (0..<min(8, terminal.rows)).compactMap { visibleRow in
+            terminal.getLine(row: visibleRow)?.translateToString(
+                trimRight: true, skipNullCellsFollowingWide: true)
+        }
+        guard !signature.isEmpty else { return nil }
+        return ViewportAnchor(signature: signature, row: row, totalRows: totalTerminalRows)
+    }
+
+    private func restoreViewportAnchor(_ anchor: ViewportAnchor?) {
+        guard let anchor else { return }
+        let terminal = getTerminal()
+        let maximumTopRow = max(0, totalTerminalRows - terminal.rows)
+        let predictedRow = min(
+            maximumTopRow, max(0, anchor.row + totalTerminalRows - anchor.totalRows))
+        var matchingRow: Int?
+        var matchingDistance = Int.max
+
+        for candidate in 0...maximumTopRow {
+            let matches = anchor.signature.enumerated().allSatisfy { offset, expected in
+                terminal.getScrollInvariantLine(row: candidate + offset)?.translateToString(
+                    trimRight: true, skipNullCellsFollowingWide: true) == expected
+            }
+            guard matches else { continue }
+            let distance = abs(candidate - predictedRow)
+            if distance < matchingDistance {
+                matchingRow = candidate
+                matchingDistance = distance
+            }
+        }
+
+        scrollTo(row: matchingRow ?? predictedRow, notifyAccessibility: false)
+    }
+
+    private var totalTerminalRows: Int {
+        let lineHeight = max(1, ceil(font.lineHeight))
+        return max(0, Int((contentSize.height / lineHeight).rounded()))
     }
 
     override func scrolled(source: Terminal, yDisp: Int) {
@@ -147,16 +228,40 @@ final class SizeReportingTerminalView: TerminalView {
         didSet {
             guard !allowsInput, !appliesReadOnlySnapshot else { return }
             guard isTracking || (browsesHistory && isDecelerating) else { return }
-            updateHistoryBrowsing()
+            handleUserScroll()
         }
     }
 
     override func accessibilityScroll(_ direction: UIAccessibilityScrollDirection) -> Bool {
-        let didScroll = super.accessibilityScroll(direction)
-        if didScroll, !allowsInput {
-            updateHistoryBrowsing()
+        guard !allowsInput else { return super.accessibilityScroll(direction) }
+        let terminal = getTerminal()
+        let originalRow = terminal.getTopVisibleRow()
+        switch direction {
+        case .up, .left, .previous:
+            scrollUp(lines: terminal.rows)
+        case .down, .right, .next:
+            scrollDown(lines: terminal.rows)
+        default:
+            return super.accessibilityScroll(direction)
         }
+
+        let didScroll = terminal.getTopVisibleRow() != originalRow
+        guard didScroll else { return false }
+        handleUserScroll()
+        UIAccessibility.post(notification: .pageScrolled, argument: nil)
         return didScroll
+    }
+
+    private func handleUserScroll() {
+        if isAtTop {
+            if !requestedEarlierAtTop {
+                requestedEarlierAtTop = true
+                _ = onLoadEarlier?()
+            }
+        } else {
+            requestedEarlierAtTop = false
+        }
+        updateHistoryBrowsing()
     }
 
     private func updateHistoryBrowsing() {
@@ -164,7 +269,7 @@ final class SizeReportingTerminalView: TerminalView {
             browsesHistory = false
             guard let pendingReadOnlySnapshot else { return }
             self.pendingReadOnlySnapshot = nil
-            consume(pendingReadOnlySnapshot)
+            consume(.bytes(pendingReadOnlySnapshot))
         } else {
             browsesHistory = true
         }
@@ -174,6 +279,10 @@ final class SizeReportingTerminalView: TerminalView {
         let maximumOffset = max(
             0, contentSize.height - bounds.height + adjustedContentInset.bottom)
         return contentOffset.y >= maximumOffset - max(1, font.lineHeight / 2)
+    }
+
+    private var isAtTop: Bool {
+        contentOffset.y <= max(1, font.lineHeight / 2)
     }
 
     override func showCursor(source: Terminal) {

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -2,6 +2,23 @@ import SwiftTerm
 import SwiftUI
 import UIKit
 
+/// Presentation-specific terminal typography. Observe prioritizes fitting a
+/// useful amount of a desktop transcript on a phone; Attach keeps SwiftTerm's
+/// default size for interactive use.
+enum TerminalScreenStyle {
+    case observe
+    case attach
+
+    fileprivate var font: UIFont? {
+        switch self {
+        case .observe:
+            UIFont.monospacedSystemFont(ofSize: 9.5, weight: .regular)
+        case .attach:
+            nil
+        }
+    }
+}
+
 /// The shared SwiftTerm surface: Observe (#9) renders it read-only, Attach
 /// (#11) drives the same view with `allowsInput` and `onSend` wired. Bytes
 /// arrive through a `TerminalByteFeed`; geometry flows out through
@@ -9,6 +26,7 @@ import UIKit
 /// the real cols/rows.
 struct TerminalScreenView: UIViewRepresentable {
     let feed: TerminalByteFeed
+    var style: TerminalScreenStyle = .observe
     var allowsInput = false
     var onSizeChanged: ((_ cols: Int, _ rows: Int) -> Void)?
     /// Keystrokes the terminal wants sent to the remote; nil (Observe)
@@ -16,7 +34,7 @@ struct TerminalScreenView: UIViewRepresentable {
     var onSend: ((Data) -> Void)?
 
     func makeUIView(context: Context) -> SizeReportingTerminalView {
-        let view = SizeReportingTerminalView(frame: .zero)
+        let view = SizeReportingTerminalView(frame: .zero, font: style.font)
         view.allowsInput = allowsInput
         view.terminalDelegate = context.coordinator
         view.onSizeReport = { [weak coordinator = context.coordinator] cols, rows in

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -41,7 +41,7 @@ struct TerminalScreenView: UIViewRepresentable {
             coordinator?.onSizeChanged?(cols, rows)
         }
         feed.attach { [weak view] data in
-            view?.feed(byteArray: ArraySlice([UInt8](data)))
+            view?.consume(data)
         }
         return view
     }
@@ -107,6 +107,74 @@ final class SizeReportingTerminalView: TerminalView {
     }
     var onSizeReport: ((_ cols: Int, _ rows: Int) -> Void)?
     private var lastReported: (cols: Int, rows: Int)?
+    private var defersScrollerUpdates = false
+    private var pendingReadOnlySnapshot: Data?
+    private var appliesReadOnlySnapshot = false
+    private var browsesHistory = false
+
+    /// Feeds one transport delivery as an atomic visual update. Observe
+    /// replaces its entire snapshot in one delivery; SwiftTerm otherwise
+    /// updates `contentSize` for every rebuilt line, which makes the scroll
+    /// indicator collapse and grow. While the user browses history, keep only
+    /// the latest snapshot pending and apply it on returning to the bottom.
+    /// Attach keeps SwiftTerm's normal incremental behavior.
+    func consume(_ data: Data) {
+        guard !data.isEmpty else { return }
+        guard !allowsInput else {
+            feed(byteArray: ArraySlice([UInt8](data)))
+            return
+        }
+        if browsesHistory, !appliesReadOnlySnapshot {
+            pendingReadOnlySnapshot = data
+            return
+        }
+
+        let terminal = getTerminal()
+        appliesReadOnlySnapshot = true
+        defersScrollerUpdates = true
+        feed(byteArray: ArraySlice([UInt8](data)))
+        defersScrollerUpdates = false
+        super.scrolled(source: terminal, yDisp: terminal.getTopVisibleRow())
+        appliesReadOnlySnapshot = false
+    }
+
+    override func scrolled(source: Terminal, yDisp: Int) {
+        guard !defersScrollerUpdates else { return }
+        super.scrolled(source: source, yDisp: yDisp)
+    }
+
+    override var contentOffset: CGPoint {
+        didSet {
+            guard !allowsInput, !appliesReadOnlySnapshot else { return }
+            guard isTracking || (browsesHistory && isDecelerating) else { return }
+            updateHistoryBrowsing()
+        }
+    }
+
+    override func accessibilityScroll(_ direction: UIAccessibilityScrollDirection) -> Bool {
+        let didScroll = super.accessibilityScroll(direction)
+        if didScroll, !allowsInput {
+            updateHistoryBrowsing()
+        }
+        return didScroll
+    }
+
+    private func updateHistoryBrowsing() {
+        if isAtBottom {
+            browsesHistory = false
+            guard let pendingReadOnlySnapshot else { return }
+            self.pendingReadOnlySnapshot = nil
+            consume(pendingReadOnlySnapshot)
+        } else {
+            browsesHistory = true
+        }
+    }
+
+    private var isAtBottom: Bool {
+        let maximumOffset = max(
+            0, contentSize.height - bounds.height + adjustedContentInset.bottom)
+        return contentOffset.y >= maximumOffset - max(1, font.lineHeight / 2)
+    }
 
     override func showCursor(source: Terminal) {
         guard allowsInput else {

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -90,15 +90,31 @@ struct TerminalScreenView: UIViewRepresentable {
 }
 
 /// TerminalView with three app-side behaviors: input is opt-in (read-only
-/// Observe must never pop a keyboard) and grabs focus on appearance so both
-/// the soft keyboard and iPad hardware keyboards work without a preliminary
-/// tap, and the current cols/rows are reported from layout — the stock view
-/// only reports *changes*, which would leave a store waiting forever when
-/// the laid-out size happens to equal SwiftTerm's 80x25 default.
+/// Observe never pops a keyboard or displays a cursor), interactive Attach
+/// grabs focus on appearance, and the current cols/rows are reported from
+/// layout. The stock view only reports *changes*, which would leave a store
+/// waiting forever when the laid-out size equals SwiftTerm's 80x25 default.
 final class SizeReportingTerminalView: TerminalView {
-    var allowsInput = false
+    var allowsInput = true {
+        didSet {
+            guard oldValue != allowsInput else { return }
+            if allowsInput {
+                getTerminal().showCursor()
+            } else {
+                getTerminal().hideCursor()
+            }
+        }
+    }
     var onSizeReport: ((_ cols: Int, _ rows: Int) -> Void)?
     private var lastReported: (cols: Int, rows: Int)?
+
+    override func showCursor(source: Terminal) {
+        guard allowsInput else {
+            source.hideCursor()
+            return
+        }
+        super.showCursor(source: source)
+    }
 
     override var canBecomeFirstResponder: Bool {
         allowsInput && super.canBecomeFirstResponder

--- a/Sources/HerdrMobile/Transport/Generated/HerdrAPITypes.swift
+++ b/Sources/HerdrMobile/Transport/Generated/HerdrAPITypes.swift
@@ -167,17 +167,6 @@ struct AgentRenameParams: Codable, Equatable, Sendable {
     }
 }
 
-/// herdr schema `$defs/AgentSendParams`.
-struct AgentSendParams: Codable, Equatable, Sendable {
-    let target: String
-    let text: String
-
-    init(target: String, text: String) {
-        self.target = target
-        self.text = text
-    }
-}
-
 /// herdr schema `$defs/AgentSessionInfo`.
 struct AgentSessionInfo: Codable, Equatable, Sendable {
     let agent: String
@@ -569,6 +558,25 @@ struct PaneScrollInfo: Codable, Equatable, Sendable {
     }
 }
 
+/// herdr schema `$defs/PaneSendInputParams`.
+struct PaneSendInputParams: Codable, Equatable, Sendable {
+    let keys: [String]?
+    let paneID: String
+    let text: String?
+
+    init(paneID: String, keys: [String]? = nil, text: String? = nil) {
+        self.paneID = paneID
+        self.keys = keys
+        self.text = text
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case keys
+        case paneID = "pane_id"
+        case text
+    }
+}
+
 /// herdr schema `$defs/PaneSendKeysParams`.
 struct PaneSendKeysParams: Codable, Equatable, Sendable {
     let keys: [String]
@@ -582,22 +590,6 @@ struct PaneSendKeysParams: Codable, Equatable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case keys
         case paneID = "pane_id"
-    }
-}
-
-/// herdr schema `$defs/PaneSendTextParams`.
-struct PaneSendTextParams: Codable, Equatable, Sendable {
-    let paneID: String
-    let text: String
-
-    init(paneID: String, text: String) {
-        self.paneID = paneID
-        self.text = text
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case paneID = "pane_id"
-        case text
     }
 }
 

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -8,6 +8,8 @@ import NIOCore
 
 /// How to reach one Host, authenticate against it, and find its herdr socket.
 struct SSHTransportSettings: Sendable {
+    static let defaultObserveCommand = "herdr terminal session control"
+
     var host: String
     var port: Int
     var username: String
@@ -29,13 +31,17 @@ struct SSHTransportSettings: Sendable {
     /// herdr is not on the login shell's PATH.
     var wakeCommand: String = "herdr remote-client-bridge"
     /// Command that streams a Pane's terminal as NDJSON frame lines over a
-    /// no-PTY exec channel (#9 probe: observe needs no PTY); the observe
-    /// target and geometry are appended, and the whole thing runs inside a
-    /// kill-on-stdin-EOF wrapper (see `observeChannelCommand`), so it must
-    /// contain no single quotes. Injectable so tests can substitute a
+    /// no-PTY exec channel. The default claims a non-takeover control
+    /// session so herdr applies the phone geometry to the Agent's PTY; the
+    /// app never writes control input on this channel. The target and
+    /// geometry are appended. Injectable so tests can substitute a
     /// frame-emitting script at the environment boundary; per-Host override
     /// also covers hosts where herdr is not on the login shell's PATH.
-    var observeCommand: String = "herdr terminal session observe"
+    var observeCommand: String = Self.defaultObserveCommand
+    /// Whether `observeCommand` treats stdin EOF as a graceful detach. The
+    /// production control command does; inert test commands can opt into the
+    /// legacy kill-on-EOF wrapper instead.
+    var observeCommandHandlesStdinEOF = true
     /// Command that attaches interactively to a Pane, run on the Host's
     /// dedicated terminal channel with a PTY (#11); the attach target and
     /// takeover flag are appended (see `attachBootstrapLine`). Injectable so
@@ -67,6 +73,7 @@ actor SSHTransport: Transport {
     private let socatPath: String
     private let wakeCommand: String
     private let observeCommand: String
+    private let observeCommandHandlesStdinEOF: Bool
     private let attachCommand: String
     private let requestTimeout: Duration
     /// Remote home directory resolution, resolved over exec once per Host:
@@ -149,7 +156,8 @@ actor SSHTransport: Transport {
 
     private init(
         client: SSHClient, socketLocation: HerdrSocketLocation, socatPath: String,
-        wakeCommand: String, observeCommand: String, attachCommand: String,
+        wakeCommand: String, observeCommand: String, observeCommandHandlesStdinEOF: Bool,
+        attachCommand: String,
         requestTimeout: Duration
     ) {
         self.client = client
@@ -157,6 +165,7 @@ actor SSHTransport: Transport {
         self.socatPath = socatPath
         self.wakeCommand = wakeCommand
         self.observeCommand = observeCommand
+        self.observeCommandHandlesStdinEOF = observeCommandHandlesStdinEOF
         self.attachCommand = attachCommand
         self.requestTimeout = requestTimeout
     }
@@ -188,6 +197,7 @@ actor SSHTransport: Transport {
         return SSHTransport(
             client: client, socketLocation: settings.socket, socatPath: settings.socatPath,
             wakeCommand: settings.wakeCommand, observeCommand: settings.observeCommand,
+            observeCommandHandlesStdinEOF: settings.observeCommandHandlesStdinEOF,
             attachCommand: settings.attachCommand, requestTimeout: settings.requestTimeout)
     }
 
@@ -448,14 +458,14 @@ actor SSHTransport: Transport {
 
     // MARK: Terminal channel (#9)
     //
-    // One dedicated exec channel carries the terminal surface: the Observe
-    // live-follow runs `herdr terminal session observe <target>` (no PTY —
-    // verified against herdr 0.7.4) and streams NDJSON frame lines until
-    // the channel is closed explicitly. Like the events channel it is
-    // exempt from the exec-slot queue: the session budget is 8 RPC slots +
-    // events + this terminal channel = sshd's default MaxSessions 10.
-    // Attach (#11) will reuse this single-channel budget; the state below
-    // keeps it to exactly one terminal channel per Host.
+    // One dedicated exec channel carries the terminal surface. Observe runs
+    // `herdr terminal session control <target>` without a PTY or takeover:
+    // herdr applies the phone geometry to the Agent's PTY, while the app
+    // exposes no terminal-input path and renders the NDJSON frames read-only.
+    // Like the events channel it is exempt from the exec-slot queue: the
+    // session budget is 8 RPC slots + events + this terminal channel = sshd's
+    // default MaxSessions 10. Attach (#11) reuses this single-channel budget;
+    // the state below keeps it to exactly one terminal channel per Host.
 
     private enum TerminalChannelState: Equatable {
         case idle
@@ -470,7 +480,9 @@ actor SSHTransport: Transport {
             throw TransportError.terminalChannelAlreadyOpen
         }
         let command = Self.observeChannelCommand(
-            observeCommand: observeCommand, request: request)
+            observeCommand: observeCommand,
+            handlesStdinEOF: observeCommandHandlesStdinEOF,
+            request: request)
         // Bounded like the events path (#22): a shed frame leaves a hole in
         // the `seq` counter, and the observe consumer already treats any
         // seq gap as "re-observe for a fresh full repaint" — local drops
@@ -495,29 +507,33 @@ actor SSHTransport: Transport {
     }
 
     /// The full remote command for one observe channel. Everything this
-    /// transport runs must die on stdin EOF — explicit close is the only way
+    /// transport runs must die on stdin EOF: explicit close is the only way
     /// to end a Citadel channel, and the close only completes once the
-    /// remote command exits (verified against localhost sshd: a command that
-    /// ignores EOF pins the teardown for its whole lifetime). socat has that
-    /// property natively; `herdr terminal session observe` does not (probed
-    /// against herdr 0.7.4: it streams on regardless), so a POSIX wrapper
-    /// adds it: a watcher waits for stdin EOF and kills observe.
+    /// remote command exits. The production control CLI handles EOF by
+    /// sending Detach, so it stays in the foreground with stdin intact.
+    /// Injectable commands that ignore EOF use a POSIX wrapper whose watcher
+    /// kills the command instead.
     ///
     /// Runs under `/bin/sh` explicitly because the login shell owning the
     /// exec command line may not speak POSIX (fish). The target rides as a
     /// positional argument so only the outer shell ever quotes it.
     ///
-    /// The stdin dance: POSIX hands `/dev/null` to backgrounded (`&`)
-    /// commands, so the real stdin is saved to fd 3 first and the watcher
-    /// reads that. Observe exiting on its own (pane closed, herdr died)
-    /// takes the `wait` path: the watcher is killed and the wrapper exits,
-    /// so the remote death still surfaces as the stream ending.
+    /// In the fallback stdin dance, POSIX hands `/dev/null` to backgrounded
+    /// (`&`) commands, so the real stdin is saved to fd 3 first and the
+    /// watcher reads that. The command exiting on its own takes the `wait`
+    /// path: the watcher is killed and the wrapper exits, so the remote death
+    /// still surfaces as the stream ending.
     static func observeChannelCommand(
-        observeCommand: String, request: TerminalObserveRequest
+        observeCommand: String,
+        handlesStdinEOF: Bool,
+        request: TerminalObserveRequest
     ) -> String {
         let quotedTarget =
             "'" + request.target.replacingOccurrences(of: "'", with: #"'\''"#) + "'"
         let observe = "\(observeCommand) \"$1\" --cols \(request.cols) --rows \(request.rows)"
+        if handlesStdinEOF {
+            return "/bin/sh -c 'exec \(observe)' observe \(quotedTarget)"
+        }
         let wrapper =
             "exec 3<&0 0</dev/null; \(observe) & p=$!; "
             + "(cat <&3 >/dev/null 2>&1 3<&-; kill $p 2>/dev/null) & w=$!; "

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -236,8 +236,8 @@ actor SSHTransport: Transport {
         return Agent(response.agent)
     }
 
-    func sendToAgent(_ params: AgentSendParams) async throws {
-        _ = try await request(method: "agent.send", params: params, decoding: OkResponse.self)
+    func sendInput(_ params: PaneSendInputParams) async throws {
+        _ = try await request(method: "pane.send_input", params: params, decoding: OkResponse.self)
     }
 
     func sendKeys(_ params: PaneSendKeysParams) async throws {

--- a/Sources/HerdrMobile/Transport/TerminalObserve.swift
+++ b/Sources/HerdrMobile/Transport/TerminalObserve.swift
@@ -1,8 +1,7 @@
 import Foundation
 
-/// One Observe live-follow request (#9): the `herdr terminal session
-/// observe` target (a Pane address) plus the terminal geometry the server
-/// should render frames for.
+/// One Observe live-follow request (#9): the Pane address plus the phone
+/// geometry that a non-takeover control session applies to the Agent's PTY.
 struct TerminalObserveRequest: Sendable, Equatable {
     let target: String
     let cols: Int

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -64,11 +64,12 @@ protocol Transport: Sendable {
     func subscribeToEvents(_ subscriptions: [EventSubscription]) async throws -> HerdrEventStream
 
     /// Opens this Host's dedicated terminal channel and starts the read-only
-    /// Observe live-follow (#9): NDJSON frame lines from `herdr terminal
-    /// session observe`, decoded and base64-unwrapped, until `end()` closes
-    /// the channel explicitly. One terminal channel per Host — the session
-    /// slot budgeted for the terminal surface — so a second call while one
-    /// is live throws `.terminalChannelAlreadyOpen`.
+    /// Observe live-follow (#9): a non-takeover `herdr terminal session
+    /// control` applies the phone geometry to the Agent's PTY and emits NDJSON
+    /// frames, while the app exposes no terminal-input path. Frames are
+    /// decoded and base64-unwrapped until `end()` closes the channel. One
+    /// terminal channel per Host, so a second call while one is live throws
+    /// `.terminalChannelAlreadyOpen`.
     func observeTerminal(_ request: TerminalObserveRequest) async throws -> TerminalFrameStream
 
     /// Opens this Host's dedicated terminal channel as a full interactive

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -16,15 +16,16 @@ protocol Transport: Sendable {
     func sessionSnapshot() async throws -> SessionSnapshot
 
     /// Reads a Pane's terminal output; the Console's last-output snippet
-    /// source (`source: .recent`, ANSI stripped) and the Observe backfill.
+    /// uses `.recent`, while Observe uses `.recentUnwrapped` so the phone can
+    /// wrap complete logical lines at its own width.
     func readPane(_ params: PaneReadParams) async throws -> PaneReadResult
 
-    /// Delivers a typed message to an Agent (`agent.send`): the detail
-    /// screen's message box (#10, User Story 6 — answering a Blocked agent
-    /// without Attach). herdr's agent-aware send, targeted by the Agent's
-    /// pane id. Returns once the server acknowledges; the effect shows up on
-    /// the Observe stream.
-    func sendToAgent(_ params: AgentSendParams) async throws
+    /// Atomically writes text and key presses to a Pane (`pane.send_input`):
+    /// the detail screen's message box (#10, User Story 6 — answering a
+    /// Blocked agent without Attach). Keeping the text and Enter key in one
+    /// RPC prevents a half-complete state where the reply is typed but not
+    /// submitted.
+    func sendInput(_ params: PaneSendInputParams) async throws
 
     /// Starts a new Agent (`agent.start`): the new-agent flow (#12, User
     /// Story 8 — dispatch work from the road). Runs the given command as a

--- a/Tests/HerdrMobileTests/AgentInputStoreTests.swift
+++ b/Tests/HerdrMobileTests/AgentInputStoreTests.swift
@@ -4,9 +4,9 @@ import Testing
 @testable import HerdrMobile
 
 /// The detail screen's input store (#10) against a scripted transport: the
-/// message box sends via `agent.send`, the quick-key bar via
-/// `pane.send_keys`, failures surface, and success clears the box — protocol
-/// level, no SSH, no UI.
+/// message box sends text plus Enter via `pane.send_input`, the quick-key bar
+/// via `pane.send_keys`, failures surface, and success clears the box —
+/// protocol level, no SSH, no UI.
 @MainActor
 @Suite("Agent input store")
 struct AgentInputStoreTests {
@@ -29,7 +29,7 @@ struct AgentInputStoreTests {
         #expect(await condition(), comment)
     }
 
-    @Test func sendDraftDeliversViaAgentSendAndClearsTheBox() async throws {
+    @Test func sendDraftAtomicallyWritesTextAndEnterThenClearsTheBox() async throws {
         let transport = ScriptedTransport()
         let store = makeStore(transport: transport)
         store.draft = "  yes, proceed  "
@@ -40,8 +40,9 @@ struct AgentInputStoreTests {
         #expect(store.draft.isEmpty)
         // The draft is trimmed on the way out, targeted by pane id.
         #expect(
-            await transport.agentSends == [
-                AgentSendParams(target: "w1:p1", text: "yes, proceed")
+            await transport.sentInputs == [
+                PaneSendInputParams(
+                    paneID: "w1:p1", keys: ["enter"], text: "yes, proceed")
             ])
     }
 
@@ -69,8 +70,8 @@ struct AgentInputStoreTests {
         await first.value
 
         #expect(
-            await transport.agentSends == [
-                AgentSendParams(target: "w1:p1", text: "reply once")
+            await transport.sentInputs == [
+                PaneSendInputParams(paneID: "w1:p1", keys: ["enter"], text: "reply once")
             ])
         #expect(store.draft.isEmpty)
     }
@@ -82,7 +83,7 @@ struct AgentInputStoreTests {
 
         await store.sendDraft()
 
-        #expect(await transport.agentSends.isEmpty)
+        #expect(await transport.sentInputs.isEmpty)
         #expect(store.state == .idle)
     }
 
@@ -128,7 +129,7 @@ struct AgentInputStoreTests {
         #expect(store.state == .failed("The Host did not answer in time."))
         // The draft survives so the user can retry rather than retype.
         #expect(store.draft == "important reply")
-        #expect(await transport.agentSends.isEmpty)
+        #expect(await transport.sentInputs.isEmpty)
     }
 
     @Test func serverRejectionSurfacesTheHerdrMessage() async throws {
@@ -205,7 +206,7 @@ private actor RejectingTransport: Transport {
     }
 
     func startAgent(_ params: AgentStartParams) async throws -> Agent { throw error }
-    func sendToAgent(_ params: AgentSendParams) async throws { throw error }
+    func sendInput(_ params: PaneSendInputParams) async throws { throw error }
     func sendKeys(_ params: PaneSendKeysParams) async throws { throw error }
     func closePane(_ params: PaneTarget) async throws { throw error }
 

--- a/Tests/HerdrMobileTests/EventsSessionE2ETests.swift
+++ b/Tests/HerdrMobileTests/EventsSessionE2ETests.swift
@@ -432,8 +432,8 @@ struct EventsSessionE2ETests {
             try await inner.startAgent(params)
         }
 
-        func sendToAgent(_ params: AgentSendParams) async throws {
-            try await inner.sendToAgent(params)
+        func sendInput(_ params: PaneSendInputParams) async throws {
+            try await inner.sendInput(params)
         }
 
         func sendKeys(_ params: PaneSendKeysParams) async throws {

--- a/Tests/HerdrMobileTests/GeneratedWireTypesTests.swift
+++ b/Tests/HerdrMobileTests/GeneratedWireTypesTests.swift
@@ -126,7 +126,7 @@ import Testing
     }
 
     @Test func okResponseDecodes() throws {
-        // The bare-acknowledgement result shape (`pane.send_text` et al.).
+        // The bare-acknowledgement result shape (`pane.send_input` et al.).
         _ = try roundTrip(OkResponse.self, #"{"type":"ok"}"#)
     }
 
@@ -190,16 +190,17 @@ import Testing
         #expect((envelope["params"] as? [String: Any])?["pane_id"] as? String == "w1:p1")
     }
 
-    @Test func sendKeysAndSendTextParamsEncodeWireNames() throws {
+    @Test func sendInputAndKeysParamsEncodeWireNames() throws {
+        let input = try JSONSerialization.jsonObject(
+            with: JSONEncoder().encode(
+                PaneSendInputParams(paneID: "w1:p1", keys: ["enter"], text: "y"))
+        ) as? [String: Any]
+        #expect(input?.keys.sorted() == ["keys", "pane_id", "text"])
+
         let keys = try JSONSerialization.jsonObject(
             with: JSONEncoder().encode(PaneSendKeysParams(keys: ["Enter"], paneID: "w1:p1"))
         ) as? [String: Any]
         #expect(keys?.keys.sorted() == ["keys", "pane_id"])
-
-        let text = try JSONSerialization.jsonObject(
-            with: JSONEncoder().encode(PaneSendTextParams(paneID: "w1:p1", text: "y"))
-        ) as? [String: Any]
-        #expect(text?.keys.sorted() == ["pane_id", "text"])
 
         let target = try JSONSerialization.jsonObject(
             with: JSONEncoder().encode(AgentTarget(target: "w1:p1"))

--- a/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
@@ -1,5 +1,7 @@
 import Foundation
+import SwiftUI
 import Testing
+import UIKit
 
 @testable import HerdrMobile
 
@@ -25,6 +27,18 @@ struct ObserveTerminalStoreTests {
         var text: String {
             String(decoding: chunks.reduce(Data(), +), as: UTF8.self)
         }
+    }
+
+    private func terminalView(in root: UIView) -> SizeReportingTerminalView? {
+        if let terminal = root as? SizeReportingTerminalView {
+            return terminal
+        }
+        for subview in root.subviews {
+            if let terminal = terminalView(in: subview) {
+                return terminal
+            }
+        }
+        return nil
     }
 
     /// Polls until `condition` holds, yielding so the store's tasks progress.
@@ -85,6 +99,30 @@ struct ObserveTerminalStoreTests {
         #expect(!captured.text.contains("cropped ending"))
 
         await store.stop()
+    }
+
+    @Test func observeUsesEnoughColumnsToLimitWidePaneReflow() throws {
+        // A 393-point iPhone showing the default 12-point terminal only fits
+        // about 52 columns. A 185-column desktop line then expands to four
+        // mobile rows, which makes the transcript unnecessarily tall.
+        let host = UIHostingController(
+            rootView: TerminalScreenView(feed: TerminalByteFeed(), style: .observe))
+        let frame = CGRect(x: 0, y: 0, width: 393, height: 600)
+        let window = UIWindow(frame: frame)
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        host.view.frame = frame
+        host.view.layoutIfNeeded()
+
+        let terminal = try #require(terminalView(in: host.view))
+        terminal.layoutIfNeeded()
+
+        #expect(terminal.font.pointSize < 12)
+        let columns = terminal.getTerminal().cols
+        let rowsForDesktopLine = (185 + columns - 1) / columns
+        #expect(columns >= 64)
+        #expect(rowsForDesktopLine <= 3)
     }
 
     @Test func duplicateSizeReportsDoNotRestartTheStream() async throws {

--- a/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftTerm
 import SwiftUI
 import Testing
 import UIKit
@@ -153,6 +154,36 @@ struct ObserveTerminalStoreTests {
         let rowsForDesktopLine = (185 + columns - 1) / columns
         #expect(columns >= 64)
         #expect(rowsForDesktopLine <= 3)
+    }
+
+    @Test func readOnlyTerminalKeepsCursorHiddenWhenRemoteShowsIt() {
+        var responses = Data()
+        let coordinator = TerminalScreenView.Coordinator(
+            onSizeChanged: nil,
+            onSend: { responses.append($0) })
+        let terminalView = SizeReportingTerminalView(frame: .zero, font: nil)
+        terminalView.terminalDelegate = coordinator
+        terminalView.allowsInput = false
+
+        // Simulate a remote TUI showing its cursor, then query DECTCEM.
+        terminalView.feed(byteArray: ArraySlice([UInt8]("\u{1B}[?25h\u{1B}[?25$p".utf8)))
+
+        #expect(String(decoding: responses, as: UTF8.self) == "\u{1B}[?25;2$y")
+    }
+
+    @Test func interactiveTerminalStillHonorsRemoteCursorVisibility() {
+        var responses = Data()
+        let coordinator = TerminalScreenView.Coordinator(
+            onSizeChanged: nil,
+            onSend: { responses.append($0) })
+        let terminalView = SizeReportingTerminalView(frame: .zero, font: nil)
+        terminalView.terminalDelegate = coordinator
+        terminalView.allowsInput = true
+
+        terminalView.feed(
+            byteArray: ArraySlice([UInt8]("\u{1B}[?25l\u{1B}[?25h\u{1B}[?25$p".utf8)))
+
+        #expect(String(decoding: responses, as: UTF8.self) == "\u{1B}[?25;1$y")
     }
 
     @Test func duplicateSizeReportsDoNotRestartTheStream() async throws {

--- a/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
@@ -150,6 +150,7 @@ struct ObserveTerminalStoreTests {
         terminal.layoutIfNeeded()
 
         #expect(terminal.font.pointSize < 12)
+        #expect(terminal.getTerminal().options.scrollback == 5_000)
         let columns = terminal.getTerminal().cols
         let rowsForDesktopLine = (185 + columns - 1) / columns
         #expect(columns >= 64)
@@ -190,6 +191,83 @@ struct ObserveTerminalStoreTests {
         }
         #expect(terminal.contentSize.height > originalExtent)
         #expect(terminal.scrollPosition == 1)
+    }
+
+    @Test func reachingTheTopLoadsEarlierHistoryWithoutMovingTheViewport() async throws {
+        let feed = TerminalByteFeed()
+        var loadRequests = 0
+        let host = UIHostingController(
+            rootView: TerminalScreenView(
+                feed: feed, style: .observe,
+                onLoadEarlier: {
+                    loadRequests += 1
+                    return true
+                }))
+        let frame = CGRect(x: 0, y: 0, width: 393, height: 600)
+        let window = UIWindow(frame: frame)
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        host.view.frame = frame
+        host.view.layoutIfNeeded()
+
+        let terminal = try #require(terminalView(in: host.view))
+        terminal.layoutIfNeeded()
+        let initialTranscript = (200..<320)
+            .map { String(format: "line %03d", $0) }
+            .joined(separator: "\r\n")
+        feed.write(Data(initialTranscript.utf8))
+        while terminal.accessibilityScroll(.up) {}
+
+        #expect(loadRequests == 1)
+        let originalTopLine = try #require(terminal.getTerminal().getLine(row: 0))
+            .translateToString(trimRight: true)
+        #expect(originalTopLine == "line 200")
+
+        let expandedTranscript = (0..<320)
+            .map { String(format: "line %03d", $0) }
+            .joined(separator: "\r\n")
+        feed.writeHistorySnapshot(
+            Data("\u{1B}[3J\u{1B}[2J\u{1B}[H\(expandedTranscript)".utf8))
+        try await Task.sleep(for: .milliseconds(30))
+
+        let restoredTopLine = try #require(terminal.getTerminal().getLine(row: 0))
+            .translateToString(trimRight: true)
+        #expect(restoredTopLine == originalTopLine)
+        #expect(terminal.getTerminal().getTopVisibleRow() > 0)
+        #expect(loadRequests == 1)
+    }
+
+    @Test func loadingEarlierExpandsTheReadWindowUntilHistoryEnds() async throws {
+        let transport = ScriptedTransport()
+        let initial = (0..<80).map(String.init).joined(separator: "\n")
+        await transport.setPaneText(initial, paneID: "w1:p1")
+        let (store, _) = makeStore(transport: transport)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("store should go live") { store.status == .live }
+        #expect(await transport.paneReadParams.first?.lines == 80)
+
+        let expanded = (0..<280).map(String.init).joined(separator: "\n")
+        await transport.setPaneText(expanded, paneID: "w1:p1")
+        #expect(store.loadEarlier())
+        try await waitUntil("the first pull should request 280 lines") {
+            await transport.paneReadParams.count == 2 && !store.isLoadingEarlier
+        }
+        #expect(await transport.paneReadParams.last?.lines == 280)
+        #expect(store.canLoadEarlier)
+
+        let exhausted = (0..<350).map(String.init).joined(separator: "\n")
+        await transport.setPaneText(exhausted, paneID: "w1:p1")
+        #expect(store.loadEarlier())
+        try await waitUntil("a short response should mark history exhausted") {
+            await transport.paneReadParams.count == 3 && !store.isLoadingEarlier
+        }
+        #expect(await transport.paneReadParams.last?.lines == 480)
+        #expect(!store.canLoadEarlier)
+        #expect(!store.loadEarlier())
+
+        await store.stop()
     }
 
     @Test func readOnlyTerminalKeepsCursorHiddenWhenRemoteShowsIt() {

--- a/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
@@ -236,11 +236,14 @@ struct ObserveTerminalStoreTests {
         #expect(restoredTopLine == originalTopLine)
         #expect(terminal.getTerminal().getTopVisibleRow() > 0)
         #expect(loadRequests == 1)
+
+        while terminal.accessibilityScroll(.up) {}
+        #expect(loadRequests == 2)
     }
 
     @Test func loadingEarlierExpandsTheReadWindowUntilHistoryEnds() async throws {
         let transport = ScriptedTransport()
-        let initial = (0..<80).map(String.init).joined(separator: "\n")
+        let initial = (120..<200).map(String.init).joined(separator: "\n")
         await transport.setPaneText(initial, paneID: "w1:p1")
         let (store, _) = makeStore(transport: transport)
 
@@ -248,7 +251,10 @@ struct ObserveTerminalStoreTests {
         try await waitUntil("store should go live") { store.status == .live }
         #expect(await transport.paneReadParams.first?.lines == 80)
 
-        let expanded = (0..<280).map(String.init).joined(separator: "\n")
+        // recent_unwrapped counts terminal rows before joining wrapped rows,
+        // so a 280-row request can legitimately return fewer than 280
+        // logical lines while still adding earlier history.
+        let expanded = (0..<200).map(String.init).joined(separator: "\n")
         await transport.setPaneText(expanded, paneID: "w1:p1")
         #expect(store.loadEarlier())
         try await waitUntil("the first pull should request 280 lines") {
@@ -257,10 +263,10 @@ struct ObserveTerminalStoreTests {
         #expect(await transport.paneReadParams.last?.lines == 280)
         #expect(store.canLoadEarlier)
 
-        let exhausted = (0..<350).map(String.init).joined(separator: "\n")
-        await transport.setPaneText(exhausted, paneID: "w1:p1")
+        // The next, wider request returning the same transcript proves that
+        // the retained history is exhausted.
         #expect(store.loadEarlier())
-        try await waitUntil("a short response should mark history exhausted") {
+        try await waitUntil("an unchanged response should mark history exhausted") {
             await transport.paneReadParams.count == 3 && !store.isLoadingEarlier
         }
         #expect(await transport.paneReadParams.last?.lines == 480)

--- a/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
@@ -156,6 +156,42 @@ struct ObserveTerminalStoreTests {
         #expect(rowsForDesktopLine <= 3)
     }
 
+    @Test func replacingObserveSnapshotKeepsScrollExtentAndViewportStable() async throws {
+        let feed = TerminalByteFeed()
+        let host = UIHostingController(
+            rootView: TerminalScreenView(feed: feed, style: .observe))
+        let frame = CGRect(x: 0, y: 0, width: 393, height: 600)
+        let window = UIWindow(frame: frame)
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        host.view.frame = frame
+        host.view.layoutIfNeeded()
+
+        let terminal = try #require(terminalView(in: host.view))
+        terminal.layoutIfNeeded()
+        let transcript = (0..<120)
+            .map { String(format: "line %03d", $0) }
+            .joined(separator: "\r\n")
+        let updatedTranscript = transcript + "\r\nline 120"
+        feed.write(Data(transcript.utf8))
+        #expect(terminal.accessibilityScroll(.up))
+        let originalExtent = terminal.contentSize.height
+        let originalTopRow = terminal.getTerminal().getTopVisibleRow()
+
+        feed.write(Data("\u{1B}[3J\u{1B}[2J\u{1B}[H\(updatedTranscript)".utf8))
+        try await Task.sleep(for: .milliseconds(30))
+
+        #expect(terminal.contentSize.height == originalExtent)
+        #expect(terminal.getTerminal().getTopVisibleRow() == originalTopRow)
+
+        for _ in 0..<10 {
+            if !terminal.accessibilityScroll(.down) { break }
+        }
+        #expect(terminal.contentSize.height > originalExtent)
+        #expect(terminal.scrollPosition == 1)
+    }
+
     @Test func readOnlyTerminalKeepsCursorHiddenWhenRemoteShowsIt() {
         var responses = Data()
         let coordinator = TerminalScreenView.Coordinator(

--- a/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
@@ -101,6 +101,36 @@ struct ObserveTerminalStoreTests {
         await store.stop()
     }
 
+    @Test func observeOmitsTheRemoteTerminalInputArea() async throws {
+        let transport = ScriptedTransport()
+        await transport.setPaneText(
+            """
+            › Previous submitted input
+
+            Agent answer stays visible.
+
+            \u{1B}[2m• Worked for 12s\u{1B}[0m
+
+            \u{1B}[7m› Draft input owned by the remote terminal\u{1B}[0m
+
+              Context 54% used · ~/project · model
+            """,
+            paneID: "w1:p1")
+        let (store, captured) = makeStore(transport: transport)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the output-only transcript should render") {
+            store.status == .live && captured.text.contains("Agent answer stays visible.")
+        }
+
+        #expect(!captured.text.contains("Draft input owned by the remote terminal"))
+        #expect(!captured.text.contains("Context 54% used"))
+        #expect(!captured.text.contains("Worked for 12s"))
+        #expect(captured.text.contains("Previous submitted input"))
+
+        await store.stop()
+    }
+
     @Test func observeUsesEnoughColumnsToLimitWidePaneReflow() throws {
         // A 393-point iPhone showing the default 12-point terminal only fits
         // about 52 columns. A 185-column desktop line then expands to four

--- a/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
@@ -49,12 +49,12 @@ struct ObserveTerminalStoreTests {
         store.viewDidResize(cols: 80, rows: 24)
         try await waitUntil("store should go live") { store.status == .live }
 
-        // Backfill first: `pane.read --format ansi --source recent`, bare
-        // newlines normalized for a raw-mode terminal.
+        // The mobile view reads logical lines instead of the PC-width screen
+        // so SwiftTerm can wrap them to the local geometry.
         let read = try #require(await transport.paneReadParams.first)
         #expect(read.paneID == "w1:p1")
         #expect(read.format == .ansi)
-        #expect(read.source == .recent)
+        #expect(read.source == .recentUnwrapped)
         #expect(read.stripANSI != true)
         #expect(captured.text == "old line 1\r\nold line 2")
 
@@ -62,11 +62,27 @@ struct ObserveTerminalStoreTests {
         let request = try #require(await transport.observeRequests.first)
         #expect(request == TerminalObserveRequest(target: "w1:p1", cols: 80, rows: 24))
 
+        let completeLine = "This line is wider than the phone and must keep its final words."
+        await transport.setPaneText(completeLine, paneID: "w1:p1")
         await transport.emitFrame(
-            TerminalFrame(seq: 1, isFull: true, bytes: Data("SCREEN".utf8)))
-        try await waitUntil("the frame should reach the feed") {
-            captured.text == "old line 1\r\nold line 2SCREEN"
+            TerminalFrame(seq: 1, isFull: true, bytes: Data("This line is cropped".utf8)))
+        try await waitUntil("a frame should refresh the complete logical transcript") {
+            await transport.paneReadParams.count == 2
+                && captured.text.contains("must keep its final words.")
         }
+        #expect(!captured.text.contains("This line is cropped"))
+
+        // A second frame arriving during the coalescing interval must still
+        // produce a trailing refresh after output becomes quiet.
+        await transport.setPaneText(
+            "The final answer has a distinct complete ending.", paneID: "w1:p1")
+        await transport.emitFrame(
+            TerminalFrame(seq: 2, isFull: false, bytes: Data("cropped ending".utf8)))
+        try await waitUntil("the quiet tail should receive its final refresh") {
+            await transport.paneReadParams.count == 3
+                && captured.text.contains("distinct complete ending.")
+        }
+        #expect(!captured.text.contains("cropped ending"))
 
         await store.stop()
     }
@@ -111,34 +127,39 @@ struct ObserveTerminalStoreTests {
     }
 
     @Test func sequenceGapRestartsForAFreshFullRepaint() async throws {
-        // Dropped frames leave the screen undefined; there is no
-        // request-repaint on the wire, so the store re-observes (the first
-        // frame of a new stream is always a full repaint).
+        // A gap means change notifications were lost, so the store
+        // re-observes before trusting later notifications.
         let transport = ScriptedTransport()
         let (store, captured) = makeStore(transport: transport)
 
         store.viewDidResize(cols: 80, rows: 24)
         try await waitUntil("store should go live") { store.status == .live }
 
+        await transport.setPaneText("one two", paneID: "w1:p1")
         await transport.emitFrame(TerminalFrame(seq: 1, isFull: true, bytes: Data("one".utf8)))
         await transport.emitFrame(TerminalFrame(seq: 2, isFull: false, bytes: Data("two".utf8)))
+        try await waitUntil("accepted notifications should refresh the transcript") {
+            captured.text.contains("one two")
+        }
         await transport.emitFrame(TerminalFrame(seq: 5, isFull: false, bytes: Data("FIVE".utf8)))
 
         try await waitUntil("the gap should trigger a re-observe") {
             await transport.observeRequests.count == 2
         }
-        // The post-gap frame was not fed; the fresh repaint recovers instead.
-        #expect(captured.text == "onetwo")
+        // The post-gap cropped payload was not rendered.
+        #expect(!captured.text.contains("FIVE"))
 
         try await waitUntil("the restarted stream should be live") {
             guard store.status == .live else { return false }
             return await transport.hasLiveFrameStream
         }
+        await transport.setPaneText("fresh complete transcript", paneID: "w1:p1")
         await transport.emitFrame(
             TerminalFrame(seq: 1, isFull: true, bytes: Data("REPAINT".utf8)))
-        try await waitUntil("the repaint should reach the feed") {
-            captured.text == "onetwoREPAINT"
+        try await waitUntil("the restarted notification should refresh the transcript") {
+            captured.text.contains("fresh complete transcript")
         }
+        #expect(!captured.text.contains("REPAINT"))
 
         await store.stop()
     }

--- a/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
@@ -101,18 +101,21 @@ struct SSHTransportE2ETests {
         }
     }
 
-    @Test func agentSendRoundTripsItsParams() async throws {
-        // The message box (#10): agent.send carries the reply to a Blocked
-        // agent, targeted by pane id, answered with the bare `ok` envelope.
+    @Test func sendInputRoundTripsTextAndEnterAtomically() async throws {
+        // The message box (#10): pane.send_input writes the reply and presses
+        // Enter in one request, targeted by pane id and answered with `ok`.
         try await withTransport { request in
             [#"{"id":"\#(request.id)","result":{"type":"ok"}}"#]
         } body: { transport, server in
-            try await transport.sendToAgent(
-                AgentSendParams(target: "w1:p1", text: "yes, proceed"))
+            try await transport.sendInput(
+                PaneSendInputParams(
+                    paneID: "w1:p1", keys: ["enter"], text: "yes, proceed"))
 
             let request = try #require(server.receivedRequests.first)
-            #expect(request.method == "agent.send")
-            #expect(request.params == #"{"target":"w1:p1","text":"yes, proceed"}"#)
+            #expect(request.method == "pane.send_input")
+            #expect(
+                request.params
+                    == #"{"keys":["enter"],"pane_id":"w1:p1","text":"yes, proceed"}"#)
         }
     }
 

--- a/Tests/HerdrMobileTests/Support/FakeTransportConnector.swift
+++ b/Tests/HerdrMobileTests/Support/FakeTransportConnector.swift
@@ -45,7 +45,7 @@ final actor FakeTransport: Transport {
         throw TransportError.channelFailed(detail: "FakeTransport does not script agent starts")
     }
 
-    func sendToAgent(_ params: AgentSendParams) async throws {
+    func sendInput(_ params: PaneSendInputParams) async throws {
         throw TransportError.channelFailed(detail: "FakeTransport does not script sends")
     }
 

--- a/Tests/HerdrMobileTests/Support/ScriptedTransport.swift
+++ b/Tests/HerdrMobileTests/Support/ScriptedTransport.swift
@@ -11,9 +11,8 @@ final actor ScriptedTransport: Transport {
     /// resubscribe-on-membership-change behavior asserts on this.
     private(set) var capturedSubscriptions: [[EventSubscription]] = []
     private(set) var paneReadParams: [PaneReadParams] = []
-    /// Every message sent through `agent.send`, in order; the input store's
-    /// message-box behavior asserts on this.
-    private(set) var agentSends: [AgentSendParams] = []
+    /// Every atomic text-and-key batch sent through `pane.send_input`.
+    private(set) var sentInputs: [PaneSendInputParams] = []
     /// Every key batch sent through `pane.send_keys`, in order; the input
     /// store's quick-key behavior asserts on this.
     private(set) var sentKeys: [PaneSendKeysParams] = []
@@ -79,7 +78,7 @@ final actor ScriptedTransport: Transport {
         paneReadFailure = failure
     }
 
-    /// Makes every subsequent `sendToAgent`/`sendKeys` throw `failure`.
+    /// Makes every subsequent `sendInput`/`sendKeys` throw `failure`.
     func setSendFailure(_ failure: TransportError?) {
         sendFailure = failure
     }
@@ -206,9 +205,9 @@ final actor ScriptedTransport: Transport {
                 title: params.name))
     }
 
-    func sendToAgent(_ params: AgentSendParams) async throws {
+    func sendInput(_ params: PaneSendInputParams) async throws {
         if let sendFailure { throw sendFailure }
-        agentSends.append(params)
+        sentInputs.append(params)
     }
 
     func sendKeys(_ params: PaneSendKeysParams) async throws {

--- a/Tests/HerdrMobileTests/TerminalAttachE2ETests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachE2ETests.swift
@@ -218,6 +218,7 @@ struct TerminalAttachE2ETests {
         settings.attachCommand = "/bin/sh \(try write(script, prefix: "attach").path)"
         if let observeScript {
             settings.observeCommand = "/bin/sh \(try write(observeScript, prefix: "observe").path)"
+            settings.observeCommandHandlesStdinEOF = false
         }
         let transport = try await SSHTransport.connect(settings: settings)
         do {

--- a/Tests/HerdrMobileTests/TerminalFrameTests.swift
+++ b/Tests/HerdrMobileTests/TerminalFrameTests.swift
@@ -11,6 +11,12 @@ struct TerminalFrameTests {
         Data(text.utf8)
     }
 
+    @Test func observeClaimsAControlSessionSoHerdrAppliesPhoneGeometry() {
+        #expect(
+            SSHTransportSettings.defaultObserveCommand
+                == "herdr terminal session control")
+    }
+
     @Test func decodesAFullRepaintFrame() throws {
         // The live-captured shape from the #9 probe: base64 of ANSI bytes.
         let payload = Data("\u{1B}[2J\u{1B}[Hhello".utf8)

--- a/Tests/HerdrMobileTests/TerminalObserveE2ETests.swift
+++ b/Tests/HerdrMobileTests/TerminalObserveE2ETests.swift
@@ -6,9 +6,9 @@ import Testing
 
 /// The Observe terminal channel (#9) over the real stack: Citadel ->
 /// localhost sshd -> a frame-emitting script standing in for `herdr terminal
-/// session observe` (injectable at the environment boundary, like the wake
-/// command). No PTY anywhere — the #9 probe verified observe does not need
-/// one.
+/// session control` (injectable at the environment boundary, like the wake
+/// command). No PTY exists on this SSH channel; herdr controls the Agent's
+/// existing PTY remotely.
 @Suite(
     "Terminal observe e2e",
     .enabled(
@@ -104,11 +104,9 @@ struct TerminalObserveE2ETests {
     @Test func endClosesTheChannelPromptlyAndFreesTheHost() async throws {
         // The spike gotcha again: a live exec channel ignores task
         // cancellation, so end() must close it explicitly, after which a
-        // new observe must be possible. Promptness is load-bearing: the real
-        // observe CLI ignores stdin EOF and the channel close only completes
-        // once the remote command exits, so without the kill-on-EOF wrapper
-        // this end() would sit out the script's full 15s hold (and in
-        // production, hang until the SSH connection died).
+        // new observe must be possible. This injected command ignores stdin
+        // EOF, exercising the fallback kill-on-EOF wrapper; without it,
+        // end() would sit out the script's full 15s hold.
         try await withObserveTransport(
             script: """
             echo '\(Self.frameLine(seq: 1, full: true, bytes: "one"))'
@@ -130,6 +128,27 @@ struct TerminalObserveE2ETests {
             var secondIterator = second.frames.makeAsyncIterator()
             _ = try #require(try await secondIterator.next())
             await second.end()
+        }
+    }
+
+    @Test func stdinAwareControlCommandDetachesOnChannelEOF() async throws {
+        try await withObserveTransport(
+            script: """
+            echo '\(Self.frameLine(seq: 1, full: true, bytes: "one"))'
+            cat >/dev/null
+            """,
+            commandHandlesStdinEOF: true
+        ) { transport in
+            let stream = try await transport.observeTerminal(
+                TerminalObserveRequest(target: "w1:p1", cols: 64, rows: 30))
+            var iterator = stream.frames.makeAsyncIterator()
+            _ = try #require(try await iterator.next())
+
+            let start = ContinuousClock.now
+            await stream.end()
+            let elapsed = ContinuousClock.now - start
+            #expect(elapsed < .seconds(5), "EOF-aware command took \(elapsed) to detach")
+            #expect(try await iterator.next() == nil)
         }
     }
 
@@ -220,6 +239,7 @@ struct TerminalObserveE2ETests {
         script: String,
         socketPath: String? = nil,
         requestTimeout: Duration = .seconds(15),
+        commandHandlesStdinEOF: Bool = false,
         body: (SSHTransport) async throws -> Void
     ) async throws {
         let environment = try #require(LocalSSHTestEnvironment.current)
@@ -233,6 +253,7 @@ struct TerminalObserveE2ETests {
             wakeCommand: "false",
             requestTimeout: requestTimeout)
         settings.observeCommand = "/bin/sh \(scriptURL.path)"
+        settings.observeCommandHandlesStdinEOF = commandHandlesStdinEOF
         let transport = try await SSHTransport.connect(settings: settings)
         do {
             try await body(transport)

--- a/scripts/generate-wire-types.py
+++ b/scripts/generate-wire-types.py
@@ -53,11 +53,10 @@ METHODS = [
     "agent.list",
     "agent.read",
     "agent.rename",
-    "agent.send",
     "agent.start",
     "events.subscribe",
     "pane.read",
-    "pane.send_text",
+    "pane.send_input",
     "pane.send_keys",
     "pane.close",
     "session.snapshot",
@@ -86,7 +85,7 @@ RESULT_TAGS = [
     "pane_read",  # pane.read, agent.read
     "session_snapshot",  # session.snapshot
     "subscription_started",  # events.subscribe ack
-    "ok",  # pane.send_text, pane.send_keys, pane.close, agent.send
+    "ok",  # pane.send_input, pane.send_keys, pane.close
 ]
 
 # Wire-name overrides for members whose mechanical camelCase would be a Swift


### PR DESCRIPTION
## Summary

- submit non-Attach replies atomically through `pane.send_input` and Enter
- render Observe output using the phone geometry while hiding remote input chrome and cursor
- preserve the viewport during refreshes and progressively load earlier history up to the server limit
- add regression coverage for reply submission, transcript reflow, refresh behavior, and repeated history loading

## Testing

- `xcodebuild test -quiet -project HerdrMobile.xcodeproj -scheme HerdrMobile -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=latest"`
- manual acceptance on the iPhone 17 Pro simulator