### PR TITLE
feat(terminal): add attach terminal keyboard

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,10 @@ _Avoid_: watch, monitor, preview
 Full interactive terminal control of an Agent's pane through the embedded terminal.
 _Avoid_: takeover (that's herdr's flag, not our surface), connect
 
+**Terminal Keyboard**:
+The input surface used only within Attach to send text and terminal key sequences to an Agent's pane. It models terminal input, not remote-computer hardware events, and never appears in Observe.
+_Avoid_: computer keyboard, remote keyboard, Observe keyboard, reply keyboard
+
 **Transport**:
 The app-side abstraction that executes herdr API requests and delivers event streams over SSH. UI code talks to Transport, never to SSH primitives.
 _Avoid_: client, bridge, tunnel

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		1BBEEF5478D91222F48C2048 /* ReconnectPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66B41C393D38FA09388E3E2 /* ReconnectPolicyTests.swift */; };
 		1BF53C7A5E6402747F26096A /* HostCredentialsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC07C7B3772EEED1EB8BA9C /* HostCredentialsProvider.swift */; };
 		1F4B065DFCAF8E6656600F1E /* TOFUHostKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */; };
+		20A064874CEFDC701B9E3AAF /* TerminalKeyboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AF05342715F0EE8F294ED2 /* TerminalKeyboardView.swift */; };
 		225ECBDC69A7785559BC4D20 /* AttachTerminalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97970F4D535CC80592333995 /* AttachTerminalStore.swift */; };
 		27C44B69FBE155A397F54B77 /* HostStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AECAD39A269D97DAB4ED194 /* HostStore.swift */; };
 		29832666B5E02B0D33453DB1 /* EventsSessionBufferingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641088A470B51F40C898830F /* EventsSessionBufferingTests.swift */; };
@@ -55,6 +56,7 @@
 		7EEB41E5CD728587D7DCEC96 /* StartAgentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18AE2DC88A745FB457350957 /* StartAgentView.swift */; };
 		86C5F3E2D17523948343DF09 /* GeneratedWireTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87B816CE7206B37622287C4 /* GeneratedWireTypesTests.swift */; };
 		8C514AFC85DAED69A4988C13 /* SSHCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90875ADAF6E348E186C8125A /* SSHCredentials.swift */; };
+		8DF99F3257BCC6AE08595A45 /* TerminalKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DB204D5F25D5375D5B2974 /* TerminalKeyboard.swift */; };
 		91833D21F64358A8E82A0D34 /* HostOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E538BF75AE58E16C58782F7 /* HostOnboardingView.swift */; };
 		93851E040C292A16F5ECB10D /* ConsoleStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079394F4C6AC8FE4D7B0779C /* ConsoleStoreTests.swift */; };
 		950D74A1B92239CDB2DDE5DC /* EventsSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C3ACB2A319C5C1298A29F3F /* EventsSession.swift */; };
@@ -65,6 +67,7 @@
 		B0D87D1783C80597B66EDDFC /* HerdrAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD390F4EE653187BCF20037F /* HerdrAPITypes.swift */; };
 		B31E16D56EE1F19A3802625B /* TransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4476B101AA4B13190C7A7B7C /* TransportConnector.swift */; };
 		B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCA39340517CEF3DAA35A09B /* Preflight.swift */; };
+		B6D94BE6819E50A816CEB9FC /* TerminalKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE0D810D1016D8F7C2C4146 /* TerminalKeyboardTests.swift */; };
 		B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C232163905675760F37FD7A0 /* KnownHostsStore.swift */; };
 		BAC9F51A72EA9774DEDBC193 /* TerminalByteFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7C6974BD9BE77000016FCA /* TerminalByteFeed.swift */; };
 		BC107519427157CF5191E34F /* FakeTransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14983BD8988E4AAE79DC46A /* FakeTransportConnector.swift */; };
@@ -123,6 +126,7 @@
 		259E51D58B1094AC5B389EDA /* Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
 		25E3451A4ECA518B0AE43F93 /* HostDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostDraftTests.swift; sourceTree = "<group>"; };
 		278668F4D5B3EB85E6CDA16A /* HostFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostFormView.swift; sourceTree = "<group>"; };
+		29AF05342715F0EE8F294ED2 /* TerminalKeyboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeyboardView.swift; sourceTree = "<group>"; };
 		29DD3828DAEF46DBA7038B0A /* HostOnboardingStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostOnboardingStoreTests.swift; sourceTree = "<group>"; };
 		3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedAsyncOperation.swift; sourceTree = "<group>"; };
 		3E17A13DE5AFEC11CFD78274 /* TerminalObserve.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalObserve.swift; sourceTree = "<group>"; };
@@ -142,6 +146,7 @@
 		6CA5E9DDE1AB0F68F6EC56EB /* EventsSessionSubscriptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionSubscriptionsTests.swift; sourceTree = "<group>"; };
 		6F7C6974BD9BE77000016FCA /* TerminalByteFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalByteFeed.swift; sourceTree = "<group>"; };
 		71A2DB2B666DE2534DDE075B /* TerminalFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalFrameTests.swift; sourceTree = "<group>"; };
+		73DB204D5F25D5375D5B2974 /* TerminalKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeyboard.swift; sourceTree = "<group>"; };
 		78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrMobileApp.swift; sourceTree = "<group>"; };
 		7AFE5C640586747D567E1CF1 /* ScriptedTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptedTransport.swift; sourceTree = "<group>"; };
 		7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransport.swift; sourceTree = "<group>"; };
@@ -166,6 +171,7 @@
 		A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConcurrencyE2ETests.swift; sourceTree = "<group>"; };
 		B383994C2C8492694D5F3690 /* HerdrMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HerdrMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B66B41C393D38FA09388E3E2 /* ReconnectPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectPolicyTests.swift; sourceTree = "<group>"; };
+		BAE0D810D1016D8F7C2C4146 /* TerminalKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeyboardTests.swift; sourceTree = "<group>"; };
 		BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOFUHostKeyValidator.swift; sourceTree = "<group>"; };
 		BC2552636663F92A55D1DFF1 /* ClosePaneStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosePaneStoreTests.swift; sourceTree = "<group>"; };
 		BC995A571D7659F3307B6E54 /* DeviceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKey.swift; sourceTree = "<group>"; };
@@ -264,6 +270,8 @@
 			isa = PBXGroup;
 			children = (
 				6F7C6974BD9BE77000016FCA /* TerminalByteFeed.swift */,
+				73DB204D5F25D5375D5B2974 /* TerminalKeyboard.swift */,
+				29AF05342715F0EE8F294ED2 /* TerminalKeyboardView.swift */,
 				597ACEE9D688E433B20108D7 /* TerminalScreenView.swift */,
 			);
 			path = Terminal;
@@ -303,6 +311,7 @@
 				D83F34B22988623AD8E2093C /* TerminalAttachE2ETests.swift */,
 				BE8796AB629EF68A90C96B3D /* TerminalAttachTests.swift */,
 				71A2DB2B666DE2534DDE075B /* TerminalFrameTests.swift */,
