### PR TITLE
feat: complete recovery flows and session discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Instead of squeezing a desktop TUI onto a phone, herdr-mobile is an **agent cons
 The app speaks herdr's JSON API (newline-delimited JSON over a Unix socket) through SSH:
 
 - **RPC + events**: a no-PTY SSH exec channel running `socat - UNIX-CONNECT:<herdr.sock>` per request, plus one long-lived channel for `events.subscribe`.
-- **Interactive terminal**: an SSH exec channel with a PTY running `herdr agent attach <pane>`, rendered by SwiftTerm.
+- **Interactive terminal**: an SSH PTY shell channel bootstrapped with an injection-safe `exec herdr agent attach <pane>` line, then rendered by SwiftTerm.
 
 No herdr server changes required. The only remote prerequisite is `socat` installed on the host.
 

--- a/Sources/HerdrMobile/Console/ConsoleStore.swift
+++ b/Sources/HerdrMobile/Console/ConsoleStore.swift
@@ -24,18 +24,24 @@ final class ConsoleStore {
     private(set) var agents: [ConsoleAgent] = []
     /// Per-Host events-session status; the UI derives staleness from it.
     private(set) var hostStatuses: [Host.ID: EventsSessionStatus] = [:]
+    /// Snapshot failures are separate from connection state: an events
+    /// channel can remain connected while the Console data RPC is failing.
+    private(set) var hostSyncErrors: [Host.ID: String] = [:]
 
     @ObservationIgnored private var feeds: [Host.ID: HostFeed] = [:]
     @ObservationIgnored private let makeSession:
         @Sendable (Host, [EventSubscription]) -> EventsSession
+    @ObservationIgnored private let snapshotRetryDelay: Duration
     /// Whether the Console should hold live connections (foregrounded);
     /// feeds started while suspended stay down until `resume()`.
     @ObservationIgnored private var isActive = false
 
     init(
+        snapshotRetryDelay: Duration = .seconds(2),
         makeSession: @escaping @Sendable (Host, [EventSubscription]) -> EventsSession =
             ConsoleStore.sshSessionFactory()
     ) {
+        self.snapshotRetryDelay = snapshotRetryDelay
         self.makeSession = makeSession
     }
 
@@ -50,6 +56,7 @@ final class ConsoleStore {
             endFeed(feed)
             feeds[id] = nil
             hostStatuses[id] = nil
+            hostSyncErrors[id] = nil
         }
         for host in hosts where feeds[host.id] == nil {
             startFeed(for: host)
@@ -90,6 +97,8 @@ final class ConsoleStore {
 
     private func endFeed(_ feed: HostFeed) {
         feed.resyncPending = false
+        feed.resyncRetryTask?.cancel()
+        feed.resyncRetryTask = nil
         Task { await feed.session.end() }
     }
 
@@ -137,14 +146,46 @@ final class ConsoleStore {
         do {
             let snapshot = try await transport.sessionSnapshot()
             guard feeds[feed.host.id] === feed else { return }
+            feed.resyncRetryTask?.cancel()
+            feed.resyncRetryTask = nil
+            hostSyncErrors[feed.host.id] = nil
             apply(snapshot, to: feed)
             await feed.session.updateSubscriptions(
                 Self.subscriptions(paneIDs: feed.byPane.keys))
             refreshSnippets(feed: feed, transport: transport)
         } catch {
-            // Keep the last known rows. If the connection is actually dead,
-            // the session's own machinery notices and re-issues `.connected`
-            // after reconnecting, which schedules the next attempt.
+            guard feeds[feed.host.id] === feed else { return }
+            hostSyncErrors[feed.host.id] = Self.snapshotErrorMessage(error)
+            scheduleSnapshotRetry(feed: feed)
+        }
+    }
+
+    /// Snapshot RPC failures do not necessarily drop the events channel, so
+    /// they need their own bounded-rate retry instead of waiting for a future
+    /// membership event or reconnect that may never happen.
+    private func scheduleSnapshotRetry(feed: HostFeed) {
+        guard feed.resyncRetryTask == nil else { return }
+        feed.resyncRetryTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await Task.sleep(for: snapshotRetryDelay)
+            } catch {
+                return
+            }
+            guard self.feeds[feed.host.id] === feed else { return }
+            feed.resyncRetryTask = nil
+            self.scheduleResync(feed: feed)
+        }
+    }
+
+    private static func snapshotErrorMessage(_ error: any Error) -> String {
+        switch error {
+        case TransportError.timedOut:
+            "The Host did not answer while syncing Agents. Retrying…"
+        case let apiError as HerdrAPIError:
+            "herdr rejected the Console sync: \(apiError.message). Retrying…"
+        default:
+            "Could not sync this Host's Agents. Retrying…"
         }
     }
 
@@ -296,7 +337,7 @@ final class ConsoleStore {
     /// Global membership/context kinds; each triggers a Host re-snapshot.
     private static let membershipKinds: [GlobalEventKind] = [
         .paneAgentDetected, .paneClosed, .paneExited,
-        .workspaceRenamed, .workspaceMetadataUpdated, .workspaceClosed,
+        .workspaceCreated, .workspaceRenamed, .workspaceMetadataUpdated, .workspaceClosed,
     ]
     /// The membership kinds plus the local drop marker (#22): a bounded
     /// event buffer that shed updates means the deltas are incomplete, so
@@ -346,6 +387,7 @@ private final class HostFeed {
     let session: EventsSession
     var consumeTask: Task<Void, Never>?
     var resyncTask: Task<Void, Never>?
+    var resyncRetryTask: Task<Void, Never>?
     var resyncPending = false
     var byPane: [String: ConsoleAgent] = [:]
     /// Workspaces from this Host's latest snapshot, for the new-agent picker.

--- a/Sources/HerdrMobile/Console/ConsoleView.swift
+++ b/Sources/HerdrMobile/Console/ConsoleView.swift
@@ -68,8 +68,8 @@ struct ConsoleView: View {
             }
         } else {
             List {
-                ForEach(reconnectingHosts, id: \.0) { _, message in
-                    Label(message, systemImage: "wifi.exclamationmark")
+                ForEach(hostIssues, id: \.0) { _, issue in
+                    Label(issue.message, systemImage: issue.systemImage)
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
@@ -84,18 +84,27 @@ struct ConsoleView: View {
     }
 
     private var emptyDescription: String {
-        if reconnectingHosts.isEmpty {
+        if hostIssues.isEmpty {
             return "Agents detected on your Hosts appear here."
         }
-        return reconnectingHosts.map(\.1).joined(separator: "\n")
+        return hostIssues.map(\.1.message).joined(separator: "\n")
     }
 
-    /// Hosts whose events session is down, with a staleness message; what is
-    /// on screen for them may be out of date.
-    private var reconnectingHosts: [(Host.ID, String)] {
+    /// One actionable status per Host. A disconnected session takes priority;
+    /// otherwise a connected Host can still have a failing snapshot RPC.
+    private var hostIssues: [(Host.ID, (message: String, systemImage: String))] {
         hosts.hosts.compactMap { host in
-            guard case .reconnecting = console.hostStatuses[host.id] else { return nil }
-            return (host.id, "Reconnecting to \(host.displayName)…")
+            if case .reconnecting = console.hostStatuses[host.id] {
+                return (
+                    host.id,
+                    ("Reconnecting to \(host.displayName)…", "wifi.exclamationmark"))
+            }
+            if let message = console.hostSyncErrors[host.id] {
+                return (
+                    host.id,
+                    ("\(host.displayName): \(message)", "arrow.trianglehead.2.clockwise"))
+            }
+            return nil
         }
     }
 }

--- a/Sources/HerdrMobile/Hosts/Host.swift
+++ b/Sources/HerdrMobile/Hosts/Host.swift
@@ -23,8 +23,9 @@ struct Host: Identifiable, Codable, Hashable, Sendable {
     var port: Int
     var username: String
     var authMethod: AuthMethod
-    /// Manual named-session field (#14: no enumeration); blank means the
-    /// default herdr session.
+    /// Persisted session selection; onboarding discovers available sessions,
+    /// while this field remains editable for older herdr versions. Blank
+    /// means the default herdr session.
     var sessionName: String
     /// Absolute socat path on the Host.
     var socatPath: String

--- a/Sources/HerdrMobile/Hosts/HostCredentialsProvider.swift
+++ b/Sources/HerdrMobile/Hosts/HostCredentialsProvider.swift
@@ -39,4 +39,10 @@ struct HostCredentialsProvider: Sendable {
     func deviceKey() throws -> DeviceKey {
         try deviceKeys.loadOrCreate()
     }
+
+    /// User-approved recovery for a corrupt device key. Callers must explain
+    /// that every device-key Host will need the replacement public key.
+    func replaceDeviceKey() throws -> DeviceKey {
+        try deviceKeys.replaceStoredKey()
+    }
 }

--- a/Sources/HerdrMobile/Hosts/HostFormView.swift
+++ b/Sources/HerdrMobile/Hosts/HostFormView.swift
@@ -12,6 +12,9 @@ struct HostFormView: View {
     @State private var authorizedKeysLine: String?
     @State private var didCopyKeyLine = false
     @State private var saveFailed = false
+    @State private var deviceKeyIsCorrupt = false
+    @State private var isConfirmingDeviceKeyReplacement = false
+    @State private var deviceKeyReplacementError: String?
     @Environment(\.dismiss) private var dismiss
 
     private let credentials = HostCredentialsProvider()
@@ -99,9 +102,30 @@ struct HostFormView: View {
             .alert("Could not save the Host", isPresented: $saveFailed) {
                 Button("OK", role: .cancel) {}
             }
+            .alert(
+                "Could not replace the Device Key",
+                isPresented: Binding(
+                    get: { deviceKeyReplacementError != nil },
+                    set: { if !$0 { deviceKeyReplacementError = nil } })
+            ) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(deviceKeyReplacementError ?? "")
+            }
+            .confirmationDialog(
+                "Replace the Device Key?",
+                isPresented: $isConfirmingDeviceKeyReplacement,
+                titleVisibility: .visible
+            ) {
+                Button("Replace Device Key", role: .destructive) { replaceDeviceKey() }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text(
+                    "Every Host using Device Key authentication will reject the replacement "
+                        + "until you add its new public key to ~/.ssh/authorized_keys.")
+            }
             .task {
-                authorizedKeysLine = try? credentials.deviceKey()
-                    .authorizedKeysLine(comment: "herdr-mobile")
+                loadDeviceKey()
             }
         }
     }
@@ -123,10 +147,42 @@ struct HostFormView: View {
                     systemImage: didCopyKeyLine ? "checkmark" : "doc.on.doc")
             }
         } else {
-            // Only reachable when the Keychain is unavailable or the stored
-            // key is corrupt; there is nothing actionable in-form.
-            Label("Device key unavailable", systemImage: "exclamationmark.triangle")
-                .foregroundStyle(.secondary)
+            Label(
+                deviceKeyIsCorrupt ? "Device key is corrupted" : "Device key unavailable",
+                systemImage: "exclamationmark.triangle")
+                .foregroundStyle(.red)
+            if deviceKeyIsCorrupt {
+                Button("Replace Device Key", role: .destructive) {
+                    isConfirmingDeviceKeyReplacement = true
+                }
+            } else {
+                Button("Try Again") { loadDeviceKey() }
+            }
+        }
+    }
+
+    private func loadDeviceKey() {
+        do {
+            let key = try credentials.deviceKey()
+            authorizedKeysLine = key.authorizedKeysLine(comment: "herdr-mobile")
+            deviceKeyIsCorrupt = false
+        } catch DeviceKeyStoreError.storedKeyCorrupt {
+            authorizedKeysLine = nil
+            deviceKeyIsCorrupt = true
+        } catch {
+            authorizedKeysLine = nil
+            deviceKeyIsCorrupt = false
+        }
+    }
+
+    private func replaceDeviceKey() {
+        do {
+            let key = try credentials.replaceDeviceKey()
+            authorizedKeysLine = key.authorizedKeysLine(comment: "herdr-mobile")
+            deviceKeyIsCorrupt = false
+            didCopyKeyLine = false
+        } catch {
+            deviceKeyReplacementError = "The replacement could not be saved to the Keychain."
         }
     }
 

--- a/Sources/HerdrMobile/Hosts/HostListView.swift
+++ b/Sources/HerdrMobile/Hosts/HostListView.swift
@@ -1,11 +1,46 @@
+import Observation
 import SwiftUI
+
+@MainActor
+@Observable
+final class HostRemovalStore {
+    private(set) var errorMessage: String?
+
+    @ObservationIgnored
+    private let store: HostStore
+
+    init(store: HostStore) {
+        self.store = store
+    }
+
+    func remove(_ ids: [Host.ID]) {
+        for id in ids {
+            do {
+                try store.remove(id)
+            } catch {
+                errorMessage = "The Host could not be removed. Its saved credentials may still be in the Keychain."
+                return
+            }
+        }
+    }
+
+    func dismissError() {
+        errorMessage = nil
+    }
+}
 
 /// Host management (#14): the catalog of Hosts with add/edit/remove, each
 /// row leading into that Host's onboarding checklist.
 struct HostListView: View {
     let store: HostStore
+    @State private var removal: HostRemovalStore
     @State private var isAddingHost = false
     @State private var path: [Host.ID] = []
+
+    init(store: HostStore) {
+        self.store = store
+        _removal = State(initialValue: HostRemovalStore(store: store))
+    }
 
     var body: some View {
         NavigationStack(path: $path) {
@@ -51,13 +86,28 @@ struct HostListView: View {
                     path.append(saved.id)
                 }
             }
+            .alert(
+                "Could Not Remove Host",
+                isPresented: Binding(
+                    get: { removal.errorMessage != nil },
+                    set: { isPresented in
+                        if !isPresented {
+                            removal.dismissError()
+                        }
+                    }
+                )
+            ) {
+                Button("OK", role: .cancel) {
+                    removal.dismissError()
+                }
+            } message: {
+                Text(removal.errorMessage ?? "")
+            }
         }
     }
 
     private func removeHosts(at offsets: IndexSet) {
-        for id in offsets.map({ store.hosts[$0].id }) {
-            try? store.remove(id)
-        }
+        removal.remove(offsets.map { store.hosts[$0].id })
     }
 }
 

--- a/Sources/HerdrMobile/Hosts/HostOnboardingStore.swift
+++ b/Sources/HerdrMobile/Hosts/HostOnboardingStore.swift
@@ -1,6 +1,13 @@
 import Foundation
 import Observation
 
+/// A verified mismatch awaiting the user's explicit decision to replace the
+/// trusted pin. Merely observing a mismatch never mutates the known-hosts store.
+struct HostKeyReplacement: Equatable, Sendable {
+    let known: HostKeyFingerprint
+    let presented: HostKeyFingerprint
+}
+
 /// Drives one Host's onboarding preflight (#14): resolve credentials,
 /// connect (surfacing the TOFU first-connect prompt), ping, and render the
 /// outcome as the checklist. One connect + ping is the whole probe —
@@ -18,6 +25,9 @@ final class HostOnboardingStore {
     /// Set while the transport waits on the user's first-connect trust
     /// decision; the UI renders it as the fingerprint confirmation sheet.
     private(set) var pendingFingerprint: HostKeyCandidate?
+    /// Set only after a hard-failed mismatch, for the UI's explicit re-trust
+    /// flow. The old pin remains authoritative until the user confirms.
+    private(set) var pendingHostKeyReplacement: HostKeyReplacement?
     private(set) var report: PreflightReport?
     private(set) var serverInfo: ServerInfo?
 
@@ -52,6 +62,7 @@ final class HostOnboardingStore {
         phase = .running
         report = nil
         serverInfo = nil
+        pendingHostKeyReplacement = nil
         defer { phase = .finished }
 
         let resolved: SSHCredentials
@@ -80,11 +91,13 @@ final class HostOnboardingStore {
                 serverInfo = try await transport.ping()
                 report = .allPassed
             } catch {
+                captureHostKeyReplacement(error)
                 report = failureReport(error)
             }
             // Preflight only probes; the Console owns long-lived connections.
             try? await transport.close()
         } catch {
+            captureHostKeyReplacement(error)
             report = failureReport(error)
         }
     }
@@ -92,6 +105,20 @@ final class HostOnboardingStore {
     /// The user's verdict on the pending fingerprint.
     func confirmFingerprint(trusted: Bool) {
         resolveFingerprint(trusted)
+    }
+
+    /// Replaces a mismatched pin only after the UI has obtained an explicit
+    /// confirmation, then immediately proves the new pin by rerunning preflight.
+    func trustPresentedHostKey() async {
+        guard phase != .running, let replacement = pendingHostKeyReplacement else { return }
+        await knownHosts.setFingerprint(replacement.presented, host: host.address, port: host.port)
+        pendingHostKeyReplacement = nil
+        await runChecks()
+    }
+
+    private func captureHostKeyReplacement(_ error: any Error) {
+        guard case let TransportError.hostKeyMismatch(known, presented) = error else { return }
+        pendingHostKeyReplacement = HostKeyReplacement(known: known, presented: presented)
     }
 
     private func failureReport(_ error: any Error) -> PreflightReport {

--- a/Sources/HerdrMobile/Hosts/HostOnboardingStore.swift
+++ b/Sources/HerdrMobile/Hosts/HostOnboardingStore.swift
@@ -9,9 +9,8 @@ struct HostKeyReplacement: Equatable, Sendable {
 }
 
 /// Drives one Host's onboarding preflight (#14): resolve credentials,
-/// connect (surfacing the TOFU first-connect prompt), ping, and render the
-/// outcome as the checklist. One connect + ping is the whole probe —
-/// preflight is the M0 error taxonomy, not new machinery (spec #20).
+/// connect (surfacing the TOFU first-connect prompt), discover sessions,
+/// ping the selected session, and render the outcome as the checklist.
 @MainActor
 @Observable
 final class HostOnboardingStore {

--- a/Sources/HerdrMobile/Hosts/HostOnboardingStore.swift
+++ b/Sources/HerdrMobile/Hosts/HostOnboardingStore.swift
@@ -30,6 +30,8 @@ final class HostOnboardingStore {
     private(set) var pendingHostKeyReplacement: HostKeyReplacement?
     private(set) var report: PreflightReport?
     private(set) var serverInfo: ServerInfo?
+    private(set) var availableSessions: [HerdrSession] = []
+    private(set) var sessionDiscoveryError: String?
 
     let host: Host
 
@@ -62,6 +64,8 @@ final class HostOnboardingStore {
         phase = .running
         report = nil
         serverInfo = nil
+        availableSessions = []
+        sessionDiscoveryError = nil
         pendingHostKeyReplacement = nil
         defer { phase = .finished }
 
@@ -88,6 +92,11 @@ final class HostOnboardingStore {
         do {
             let transport = try await connector.connect(settings: settings)
             do {
+                availableSessions = try await transport.listSessions()
+            } catch {
+                sessionDiscoveryError = "Could not discover herdr sessions. You can still enter a session name manually."
+            }
+            do {
                 serverInfo = try await transport.ping()
                 report = .allPassed
             } catch {
@@ -105,6 +114,15 @@ final class HostOnboardingStore {
     /// The user's verdict on the pending fingerprint.
     func confirmFingerprint(trusted: Bool) {
         resolveFingerprint(trusted)
+    }
+
+    /// Persists a discovered session through the Host catalog. The enclosing
+    /// navigation destination is keyed by the Host value, so this recreates
+    /// onboarding and immediately checks the selected socket.
+    func selectSession(_ session: HerdrSession, in catalog: HostStore) throws {
+        var updated = host
+        updated.sessionName = session.isDefault ? "" : session.name
+        try catalog.update(updated)
     }
 
     /// Replaces a mismatched pin only after the UI has obtained an explicit

--- a/Sources/HerdrMobile/Hosts/HostOnboardingView.swift
+++ b/Sources/HerdrMobile/Hosts/HostOnboardingView.swift
@@ -8,6 +8,7 @@ struct HostOnboardingView: View {
     let catalog: HostStore
     @State private var store: HostOnboardingStore
     @State private var isEditing = false
+    @State private var isConfirmingHostKeyReplacement = false
 
     init(host: Host, catalog: HostStore) {
         self.catalog = catalog
@@ -51,6 +52,16 @@ struct HostOnboardingView: View {
                 }
                 .disabled(store.phase == .running)
             }
+
+            if store.pendingHostKeyReplacement != nil {
+                Section {
+                    Button("Trust New Host Key", systemImage: "key.horizontal", role: .destructive) {
+                        isConfirmingHostKeyReplacement = true
+                    }
+                } footer: {
+                    Text("Only continue after verifying the new fingerprint with the Host owner.")
+                }
+            }
         }
         .navigationTitle(store.host.displayName)
         .navigationBarTitleDisplayMode(.inline)
@@ -74,6 +85,23 @@ struct HostOnboardingView: View {
                 "First connection to \(candidate.host):\(String(candidate.port)).\n\n"
                     + "Key fingerprint:\n\(candidate.fingerprint.displayString)\n\n"
                     + "Verify it matches the Host's key before trusting.")
+        }
+        .confirmationDialog(
+            "Replace the trusted Host key?",
+            isPresented: $isConfirmingHostKeyReplacement,
+            titleVisibility: .visible
+        ) {
+            Button("Trust New Key", role: .destructive) {
+                Task { await store.trustPresentedHostKey() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            if let replacement = store.pendingHostKeyReplacement {
+                Text(
+                    "Trusted: \(replacement.known.displayString)\n\n"
+                        + "Presented: \(replacement.presented.displayString)\n\n"
+                        + "A changed key can indicate a reinstalled Host or an attack.")
+            }
         }
         .task {
             if store.phase == .idle {

--- a/Sources/HerdrMobile/Hosts/HostOnboardingView.swift
+++ b/Sources/HerdrMobile/Hosts/HostOnboardingView.swift
@@ -9,6 +9,7 @@ struct HostOnboardingView: View {
     @State private var store: HostOnboardingStore
     @State private var isEditing = false
     @State private var isConfirmingHostKeyReplacement = false
+    @State private var sessionSelectionError: String?
 
     init(host: Host, catalog: HostStore) {
         self.catalog = catalog
@@ -43,6 +44,8 @@ struct HostOnboardingView: View {
                     Text("herdr \(info.version) · protocol \(info.protocolVersion)")
                 }
             }
+
+            availableSessionsSection
 
             Section {
                 Button {
@@ -103,6 +106,16 @@ struct HostOnboardingView: View {
                         + "A changed key can indicate a reinstalled Host or an attack.")
             }
         }
+        .alert(
+            "Could Not Select Session",
+            isPresented: Binding(
+                get: { sessionSelectionError != nil },
+                set: { if !$0 { sessionSelectionError = nil } })
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(sessionSelectionError ?? "")
+        }
         .task {
             if store.phase == .idle {
                 await store.runChecks()
@@ -132,6 +145,54 @@ struct HostOnboardingView: View {
 
     private func status(for check: PreflightCheck) -> PreflightCheckStatus? {
         store.report?[check]
+    }
+
+    @ViewBuilder
+    private var availableSessionsSection: some View {
+        if !store.availableSessions.isEmpty || store.sessionDiscoveryError != nil {
+            Section {
+                ForEach(store.availableSessions, id: \.name) { session in
+                    Button {
+                        select(session)
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading) {
+                                Text(session.name)
+                                Text(session.isRunning ? "Running" : "Stopped")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            if isSelected(session) {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                    .disabled(isSelected(session) || (!session.isDefault && !session.isRunning))
+                }
+                if let error = store.sessionDiscoveryError {
+                    Label(error, systemImage: "exclamationmark.triangle")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("Available Sessions")
+            } footer: {
+                Text("Stopped named sessions must be started on the Host before selection.")
+            }
+        }
+    }
+
+    private func isSelected(_ session: HerdrSession) -> Bool {
+        session.isDefault ? store.host.sessionName.isEmpty : store.host.sessionName == session.name
+    }
+
+    private func select(_ session: HerdrSession) {
+        do {
+            try store.selectSession(session, in: catalog)
+        } catch {
+            sessionSelectionError = "The selected session could not be saved."
+        }
     }
 }
 

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -19,6 +19,18 @@ enum TerminalScreenStyle: Equatable {
     }
 }
 
+/// Remote terminal output is untrusted. Only ordinary web links cross from
+/// SwiftTerm into the system URL opener; local files and executable schemes do not.
+enum TerminalLinkPolicy {
+    static func url(for link: String) -> URL? {
+        guard let url = URL(string: link), let scheme = url.scheme?.lowercased() else {
+            return nil
+        }
+        guard (scheme == "http" || scheme == "https"), url.host != nil else { return nil }
+        return url
+    }
+}
+
 /// The shared SwiftTerm surface: Observe (#9) renders it read-only, Attach
 /// (#11) drives the same view with `allowsInput` and `onSend` wired. Bytes
 /// arrive through a `TerminalByteFeed`; geometry flows out through
@@ -33,6 +45,7 @@ struct TerminalScreenView: UIViewRepresentable {
     /// Keystrokes the terminal wants sent to the remote; nil (Observe)
     /// discards them — this surface never sends input (CONTEXT.md).
     var onSend: ((Data) -> Void)?
+    @Environment(\.openURL) private var openURL
 
     func makeUIView(context: Context) -> SizeReportingTerminalView {
         let view = SizeReportingTerminalView(frame: .zero, font: style.font)
@@ -60,11 +73,13 @@ struct TerminalScreenView: UIViewRepresentable {
         context.coordinator.onSizeChanged = onSizeChanged
         context.coordinator.onLoadEarlier = onLoadEarlier
         context.coordinator.onSend = onSend
+        context.coordinator.onOpenLink = { url in openURL(url) }
     }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
-            onSizeChanged: onSizeChanged, onLoadEarlier: onLoadEarlier, onSend: onSend)
+            onSizeChanged: onSizeChanged, onLoadEarlier: onLoadEarlier, onSend: onSend,
+            onOpenLink: { url in openURL(url) })
     }
 
     /// SwiftTerm's delegate protocol is not actor-annotated but the view
@@ -76,14 +91,16 @@ struct TerminalScreenView: UIViewRepresentable {
         var onSizeChanged: ((Int, Int) -> Void)?
         var onLoadEarlier: (() -> Bool)?
         var onSend: ((Data) -> Void)?
+        var onOpenLink: ((URL) -> Void)?
 
         init(
             onSizeChanged: ((Int, Int) -> Void)?, onLoadEarlier: (() -> Bool)? = nil,
-            onSend: ((Data) -> Void)?
+            onSend: ((Data) -> Void)?, onOpenLink: ((URL) -> Void)? = nil
         ) {
             self.onSizeChanged = onSizeChanged
             self.onLoadEarlier = onLoadEarlier
             self.onSend = onSend
+            self.onOpenLink = onOpenLink
         }
 
         nonisolated func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {
@@ -100,7 +117,10 @@ struct TerminalScreenView: UIViewRepresentable {
         nonisolated func scrolled(source: TerminalView, position: Double) {}
         nonisolated func requestOpenLink(
             source: TerminalView, link: String, params: [String: String]
-        ) {}
+        ) {
+            guard let url = TerminalLinkPolicy.url(for: link) else { return }
+            MainActor.assumeIsolated { onOpenLink?(url) }
+        }
         nonisolated func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
     }
 }

--- a/Sources/HerdrMobile/Transport/DeviceKeyStore.swift
+++ b/Sources/HerdrMobile/Transport/DeviceKeyStore.swift
@@ -34,4 +34,13 @@ struct DeviceKeyStore: Sendable {
         try secrets.write(key.rawRepresentation, account: account)
         return DeviceKey(privateKey: key)
     }
+
+    /// Replaces the stored key only after a user-approved recovery flow. This
+    /// is deliberately separate from `loadOrCreate`: silent replacement would
+    /// invalidate access to every Host that trusts the previous public key.
+    func replaceStoredKey() throws -> DeviceKey {
+        let key = Curve25519.Signing.PrivateKey()
+        try secrets.write(key.rawRepresentation, account: account)
+        return DeviceKey(privateKey: key)
+    }
 }

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -9,6 +9,7 @@ import NIOCore
 /// How to reach one Host, authenticate against it, and find its herdr socket.
 struct SSHTransportSettings: Sendable {
     static let defaultObserveCommand = "herdr terminal session control"
+    static let defaultSessionListCommand = "herdr session list --json"
 
     var host: String
     var port: Int
@@ -30,6 +31,9 @@ struct SSHTransportSettings: Sendable {
     /// the environment boundary; per-Host override also covers hosts where
     /// herdr is not on the login shell's PATH.
     var wakeCommand: String = "herdr remote-client-bridge"
+    /// Official Host-local CLI command for discovering default and named
+    /// sessions. It does not depend on a running API socket.
+    var sessionListCommand: String = Self.defaultSessionListCommand
     /// Command that streams a Pane's terminal as NDJSON frame lines over a
     /// no-PTY exec channel. The default claims a non-takeover control
     /// session so herdr applies the phone geometry to the Agent's PTY; the
@@ -56,6 +60,10 @@ struct SSHTransportSettings: Sendable {
     var requestTimeout: Duration = .seconds(15)
 }
 
+private struct HerdrSessionListResponse: Decodable {
+    let sessions: [HerdrSession]
+}
+
 /// Transport over SSH exec channels running `socat - UNIX-CONNECT:<sock>`,
 /// one channel per request because herdr serves one request per connection
 /// (ADR 0002). An actor because Citadel's SSHClient is not Sendable.
@@ -72,6 +80,7 @@ actor SSHTransport: Transport {
     private let socketLocation: HerdrSocketLocation
     private let socatPath: String
     private let wakeCommand: String
+    private let sessionListCommand: String
     private let observeCommand: String
     private let observeCommandHandlesStdinEOF: Bool
     private let attachCommand: String
@@ -156,7 +165,8 @@ actor SSHTransport: Transport {
 
     private init(
         client: SSHClient, socketLocation: HerdrSocketLocation, socatPath: String,
-        wakeCommand: String, observeCommand: String, observeCommandHandlesStdinEOF: Bool,
+        wakeCommand: String, sessionListCommand: String, observeCommand: String,
+        observeCommandHandlesStdinEOF: Bool,
         attachCommand: String,
         requestTimeout: Duration
     ) {
@@ -164,6 +174,7 @@ actor SSHTransport: Transport {
         self.socketLocation = socketLocation
         self.socatPath = socatPath
         self.wakeCommand = wakeCommand
+        self.sessionListCommand = sessionListCommand
         self.observeCommand = observeCommand
         self.observeCommandHandlesStdinEOF = observeCommandHandlesStdinEOF
         self.attachCommand = attachCommand
@@ -196,7 +207,8 @@ actor SSHTransport: Transport {
         }
         return SSHTransport(
             client: client, socketLocation: settings.socket, socatPath: settings.socatPath,
-            wakeCommand: settings.wakeCommand, observeCommand: settings.observeCommand,
+            wakeCommand: settings.wakeCommand, sessionListCommand: settings.sessionListCommand,
+            observeCommand: settings.observeCommand,
             observeCommandHandlesStdinEOF: settings.observeCommandHandlesStdinEOF,
             attachCommand: settings.attachCommand, requestTimeout: settings.requestTimeout)
     }
@@ -223,6 +235,31 @@ actor SSHTransport: Transport {
                 server: pong.protocolVersion, supported: Self.supportedProtocolVersion)
         }
         return ServerInfo(version: pong.version, protocolVersion: pong.protocolVersion)
+    }
+
+    func listSessions() async throws -> [HerdrSession] {
+        let output = try await Self.withRequestDeadline(requestTimeout) {
+            try await self.runSessionListCommand()
+        }
+        do {
+            return try JSONDecoder().decode(HerdrSessionListResponse.self, from: output).sessions
+        } catch {
+            throw TransportError.malformedResponse(
+                "herdr session list returned invalid JSON: \(Self.preview(output))")
+        }
+    }
+
+    private func runSessionListCommand() async throws -> Data {
+        try await acquireExecChannelSlot()
+        defer { releaseExecChannelSlot() }
+        do {
+            let output = try await client.executeCommand(sessionListCommand)
+            return Data(output.readableBytesView)
+        } catch is CancellationError {
+            throw TransportError.cancelled
+        } catch {
+            throw TransportError.channelFailed(detail: String(describing: error))
+        }
     }
 
     func listAgents() async throws -> [Agent] {

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -253,7 +253,7 @@ actor SSHTransport: Transport {
         try await acquireExecChannelSlot()
         defer { releaseExecChannelSlot() }
         do {
-            let output = try await client.executeCommand(sessionListCommand)
+            let output = try await client.executeCommand(Self.cLocaleCommand(sessionListCommand))
             return Data(output.readableBytesView)
         } catch is CancellationError {
             throw TransportError.cancelled
@@ -417,7 +417,8 @@ actor SSHTransport: Transport {
         /// a no-op, so this is only observed when the ack line never came.
         var ackFailure = TransportError.cancelled
         do {
-            try await client.withExec("\(socatPath) - UNIX-CONNECT:\(socketPath)") {
+            try await client.withExec(
+                Self.cLocaleCommand("\(socatPath) - UNIX-CONNECT:\(socketPath)")) {
                 inbound, outbound in
                 try? await outbound.write(ByteBuffer(string: requestLine))
                 for try await chunk in inbound {
@@ -531,7 +532,7 @@ actor SSHTransport: Transport {
         let readerID = nextTerminalReaderID
         let readerTask = Task {
             await self.runTerminalChannel(
-                readerID: readerID, command: command, frames: continuation)
+                readerID: readerID, command: Self.cLocaleCommand(command), frames: continuation)
         }
         // No suspension between the idle guard and here, and the reader is
         // actor-isolated too, so it cannot have observed — let alone ended —
@@ -876,7 +877,8 @@ actor SSHTransport: Transport {
     private func runWakeCommand() async throws {
         try await acquireExecChannelSlot()
         defer { releaseExecChannelSlot() }
-        _ = try await client.executeCommand("\(wakeCommand) < /dev/null")
+        _ = try await client.executeCommand(
+            Self.cLocaleCommand("\(wakeCommand) < /dev/null"))
     }
 
     /// One no-PTY exec channel per request, raced against the per-request
@@ -906,7 +908,8 @@ actor SSHTransport: Transport {
         var stdout = Data()
         var stderr = Data()
         do {
-            try await client.withExec("\(socatPath) - UNIX-CONNECT:\(socketPath)") {
+            try await client.withExec(
+                Self.cLocaleCommand("\(socatPath) - UNIX-CONNECT:\(socketPath)")) {
                 inbound, outbound in
                 // A fast-failing command (socat missing, socket absent) can
                 // close the channel before this write lands; the read loop
@@ -999,7 +1002,7 @@ actor SSHTransport: Transport {
         let output: ByteBuffer
         do {
             // $HOME expands in every mainstream login shell, fish included.
-            output = try await client.executeCommand("echo $HOME")
+            output = try await client.executeCommand(Self.cLocaleCommand("echo $HOME"))
         } catch {
             throw TransportError.homeDirectoryUnresolvable(detail: String(describing: error))
         }
@@ -1039,6 +1042,12 @@ actor SSHTransport: Transport {
 
     private static func preview(_ stderr: Data) -> String {
         String(decoding: stderr.prefix(200), as: UTF8.self)
+    }
+
+    /// Stabilizes every parsed remote exec surface. Error classification and
+    /// JSON diagnostics must not change with the Host account's locale.
+    private static func cLocaleCommand(_ command: String) -> String {
+        "LC_ALL=C \(command)"
     }
 }
 

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -7,6 +7,11 @@ protocol Transport: Sendable {
     /// its identity. Must be the first call on every new connection path.
     func ping() async throws -> ServerInfo
 
+    /// Lists the local herdr sessions visible to this SSH account. This is a
+    /// Host-level capability and does not depend on the currently selected
+    /// API socket, so onboarding can recover from a stale manual selection.
+    func listSessions() async throws -> [HerdrSession]
+
     /// Lists the Agents herdr has detected across all workspaces.
     func listAgents() async throws -> [Agent]
 
@@ -90,6 +95,12 @@ protocol Transport: Sendable {
     func close() async throws
 }
 
+extension Transport {
+    /// Test doubles and alternative transports that do not expose Host-level
+    /// session discovery can opt out without inventing sessions.
+    func listSessions() async throws -> [HerdrSession] { [] }
+}
+
 /// herdr server identity as reported by `ping`.
 struct ServerInfo: Sendable, Equatable {
     let version: String
@@ -98,6 +109,25 @@ struct ServerInfo: Sendable, Equatable {
     init(version: String, protocolVersion: Int) {
         self.version = version
         self.protocolVersion = protocolVersion
+    }
+}
+
+/// One entry from `herdr session list --json` on a Host.
+struct HerdrSession: Sendable, Equatable, Decodable {
+    let name: String
+    let isDefault: Bool
+    let isRunning: Bool
+
+    init(name: String, isDefault: Bool, isRunning: Bool) {
+        self.name = name
+        self.isDefault = isDefault
+        self.isRunning = isRunning
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case isDefault = "default"
+        case isRunning = "running"
     }
 }
 

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -4,7 +4,8 @@ import Foundation
 /// UI code talks to Transport, never to SSH primitives (ADR 0002).
 protocol Transport: Sendable {
     /// Verifies the server speaks a protocol version we support and returns
-    /// its identity. Must be the first call on every new connection path.
+    /// its identity. Must be the first herdr API call on every new connection
+    /// path; Host-local session discovery may run before it.
     func ping() async throws -> ServerInfo
 
     /// Lists the local herdr sessions visible to this SSH account. This is a

--- a/Tests/HerdrMobileTests/ConsoleStoreTests.swift
+++ b/Tests/HerdrMobileTests/ConsoleStoreTests.swift
@@ -16,7 +16,7 @@ struct ConsoleStoreTests {
     /// A store whose session factory routes each Host to its scripted
     /// transport; unknown Hosts fail the connect.
     private func makeStore(transports: [Host.ID: ScriptedTransport]) -> ConsoleStore {
-        ConsoleStore { host, subscriptions in
+        ConsoleStore(snapshotRetryDelay: .milliseconds(10)) { host, subscriptions in
             EventsSession(
                 subscriptions: subscriptions,
                 connect: {
@@ -277,6 +277,59 @@ struct ConsoleStoreTests {
         try await waitUntil("the detected agent should appear via re-snapshot") {
             store.agents.count == 2
         }
+
+        store.setHosts([])
+    }
+
+    @Test func workspaceCreationRefreshesTheNewAgentPicker() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: .fixture(workspaces: [.fixture(workspaceID: "w1", label: "Proj")]))
+        let store = makeStore(transports: [host.id: transport])
+
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the initial workspace should arrive") {
+            store.workspaces(for: host.id).map(\.id) == ["w1"]
+        }
+        try await waitUntil("workspace creation should be subscribed") {
+            await transport.capturedSubscriptions.last?.contains(.global(.workspaceCreated)) == true
+        }
+
+        await transport.setSnapshot(
+            .fixture(workspaces: [
+                .fixture(workspaceID: "w1", label: "Proj"),
+                .fixture(workspaceID: "w2", label: "Api"),
+            ]))
+        await transport.emit(
+            HerdrEvent(kind: GlobalEventKind.workspaceCreated.kind, data: .object([:])))
+
+        try await waitUntil("the new workspace should appear without reconnecting") {
+            store.workspaces(for: host.id).map(\.id) == ["w2", "w1"]
+        }
+
+        store.setHosts([])
+    }
+
+    @Test func snapshotFailureSurfacesAndRetriesUntilRecovery() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: .fixture(agents: [.fixture(paneID: "w1:p1")]))
+        await transport.setSnapshotFailure(.timedOut)
+        let store = makeStore(transports: [host.id: transport])
+
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the sync failure should be visible") {
+            store.hostSyncErrors[host.id] != nil
+        }
+
+        await transport.setSnapshotFailure(nil)
+        try await waitUntil("the retry should recover the snapshot") {
+            store.agents.map(\.agent.paneID) == ["w1:p1"]
+                && store.hostSyncErrors[host.id] == nil
+        }
+        #expect(await transport.snapshotFetchCount >= 2)
 
         store.setHosts([])
     }

--- a/Tests/HerdrMobileTests/DeviceKeyStoreTests.swift
+++ b/Tests/HerdrMobileTests/DeviceKeyStoreTests.swift
@@ -30,6 +30,21 @@ struct DeviceKeyStoreTests {
 
         #expect(first.openSSHPublicKey != second.openSSHPublicKey)
     }
+
+    @Test func explicitReplacementRecoversACorruptStoredKey() throws {
+        let secrets = InMemorySecretStore()
+        let account = "corrupt-device-key"
+        try secrets.write(Data("not-an-ed25519-key".utf8), account: account)
+        let store = DeviceKeyStore(secrets: secrets, account: account)
+
+        #expect(throws: DeviceKeyStoreError.storedKeyCorrupt) {
+            try store.loadOrCreate()
+        }
+
+        let replacement = try store.replaceStoredKey()
+
+        #expect(try store.loadOrCreate().openSSHPublicKey == replacement.openSSHPublicKey)
+    }
 }
 
 // The real Keychain works in simulator test bundles for generic passwords;

--- a/Tests/HerdrMobileTests/DeviceKeyTests.swift
+++ b/Tests/HerdrMobileTests/DeviceKeyTests.swift
@@ -14,6 +14,12 @@ struct DeviceKeyTests {
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAOhB7/zzhC+HXDdGOdLwJln5NYwm6UNXx3chmQSVTG4"
     private static let expectedFingerprint =
         "SHA256:lbmsoA0yIEcEiVDRnMWuzm+nV+3ZEEpVIURqFoeSspg"
+    /// Fixed macOS OpenSSH ECDSA Host public-key blob. The expected digest
+    /// was produced independently with `ssh-keygen -lf ... -E sha256`.
+    private static let hostKeyBlobBase64 =
+        "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLyV4P8X5ejHCiSXChjxKWe2cdgcIxeGntnlZT3vKZnj7aFm1F8ZQ6x87oi61JenL3bH0Vw/Ipz4Pk6CL+zrLiA="
+    private static let expectedHostKeyFingerprint =
+        "SHA256:/z4b3jFj66ra/PAPVBN+nGDlLnPuHGm/Mlt0Je1YvyM"
 
     private var key: DeviceKey {
         get throws {
@@ -39,5 +45,13 @@ struct DeviceKeyTests {
     @Test func fingerprintRoundTripsThroughItsDigest() throws {
         let fingerprint = HostKeyFingerprint(publicKeyBlob: try key.publicKeyBlob)
         #expect(HostKeyFingerprint(digest: fingerprint.digest) == fingerprint)
+    }
+
+    @Test func ecdsaHostKeyFingerprintMatchesSSHKeygenOracle() throws {
+        let blob = try #require(Data(base64Encoded: Self.hostKeyBlobBase64))
+
+        let fingerprint = HostKeyFingerprint(publicKeyBlob: blob)
+
+        #expect(fingerprint.displayString == Self.expectedHostKeyFingerprint)
     }
 }

--- a/Tests/HerdrMobileTests/HostOnboardingStoreTests.swift
+++ b/Tests/HerdrMobileTests/HostOnboardingStoreTests.swift
@@ -17,10 +17,11 @@ struct HostOnboardingStoreTests {
         presentedKeyBlob: Data? = nil,
         knownHosts: InMemoryKnownHostsStore = InMemoryKnownHostsStore(),
         password: String? = nil,
+        sessions: [HerdrSession] = [],
         fingerprintTimeout: Duration = .seconds(5)
     ) throws -> (HostOnboardingStore, FakeTransportConnector) {
         let connector = FakeTransportConnector(
-            outcome: outcome, presentedKeyBlob: presentedKeyBlob)
+            outcome: outcome, presentedKeyBlob: presentedKeyBlob, sessions: sessions)
         let secrets = InMemorySecretStore()
         if let password {
             try secrets.write(
@@ -57,6 +58,34 @@ struct HostOnboardingStoreTests {
         #expect(store.serverInfo == ServerInfo(version: "0.7.4", protocolVersion: 16))
         let transport = try #require(await connector.transports.last)
         #expect(await transport.isClosed)
+    }
+
+    @Test func sessionDiscoveryPublishesDefaultAndNamedSessions() async throws {
+        let sessions = [
+            HerdrSession(name: "default", isDefault: true, isRunning: true),
+            HerdrSession(name: "work", isDefault: false, isRunning: true),
+        ]
+        let (store, _) = try makeStore(sessions: sessions)
+
+        await store.runChecks()
+
+        #expect(store.availableSessions == sessions)
+    }
+
+    @Test func selectingADiscoveredSessionUpdatesTheCatalogHost() throws {
+        let host = Host.fixture()
+        let suiteName = "HostOnboardingStoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let catalog = HostStore(defaults: defaults, secrets: InMemorySecretStore())
+        try catalog.add(host)
+        let (store, _) = try makeStore(host: host)
+
+        try store.selectSession(
+            HerdrSession(name: "work", isDefault: false, isRunning: true),
+            in: catalog)
+
+        #expect(catalog.hosts.first?.sessionName == "work")
     }
 
     @Test func connectFailureFailsTheConnectionCheck() async throws {

--- a/Tests/HerdrMobileTests/HostOnboardingStoreTests.swift
+++ b/Tests/HerdrMobileTests/HostOnboardingStoreTests.swift
@@ -154,6 +154,27 @@ struct HostOnboardingStoreTests {
         #expect(store.report?.isFullyPassed == true)
     }
 
+    @Test func explicitTrustReplacesThePresentedHostKeyAndReconnects() async throws {
+        let knownHosts = InMemoryKnownHostsStore()
+        let trusted = HostKeyFingerprint(publicKeyBlob: Data("trusted-host-key".utf8))
+        let presented = HostKeyFingerprint(publicKeyBlob: keyBlob)
+        await knownHosts.setFingerprint(trusted, host: "host.example", port: 22)
+        let (store, _) = try makeStore(presentedKeyBlob: keyBlob, knownHosts: knownHosts)
+
+        await store.runChecks()
+
+        #expect(
+            store.pendingHostKeyReplacement
+                == HostKeyReplacement(known: trusted, presented: presented))
+        #expect(await knownHosts.fingerprint(host: "host.example", port: 22) == trusted)
+
+        await store.trustPresentedHostKey()
+
+        #expect(store.pendingHostKeyReplacement == nil)
+        #expect(store.report?.isFullyPassed == true)
+        #expect(await knownHosts.fingerprint(host: "host.example", port: 22) == presented)
+    }
+
     @Test func settingsCarryTheHostCoordinatesAndStoredPassword() async throws {
         var host = Host.fixture(address: "box.example", username: "dev", authMethod: .password)
         host.port = 2222

--- a/Tests/HerdrMobileTests/HostStoreTests.swift
+++ b/Tests/HerdrMobileTests/HostStoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Synchronization
 import Testing
 
 @testable import HerdrMobile
@@ -123,6 +124,41 @@ struct HostStoreTests {
         try store.update(host)
 
         #expect(try store.password(for: host) == nil)
+    }
+
+    @Test func removalFailureStaysVisibleAndKeepsTheHost() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let secrets = RemovalFailingSecretStore()
+        let store = HostStore(defaults: defaults, secrets: secrets)
+        let host = Host.fixture(authMethod: .password)
+        try store.add(host, password: "hunter2")
+        secrets.failRemovals()
+        let removal = HostRemovalStore(store: store)
+
+        removal.remove([host.id])
+
+        #expect(store.hosts == [host])
+        #expect(removal.errorMessage != nil)
+        removal.dismissError()
+        #expect(removal.errorMessage == nil)
+    }
+}
+
+private final class RemovalFailingSecretStore: SecretStore {
+    private let shouldFailRemoval = Mutex(false)
+
+    func failRemovals() {
+        shouldFailRemoval.withLock { $0 = true }
+    }
+
+    func read(account: String) throws -> Data? { nil }
+    func write(_ secret: Data, account: String) throws {}
+
+    func removeSecret(account: String) throws {
+        if shouldFailRemoval.withLock({ $0 }) {
+            throw KeychainError.unexpectedStatus(-1)
+        }
     }
 }
 

--- a/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
@@ -224,6 +224,7 @@ struct SSHTransportE2ETests {
             .appendingPathComponent("herdr-session-list-\(UUID().uuidString).sh")
         let script = """
             #!/bin/sh
+            [ "$LC_ALL" = C ] || exit 2
             printf '%s' '{"sessions":[{"name":"default","default":true,"running":false},{"name":"work","default":false,"running":true}]}'
             """
         try Data(script.utf8).write(to: scriptURL, options: .atomic)

--- a/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
@@ -218,6 +218,37 @@ struct SSHTransportE2ETests {
         #expect(await !transport.isConnected)
     }
 
+    @Test func sessionDiscoveryDecodesTheOfficialCLIJSON() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let scriptURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herdr-session-list-\(UUID().uuidString).sh")
+        let script = """
+            #!/bin/sh
+            printf '%s' '{"sessions":[{"name":"default","default":true,"running":false},{"name":"work","default":false,"running":true}]}'
+            """
+        try Data(script.utf8).write(to: scriptURL, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700], ofItemAtPath: scriptURL.path)
+        defer { try? FileManager.default.removeItem(at: scriptURL) }
+        var settings = environment.makeSettings(
+            socket: .absolutePath("/tmp/herdr-irrelevant.sock"))
+        settings.sessionListCommand = scriptURL.path
+        let transport = try await SSHTransport.connect(settings: settings)
+        do {
+            let sessions = try await transport.listSessions()
+
+            #expect(
+                sessions == [
+                    HerdrSession(name: "default", isDefault: true, isRunning: false),
+                    HerdrSession(name: "work", isDefault: false, isRunning: true),
+                ])
+        } catch {
+            try? await transport.close()
+            throw error
+        }
+        try await transport.close()
+    }
+
     @Test func namedSessionSocketPathResolvesOverRemoteHome() async throws {
         // The transport is given only a session name; it must resolve the
         // remote home directory over exec and find the socket at

--- a/Tests/HerdrMobileTests/StartAgentStoreTests.swift
+++ b/Tests/HerdrMobileTests/StartAgentStoreTests.swift
@@ -92,10 +92,9 @@ struct StartAgentStoreTests {
 
         #expect(store.state == .started)
         #expect(recorder.hostIDs == [host.id])
-        let params = try? #require(recorder.params.first)
-        #expect(params?.argv == ["claude", "--continue"])
-        #expect(params?.name == "claude")
-        #expect(params?.workspaceID == "w1")
+        #expect(recorder.params.first?.argv == ["claude", "--continue"])
+        #expect(recorder.params.first?.name == "claude")
+        #expect(recorder.params.first?.workspaceID == "w1")
     }
 
     @Test func submitOmitsTheWorkspaceWhenTargetingTheCurrentOne() async {

--- a/Tests/HerdrMobileTests/Support/FakeTransportConnector.swift
+++ b/Tests/HerdrMobileTests/Support/FakeTransportConnector.swift
@@ -5,14 +5,20 @@ import Foundation
 /// Scripted `Transport` for store tests: protocol-level, no SSH.
 final actor FakeTransport: Transport {
     private let pingResult: Result<ServerInfo, TransportError>
+    private let sessions: [HerdrSession]
     private(set) var isClosed = false
 
-    init(pingResult: Result<ServerInfo, TransportError>) {
+    init(pingResult: Result<ServerInfo, TransportError>, sessions: [HerdrSession] = []) {
         self.pingResult = pingResult
+        self.sessions = sessions
     }
 
     func ping() async throws -> ServerInfo {
         try pingResult.get()
+    }
+
+    func listSessions() async throws -> [HerdrSession] {
+        sessions
     }
 
     func listAgents() async throws -> [Agent] {
@@ -80,12 +86,17 @@ final actor FakeTransportConnector: TransportConnector {
     /// The host key the fake "server" presents; nil skips host key
     /// evaluation entirely.
     private let presentedKeyBlob: Data?
+    private let sessions: [HerdrSession]
     private(set) var capturedSettings: [SSHTransportSettings] = []
     private(set) var transports: [FakeTransport] = []
 
-    init(outcome: Outcome, presentedKeyBlob: Data? = nil) {
+    init(
+        outcome: Outcome, presentedKeyBlob: Data? = nil,
+        sessions: [HerdrSession] = []
+    ) {
         self.outcome = outcome
         self.presentedKeyBlob = presentedKeyBlob
+        self.sessions = sessions
     }
 
     func connect(settings: SSHTransportSettings) async throws -> any Transport {
@@ -98,7 +109,7 @@ final actor FakeTransportConnector: TransportConnector {
         case .connectFails(let error):
             throw error
         case .connects(let pingResult):
-            let transport = FakeTransport(pingResult: pingResult)
+            let transport = FakeTransport(pingResult: pingResult, sessions: sessions)
             transports.append(transport)
             return transport
         }

--- a/Tests/HerdrMobileTests/Support/ScriptedTransport.swift
+++ b/Tests/HerdrMobileTests/Support/ScriptedTransport.swift
@@ -272,7 +272,7 @@ final actor ScriptedTransport: Transport {
         attachContinuation = outputContinuation
         attachInputTask = Task {
             for await item in input {
-                await self.recordAttachInput(item)
+                self.recordAttachInput(item)
             }
         }
         return TerminalAttachSession(output: output, input: inputContinuation) {

--- a/Tests/HerdrMobileTests/Support/ScriptedTransport.swift
+++ b/Tests/HerdrMobileTests/Support/ScriptedTransport.swift
@@ -40,6 +40,7 @@ final actor ScriptedTransport: Transport {
 
     private var serverInfo: ServerInfo
     private var snapshot: SessionSnapshot
+    private var snapshotFailure: TransportError?
     private var paneTexts: [String: String] = [:]
     private var paneReadFailure: TransportError?
     private var nextStreamID: UInt64 = 0
@@ -66,6 +67,11 @@ final actor ScriptedTransport: Transport {
     /// Replaces the snapshot subsequent `sessionSnapshot()` calls return.
     func setSnapshot(_ snapshot: SessionSnapshot) {
         self.snapshot = snapshot
+    }
+
+    /// Makes every subsequent `sessionSnapshot` throw `failure`.
+    func setSnapshotFailure(_ failure: TransportError?) {
+        snapshotFailure = failure
     }
 
     /// Scripts the text `readPane` returns for `paneID`.
@@ -178,6 +184,7 @@ final actor ScriptedTransport: Transport {
 
     func sessionSnapshot() async throws -> SessionSnapshot {
         snapshotFetchCount += 1
+        if let snapshotFailure { throw snapshotFailure }
         return snapshot
     }
 

--- a/Tests/HerdrMobileTests/TerminalFrameTests.swift
+++ b/Tests/HerdrMobileTests/TerminalFrameTests.swift
@@ -17,6 +17,17 @@ struct TerminalFrameTests {
                 == "herdr terminal session control")
     }
 
+    @Test func terminalLinksOpenOnlySafeWebURLs() {
+        #expect(
+            TerminalLinkPolicy.url(for: "https://example.com/docs?q=ssh")
+                == URL(string: "https://example.com/docs?q=ssh"))
+        #expect(TerminalLinkPolicy.url(for: "http://127.0.0.1:8080") != nil)
+        #expect(TerminalLinkPolicy.url(for: "file:///etc/passwd") == nil)
+        #expect(TerminalLinkPolicy.url(for: "javascript:alert(1)") == nil)
+        #expect(TerminalLinkPolicy.url(for: "https://") == nil)
+        #expect(TerminalLinkPolicy.url(for: "not a URL") == nil)
+    }
+
     @Test func decodesAFullRepaintFrame() throws {
         // The live-captured shape from the #9 probe: base64 of ANSI bytes.
         let payload = Data("\u{1B}[2J\u{1B}[Hhello".utf8)

--- a/docs/adr/0002-ssh-exec-socat-transport.md
+++ b/docs/adr/0002-ssh-exec-socat-transport.md
@@ -1,6 +1,6 @@
 # Transport: herdr JSON API over SSH exec + socat, no herdr changes
 
-The app reaches herdr's JSON API (NDJSON over a Unix domain socket, one request per connection) by opening a no-PTY SSH exec channel running `socat - UNIX-CONNECT:<sock>` per request, plus one long-lived channel for `events.subscribe`. Interactive terminals use a separate PTY exec channel running `herdr agent attach`. We deliberately require `socat` on every host and change nothing in herdr.
+The app reaches herdr's JSON API (NDJSON over a Unix domain socket, one request per connection) by opening a no-PTY SSH exec channel running `socat - UNIX-CONNECT:<sock>` per request, plus one long-lived channel for `events.subscribe`. Interactive terminals use a separate SSH PTY shell channel. Citadel 0.12.1 cannot combine a PTY request with an exec request, so the app writes an injection-safe `exec herdr agent attach <pane>` bootstrap line into that shell; `exec` replaces the shell, making the resulting channel mechanically equivalent to a PTY exec channel for lifecycle and byte streaming. We deliberately require `socat` on every host and change nothing in herdr.
 
 ## Considered Options
 


### PR DESCRIPTION
## Summary

- surface Console snapshot failures, retry until recovery, and refresh workspace creation events
- add explicit device-key replacement and changed host-key trust flows
- open only safe web links from terminal output and surface Host removal failures
- discover herdr sessions through the structured session-list command and allow switching from onboarding
- force parsed remote exec commands to a stable C locale, pin the host-key fingerprint oracle, and correct Attach transport documentation

## Testing

- scripts/generate-wire-types.py --check --schema scripts/herdr-schema.json
- xcodebuild test -quiet -project HerdrMobile.xcodeproj -scheme HerdrMobile -destination platform=iOS\ Simulator,name=iPhone\ 17,OS=latest (253 passed, 0 failed, 0 skipped)

Closes #24
Closes #25
Closes #26
Closes #27