+				BAE0D810D1016D8F7C2C4146 /* TerminalKeyboardTests.swift */,
 				DD6107DA82C2AC6705955ABD /* TerminalObserveE2ETests.swift */,
 				A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */,
 				02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */,
@@ -523,6 +532,8 @@
 				1F4B065DFCAF8E6656600F1E /* TOFUHostKeyValidator.swift in Sources */,
 				41BBA40C97BAE65E56D0E3B5 /* TerminalAttach.swift in Sources */,
 				BAC9F51A72EA9774DEDBC193 /* TerminalByteFeed.swift in Sources */,
+				8DF99F3257BCC6AE08595A45 /* TerminalKeyboard.swift in Sources */,
+				20A064874CEFDC701B9E3AAF /* TerminalKeyboardView.swift in Sources */,
 				46CF6496D795837D483F9EC5 /* TerminalObserve.swift in Sources */,
 				F96C5D15E14B947BE426B2F3 /* TerminalScreenView.swift in Sources */,
 				49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */,
@@ -570,6 +581,7 @@
 				E8E50DCA9F56799E022F9252 /* TerminalAttachE2ETests.swift in Sources */,
 				0CF1AA5AF7F2357186A5E486 /* TerminalAttachTests.swift in Sources */,
 				06B1CE9615AF78A90F3436CE /* TerminalFrameTests.swift in Sources */,
+				B6D94BE6819E50A816CEB9FC /* TerminalKeyboardTests.swift in Sources */,
 				54B68E64112970D45E0B0525 /* TerminalObserveE2ETests.swift in Sources */,
 				E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */,
 				782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */,

--- a/Sources/HerdrMobile/Terminal/TerminalKeyboard.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalKeyboard.swift
@@ -1,0 +1,473 @@
+import Foundation
+import SwiftTerm
+
+enum TerminalKeyboardMode: Hashable, Sendable {
+    case inputMethod
+    case terminal
+}
+
+enum TerminalKeyboardPage: Int, CaseIterable, Hashable, Sendable {
+    case typing
+    case navigation
+}
+
+enum TerminalModifier: CaseIterable, Hashable, Sendable {
+    case control
+    case shift
+    case alt
+}
+
+enum TerminalModifierPhase: Equatable, Sendable {
+    case inactive
+    case armed
+    case locked
+}
+
+struct TerminalKeyboardState: Equatable, Sendable {
+    private(set) var mode: TerminalKeyboardMode = .inputMethod
+    private(set) var page: TerminalKeyboardPage = .typing
+    private(set) var armedModifiers: Set<TerminalModifier> = []
+    private(set) var lockedModifiers: Set<TerminalModifier> = []
+
+    var activeModifiers: Set<TerminalModifier> {
+        armedModifiers.union(lockedModifiers)
+    }
+
+    func phase(of modifier: TerminalModifier) -> TerminalModifierPhase {
+        if lockedModifiers.contains(modifier) { return .locked }
+        if armedModifiers.contains(modifier) { return .armed }
+        return .inactive
+    }
+
+    mutating func selectMode(_ mode: TerminalKeyboardMode) {
+        guard self.mode != mode else { return }
+        self.mode = mode
+        clearModifiers()
+    }
+
+    mutating func selectPage(_ page: TerminalKeyboardPage) {
+        self.page = page
+    }
+
+    mutating func toggle(_ modifier: TerminalModifier, locks: Bool = false) {
+        switch phase(of: modifier) {
+        case .inactive:
+            if modifier == .shift, locks {
+                lockedModifiers.insert(modifier)
+            } else {
+                armedModifiers.insert(modifier)
+            }
+        case .armed:
+            armedModifiers.remove(modifier)
+            if modifier == .shift, locks {
+                lockedModifiers.insert(modifier)
+            }
+        case .locked:
+            lockedModifiers.remove(modifier)
+        }
+    }
+
+    mutating func consumeOneShotModifiers() {
+        armedModifiers.removeAll()
+    }
+
+    mutating func clearModifiers() {
+        armedModifiers.removeAll()
+        lockedModifiers.removeAll()
+    }
+}
+
+enum TerminalFunctionKey: Int, CaseIterable, Hashable, Sendable {
+    case f1 = 1
+    case f2
+    case f3
+    case f4
+    case f5
+    case f6
+    case f7
+    case f8
+    case f9
+    case f10
+    case f11
+    case f12
+}
+
+enum TerminalKey: Hashable, Sendable {
+    case character(base: Character, shifted: Character)
+    case escape
+    case tab
+    case backspace
+    case enter
+    case insert
+    case delete
+    case home
+    case end
+    case pageUp
+    case pageDown
+    case up
+    case down
+    case left
+    case right
+    case function(TerminalFunctionKey)
+
+    var isRepeatable: Bool {
+        switch self {
+        case .backspace, .delete, .up, .down, .left, .right:
+            true
+        default:
+            false
+        }
+    }
+
+    var id: String {
+        switch self {
+        case .character(let base, _): "character-\(base)"
+        case .escape: "escape"
+        case .tab: "tab"
+        case .backspace: "backspace"
+        case .enter: "enter"
+        case .insert: "insert"
+        case .delete: "delete"
+        case .home: "home"
+        case .end: "end"
+        case .pageUp: "page-up"
+        case .pageDown: "page-down"
+        case .up: "up"
+        case .down: "down"
+        case .left: "left"
+        case .right: "right"
+        case .function(let function): "f\(function.rawValue)"
+        }
+    }
+
+    var width: Double {
+        switch self {
+        case .backspace:
+            1.35
+        case .enter:
+            1.65
+        case .character(let base, _) where base == " ":
+            2.7
+        default:
+            1
+        }
+    }
+}
+
+extension TerminalKeyboardPage {
+    var rows: [[TerminalKey]] {
+        switch self {
+        case .typing:
+            [
+                [
+                    .character(base: "`", shifted: "~"),
+                    .character(base: "-", shifted: "_"),
+                    .character(base: "=", shifted: "+"),
+                    .character(base: "[", shifted: "{"),
+                    .character(base: "]", shifted: "}"),
+                    .character(base: "\\", shifted: "|"),
+                    .character(base: ";", shifted: ":"),
+                    .character(base: "'", shifted: "\""),
+                    .character(base: ",", shifted: "<"),
+                    .character(base: ".", shifted: ">"),
+                    .character(base: "/", shifted: "?"),
+                ],
+                "1234567890".map { key(for: $0) },
+                "qwertyuiop".map { key(for: $0) },
+                "asdfghjkl".map { key(for: $0) } + [.backspace],
+                "zxcvbnm".map { key(for: $0) }
+                    + [.character(base: " ", shifted: " "), .enter],
+            ]
+        case .navigation:
+            [
+                TerminalFunctionKey.allCases.prefix(6).map(TerminalKey.function),
+                TerminalFunctionKey.allCases.suffix(6).map(TerminalKey.function),
+                [.insert, .home, .pageUp],
+                [.delete, .end, .pageDown],
+                [.left, .down, .up, .right],
+            ]
+        }
+    }
+
+    private func key(for character: Character) -> TerminalKey {
+        let shiftedCharacters: [Character: Character] = [
+            "1": "!", "2": "@", "3": "#", "4": "$", "5": "%",
+            "6": "^", "7": "&", "8": "*", "9": "(", "0": ")",
+        ]
+        if let shifted = shiftedCharacters[character] {
+            return .character(base: character, shifted: shifted)
+        }
+        return .character(
+            base: character,
+            shifted: Character(String(character).uppercased()))
+    }
+}
+
+struct TerminalKeyEncodingContext {
+    var kittyFlags: KittyKeyboardFlags = []
+    var applicationCursor = false
+    var backspaceSendsControlH = false
+}
+
+enum TerminalKeyEncoder {
+    static func encode(
+        _ key: TerminalKey,
+        modifiers: Set<TerminalModifier>,
+        context: TerminalKeyEncodingContext
+    ) -> Data {
+        Data(bytes(for: key, modifiers: modifiers, context: context))
+    }
+
+    private static func bytes(
+        for key: TerminalKey,
+        modifiers: Set<TerminalModifier>,
+        context: TerminalKeyEncodingContext
+    ) -> [UInt8] {
+        if case .character(let base, let shifted) = key {
+            return textBytes(
+                base: base, shifted: shifted, modifiers: modifiers, context: context)
+        }
+
+        let disambiguates = context.kittyFlags.contains(.disambiguate)
+            || context.kittyFlags.contains(.reportAllKeys)
+        let modifierValue = kittyModifierValue(modifiers)
+
+        switch key {
+        case .escape:
+            if disambiguates {
+                return csiU(codepoint: 27, modifiers: modifierValue)
+            }
+            return legacy(bytes: EscapeSequences.cmdEsc, modifiers: modifiers)
+        case .enter:
+            return characterLikeSpecialKey(
+                codepoint: 13,
+                legacy: EscapeSequences.cmdRet,
+                modifiers: modifiers,
+                context: context)
+        case .tab:
+            let legacyBytes = modifiers.contains(.shift)
+                ? EscapeSequences.cmdBackTab : EscapeSequences.cmdTab
+            return characterLikeSpecialKey(
+                codepoint: 9,
+                legacy: legacyBytes,
+                modifiers: modifiers,
+                context: context)
+        case .backspace:
+            let byte: UInt8 = modifiers.contains(.control) || context.backspaceSendsControlH
+                ? 0x08 : 0x7F
+            return characterLikeSpecialKey(
+                codepoint: 127,
+                legacy: [byte],
+                modifiers: modifiers,
+                context: context)
+        case .up:
+            return cursorBytes(
+                letter: "A", appBytes: EscapeSequences.moveUpApp,
+                normalBytes: EscapeSequences.moveUpNormal,
+                modifiers: modifiers, context: context)
+        case .down:
+            return cursorBytes(
+                letter: "B", appBytes: EscapeSequences.moveDownApp,
+                normalBytes: EscapeSequences.moveDownNormal,
+                modifiers: modifiers, context: context)
+        case .right:
+            return cursorBytes(
+                letter: "C", appBytes: EscapeSequences.moveRightApp,
+                normalBytes: EscapeSequences.moveRightNormal,
+                modifiers: modifiers, context: context)
+        case .left:
+            return cursorBytes(
+                letter: "D", appBytes: EscapeSequences.moveLeftApp,
+                normalBytes: EscapeSequences.moveLeftNormal,
+                modifiers: modifiers, context: context)
+        case .home:
+            return cursorBytes(
+                letter: "H", appBytes: EscapeSequences.moveHomeApp,
+                normalBytes: EscapeSequences.moveHomeNormal,
+                modifiers: modifiers, context: context)
+        case .end:
+            return cursorBytes(
+                letter: "F", appBytes: EscapeSequences.moveEndApp,
+                normalBytes: EscapeSequences.moveEndNormal,
+                modifiers: modifiers, context: context)
+        case .insert:
+            return tildeBytes(
+                number: 2, legacyBytes: EscapeSequences.cmdInsert,
+                modifiers: modifiers, context: context)
+        case .delete:
+            return tildeBytes(
+                number: 3, legacyBytes: EscapeSequences.cmdDelKey,
+                modifiers: modifiers, context: context)
+        case .pageUp:
+            return tildeBytes(
+                number: 5, legacyBytes: EscapeSequences.cmdPageUp,
+                modifiers: modifiers, context: context)
+        case .pageDown:
+            return tildeBytes(
+                number: 6, legacyBytes: EscapeSequences.cmdPageDown,
+                modifiers: modifiers, context: context)
+        case .function(let function):
+            return functionBytes(function, modifiers: modifiers, context: context)
+        case .character:
+            return []
+        }
+    }
+
+    private static func textBytes(
+        base: Character,
+        shifted: Character,
+        modifiers: Set<TerminalModifier>,
+        context: TerminalKeyEncodingContext
+    ) -> [UInt8] {
+        let output = modifiers.contains(.shift) ? shifted : base
+        guard let baseScalar = String(base).unicodeScalars.first,
+              let outputScalar = String(output).unicodeScalars.first else {
+            return Array(String(output).utf8)
+        }
+
+        let reportsAll = context.kittyFlags.contains(.reportAllKeys)
+        let disambiguates = context.kittyFlags.contains(.disambiguate) || reportsAll
+        let reportsAlternates = context.kittyFlags.contains(.reportAlternates)
+        let hasControlOrAlt = modifiers.contains(.control) || modifiers.contains(.alt)
+
+        if disambiguates
+            && (reportsAll || hasControlOrAlt
+                || (reportsAlternates && modifiers.contains(.shift)))
+        {
+            let shiftedScalar = modifiers.contains(.shift) ? outputScalar : nil
+            return csiU(
+                codepoint: Int(baseScalar.value),
+                shiftedCodepoint: shiftedScalar.map { Int($0.value) },
+                modifiers: kittyModifierValue(modifiers))
+        }
+
+        var bytes: [UInt8] = modifiers.contains(.alt) ? EscapeSequences.cmdEsc : []
+        if modifiers.contains(.control), let control = controlByte(for: outputScalar) {
+            bytes.append(control)
+        } else {
+            bytes.append(contentsOf: String(output).utf8)
+        }
+        return bytes
+    }
+
+    private static func characterLikeSpecialKey(
+        codepoint: Int,
+        legacy: [UInt8],
+        modifiers: Set<TerminalModifier>,
+        context: TerminalKeyEncodingContext
+    ) -> [UInt8] {
+        let reportsAll = context.kittyFlags.contains(.reportAllKeys)
+        let disambiguates = context.kittyFlags.contains(.disambiguate) || reportsAll
+        if reportsAll || (disambiguates && !modifiers.isEmpty) {
+            return csiU(codepoint: codepoint, modifiers: kittyModifierValue(modifiers))
+        }
+        return self.legacy(bytes: legacy, modifiers: modifiers)
+    }
+
+    private static func cursorBytes(
+        letter: Character,
+        appBytes: [UInt8],
+        normalBytes: [UInt8],
+        modifiers: Set<TerminalModifier>,
+        context: TerminalKeyEncodingContext
+    ) -> [UInt8] {
+        let disambiguates = context.kittyFlags.contains(.disambiguate)
+            || context.kittyFlags.contains(.reportAllKeys)
+        if disambiguates || !modifiers.isEmpty {
+            return csi(number: 1, modifiers: kittyModifierValue(modifiers), terminator: letter)
+        }
+        return context.applicationCursor ? appBytes : normalBytes
+    }
+
+    private static func tildeBytes(
+        number: Int,
+        legacyBytes: [UInt8],
+        modifiers: Set<TerminalModifier>,
+        context: TerminalKeyEncodingContext
+    ) -> [UInt8] {
+        let disambiguates = context.kittyFlags.contains(.disambiguate)
+            || context.kittyFlags.contains(.reportAllKeys)
+        if disambiguates || !modifiers.isEmpty {
+            return csi(number: number, modifiers: kittyModifierValue(modifiers), terminator: "~")
+        }
+        return legacyBytes
+    }
+
+    private static func functionBytes(
+        _ function: TerminalFunctionKey,
+        modifiers: Set<TerminalModifier>,
+        context: TerminalKeyEncodingContext
+    ) -> [UInt8] {
+        let disambiguates = context.kittyFlags.contains(.disambiguate)
+            || context.kittyFlags.contains(.reportAllKeys)
+        let modifierValue = kittyModifierValue(modifiers)
+        switch function {
+        case .f1, .f2, .f3, .f4:
+            let letters: [Character] = ["P", "Q", "R", "S"]
+            if disambiguates || !modifiers.isEmpty {
+                return csi(
+                    number: 1, modifiers: modifierValue,
+                    terminator: letters[function.rawValue - 1])
+            }
+            return EscapeSequences.cmdF[function.rawValue - 1]
+        case .f5, .f6, .f7, .f8, .f9, .f10, .f11, .f12:
+            let numbers = [15, 17, 18, 19, 20, 21, 23, 24]
+            if disambiguates || !modifiers.isEmpty {
+                return csi(
+                    number: numbers[function.rawValue - 5],
+                    modifiers: modifierValue, terminator: "~")
+            }
+            return EscapeSequences.cmdF[function.rawValue - 1]
+        }
+    }
+
+    private static func legacy(
+        bytes: [UInt8], modifiers: Set<TerminalModifier>
+    ) -> [UInt8] {
+        modifiers.contains(.alt) ? EscapeSequences.cmdEsc + bytes : bytes
+    }
+
+    private static func kittyModifierValue(_ modifiers: Set<TerminalModifier>) -> Int {
+        var value = 0
+        if modifiers.contains(.shift) { value |= 1 }
+        if modifiers.contains(.alt) { value |= 2 }
+        if modifiers.contains(.control) { value |= 4 }
+        return value
+    }
+
+    private static func csiU(
+        codepoint: Int,
+        shiftedCodepoint: Int? = nil,
+        modifiers: Int
+    ) -> [UInt8] {
+        var payload = "\(codepoint)"
+        if let shiftedCodepoint {
+            payload += ":\(shiftedCodepoint)"
+        }
+        if modifiers != 0 {
+            payload += ";\(modifiers + 1)"
+        }
+        return Array("\u{1B}[\(payload)u".utf8)
+    }
+
+    private static func csi(
+        number: Int,
+        modifiers: Int,
+        terminator: Character
+    ) -> [UInt8] {
+        let modifierField = modifiers == 0 ? "" : ";\(modifiers + 1)"
+        return Array("\u{1B}[\(number)\(modifierField)\(terminator)".utf8)
+    }
+
+    private static func controlByte(for scalar: UnicodeScalar) -> UInt8? {
+        let lower = Character(String(scalar).lowercased())
+        if let ascii = lower.asciiValue, ascii >= 0x61, ascii <= 0x7A {
+            return ascii - 0x60
+        }
+        let mapping: [UnicodeScalar: UInt8] = [
+            " ": 0, "@": 0, "[": 27, "\\": 28, "]": 29,
+            "^": 30, "_": 31, "?": 127,
+        ]
+        return mapping[scalar]
+    }
+}

--- a/Sources/HerdrMobile/Terminal/TerminalKeyboardView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalKeyboardView.swift
@@ -147,7 +147,6 @@ private final class TerminalKeyboardHostingView: UIInputView, UIInputViewAudioFe
 
     private let role: Role
     private let hostingController: UIHostingController<AnyView>
-    private var lastVerticalSizeClass: UIUserInterfaceSizeClass?
 
     init(role: Role, rootView: AnyView) {
         self.role = role
@@ -184,10 +183,6 @@ private final class TerminalKeyboardHostingView: UIInputView, UIInputViewAudioFe
     override func layoutSubviews() {
         super.layoutSubviews()
         hostingController.view.frame = bounds
-        if lastVerticalSizeClass != traitCollection.verticalSizeClass {
-            lastVerticalSizeClass = traitCollection.verticalSizeClass
-            invalidateIntrinsicContentSize()
-        }
     }
 
     func playClick() {
@@ -199,8 +194,7 @@ private final class TerminalKeyboardHostingView: UIInputView, UIInputViewAudioFe
         case .accessory:
             return UIDevice.current.userInterfaceIdiom == .pad ? 56 : 50
         case .keyboard:
-            if UIDevice.current.userInterfaceIdiom == .pad { return 360 }
-            return traitCollection.verticalSizeClass == .compact ? 244 : 306
+            return UIDevice.current.userInterfaceIdiom == .pad ? 360 : 244
         }
     }
 
@@ -209,7 +203,7 @@ private final class TerminalKeyboardHostingView: UIInputView, UIInputViewAudioFe
         case .accessory:
             UIDevice.current.userInterfaceIdiom == .pad ? 56 : 50
         case .keyboard:
-            UIDevice.current.userInterfaceIdiom == .pad ? 360 : 306
+            UIDevice.current.userInterfaceIdiom == .pad ? 360 : 244
         }
     }
 }
@@ -267,6 +261,16 @@ private struct TerminalKeyboardView: View {
                 }
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 20)
+                    .onEnded { value in
+                        let translation = value.translation
+                        guard abs(translation.width) > abs(translation.height) else { return }
+
+                        let projectedWidth = value.predictedEndTranslation.width
+                        guard abs(projectedWidth) >= 80 else { return }
+                        session.movePage(by: projectedWidth < 0 ? 1 : -1)
+                    })
             .accessibilityLabel("Terminal keyboard pages")
             .accessibilityAdjustableAction { direction in
                 switch direction {

--- a/Sources/HerdrMobile/Terminal/TerminalKeyboardView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalKeyboardView.swift
@@ -1,0 +1,565 @@
+import Observation
+import SwiftUI
+import UIKit
+
+@MainActor
+@Observable
+final class TerminalKeyboardSession {
+    private(set) var state = TerminalKeyboardState()
+    var onModeChanged: ((TerminalKeyboardMode) -> Void)?
+    var onClose: (() -> Void)?
+    var onKey: ((TerminalKey, Set<TerminalModifier>) -> Void)?
+
+    private var lastShiftTapUptime: TimeInterval?
+    private var repeatTask: Task<Void, Never>?
+
+    func selectMode(_ mode: TerminalKeyboardMode) {
+        guard state.mode != mode else { return }
+        cancelRepeat()
+        lastShiftTapUptime = nil
+        state.selectMode(mode)
+        onModeChanged?(mode)
+    }
+
+    func selectPage(_ page: TerminalKeyboardPage) {
+        state.selectPage(page)
+    }
+
+    func movePage(by offset: Int) {
+        let rawValue = min(
+            TerminalKeyboardPage.allCases.count - 1,
+            max(0, state.page.rawValue + offset))
+        guard let page = TerminalKeyboardPage(rawValue: rawValue) else { return }
+        selectPage(page)
+    }
+
+    func tapModifier(_ modifier: TerminalModifier) {
+        let now = ProcessInfo.processInfo.systemUptime
+        let locks = modifier == .shift
+            && state.phase(of: .shift) == .armed
+            && lastShiftTapUptime.map { now - $0 <= 0.35 } == true
+
+        state.toggle(modifier, locks: locks)
+        lastShiftTapUptime = modifier == .shift && !locks ? now : nil
+    }
+
+    func press(_ key: TerminalKey) {
+        cancelRepeat()
+        lastShiftTapUptime = nil
+        let modifiers = state.activeModifiers
+        onKey?(key, modifiers)
+        state.consumeOneShotModifiers()
+    }
+
+    func beginRepeating(_ key: TerminalKey) {
+        guard key.isRepeatable else {
+            press(key)
+            return
+        }
+        cancelRepeat()
+        lastShiftTapUptime = nil
+        let modifiers = state.activeModifiers
+        onKey?(key, modifiers)
+        state.consumeOneShotModifiers()
+
+        repeatTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: .milliseconds(500))
+                while !Task.isCancelled {
+                    guard let self else { return }
+                    self.onKey?(key, modifiers)
+                    try await Task.sleep(for: .milliseconds(80))
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                return
+            }
+        }
+    }
+
+    func endRepeating() {
+        cancelRepeat()
+    }
+
+    func close() {
+        cancelRepeat()
+        lastShiftTapUptime = nil
+        state.clearModifiers()
+        onClose?()
+    }
+
+    private func cancelRepeat() {
+        repeatTask?.cancel()
+        repeatTask = nil
+    }
+}
+
+@MainActor
+final class TerminalKeyboardHost {
+    let session: TerminalKeyboardSession
+    private let accessoryView: TerminalKeyboardHostingView
+    private let keyboardView: TerminalKeyboardHostingView
+
+    init(terminalView: SizeReportingTerminalView) {
+        let session = TerminalKeyboardSession()
+        self.session = session
+
+        let accessoryView = TerminalKeyboardHostingView(
+            role: .accessory,
+            rootView: AnyView(TerminalKeyboardAccessory(session: session)))
+        let keyboardView = TerminalKeyboardHostingView(
+            role: .keyboard,
+            rootView: AnyView(TerminalKeyboardView(session: session)))
+        self.accessoryView = accessoryView
+        self.keyboardView = keyboardView
+
+        terminalView.inputAccessoryView = accessoryView
+        terminalView.inputView = nil
+
+        session.onModeChanged = { [weak terminalView, weak keyboardView] mode in
+            guard let terminalView else { return }
+            terminalView.unmarkText()
+            terminalView.inputView = mode == .terminal ? keyboardView : nil
+            UIView.performWithoutAnimation {
+                terminalView.reloadInputViews()
+            }
+        }
+        session.onClose = { [weak terminalView] in
+            guard let terminalView else { return }
+            terminalView.unmarkText()
+            _ = terminalView.resignFirstResponder()
+        }
+        session.onKey = { [weak terminalView, weak keyboardView] key, modifiers in
+            guard let terminalView else { return }
+            keyboardView?.playClick()
+            terminalView.sendTerminalKey(key, modifiers: modifiers)
+        }
+    }
+}
+
+@MainActor
+private final class TerminalKeyboardHostingView: UIInputView, UIInputViewAudioFeedback {
+    enum Role {
+        case accessory
+        case keyboard
+    }
+
+    private let role: Role
+    private let hostingController: UIHostingController<AnyView>
+    private var lastVerticalSizeClass: UIUserInterfaceSizeClass?
+
+    init(role: Role, rootView: AnyView) {
+        self.role = role
+        hostingController = UIHostingController(rootView: rootView)
+        super.init(
+            frame: CGRect(
+                x: 0,
+                y: 0,
+                width: 0,
+                height: Self.initialHeight(for: role)),
+            inputViewStyle: .keyboard)
+        allowsSelfSizing = true
+        autoresizingMask = [.flexibleWidth]
+        backgroundColor = .clear
+
+        let hostedView = hostingController.view
+        hostedView?.backgroundColor = .clear
+        if let hostedView {
+            addSubview(hostedView)
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    var enableInputClicksWhenVisible: Bool { true }
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: UIView.noIntrinsicMetric, height: preferredHeight)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        hostingController.view.frame = bounds
+        if lastVerticalSizeClass != traitCollection.verticalSizeClass {
+            lastVerticalSizeClass = traitCollection.verticalSizeClass
+            invalidateIntrinsicContentSize()
+        }
+    }
+
+    func playClick() {
+        UIDevice.current.playInputClick()
+    }
+
+    private var preferredHeight: CGFloat {
+        switch role {
+        case .accessory:
+            return UIDevice.current.userInterfaceIdiom == .pad ? 56 : 50
+        case .keyboard:
+            if UIDevice.current.userInterfaceIdiom == .pad { return 360 }
+            return traitCollection.verticalSizeClass == .compact ? 244 : 306
+        }
+    }
+
+    private static func initialHeight(for role: Role) -> CGFloat {
+        switch role {
+        case .accessory:
+            UIDevice.current.userInterfaceIdiom == .pad ? 56 : 50
+        case .keyboard:
+            UIDevice.current.userInterfaceIdiom == .pad ? 360 : 306
+        }
+    }
+}
+
+private struct TerminalKeyboardAccessory: View {
+    @Bindable var session: TerminalKeyboardSession
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Picker(
+                "Keyboard Mode",
+                selection: Binding(
+                    get: { session.state.mode },
+                    set: { session.selectMode($0) })
+            ) {
+                Text("Input Method").tag(TerminalKeyboardMode.inputMethod)
+                Text("Terminal Keyboard").tag(TerminalKeyboardMode.terminal)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            Button {
+                session.close()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title2)
+                    .symbolRenderingMode(.hierarchical)
+                    .frame(width: 44, height: 44)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close Keyboard")
+        }
+        .padding(.horizontal, 12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.bar)
+    }
+}
+
+private struct TerminalKeyboardView: View {
+    @Bindable var session: TerminalKeyboardSession
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(spacing: 6) {
+            controlRow
+
+            TabView(
+                selection: Binding(
+                    get: { session.state.page },
+                    set: { session.selectPage($0) })
+            ) {
+                ForEach(TerminalKeyboardPage.allCases, id: \.self) { page in
+                    TerminalKeyboardPageView(page: page, session: session)
+                        .tag(page)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .accessibilityLabel("Terminal keyboard pages")
+            .accessibilityAdjustableAction { direction in
+                switch direction {
+                case .increment:
+                    session.movePage(by: 1)
+                case .decrement:
+                    session.movePage(by: -1)
+                @unknown default:
+                    break
+                }
+            }
+
+            HStack(spacing: 8) {
+                ForEach(TerminalKeyboardPage.allCases, id: \.self) { page in
+                    Button {
+                        withAnimation(reduceMotion ? nil : .snappy(duration: 0.2)) {
+                            session.selectPage(page)
+                        }
+                    } label: {
+                        Circle()
+                            .fill(
+                                session.state.page == page
+                                    ? Color.primary : Color.secondary.opacity(0.35))
+                            .frame(width: 7, height: 7)
+                            .frame(width: 44, height: 24)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(
+                        page == .typing ? "Typing keyboard page" : "Navigation keyboard page")
+                    .accessibilityAddTraits(
+                        session.state.page == page ? .isSelected : [])
+                }
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.top, 6)
+        .padding(.bottom, 4)
+        .background(Color(uiColor: .systemGray6))
+    }
+
+    private var controlRow: some View {
+        HStack(spacing: 6) {
+            ForEach(TerminalModifier.allCases, id: \.self) { modifier in
+                TerminalModifierButton(modifier: modifier, session: session)
+            }
+            TerminalKeyButton(key: .escape, session: session)
+            TerminalKeyButton(key: .tab, session: session)
+        }
+        .frame(maxHeight: 42)
+    }
+}
+
+private struct TerminalKeyboardPageView: View {
+    let page: TerminalKeyboardPage
+    let session: TerminalKeyboardSession
+
+    var body: some View {
+        VStack(spacing: 5) {
+            ForEach(Array(page.rows.enumerated()), id: \.offset) { _, row in
+                TerminalKeyboardRow(keys: row, session: session)
+            }
+        }
+        .padding(.horizontal, 1)
+        .padding(.vertical, 2)
+    }
+}
+
+private struct TerminalKeyboardRow: View {
+    let keys: [TerminalKey]
+    let session: TerminalKeyboardSession
+
+    var body: some View {
+        GeometryReader { geometry in
+            let spacing: CGFloat = 5
+            let totalWeight = keys.reduce(0) { $0 + $1.width }
+            let usableWidth = geometry.size.width - spacing * CGFloat(max(0, keys.count - 1))
+
+            HStack(spacing: spacing) {
+                ForEach(keys, id: \.id) { key in
+                    TerminalKeyButton(key: key, session: session)
+                        .frame(width: usableWidth * key.width / totalWeight)
+                }
+            }
+        }
+    }
+}
+
+private struct TerminalModifierButton: View {
+    let modifier: TerminalModifier
+    let session: TerminalKeyboardSession
+
+    var body: some View {
+        Button {
+            session.tapModifier(modifier)
+        } label: {
+            HStack(spacing: 4) {
+                Text(label)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                if phase == .locked {
+                    Image(systemName: "lock.fill")
+                        .font(.caption2)
+                }
+            }
+            .font(.callout.weight(.medium))
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(background, in: RoundedRectangle(cornerRadius: 7))
+        }
+        .buttonStyle(TerminalKeyButtonStyle())
+        .accessibilityLabel(label)
+        .accessibilityValue(accessibilityValue)
+        .accessibilityAddTraits(phase == .inactive ? [] : .isSelected)
+    }
+
+    private var phase: TerminalModifierPhase {
+        session.state.phase(of: modifier)
+    }
+
+    private var label: String {
+        switch modifier {
+        case .control: "Ctrl"
+        case .shift: "Shift"
+        case .alt: "Alt"
+        }
+    }
+
+    private var background: Color {
+        switch phase {
+        case .inactive: Color(uiColor: .tertiarySystemBackground)
+        case .armed: Color.accentColor.opacity(0.65)
+        case .locked: Color.accentColor
+        }
+    }
+
+    private var accessibilityValue: String {
+        switch phase {
+        case .inactive: "Off"
+        case .armed: "Applies to the next key"
+        case .locked: "Locked"
+        }
+    }
+}
+
+private struct TerminalKeyButton: View {
+    let key: TerminalKey
+    let session: TerminalKeyboardSession
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isPressed = false
+
+    var body: some View {
+        if key.isRepeatable {
+            keyCap
+                .brightness(isPressed ? -0.08 : 0)
+                .scaleEffect(isPressed && !reduceMotion ? 0.97 : 1)
+                .animation(
+                    reduceMotion ? nil : .easeOut(duration: 0.08),
+                    value: isPressed)
+                .contentShape(Rectangle())
+                .onLongPressGesture(
+                    minimumDuration: .infinity,
+                    maximumDistance: 20,
+                    pressing: { isPressing in
+                        isPressed = isPressing
+                        if isPressing {
+                            session.beginRepeating(key)
+                        } else {
+                            session.endRepeating()
+                        }
+                    },
+                    perform: {})
+                .accessibilityAddTraits(.isButton)
+                .accessibilityAction { session.press(key) }
+        } else {
+            Button {
+                session.press(key)
+            } label: {
+                keyCap
+            }
+            .buttonStyle(TerminalKeyButtonStyle())
+        }
+    }
+
+    private var keyCap: some View {
+        keyLabel
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(
+                Color(uiColor: .tertiarySystemBackground),
+                in: RoundedRectangle(cornerRadius: 7))
+            .accessibilityLabel(accessibilityLabel)
+    }
+
+    @ViewBuilder
+    private var keyLabel: some View {
+        switch key {
+        case .character(let base, let shifted):
+            if base == " " {
+                Text("Space")
+                    .font(.callout)
+            } else if base.isLetter {
+                Text(String(base).uppercased())
+                    .font(.title3)
+            } else {
+                HStack(spacing: 2) {
+                    Text(String(base))
+                    Text(String(shifted))
+                        .foregroundStyle(.secondary)
+                }
+                .font(.callout)
+                .minimumScaleFactor(0.65)
+            }
+        case .backspace:
+            Image(systemName: "delete.left")
+        case .up:
+            Image(systemName: "arrow.up")
+        case .down:
+            Image(systemName: "arrow.down")
+        case .left:
+            Image(systemName: "arrow.left")
+        case .right:
+            Image(systemName: "arrow.right")
+        default:
+            Text(textLabel)
+                .font(.callout)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+        }
+    }
+
+    private var textLabel: String {
+        switch key {
+        case .escape: "Esc"
+        case .tab: "Tab"
+        case .enter: "Enter"
+        case .insert: "Insert"
+        case .delete: "Delete"
+        case .home: "Home"
+        case .end: "End"
+        case .pageUp: "Page Up"
+        case .pageDown: "Page Down"
+        case .function(let function): "F\(function.rawValue)"
+        case .character, .backspace, .up, .down, .left, .right: ""
+        }
+    }
+
+    private var accessibilityLabel: String {
+        switch key {
+        case .character(let base, _):
+            base == " " ? "Space" : String(base)
+        case .backspace: "Backspace"
+        case .up: "Up Arrow"
+        case .down: "Down Arrow"
+        case .left: "Left Arrow"
+        case .right: "Right Arrow"
+        default: textLabel
+        }
+    }
+}
+
+private struct TerminalKeyButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .brightness(configuration.isPressed ? -0.08 : 0)
+            .scaleEffect(configuration.isPressed && !reduceMotion ? 0.97 : 1)
+            .animation(
+                reduceMotion ? nil : .easeOut(duration: 0.08),
+                value: configuration.isPressed)
+    }
+}
+
+private extension Character {
+    var isLetter: Bool {
+        unicodeScalars.allSatisfy(CharacterSet.letters.contains)
+    }
+}
+
+extension SizeReportingTerminalView {
+    func installTerminalKeyboard() {
+        guard terminalKeyboardHost == nil else { return }
+        terminalKeyboardHost = TerminalKeyboardHost(terminalView: self)
+    }
+
+    fileprivate func sendTerminalKey(
+        _ key: TerminalKey,
+        modifiers: Set<TerminalModifier>
+    ) {
+        let terminal = getTerminal()
+        let context = TerminalKeyEncodingContext(
+            kittyFlags: terminal.keyboardEnhancementFlags,
+            applicationCursor: terminal.applicationCursor,
+            backspaceSendsControlH: backspaceSendsControlH)
+        let data = TerminalKeyEncoder.encode(key, modifiers: modifiers, context: context)
+        onTerminalKeyboardSend?(data)
+    }
+}

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -152,6 +152,7 @@ final class SizeReportingTerminalView: TerminalView {
     var onTerminalKeyboardSend: ((Data) -> Void)?
     var terminalKeyboardHost: TerminalKeyboardHost?
     private var lastReported: (cols: Int, rows: Int)?
+    private var lastInputWindowSize: CGSize?
     private var defersScrollerUpdates = false
     private var pendingReadOnlySnapshot: Data?
     private var appliesReadOnlySnapshot = false
@@ -334,11 +335,27 @@ final class SizeReportingTerminalView: TerminalView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+        reloadInputViewsAfterWindowResize()
         guard bounds.width > 0, bounds.height > 0 else { return }
         let terminal = getTerminal()
         let size = (cols: terminal.cols, rows: terminal.rows)
         if let lastReported, lastReported == size { return }
         lastReported = size
         onSizeReport?(size.cols, size.rows)
+    }
+
+    private func reloadInputViewsAfterWindowResize() {
+        guard allowsInput, let windowSize = window?.bounds.size else { return }
+        defer { lastInputWindowSize = windowSize }
+        guard let lastInputWindowSize, lastInputWindowSize != windowSize, isFirstResponder else {
+            return
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.isFirstResponder else { return }
+            UIView.performWithoutAnimation {
+                self.reloadInputViews()
+            }
+        }
     }
 }

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -56,6 +56,12 @@ struct TerminalScreenView: UIViewRepresentable {
             view.changeScrollback(5_000)
         }
         view.terminalDelegate = context.coordinator
+        view.onTerminalKeyboardSend = { [weak coordinator = context.coordinator] data in
+            coordinator?.onSend?(data)
+        }
+        if style == .attach, allowsInput {
+            view.installTerminalKeyboard()
+        }
         view.onSizeReport = { [weak coordinator = context.coordinator] cols, rows in
             coordinator?.onSizeChanged?(cols, rows)
         }
@@ -143,6 +149,8 @@ final class SizeReportingTerminalView: TerminalView {
     }
     var onSizeReport: ((_ cols: Int, _ rows: Int) -> Void)?
     var onLoadEarlier: (() -> Bool)?
+    var onTerminalKeyboardSend: ((Data) -> Void)?
+    var terminalKeyboardHost: TerminalKeyboardHost?
     private var lastReported: (cols: Int, rows: Int)?
     private var defersScrollerUpdates = false
     private var pendingReadOnlySnapshot: Data?

--- a/Tests/HerdrMobileTests/TerminalKeyboardTests.swift
+++ b/Tests/HerdrMobileTests/TerminalKeyboardTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import SwiftTerm
+import Testing
+
+@testable import HerdrMobile
+
+@Suite("Terminal keyboard")
+struct TerminalKeyboardTests {
+    @Test func defaultsToInputMethodAndTypingPage() {
+        let state = TerminalKeyboardState()
+
+        #expect(state.mode == .inputMethod)
+        #expect(state.page == .typing)
+        #expect(state.activeModifiers.isEmpty)
+    }
+
+    @Test func oneShotModifiersCombineAndAreConsumedTogether() {
+        var state = TerminalKeyboardState()
+        state.toggle(.control)
+        state.toggle(.shift)
+
+        #expect(state.activeModifiers == [.control, .shift])
+        #expect(state.phase(of: .control) == .armed)
+        #expect(state.phase(of: .shift) == .armed)
+
+        state.consumeOneShotModifiers()
+
+        #expect(state.activeModifiers.isEmpty)
+    }
+
+    @Test func shiftCanLockWhileOtherModifiersRemainOneShot() {
+        var state = TerminalKeyboardState()
+        state.toggle(.shift)
+        state.toggle(.shift, locks: true)
+        state.toggle(.alt)
+
+        #expect(state.phase(of: .shift) == .locked)
+        #expect(state.phase(of: .alt) == .armed)
+
+        state.consumeOneShotModifiers()
+
+        #expect(state.activeModifiers == [.shift])
+        state.toggle(.shift)
+        #expect(state.activeModifiers.isEmpty)
+    }
+
+    @Test func switchingModesClearsModifiersButKeepsThePage() {
+        var state = TerminalKeyboardState()
+        state.selectPage(.navigation)
+        state.toggle(.control)
+        state.selectMode(.terminal)
+
+        #expect(state.mode == .terminal)
+        #expect(state.page == .navigation)
+        #expect(state.activeModifiers.isEmpty)
+    }
+
+    @MainActor
+    @Test func closingRemembersTheAttachModeAndPageButClearsModifiers() {
+        let session = TerminalKeyboardSession()
+        session.selectMode(.terminal)
+        session.selectPage(.navigation)
+        session.tapModifier(.control)
+
+        session.close()
+
+        #expect(session.state.mode == .terminal)
+        #expect(session.state.page == .navigation)
+        #expect(session.state.activeModifiers.isEmpty)
+    }
+
+    @Test func typingLayoutContainsEveryDecidedPrintableKey() {
+        let keys = TerminalKeyboardPage.typing.rows.flatMap { $0 }
+        let baseCharacters = Set(
+            keys.compactMap { key -> Character? in
+                guard case .character(let base, _) = key else { return nil }
+                return base
+            })
+
+        #expect(baseCharacters.isSuperset(of: Set("abcdefghijklmnopqrstuvwxyz")))
+        #expect(baseCharacters.isSuperset(of: Set("1234567890")))
+        #expect(baseCharacters.isSuperset(of: Set("`-=[]\\;',./ ")))
+        #expect(keys.contains(.backspace))
+        #expect(keys.contains(.enter))
+    }
+
+    @Test func navigationLayoutContainsFunctionsAndNavigationKeys() {
+        let keys = Set(TerminalKeyboardPage.navigation.rows.flatMap { $0 })
+
+        for function in TerminalFunctionKey.allCases {
+            #expect(keys.contains(.function(function)))
+        }
+        for key in [
+            TerminalKey.insert, .delete, .home, .end, .pageUp, .pageDown,
+            .up, .down, .left, .right,
+        ] {
+            #expect(keys.contains(key))
+        }
+    }
+
+    @Test func plainAndShiftedTextUseUtf8WithoutEnhancements() {
+        let key = TerminalKey.character(base: "a", shifted: "A")
+
+        #expect(text(encode(key)) == "a")
+        #expect(text(encode(key, modifiers: [.shift])) == "A")
+        #expect(
+            text(encode(.character(base: "1", shifted: "!"), modifiers: [.shift]))
+                == "!")
+    }
+
+    @Test func legacyControlAndAltTextUseControlBytesAndEscapePrefix() {
+        let key = TerminalKey.character(base: "c", shifted: "C")
+
+        #expect(Array(encode(key, modifiers: [.control])) == [0x03])
+        #expect(Array(encode(key, modifiers: [.alt])) == [0x1B, 0x63])
+        #expect(Array(encode(key, modifiers: [.control, .alt])) == [0x1B, 0x03])
+    }
+
+    @Test func legacyControlUsesTheShiftedSymbolForAsciiControlCodes() {
+        #expect(
+            Array(encode(
+                .character(base: "2", shifted: "@"),
+                modifiers: [.control, .shift]))
+                == [0x00])
+        #expect(
+            Array(encode(
+                .character(base: "6", shifted: "^"),
+                modifiers: [.control, .shift]))
+                == [0x1E])
+        #expect(
+            Array(encode(
+                .character(base: "-", shifted: "_"),
+                modifiers: [.control, .shift]))
+                == [0x1F])
+    }
+
+    @Test func kittyTextReportsShiftedAndModifiedKeysWithoutAmbiguity() {
+        let context = TerminalKeyEncodingContext(
+            kittyFlags: [.disambiguate, .reportEvents, .reportAlternates])
+
+        #expect(
+            text(encode(
+                .character(base: "a", shifted: "A"), modifiers: [.shift], context: context))
+                == "\u{1B}[97:65;2u")
+        #expect(
+            text(encode(
+                .character(base: "p", shifted: "P"),
+                modifiers: [.control, .shift], context: context))
+                == "\u{1B}[112:80;6u")
+        #expect(
+            text(encode(
+                .character(base: "x", shifted: "X"), modifiers: [.alt], context: context))
+                == "\u{1B}[120;3u")
+    }
+
+    @Test func cursorKeysRespectApplicationModeAndKittyModifiers() {
+        #expect(text(encode(.up)) == "\u{1B}[A")
+        #expect(
+            text(encode(
+                .up, context: TerminalKeyEncodingContext(applicationCursor: true)))
+                == "\u{1B}OA")
+
+        let context = TerminalKeyEncodingContext(kittyFlags: [.disambiguate])
+        #expect(text(encode(.left, modifiers: [.control], context: context)) == "\u{1B}[1;5D")
+    }
+
+    @Test func characterLikeSpecialKeysUseKittyOnlyWhenNeeded() {
+        let context = TerminalKeyEncodingContext(kittyFlags: [.disambiguate])
+
+        #expect(Array(encode(.enter, context: context)) == [0x0D])
+        #expect(text(encode(.enter, modifiers: [.shift], context: context)) == "\u{1B}[13;2u")
+        #expect(text(encode(.tab, modifiers: [.shift], context: context)) == "\u{1B}[9;2u")
+        #expect(text(encode(.escape, context: context)) == "\u{1B}[27u")
+    }
+
+    @Test func functionsAndEditingKeysUseXtermModifierParameters() {
+        let context = TerminalKeyEncodingContext(kittyFlags: [.disambiguate])
+
+        #expect(text(encode(.function(.f1))) == "\u{1B}OP")
+        #expect(
+            text(encode(.function(.f1), modifiers: [.control], context: context))
+                == "\u{1B}[1;5P")
+        #expect(
+            text(encode(.function(.f12), modifiers: [.alt], context: context))
+                == "\u{1B}[24;3~")
+        #expect(text(encode(.delete, modifiers: [.shift], context: context)) == "\u{1B}[3;2~")
+    }
+
+    private func encode(
+        _ key: TerminalKey,
+        modifiers: Set<TerminalModifier> = [],
+        context: TerminalKeyEncodingContext = TerminalKeyEncodingContext()
+    ) -> Data {
+        TerminalKeyEncoder.encode(key, modifiers: modifiers, context: context)
+    }
+
+    private func text(_ data: Data) -> String {
+        String(decoding: data, as: UTF8.self)
+    }
+}

--- a/Tests/HerdrMobileTests/TerminalKeyboardTests.swift
+++ b/Tests/HerdrMobileTests/TerminalKeyboardTests.swift
@@ -69,6 +69,23 @@ struct TerminalKeyboardTests {
         #expect(session.state.activeModifiers.isEmpty)
     }
 
+    @MainActor
+    @Test func movingPagesStopsAtTheKeyboardBoundaries() {
+        let session = TerminalKeyboardSession()
+
+        session.movePage(by: -1)
+        #expect(session.state.page == .typing)
+
+        session.movePage(by: 1)
+        #expect(session.state.page == .navigation)
+
+        session.movePage(by: 1)
+        #expect(session.state.page == .navigation)
+
+        session.movePage(by: -1)
+        #expect(session.state.page == .typing)
+    }
+
     @Test func typingLayoutContainsEveryDecidedPrintableKey() {
         let keys = TerminalKeyboardPage.typing.rows.flatMap { $0 }
         let baseCharacters = Set(


### PR DESCRIPTION
## Summary

- add an Attach-only keyboard accessory that switches between the iOS input method and a dedicated terminal keyboard
- provide typing and navigation pages with swipe navigation, terminal modifiers, key repeat, and terminal escape-sequence encoding
- preserve keyboard mode and page state while clearing one-shot modifiers when switching modes or closing
- keep the keyboard accessory visible and correctly sized across phone rotations

## Testing

- `xcodebuild test -quiet -project HerdrMobile.xcodeproj -scheme HerdrMobile -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:HerdrMobileTests/TerminalKeyboardTests`
- Computer Use acceptance on iPhone 17 Pro Simulator: input-method switching, modifier behavior, bidirectional page swipes, close/reopen, and portrait/landscape rotation