### PR TITLE
fix: harden host persistence and transport recovery

### DIFF
--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// and the full interactive Attach terminal (#11) behind the toolbar button.
 struct AgentDetailView: View {
     let agent: ConsoleAgent
+    private let console: ConsoleStore
     /// Kept for the Observe/Attach handover: fresh stores are minted per
     /// surface switch, all sharing this provider.
     private let transport: @Sendable () async -> (any Transport)?
@@ -19,6 +20,7 @@ struct AgentDetailView: View {
 
     init(agent: ConsoleAgent, console: ConsoleStore) {
         self.agent = agent
+        self.console = console
         let transport = console.transportProvider(for: agent.hostID)
         self.transport = transport
         _store = State(
@@ -110,8 +112,12 @@ struct AgentDetailView: View {
         }
         .onDisappear {
             // Explicit close, never abandonment: a live exec channel ignores
-            // task cancellation (ADR 0002).
-            Task { await store.stop() }
+            // task cancellation (ADR 0002). Registering with the Console is
+            // synchronous, so the next detail waits for this channel close.
+            let observe = store
+            console.scheduleTerminalTeardown(for: agent.hostID) {
+                await observe.stop()
+            }
         }
     }
 

--- a/Sources/HerdrMobile/Console/AgentInputBar.swift
+++ b/Sources/HerdrMobile/Console/AgentInputBar.swift
@@ -11,7 +11,7 @@ struct AgentInputBar: View {
     var body: some View {
         VStack(spacing: 8) {
             QuickKeyBar { key in
-                Task { await store.send(key) }
+                _ = store.queue(key)
             }
 
             if case .failed(let message) = store.state {
@@ -29,12 +29,12 @@ struct AgentInputBar: View {
                     .submitLabel(.send)
                     .onSubmit {
                         messageFocused = false
-                        Task { await store.sendDraft() }
+                        store.submitDraft()
                     }
 
                 Button {
                     messageFocused = false
-                    Task { await store.sendDraft() }
+                    store.submitDraft()
                 } label: {
                     Image(systemName: "paperplane.fill")
                         .font(.title2)

--- a/Sources/HerdrMobile/Console/AgentInputStore.swift
+++ b/Sources/HerdrMobile/Console/AgentInputStore.swift
@@ -93,6 +93,11 @@ final class AgentInputStore {
     /// button's `state == .sending` disable only latches after the transport
     /// hop, leaving a window the second tap slips through.
     private var isSendingDraft = false
+    /// One FIFO for draft and quick-key RPCs. Separate fire-and-forget Tasks
+    /// can otherwise overtake each other before the transport's request queue
+    /// sees them, making rapid navigation keys arrive out of tap order.
+    private var pendingSend: PendingSend?
+    private var nextSendID: UInt64 = 0
 
     /// The Agent's pane id — the target for both `pane.send_input` and
     /// `pane.send_keys`.
@@ -115,25 +120,65 @@ final class AgentInputStore {
     /// Writes the composed message and presses Enter in one RPC, clearing the
     /// box on success. Whitespace-only drafts are ignored.
     func sendDraft() async {
-        guard !isSendingDraft else { return }
+        _ = await queueDraft()?.value
+    }
+
+    /// Synchronous UI entry point: records the draft in the FIFO during the
+    /// button callback, before a later tap can overtake a newly spawned Task.
+    func submitDraft() {
+        _ = queueDraft()
+    }
+
+    private func queueDraft() -> Task<Bool, Never>? {
+        guard !isSendingDraft else { return nil }
         let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty else { return }
+        guard !text.isEmpty else { return nil }
         isSendingDraft = true
-        defer { isSendingDraft = false }
-        let sent = await run { transport in
-            try await transport.sendInput(
-                PaneSendInputParams(paneID: target, keys: ["enter"], text: text))
-        }
-        if sent {
-            draft = ""
+        return enqueue { [self] in
+            defer { isSendingDraft = false }
+            let sent = await run { transport in
+                try await transport.sendInput(
+                    PaneSendInputParams(paneID: target, keys: ["enter"], text: text))
+            }
+            // Do not erase a follow-up the user typed while this RPC was in
+            // flight; only clear the exact draft that succeeded.
+            if sent, draft.trimmingCharacters(in: .whitespacesAndNewlines) == text {
+                draft = ""
+            }
+            return sent
         }
     }
 
     /// Sends one quick-key's key sequence via `pane.send_keys`.
     func send(_ key: QuickKey) async {
-        _ = await run { transport in
-            try await transport.sendKeys(PaneSendKeysParams(keys: key.keys, paneID: target))
+        _ = await queue(key).value
+    }
+
+    /// Synchronous UI entry point preserving callback order exactly.
+    func queue(_ key: QuickKey) -> Task<Bool, Never> {
+        enqueue { [self] in
+            await run { transport in
+                try await transport.sendKeys(PaneSendKeysParams(keys: key.keys, paneID: target))
+            }
         }
+    }
+
+    private func enqueue(
+        _ action: @escaping @MainActor @Sendable () async -> Bool
+    ) -> Task<Bool, Never> {
+        let previous = pendingSend?.task
+        nextSendID &+= 1
+        let id = nextSendID
+        let task = Task { @MainActor in
+            _ = await previous?.value
+            let result = await action()
+            if pendingSend?.id == id {
+                pendingSend = nil
+            }
+            return result
+        }
+        pendingSend = PendingSend(id: id, task: task)
+        return task
     }
 
     /// Resolves the transport, runs one send under the `.sending` state, and
@@ -164,5 +209,10 @@ final class AgentInputStore {
         default:
             "Sending failed: \(error)"
         }
+    }
+
+    private struct PendingSend {
+        let id: UInt64
+        let task: Task<Bool, Never>
     }
 }

--- a/Sources/HerdrMobile/Console/ConsoleStore.swift
+++ b/Sources/HerdrMobile/Console/ConsoleStore.swift
@@ -413,7 +413,7 @@ extension ConsoleStore {
     /// its onboarding checklist trusts it.
     static func sshSessionFactory(
         connector: any TransportConnector = SSHTransportConnector(),
-        knownHosts: any KnownHostsStore = UserDefaultsKnownHostsStore(),
+        knownHosts: any KnownHostsStore = UserDefaultsKnownHostsStore.shared,
         credentials: HostCredentialsProvider = HostCredentialsProvider()
     ) -> @Sendable (Host, [EventSubscription]) -> EventsSession {
         { host, subscriptions in

--- a/Sources/HerdrMobile/Console/ConsoleStore.swift
+++ b/Sources/HerdrMobile/Console/ConsoleStore.swift
@@ -32,6 +32,11 @@ final class ConsoleStore {
     @ObservationIgnored private let makeSession:
         @Sendable (Host, [EventSubscription]) -> EventsSession
     @ObservationIgnored private let snapshotRetryDelay: Duration
+    /// Explicit terminal-channel teardowns registered synchronously by a
+    /// disappearing detail screen. A new detail waits for the latest task,
+    /// preventing Observe from racing the previous screen's channel close.
+    @ObservationIgnored private var terminalTeardowns: [Host.ID: TerminalTeardown] = [:]
+    @ObservationIgnored private var nextTerminalTeardownID: UInt64 = 0
     /// Whether the Console should hold live connections (foregrounded);
     /// feeds started while suspended stay down until `resume()`.
     @ObservationIgnored private var isActive = false
@@ -281,8 +286,47 @@ final class ConsoleStore {
     /// session may reconnect onto a fresh transport at any time, so it is
     /// re-queried per use; nil while the Host is disconnected or gone.
     func transportProvider(for hostID: Host.ID) -> @Sendable () async -> (any Transport)? {
-        let session = feeds[hostID]?.session
-        return { await session?.currentTransport }
+        return { [weak self] in
+            await self?.transportAfterTerminalTeardown(for: hostID)
+        }
+    }
+
+    /// Registers teardown before `onDisappear` returns. Merely launching an
+    /// untracked Task here is insufficient: the next detail screen can ask
+    /// for the terminal slot before that Task begins executing.
+    func scheduleTerminalTeardown(
+        for hostID: Host.ID,
+        operation: @escaping @MainActor @Sendable () async -> Void
+    ) {
+        let previous = terminalTeardowns[hostID]?.task
+        nextTerminalTeardownID &+= 1
+        let id = nextTerminalTeardownID
+        let task = Task { @MainActor in
+            await previous?.value
+            await operation()
+        }
+        terminalTeardowns[hostID] = TerminalTeardown(id: id, task: task)
+        Task { @MainActor [weak self] in
+            await task.value
+            guard self?.terminalTeardowns[hostID]?.id == id else { return }
+            self?.terminalTeardowns[hostID] = nil
+        }
+    }
+
+    private func transportAfterTerminalTeardown(for hostID: Host.ID) async -> (any Transport)? {
+        let teardown = terminalTeardowns[hostID]
+        await teardown?.task.value
+        return await feeds[hostID]?.session.currentTransport
+    }
+
+    /// Retries Hosts whose session stopped on an action-required failure.
+    /// Host management calls this after dismissal so corrected credentials,
+    /// trust, paths, or protocol versions take effect immediately.
+    func retryFailedHosts() async {
+        for (id, feed) in feeds {
+            guard case .failed = hostStatuses[id] else { continue }
+            await feed.session.retry()
+        }
     }
 
     // MARK: New-agent flow (#12)
@@ -355,6 +399,12 @@ final class ConsoleStore {
     }
 }
 
+@MainActor
+private struct TerminalTeardown {
+    let id: UInt64
+    let task: Task<Void, Never>
+}
+
 extension ConsoleStore {
     /// The production session factory: SSH transports built from the Host
     /// catalog's credentials. TOFU is restricted to already-trusted
@@ -368,7 +418,12 @@ extension ConsoleStore {
     ) -> @Sendable (Host, [EventSubscription]) -> EventsSession {
         { host, subscriptions in
             EventsSession(subscriptions: subscriptions) {
-                let resolved = try credentials.credentials(for: host)
+                let resolved: SSHCredentials
+                do {
+                    resolved = try credentials.credentials(for: host)
+                } catch HostCredentialsError.passwordNotSet {
+                    throw TransportError.authenticationFailed
+                }
                 let policy = HostKeyPolicy(knownHosts: knownHosts) { _ in false }
                 return try await connector.connect(
                     settings: SSHTransportSettings(

--- a/Sources/HerdrMobile/Console/ConsoleView.swift
+++ b/Sources/HerdrMobile/Console/ConsoleView.swift
@@ -38,7 +38,10 @@ struct ConsoleView: View {
                         }
                     }
                 }
-                .sheet(isPresented: $isManagingHosts) {
+                .sheet(
+                    isPresented: $isManagingHosts,
+                    onDismiss: { Task { await console.retryFailedHosts() } }
+                ) {
                     // HostListView brings its own NavigationStack.
                     HostListView(store: hosts)
                 }
@@ -65,13 +68,21 @@ struct ConsoleView: View {
                 Label("No Agents", systemImage: "rectangle.on.rectangle.slash")
             } description: {
                 Text(emptyDescription)
+            } actions: {
+                if !hostIssues.isEmpty {
+                    Button("Manage Hosts") { isManagingHosts = true }
+                        .buttonStyle(.borderedProminent)
+                }
             }
         } else {
             List {
-                ForEach(hostIssues, id: \.0) { _, issue in
-                    Label(issue.message, systemImage: issue.systemImage)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
+                ForEach(hostIssues, id: \.id) { issue in
+                    Button { isManagingHosts = true } label: {
+                        Label(issue.message, systemImage: issue.systemImage)
+                            .font(.footnote)
+                            .foregroundStyle(issue.isCritical ? Color.red : Color.secondary)
+                    }
+                    .buttonStyle(.plain)
                 }
                 ForEach(console.agents) { agent in
                     NavigationLink(value: agent.id) {
@@ -87,24 +98,90 @@ struct ConsoleView: View {
         if hostIssues.isEmpty {
             return "Agents detected on your Hosts appear here."
         }
-        return hostIssues.map(\.1.message).joined(separator: "\n")
+        return hostIssues.map(\.message).joined(separator: "\n")
+    }
+
+    private struct HostIssue {
+        let id: Host.ID
+        let message: String
+        let systemImage: String
+        let isCritical: Bool
     }
 
     /// One actionable status per Host. A disconnected session takes priority;
     /// otherwise a connected Host can still have a failing snapshot RPC.
-    private var hostIssues: [(Host.ID, (message: String, systemImage: String))] {
+    private var hostIssues: [HostIssue] {
         hosts.hosts.compactMap { host in
-            if case .reconnecting = console.hostStatuses[host.id] {
-                return (
-                    host.id,
-                    ("Reconnecting to \(host.displayName)…", "wifi.exclamationmark"))
+            switch console.hostStatuses[host.id] {
+            case .reconnecting(_, _, let failure):
+                return HostIssue(
+                    id: host.id,
+                    message: "Reconnecting to \(host.displayName): \(summary(for: failure))",
+                    systemImage: "wifi.exclamationmark",
+                    isCritical: false)
+            case .failed(let failure):
+                return HostIssue(
+                    id: host.id,
+                    message: "\(host.displayName): \(guidance(for: failure))",
+                    systemImage: failure.isHostKeySecurityFailure
+                        ? "exclamationmark.shield.fill" : "exclamationmark.triangle.fill",
+                    isCritical: failure.isHostKeySecurityFailure)
+            case .connected, .suspended, .ended, nil:
+                break
             }
             if let message = console.hostSyncErrors[host.id] {
-                return (
-                    host.id,
-                    ("\(host.displayName): \(message)", "arrow.trianglehead.2.clockwise"))
+                return HostIssue(
+                    id: host.id,
+                    message: "\(host.displayName): \(message)",
+                    systemImage: "arrow.trianglehead.2.clockwise",
+                    isCritical: false)
             }
             return nil
+        }
+    }
+
+    private func summary(for failure: TransportError) -> String {
+        switch failure {
+        case .sshUnreachable: "SSH unavailable"
+        case .serverNotRunning: "herdr is not answering"
+        case .timedOut: "request timed out"
+        case .cancelled: "request was cancelled"
+        case .channelFailed: "connection dropped"
+        default: "connection failed"
+        }
+    }
+
+    private func guidance(for failure: TransportError) -> String {
+        switch failure {
+        case .authenticationFailed:
+            "Authentication failed. Update the credentials in Hosts."
+        case .hostKeyRejected:
+            "The host key is not trusted. Verify it in Hosts."
+        case .hostKeyMismatch:
+            "Host key changed. Verify the machine before updating trust in Hosts."
+        case .protocolVersionMismatch(let server, let supported):
+            "herdr protocol \(server) is incompatible with app protocol \(supported). Update herdr or the app."
+        case .socketNotFound:
+            "The herdr socket was not found. Check the session in Hosts."
+        case .socatMissing:
+            "socat was not found. Check its path in Hosts."
+        case .homeDirectoryUnresolvable:
+            "The remote home directory could not be resolved. Check the Host login shell."
+        case .malformedResponse:
+            "herdr returned an invalid response. Check its version, then retry."
+        case .eventsChannelAlreadyOpen, .terminalChannelAlreadyOpen:
+            "The connection is busy. Close the other terminal, then retry."
+        default:
+            "Connection failed. Check this Host, then retry."
+        }
+    }
+}
+
+private extension TransportError {
+    var isHostKeySecurityFailure: Bool {
+        switch self {
+        case .hostKeyMismatch: true
+        default: false
         }
     }
 }

--- a/Sources/HerdrMobile/Hosts/Host.swift
+++ b/Sources/HerdrMobile/Hosts/Host.swift
@@ -30,6 +30,10 @@ struct Host: Identifiable, Codable, Hashable, Sendable {
     /// Absolute socat path on the Host.
     var socatPath: String
 
+    private enum CodingKeys: String, CodingKey {
+        case id, name, address, port, username, authMethod, sessionName, socatPath
+    }
+
     init(
         id: UUID = UUID(),
         name: String = "",
@@ -48,6 +52,29 @@ struct Host: Identifiable, Codable, Hashable, Sendable {
         self.authMethod = authMethod
         self.sessionName = sessionName
         self.socatPath = socatPath
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        address = try container.decode(String.self, forKey: .address)
+        port = try container.decode(Int.self, forKey: .port)
+        username = try container.decode(String.self, forKey: .username)
+        authMethod = try container.decode(AuthMethod.self, forKey: .authMethod)
+        sessionName = try container.decodeIfPresent(String.self, forKey: .sessionName) ?? ""
+        socatPath =
+            try container.decodeIfPresent(String.self, forKey: .socatPath) ?? Self.defaultSocatPath
+
+        let trimmedSessionName = sessionName.trimmingCharacters(in: .whitespaces)
+        guard trimmedSessionName.isEmpty || HerdrSessionName.isValid(trimmedSessionName) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .sessionName, in: container, debugDescription: "Invalid herdr session name")
+        }
+        guard RemoteShellPath.isQuotableAbsolute(socatPath) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .socatPath, in: container, debugDescription: "Invalid remote socat path")
+        }
     }
 
     var displayName: String {

--- a/Sources/HerdrMobile/Hosts/HostDraft.swift
+++ b/Sources/HerdrMobile/Hosts/HostDraft.swift
@@ -33,10 +33,13 @@ struct HostDraft: Equatable, Sendable {
     }
 
     var isValid: Bool {
-        !address.trimmingCharacters(in: .whitespaces).isEmpty
+        let trimmedSessionName = sessionName.trimmingCharacters(in: .whitespaces)
+        let trimmedSocatPath = socatPath.trimmingCharacters(in: .whitespaces)
+        return !address.trimmingCharacters(in: .whitespaces).isEmpty
             && !username.trimmingCharacters(in: .whitespaces).isEmpty
             && portNumber != nil
-            && socatPath.hasPrefix("/")  // remote PATH is untrusted (ADR 0002)
+            && (trimmedSessionName.isEmpty || HerdrSessionName.isValid(trimmedSessionName))
+            && RemoteShellPath.isQuotableAbsolute(trimmedSocatPath)
     }
 
     /// The catalog Host this draft describes, or nil while invalid. Pass the

--- a/Sources/HerdrMobile/Hosts/HostDraft.swift
+++ b/Sources/HerdrMobile/Hosts/HostDraft.swift
@@ -42,6 +42,16 @@ struct HostDraft: Equatable, Sendable {
             && RemoteShellPath.isQuotableAbsolute(trimmedSocatPath)
     }
 
+    /// Form-level validity including credential intent. A blank password can
+    /// only mean "keep current" when the existing Host already used password
+    /// authentication; new Hosts and Device Key -> Password changes require
+    /// an actual secret to persist.
+    func canSave(editing existingHost: Host?) -> Bool {
+        guard isValid else { return false }
+        guard authMethod == .password, password.isEmpty else { return true }
+        return existingHost?.authMethod == .password
+    }
+
     /// The catalog Host this draft describes, or nil while invalid. Pass the
     /// existing id when editing so the Host keeps its identity (and its
     /// Keychain password account).

--- a/Sources/HerdrMobile/Hosts/HostFormView.swift
+++ b/Sources/HerdrMobile/Hosts/HostFormView.swift
@@ -96,7 +96,7 @@ struct HostFormView: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") { save() }
-                        .disabled(!draft.isValid)
+                        .disabled(!draft.canSave(editing: editing))
                 }
             }
             .alert("Could not save the Host", isPresented: $saveFailed) {
@@ -187,6 +187,7 @@ struct HostFormView: View {
     }
 
     private func save() {
+        guard draft.canSave(editing: editing) else { return }
         guard let host = draft.makeHost(id: editing?.id ?? UUID()) else { return }
         do {
             if editing == nil {

--- a/Sources/HerdrMobile/Hosts/HostListView.swift
+++ b/Sources/HerdrMobile/Hosts/HostListView.swift
@@ -45,7 +45,15 @@ struct HostListView: View {
     var body: some View {
         NavigationStack(path: $path) {
             Group {
-                if store.hosts.isEmpty {
+                if store.catalogLoadError != nil {
+                    ContentUnavailableView {
+                        Label("Hosts Unavailable", systemImage: "externaldrive.badge.exclamationmark")
+                    } description: {
+                        Text(
+                            "The saved Host catalog could not be read. Its original data was preserved; "
+                                + "reinstalling or adding a Host would risk losing it.")
+                    }
+                } else if store.hosts.isEmpty {
                     ContentUnavailableView {
                         Label("No Hosts", systemImage: "server.rack")
                     } description: {
@@ -69,6 +77,7 @@ struct HostListView: View {
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button("Add Host", systemImage: "plus") { isAddingHost = true }
+                        .disabled(store.catalogLoadError != nil)
                 }
             }
             .navigationDestination(for: Host.ID.self) { id in

--- a/Sources/HerdrMobile/Hosts/HostOnboardingStore.swift
+++ b/Sources/HerdrMobile/Hosts/HostOnboardingStore.swift
@@ -46,7 +46,7 @@ final class HostOnboardingStore {
     init(
         host: Host,
         connector: any TransportConnector = SSHTransportConnector(),
-        knownHosts: any KnownHostsStore = UserDefaultsKnownHostsStore(),
+        knownHosts: any KnownHostsStore = UserDefaultsKnownHostsStore.shared,
         credentials: HostCredentialsProvider = HostCredentialsProvider(),
         fingerprintTimeout: Duration = .seconds(60)
     ) {

--- a/Sources/HerdrMobile/Hosts/HostStore.swift
+++ b/Sources/HerdrMobile/Hosts/HostStore.swift
@@ -4,6 +4,9 @@ import Observation
 enum HostStoreError: Error, Equatable {
     /// `update`/`remove` addressed a Host id the catalog does not contain.
     case unknownHost
+    /// Persisted bytes could not be decoded. They are deliberately left
+    /// untouched so a later write cannot turn a recoverable catalog into loss.
+    case catalogUnreadable
 }
 
 /// Owns the Host catalog: add/edit/remove plus persistence. Host records go
@@ -13,8 +16,15 @@ enum HostStoreError: Error, Equatable {
 @Observable
 final class HostStore {
     private static let defaultsKey = "hosts"
+    private static let catalogVersion = 1
+
+    private struct PersistedCatalog: Codable {
+        let version: Int
+        let hosts: [Host]
+    }
 
     private(set) var hosts: [Host]
+    private(set) var catalogLoadError: HostStoreError?
     // UserDefaults is documented thread-safe; Sendable modulo that promise.
     @ObservationIgnored private nonisolated(unsafe) let defaults: UserDefaults
     @ObservationIgnored private let secrets: any SecretStore
@@ -25,17 +35,34 @@ final class HostStore {
     ) {
         self.defaults = defaults
         self.secrets = secrets
-        if let data = defaults.data(forKey: Self.defaultsKey),
-            let stored = try? JSONDecoder().decode([Host].self, from: data)
-        {
-            hosts = stored
-        } else {
+        guard let data = defaults.data(forKey: Self.defaultsKey) else {
             hosts = []
+            catalogLoadError = nil
+            return
+        }
+        do {
+            let decoder = JSONDecoder()
+            if let catalog = try? decoder.decode(PersistedCatalog.self, from: data) {
+                guard catalog.version == Self.catalogVersion else {
+                    throw HostStoreError.catalogUnreadable
+                }
+                hosts = catalog.hosts
+            } else {
+                // Version 0 was the bare Host array. Decode it once, then
+                // immediately persist the versioned envelope.
+                hosts = try decoder.decode([Host].self, from: data)
+                defaults.set(try Self.encodedCatalog(hosts), forKey: Self.defaultsKey)
+            }
+            catalogLoadError = nil
+        } catch {
+            hosts = []
+            catalogLoadError = .catalogUnreadable
         }
     }
 
     /// Adds a Host, storing `password` in the secret store when given.
     func add(_ host: Host, password: String? = nil) throws {
+        try ensureCatalogIsWritable()
         try applyPassword(password, to: host)
         hosts.append(host)
         try persist()
@@ -45,6 +72,7 @@ final class HostStore {
     /// stored password untouched, so editing unrelated fields never requires
     /// re-entering it.
     func update(_ host: Host, password: String? = nil) throws {
+        try ensureCatalogIsWritable()
         guard let index = hosts.firstIndex(where: { $0.id == host.id }) else {
             throw HostStoreError.unknownHost
         }
@@ -55,6 +83,7 @@ final class HostStore {
 
     /// Removes the Host and its stored password.
     func remove(_ id: Host.ID) throws {
+        try ensureCatalogIsWritable()
         guard let index = hosts.firstIndex(where: { $0.id == id }) else {
             throw HostStoreError.unknownHost
         }
@@ -89,7 +118,17 @@ final class HostStore {
         }
     }
 
+    private func ensureCatalogIsWritable() throws {
+        if catalogLoadError != nil {
+            throw HostStoreError.catalogUnreadable
+        }
+    }
+
     private func persist() throws {
-        defaults.set(try JSONEncoder().encode(hosts), forKey: Self.defaultsKey)
+        defaults.set(try Self.encodedCatalog(hosts), forKey: Self.defaultsKey)
+    }
+
+    private static func encodedCatalog(_ hosts: [Host]) throws -> Data {
+        try JSONEncoder().encode(PersistedCatalog(version: catalogVersion, hosts: hosts))
     }
 }

--- a/Sources/HerdrMobile/Hosts/Preflight.swift
+++ b/Sources/HerdrMobile/Hosts/Preflight.swift
@@ -7,6 +7,8 @@ import Foundation
 enum PreflightCheck: CaseIterable, Sendable {
     /// SSH reachable, credentials accepted, host key trusted.
     case connection
+    /// The login shell exposes a usable absolute home directory.
+    case remoteEnvironment
     /// socat answers at its configured absolute path.
     case socat
     /// The herdr socket path exists on the Host.
@@ -19,6 +21,7 @@ enum PreflightCheck: CaseIterable, Sendable {
     var title: String {
         switch self {
         case .connection: "SSH connection"
+        case .remoteEnvironment: "remote environment"
         case .socat: "socat installed"
         case .herdrInstalled: "herdr installed"
         case .serverRunning: "herdr server running"
@@ -93,7 +96,7 @@ struct PreflightReport: Equatable, Sendable {
                 "No herdr socket at \(path). Install and start herdr on the Host, "
                 + "or fix the session name."
         case .homeDirectoryUnresolvable(let detail):
-            check = .herdrInstalled
+            check = .remoteEnvironment
             hint =
                 "Could not resolve the remote home directory, so the herdr socket "
                 + "path is unknown. (\(detail))"

--- a/Sources/HerdrMobile/Transport/EventsSession.swift
+++ b/Sources/HerdrMobile/Transport/EventsSession.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// Bounded backoff for events-channel reconnects (#18): capped exponential
-/// delay, unlimited attempts. The Console keeps trying forever and shows
-/// staleness through the session's status; the user decides when to give up.
+/// Bounded backoff for transient events-channel failures (#18): capped
+/// exponential delay, unlimited attempts. Action-required failures stop and
+/// surface their exact cause instead of burning retries forever.
 struct ReconnectPolicy: Sendable, Equatable {
     var initialDelay: Duration
     var multiplier: Int
@@ -51,6 +51,9 @@ enum EventsSessionStatus: Sendable, Equatable {
     /// everything shown since the last `.connected` may be stale. `failure`
     /// is what killed the previous attempt, for actionable user guidance.
     case reconnecting(attempt: Int, delay: Duration, failure: TransportError)
+    /// Reconnecting cannot repair this failure. The session remains stopped
+    /// until the caller retries after the Host's configuration is corrected.
+    case failed(TransportError)
     /// Deliberately torn down (app backgrounded); no reconnect activity
     /// until `resume()`.
     case suspended
@@ -162,11 +165,18 @@ actor EventsSession {
 
     /// Activates the session (initially, or after `suspend()`): establishes
     /// the transport and channel, emitting `.connected` on success and
-    /// `.reconnecting` transitions until then. Returns once any in-flight
-    /// teardown has finished and the activation is underway. No-op while
-    /// active or ended.
+    /// `.reconnecting` transitions for transient failures. Returns once any
+    /// in-flight teardown has finished and the activation is underway. No-op
+    /// while active or ended.
     func resume() async {
         await enqueueLifecycleTransition { await self.activate() }
+    }
+
+    /// Restarts an active session whose reconnect loop stopped on a
+    /// non-retryable failure. Also provides an explicit retry for a currently
+    /// reconnecting session after the user changes Host settings.
+    func retry() async {
+        await enqueueLifecycleTransition { await self.restart() }
     }
 
     /// Deliberate teardown for backgrounding: ends the events channel by
@@ -202,6 +212,16 @@ actor EventsSession {
         guard phase == .suspended else { return }
         phase = .active
         runTask = Task { await self.run() }
+    }
+
+    private func restart() async {
+        guard phase == .active else {
+            activate()
+            return
+        }
+        phase = .suspended
+        await windDown()
+        activate()
     }
 
     private func deactivate() async {
@@ -269,6 +289,10 @@ actor EventsSession {
                     // it for the retry even if it still looks alive.
                     transportSuspect = true
                 }
+                guard failure.isRetryable else {
+                    yieldUpdate(.status(.failed(failure)))
+                    return
+                }
                 attempt += 1
                 await emitReconnectingAndBackOff(attempt: attempt, failure: failure)
                 continue
@@ -308,6 +332,10 @@ actor EventsSession {
                 streamFailure ?? pendingKeepaliveFailure
                 ?? .channelFailed(detail: "events stream ended unexpectedly")
             pendingKeepaliveFailure = nil
+            guard failure.isRetryable else {
+                yieldUpdate(.status(.failed(failure)))
+                return
+            }
             attempt += 1
             await emitReconnectingAndBackOff(attempt: attempt, failure: failure)
         }

--- a/Sources/HerdrMobile/Transport/HostKeyFingerprint.swift
+++ b/Sources/HerdrMobile/Transport/HostKeyFingerprint.swift
@@ -5,20 +5,38 @@ import Foundation
 /// public key blob. This is what the user confirms on first connect and what
 /// the known-hosts store persists for TOFU.
 struct HostKeyFingerprint: Sendable, Hashable {
+    /// Marker for legacy entries that predate algorithm-aware persistence.
+    static let unknownAlgorithm = "*"
+
     /// The 32-byte SHA-256 digest.
     let digest: Data
+    /// SSH key algorithm encoded as the first string in the public-key blob.
+    let algorithm: String
 
     init(publicKeyBlob: Data) {
         digest = Data(SHA256.hash(data: publicKeyBlob))
+        algorithm = Self.readAlgorithm(from: publicKeyBlob) ?? Self.unknownAlgorithm
     }
 
     /// Reconstructs a fingerprint from a previously stored digest.
-    init(digest: Data) {
+    init(digest: Data, algorithm: String = HostKeyFingerprint.unknownAlgorithm) {
         self.digest = digest
+        self.algorithm = algorithm
     }
 
     /// The presentation OpenSSH prints: `SHA256:<base64 without padding>`.
     var displayString: String {
         "SHA256:" + digest.base64EncodedString().trimmingCharacters(in: ["="])
+    }
+
+    private static func readAlgorithm(from blob: Data) -> String? {
+        guard blob.count >= MemoryLayout<UInt32>.size else { return nil }
+        let length = blob.prefix(4).reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+        guard length > 0, length <= 256, blob.count >= 4 + Int(length) else { return nil }
+        let start = blob.index(blob.startIndex, offsetBy: 4)
+        let end = blob.index(start, offsetBy: Int(length))
+        guard let algorithm = String(data: blob[start..<end], encoding: .utf8) else { return nil }
+        return algorithm.unicodeScalars.allSatisfy { $0.isASCII && !$0.properties.isWhitespace }
+            ? algorithm : nil
     }
 }

--- a/Sources/HerdrMobile/Transport/HostKeyFingerprint.swift
+++ b/Sources/HerdrMobile/Transport/HostKeyFingerprint.swift
@@ -29,6 +29,14 @@ struct HostKeyFingerprint: Sendable, Hashable {
         "SHA256:" + digest.base64EncodedString().trimmingCharacters(in: ["="])
     }
 
+    static func == (lhs: HostKeyFingerprint, rhs: HostKeyFingerprint) -> Bool {
+        lhs.digest == rhs.digest
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(digest)
+    }
+
     private static func readAlgorithm(from blob: Data) -> String? {
         guard blob.count >= MemoryLayout<UInt32>.size else { return nil }
         let length = blob.prefix(4).reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }

--- a/Sources/HerdrMobile/Transport/KnownHostsStore.swift
+++ b/Sources/HerdrMobile/Transport/KnownHostsStore.swift
@@ -1,54 +1,130 @@
 import Foundation
 
-/// TOFU persistence: the host key fingerprint the user trusted for each
-/// Host, keyed by host and port. Not a secret — it guards against future
-/// impostors, it does not authenticate us — so app-level storage is fine.
-/// Injectable so tests can seed and observe it.
+/// TOFU persistence: fingerprints are keyed by endpoint and SSH key
+/// algorithm, matching OpenSSH's ability to trust more than one host-key
+/// algorithm for the same machine. Not a secret: it guards against future
+/// impostors, it does not authenticate us.
 protocol KnownHostsStore: Sendable {
+    func fingerprints(host: String, port: Int) async -> [HostKeyFingerprint]
+    func fingerprint(host: String, port: Int, algorithm: String) async -> HostKeyFingerprint?
     func fingerprint(host: String, port: Int) async -> HostKeyFingerprint?
     func setFingerprint(_ fingerprint: HostKeyFingerprint, host: String, port: Int) async
 }
 
-/// Volatile store for tests and previews.
-actor InMemoryKnownHostsStore: KnownHostsStore {
-    private var fingerprints: [String: HostKeyFingerprint] = [:]
-
-    func fingerprint(host: String, port: Int) -> HostKeyFingerprint? {
-        fingerprints[Self.key(host: host, port: port)]
-    }
-
-    func setFingerprint(_ fingerprint: HostKeyFingerprint, host: String, port: Int) {
-        fingerprints[Self.key(host: host, port: port)] = fingerprint
-    }
-
-    static func key(host: String, port: Int) -> String {
-        "\(host):\(port)"
+extension KnownHostsStore {
+    func fingerprint(host: String, port: Int) async -> HostKeyFingerprint? {
+        await fingerprints(host: host, port: port).first
     }
 }
 
-/// The app's persistent store: digests in UserDefaults, keyed "host:port".
-struct UserDefaultsKnownHostsStore: KnownHostsStore {
-    private static let defaultsKey = "knownHostFingerprints"
-    // UserDefaults is documented thread-safe; Sendable modulo that promise.
-    private nonisolated(unsafe) let defaults: UserDefaults
+/// Volatile store for tests and previews.
+actor InMemoryKnownHostsStore: KnownHostsStore {
+    private var storedFingerprints: [String: HostKeyFingerprint] = [:]
 
-    init(defaults: UserDefaults = .standard) {
+    func fingerprints(host: String, port: Int) -> [HostKeyFingerprint] {
+        let prefix = Self.algorithmKeyPrefix(host: host, port: port)
+        return storedFingerprints
+            .filter { $0.key.hasPrefix(prefix) }
+            .map(\.value)
+    }
+
+    func fingerprint(host: String, port: Int, algorithm: String) -> HostKeyFingerprint? {
+        storedFingerprints[Self.algorithmKey(host: host, port: port, algorithm: algorithm)]
+            ?? storedFingerprints[
+                Self.algorithmKey(
+                    host: host, port: port, algorithm: HostKeyFingerprint.unknownAlgorithm)]
+    }
+
+    func setFingerprint(_ fingerprint: HostKeyFingerprint, host: String, port: Int) {
+        if fingerprint.algorithm != HostKeyFingerprint.unknownAlgorithm {
+            storedFingerprints[
+                Self.algorithmKey(
+                    host: host, port: port, algorithm: HostKeyFingerprint.unknownAlgorithm)] = nil
+        }
+        storedFingerprints[
+            Self.algorithmKey(host: host, port: port, algorithm: fingerprint.algorithm)] =
+            fingerprint
+    }
+
+    static func endpointKey(host: String, port: Int) -> String {
+        "\(host):\(port)"
+    }
+
+    static func algorithmKeyPrefix(host: String, port: Int) -> String {
+        let endpoint = endpointKey(host: host, port: port)
+        return "v2|\(endpoint.utf8.count)|\(endpoint)|"
+    }
+
+    static func algorithmKey(host: String, port: Int, algorithm: String) -> String {
+        algorithmKeyPrefix(host: host, port: port) + algorithm
+    }
+}
+
+/// The app's persistent store. Production uses one shared actor so concurrent
+/// first connects cannot lose each other's read-modify-write updates.
+actor UserDefaultsKnownHostsStore: KnownHostsStore {
+    static let shared = UserDefaultsKnownHostsStore()
+    private static let defaultsKey = "knownHostFingerprints"
+    private let defaults: UserDefaults
+
+    init() {
+        defaults = .standard
+    }
+
+    init?(suiteName: String) {
+        guard let defaults = UserDefaults(suiteName: suiteName) else { return nil }
         self.defaults = defaults
     }
 
-    func fingerprint(host: String, port: Int) async -> HostKeyFingerprint? {
-        let stored = defaults.dictionary(forKey: Self.defaultsKey) as? [String: String]
+    func fingerprints(host: String, port: Int) -> [HostKeyFingerprint] {
+        let stored = storedValues()
+        let prefix = InMemoryKnownHostsStore.algorithmKeyPrefix(host: host, port: port)
+        var fingerprints = stored.compactMap { key, base64 -> HostKeyFingerprint? in
+            guard key.hasPrefix(prefix), let digest = Data(base64Encoded: base64) else {
+                return nil
+            }
+            let algorithm = String(key.dropFirst(prefix.count))
+            return HostKeyFingerprint(digest: digest, algorithm: algorithm)
+        }
+        if let legacy = legacyFingerprint(in: stored, host: host, port: port) {
+            fingerprints.append(legacy)
+        }
+        return fingerprints
+    }
+
+    func fingerprint(host: String, port: Int, algorithm: String) -> HostKeyFingerprint? {
+        let stored = storedValues()
+        let key = InMemoryKnownHostsStore.algorithmKey(
+            host: host, port: port, algorithm: algorithm)
+        if let base64 = stored[key], let digest = Data(base64Encoded: base64) {
+            return HostKeyFingerprint(digest: digest, algorithm: algorithm)
+        }
+        return legacyFingerprint(in: stored, host: host, port: port)
+    }
+
+    func setFingerprint(_ fingerprint: HostKeyFingerprint, host: String, port: Int) {
+        var stored = storedValues()
+        if fingerprint.algorithm != HostKeyFingerprint.unknownAlgorithm {
+            stored[InMemoryKnownHostsStore.endpointKey(host: host, port: port)] = nil
+        }
+        stored[
+            InMemoryKnownHostsStore.algorithmKey(
+                host: host, port: port, algorithm: fingerprint.algorithm)] =
+                fingerprint.digest.base64EncodedString()
+        defaults.set(stored, forKey: Self.defaultsKey)
+    }
+
+    private func storedValues() -> [String: String] {
+        defaults.dictionary(forKey: Self.defaultsKey) as? [String: String] ?? [:]
+    }
+
+    private func legacyFingerprint(
+        in stored: [String: String], host: String, port: Int
+    ) -> HostKeyFingerprint? {
         guard
-            let base64 = stored?[InMemoryKnownHostsStore.key(host: host, port: port)],
+            let base64 = stored[InMemoryKnownHostsStore.endpointKey(host: host, port: port)],
             let digest = Data(base64Encoded: base64)
         else { return nil }
         return HostKeyFingerprint(digest: digest)
-    }
-
-    func setFingerprint(_ fingerprint: HostKeyFingerprint, host: String, port: Int) async {
-        var stored = defaults.dictionary(forKey: Self.defaultsKey) as? [String: String] ?? [:]
-        stored[InMemoryKnownHostsStore.key(host: host, port: port)] =
-            fingerprint.digest.base64EncodedString()
-        defaults.set(stored, forKey: Self.defaultsKey)
     }
 }

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -242,7 +242,12 @@ actor SSHTransport: Transport {
             try await self.runSessionListCommand()
         }
         do {
-            return try JSONDecoder().decode(HerdrSessionListResponse.self, from: output).sessions
+            let sessions = try JSONDecoder().decode(HerdrSessionListResponse.self, from: output).sessions
+            guard sessions.allSatisfy({ HerdrSessionName.isValid($0.name) }) else {
+                throw TransportError.malformedResponse(
+                    "herdr session list returned an invalid session name")
+            }
+            return sessions
         } catch {
             throw TransportError.malformedResponse(
                 "herdr session list returned invalid JSON: \(Self.preview(output))")
@@ -417,8 +422,8 @@ actor SSHTransport: Transport {
         /// a no-op, so this is only observed when the ack line never came.
         var ackFailure = TransportError.cancelled
         do {
-            try await client.withExec(
-                Self.cLocaleCommand("\(socatPath) - UNIX-CONNECT:\(socketPath)")) {
+            let command = try Self.socatCommand(socatPath: socatPath, socketPath: socketPath)
+            try await client.withExec(command) {
                 inbound, outbound in
                 try? await outbound.write(ByteBuffer(string: requestLine))
                 for try await chunk in inbound {
@@ -908,8 +913,8 @@ actor SSHTransport: Transport {
         var stdout = Data()
         var stderr = Data()
         do {
-            try await client.withExec(
-                Self.cLocaleCommand("\(socatPath) - UNIX-CONNECT:\(socketPath)")) {
+            let command = try Self.socatCommand(socatPath: socatPath, socketPath: socketPath)
+            try await client.withExec(command) {
                 inbound, outbound in
                 // A fast-failing command (socat missing, socket absent) can
                 // close the channel before this write lands; the read loop
@@ -1042,6 +1047,17 @@ actor SSHTransport: Transport {
 
     private static func preview(_ stderr: Data) -> String {
         String(decoding: stderr.prefix(200), as: UTF8.self)
+    }
+
+    private static func socatCommand(socatPath: String, socketPath: String) throws -> String {
+        guard
+            let quotedSocatPath = RemoteShellPath.quotedAbsolute(socatPath),
+            let quotedSocketPath = RemoteShellPath.quotedAbsolute(socketPath)
+        else {
+            throw TransportError.channelFailed(
+                detail: "The remote socat or socket path cannot be quoted safely.")
+        }
+        return cLocaleCommand("\(quotedSocatPath) - UNIX-CONNECT:\(quotedSocketPath)")
     }
 
     /// Stabilizes every parsed remote exec surface. Error classification and

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -53,6 +53,9 @@ struct SSHTransportSettings: Sendable {
     /// override also covers hosts where herdr is not on the login shell's
     /// PATH.
     var attachCommand: String = "herdr agent attach"
+    /// Command used to print a marker-delimited remote home directory. It is
+    /// injectable only at the environment boundary for real-SSH tests.
+    var homeCommand: String = "printf '__HERDR_MOBILE_HOME__=%s\\n' \"$HOME\""
     /// Per-request deadline covering the queue wait and the exec exchange;
     /// on expiry the request fails with `.timedOut` and its channel is
     /// closed. Short in tests, generous by default: a hung host should
@@ -84,6 +87,7 @@ actor SSHTransport: Transport {
     private let observeCommand: String
     private let observeCommandHandlesStdinEOF: Bool
     private let attachCommand: String
+    private let homeCommand: String
     private let requestTimeout: Duration
     /// Remote home directory resolution, resolved over exec once per Host:
     /// concurrent first requests share one in-flight run, success is cached
@@ -167,7 +171,7 @@ actor SSHTransport: Transport {
         client: SSHClient, socketLocation: HerdrSocketLocation, socatPath: String,
         wakeCommand: String, sessionListCommand: String, observeCommand: String,
         observeCommandHandlesStdinEOF: Bool,
-        attachCommand: String,
+        attachCommand: String, homeCommand: String,
         requestTimeout: Duration
     ) {
         self.client = client
@@ -178,6 +182,7 @@ actor SSHTransport: Transport {
         self.observeCommand = observeCommand
         self.observeCommandHandlesStdinEOF = observeCommandHandlesStdinEOF
         self.attachCommand = attachCommand
+        self.homeCommand = homeCommand
         self.requestTimeout = requestTimeout
     }
 
@@ -210,7 +215,8 @@ actor SSHTransport: Transport {
             wakeCommand: settings.wakeCommand, sessionListCommand: settings.sessionListCommand,
             observeCommand: settings.observeCommand,
             observeCommandHandlesStdinEOF: settings.observeCommandHandlesStdinEOF,
-            attachCommand: settings.attachCommand, requestTimeout: settings.requestTimeout)
+            attachCommand: settings.attachCommand, homeCommand: settings.homeCommand,
+            requestTimeout: settings.requestTimeout)
     }
 
     /// Maps connect-time failures onto the taxonomy: credential rejection is
@@ -894,11 +900,12 @@ actor SSHTransport: Transport {
     private func performRequest<P: Encodable, R: Decodable>(
         method: String, params: P, decoding type: R.Type
     ) async throws -> R {
-        let socketPath = try await resolvedSocketPath()
         let requestID = UUID().uuidString
         let line = try HerdrWire.requestLine(id: requestID, method: method, params: params)
         let responseLine = try await Self.withRequestDeadline(requestTimeout) {
-            try await self.performExchange(line: line, socketPath: socketPath, method: method)
+            let socketPath = try await self.resolvedSocketPath()
+            return try await self.performExchange(
+                line: line, socketPath: socketPath, method: method)
         }
         return try HerdrWire.decodeResult(type, fromResponseLine: responseLine, requestID: requestID)
     }
@@ -1006,17 +1013,11 @@ actor SSHTransport: Transport {
         defer { releaseExecChannelSlot() }
         let output: ByteBuffer
         do {
-            // $HOME expands in every mainstream login shell, fish included.
-            output = try await client.executeCommand(Self.cLocaleCommand("echo $HOME"))
+            output = try await client.executeCommand(Self.cLocaleCommand(homeCommand))
         } catch {
             throw TransportError.homeDirectoryUnresolvable(detail: String(describing: error))
         }
-        let home = String(buffer: output).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard home.hasPrefix("/") else {
-            throw TransportError.homeDirectoryUnresolvable(
-                detail: "echo $HOME printed: \(home.prefix(200))")
-        }
-        return home
+        return try Self.parseRemoteHome(output)
     }
 
     /// Maps the observable failure shapes (verified against herdr 0.7.4 in
@@ -1047,6 +1048,25 @@ actor SSHTransport: Transport {
 
     private static func preview(_ stderr: Data) -> String {
         String(decoding: stderr.prefix(200), as: UTF8.self)
+    }
+
+    private static let homeOutputPrefix = "__HERDR_MOBILE_HOME__="
+
+    private static func parseRemoteHome(_ output: ByteBuffer) throws -> String {
+        let text = String(buffer: output)
+        let home = text.split(separator: "\n", omittingEmptySubsequences: false)
+            .reversed()
+            .first { $0.hasPrefix(homeOutputPrefix) }
+            .map { line in
+                var value = String(line.dropFirst(homeOutputPrefix.count))
+                if value.last == "\r" { value.removeLast() }
+                return value
+            }
+        guard let home, RemoteShellPath.isQuotableAbsolute(home) else {
+            throw TransportError.homeDirectoryUnresolvable(
+                detail: "home command printed: \(text.prefix(200))")
+        }
+        return home
     }
 
     private static func socatCommand(socatPath: String, socketPath: String) throws -> String {

--- a/Sources/HerdrMobile/Transport/TOFUHostKeyValidator.swift
+++ b/Sources/HerdrMobile/Transport/TOFUHostKeyValidator.swift
@@ -53,9 +53,19 @@ final class TOFUHostKeyValidator: NIOSSHClientServerAuthenticationDelegate, Send
     }
 
     private func evaluate(fingerprint: HostKeyFingerprint) async -> TransportError? {
-        if let known = await policy.knownHosts.fingerprint(host: host, port: port) {
-            return known == fingerprint
-                ? nil : .hostKeyMismatch(known: known, presented: fingerprint)
+        if let known = await policy.knownHosts.fingerprint(
+            host: host, port: port, algorithm: fingerprint.algorithm)
+        {
+            guard known.digest == fingerprint.digest else {
+                return .hostKeyMismatch(known: known, presented: fingerprint)
+            }
+            if known.algorithm == HostKeyFingerprint.unknownAlgorithm {
+                // A pre-v2 digest had no algorithm metadata. A matching key
+                // proves which algorithm it belongs to, so migrate it before
+                // allowing the handshake to continue.
+                await policy.knownHosts.setFingerprint(fingerprint, host: host, port: port)
+            }
+            return nil
         }
         let candidate = HostKeyCandidate(host: host, port: port, fingerprint: fingerprint)
         guard await policy.confirmFirstConnect(candidate) else {

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -132,6 +132,44 @@ struct HerdrSession: Sendable, Equatable, Decodable {
     }
 }
 
+/// The grammar enforced by herdr 0.7.4 for named sessions. Keeping it at the
+/// transport boundary prevents malformed discovery output from becoming part
+/// of a remote socket path; forms reuse it for immediate feedback.
+enum HerdrSessionName {
+    static let maximumUTF8Length = 64
+
+    static func isValid(_ name: String) -> Bool {
+        guard !name.isEmpty, name != ".", name != ".." else { return false }
+        guard name.utf8.count <= maximumUTF8Length else { return false }
+        return name.utf8.allSatisfy { byte in
+            (0x30...0x39).contains(byte) || (0x41...0x5A).contains(byte)
+                || (0x61...0x7A).contains(byte)
+                || byte == 0x2E || byte == 0x5F || byte == 0x2D
+        }
+    }
+}
+
+/// Paths passed through the Host's login shell use the conservative quoting
+/// subset shared by POSIX shells and fish. Spaces are safe inside single
+/// quotes; quote, backslash, and control characters are refused because their
+/// single-quote behavior differs across those shells.
+enum RemoteShellPath {
+    static func quotedAbsolute(_ path: String) -> String? {
+        guard path.hasPrefix("/") else { return nil }
+        guard path.unicodeScalars.allSatisfy(isQuotable) else { return nil }
+        return "'\(path)'"
+    }
+
+    static func isQuotableAbsolute(_ path: String) -> Bool {
+        quotedAbsolute(path) != nil
+    }
+
+    private static func isQuotable(_ scalar: Unicode.Scalar) -> Bool {
+        scalar.value >= 0x20 && scalar.value != 0x7F
+            && scalar.value != 0x27 && scalar.value != 0x5C
+    }
+}
+
 /// A coding agent process running inside a herdr Pane.
 ///
 /// The domain view of the generated wire type `AgentInfo`: only the fields

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -298,6 +298,21 @@ enum TransportError: Error, Sendable, Equatable {
     /// The exec channel failed outside the known failure shapes; carries the
     /// underlying description for diagnostics.
     case channelFailed(detail: String)
+
+    /// Whether reconnecting without user intervention can plausibly recover.
+    /// Configuration, trust, authentication, and protocol failures instead
+    /// stop so the UI can explain the required action.
+    var isRetryable: Bool {
+        switch self {
+        case .sshUnreachable, .serverNotRunning, .timedOut, .cancelled, .channelFailed:
+            true
+        case .authenticationFailed, .hostKeyRejected, .hostKeyMismatch,
+            .socketNotFound, .socatMissing, .protocolVersionMismatch,
+            .homeDirectoryUnresolvable, .eventsChannelAlreadyOpen,
+            .terminalChannelAlreadyOpen, .malformedResponse:
+            false
+        }
+    }
 }
 
 /// An error returned by the herdr server inside a response envelope.

--- a/Tests/HerdrMobileTests/AgentInputStoreTests.swift
+++ b/Tests/HerdrMobileTests/AgentInputStoreTests.swift
@@ -108,6 +108,33 @@ struct AgentInputStoreTests {
         #expect(store.state == .idle)
     }
 
+    @Test func overlappingQuickKeysStayInTapOrder() async throws {
+        let transport = ScriptedTransport()
+        let gate = Gate()
+        let store = AgentInputStore(target: "w1:p1") {
+            await gate.waitUntilOpen()
+            return transport
+        }
+
+        let first = Task { await store.send(.up) }
+        try await waitUntil("the first key should reach the transport provider") {
+            await gate.enteredCount == 1
+        }
+        let second = Task { await store.send(.enter) }
+
+        try await Task.sleep(for: .milliseconds(30))
+        #expect(await gate.enteredCount == 1)
+
+        await gate.open()
+        await first.value
+        await second.value
+        #expect(
+            await transport.sentKeys == [
+                PaneSendKeysParams(keys: ["up"], paneID: "w1:p1"),
+                PaneSendKeysParams(keys: ["enter"], paneID: "w1:p1"),
+            ])
+    }
+
     @Test func everyQuickKeyMapsToANonEmptySpelling() {
         // Guards the bar against shipping a key that sends nothing.
         for key in QuickKey.allCases {

--- a/Tests/HerdrMobileTests/ConsoleStoreTests.swift
+++ b/Tests/HerdrMobileTests/ConsoleStoreTests.swift
@@ -401,6 +401,40 @@ struct ConsoleStoreTests {
         store.setHosts([])
     }
 
+    @Test func transportProviderWaitsForPreviousTerminalTeardown() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(snapshot: .fixture())
+        let store = makeStore(transports: [host.id: transport])
+        let gate = TerminalTeardownGate()
+        let result = TerminalTransportResult()
+
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the Host should connect") {
+            store.hostStatuses[host.id] == .connected
+        }
+
+        store.scheduleTerminalTeardown(for: host.id) {
+            await gate.waitUntilOpen()
+        }
+        let provider = store.transportProvider(for: host.id)
+        let request = Task {
+            await result.set(await provider())
+        }
+
+        try await waitUntil("the previous teardown should start") {
+            await gate.enteredCount == 1
+        }
+        try await Task.sleep(for: .milliseconds(30))
+        #expect(await !result.wasSet)
+
+        await gate.open()
+        await request.value
+        #expect(await result.transport as? ScriptedTransport === transport)
+
+        store.setHosts([])
+    }
+
     @Test func workspacesExposeTheHostsSnapshotWorkspaces() async throws {
         // The new-agent picker (#12) offers the workspaces the store already
         // knows for a Host, including ones with no agents in them yet.
@@ -565,5 +599,34 @@ private actor SessionBox {
 
     func set(_ session: EventsSession) {
         self.session = session
+    }
+}
+
+private actor TerminalTeardownGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private(set) var enteredCount = 0
+
+    func waitUntilOpen() async {
+        enteredCount += 1
+        if isOpen { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        let resuming = waiters
+        waiters.removeAll()
+        for waiter in resuming { waiter.resume() }
+    }
+}
+
+private actor TerminalTransportResult {
+    private(set) var wasSet = false
+    private(set) var transport: (any Transport)?
+
+    func set(_ transport: (any Transport)?) {
+        wasSet = true
+        self.transport = transport
     }
 }

--- a/Tests/HerdrMobileTests/EventsSessionSubscriptionsTests.swift
+++ b/Tests/HerdrMobileTests/EventsSessionSubscriptionsTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Synchronization
 import Testing
 
 @testable import HerdrMobile
@@ -74,6 +75,28 @@ struct EventsSessionSubscriptionsTests {
 
         #expect(await updates.next() == .status(.connected))
         #expect(await transport.capturedSubscriptions == [updated])
+        await session.end()
+    }
+
+    @Test func permanentFailureStopsTheReconnectLoop() async throws {
+        let connectionAttempts = Mutex(0)
+        let session = EventsSession(
+            subscriptions: initial,
+            connect: { () async throws -> any Transport in
+                connectionAttempts.withLock { $0 += 1 }
+                throw TransportError.authenticationFailed
+            },
+            reconnectPolicy: ReconnectPolicy(
+                initialDelay: .milliseconds(1), multiplier: 1, maxDelay: .milliseconds(1)),
+            keepalive: nil)
+        var updates = session.updates.makeAsyncIterator()
+
+        await session.resume()
+
+        #expect(await updates.next() == .status(.failed(.authenticationFailed)))
+        try await Task.sleep(for: .milliseconds(30))
+        #expect(connectionAttempts.withLock { $0 } == 1)
+
         await session.end()
     }
 }

--- a/Tests/HerdrMobileTests/HostDraftTests.swift
+++ b/Tests/HerdrMobileTests/HostDraftTests.swift
@@ -114,4 +114,28 @@ struct HostDraftTests {
         draft.password = "hunter2"
         #expect(draft.passwordUpdate == nil)
     }
+
+    @Test func newPasswordHostRequiresAPassword() {
+        var draft = HostDraft()
+        draft.address = "host.example"
+        draft.username = "dev"
+        draft.authMethod = .password
+
+        #expect(!draft.canSave(editing: nil))
+
+        draft.password = "secret"
+        #expect(draft.canSave(editing: nil))
+    }
+
+    @Test func blankPasswordOnlyKeepsAnExistingPasswordCredential() {
+        let passwordHost = Host.fixture(authMethod: .password)
+        let keyHost = Host.fixture(authMethod: .deviceKey)
+        var draft = HostDraft(host: passwordHost)
+
+        #expect(draft.canSave(editing: passwordHost))
+
+        draft = HostDraft(host: keyHost)
+        draft.authMethod = .password
+        #expect(!draft.canSave(editing: keyHost))
+    }
 }

--- a/Tests/HerdrMobileTests/HostDraftTests.swift
+++ b/Tests/HerdrMobileTests/HostDraftTests.swift
@@ -64,6 +64,41 @@ struct HostDraftTests {
         #expect(draft.isValid)
     }
 
+    @Test func rejectsSessionNamesHerdrWouldReject() {
+        let invalidNames = [
+            "work session", "../prod", ".", "..", "work/session", String(repeating: "a", count: 65),
+        ]
+
+        for sessionName in invalidNames {
+            var draft = HostDraft()
+            draft.address = "host.example"
+            draft.username = "dev"
+            draft.sessionName = sessionName
+
+            #expect(!draft.isValid, "unexpectedly accepted session name: \(sessionName)")
+        }
+    }
+
+    @Test func acceptsHerdrSessionNameCharacterSetAndLengthLimit() {
+        var draft = HostDraft()
+        draft.address = "host.example"
+        draft.username = "dev"
+        draft.sessionName = String(repeating: "a", count: 60) + "._-9"
+
+        #expect(draft.isValid)
+    }
+
+    @Test func rejectsSocatPathsThatCannotBeQuotedForTheRemoteShell() {
+        for path in ["/tmp/socat'bad", "/tmp/socat\\bad", "/tmp/socat\nbad"] {
+            var draft = HostDraft()
+            draft.address = "host.example"
+            draft.username = "dev"
+            draft.socatPath = path
+
+            #expect(!draft.isValid, "unexpectedly accepted socat path: \(path)")
+        }
+    }
+
     @Test func passwordUpdateOnlyForPasswordAuthWithAnEntry() {
         var draft = HostDraft()
         draft.authMethod = .password

--- a/Tests/HerdrMobileTests/HostStoreTests.swift
+++ b/Tests/HerdrMobileTests/HostStoreTests.swift
@@ -49,6 +49,36 @@ struct HostStoreTests {
         #expect(reloaded.hosts == [host])
     }
 
+    @Test func legacyCatalogMissingNewFieldsMigratesWithDefaults() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let id = UUID()
+        let legacy = """
+            [{"id":"\(id.uuidString)","name":"Old","address":"old.example","port":22,
+              "username":"dev","authMethod":"deviceKey"}]
+            """
+        defaults.set(Data(legacy.utf8), forKey: "hosts")
+
+        let store = HostStore(defaults: defaults, secrets: InMemorySecretStore())
+
+        let host = try #require(store.hosts.first)
+        #expect(host.sessionName == "")
+        #expect(host.socatPath == Host.defaultSocatPath)
+    }
+
+    @Test func corruptCatalogCannotBeSilentlyOverwritten() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let corrupt = Data("not-json".utf8)
+        defaults.set(corrupt, forKey: "hosts")
+        let store = HostStore(defaults: defaults, secrets: InMemorySecretStore())
+
+        #expect(throws: HostStoreError.catalogUnreadable) {
+            try store.add(Host.fixture())
+        }
+        #expect(defaults.data(forKey: "hosts") == corrupt)
+    }
+
     @Test func updateReplacesTheStoredHost() throws {
         let (defaults, cleanup) = try makeDefaults()
         defer { cleanup() }

--- a/Tests/HerdrMobileTests/KnownHostsStoreTests.swift
+++ b/Tests/HerdrMobileTests/KnownHostsStoreTests.swift
@@ -8,6 +8,15 @@ struct KnownHostsStoreTests {
     private let fingerprint = HostKeyFingerprint(publicKeyBlob: Data("blob-a".utf8))
     private let otherFingerprint = HostKeyFingerprint(publicKeyBlob: Data("blob-b".utf8))
 
+    private func fingerprint(algorithm: String, marker: String) -> HostKeyFingerprint {
+        var blob = Data()
+        var length = UInt32(algorithm.utf8.count).bigEndian
+        withUnsafeBytes(of: &length) { blob.append(contentsOf: $0) }
+        blob.append(contentsOf: algorithm.utf8)
+        blob.append(contentsOf: marker.utf8)
+        return HostKeyFingerprint(publicKeyBlob: blob)
+    }
+
     @Test func inMemoryStoreKeysFingerprintsByHostAndPort() async throws {
         let store = InMemoryKnownHostsStore()
 
@@ -26,10 +35,10 @@ struct KnownHostsStoreTests {
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        await UserDefaultsKnownHostsStore(defaults: defaults)
-            .setFingerprint(fingerprint, host: "a.example", port: 22)
+        let original = try #require(UserDefaultsKnownHostsStore(suiteName: suiteName))
+        await original.setFingerprint(fingerprint, host: "a.example", port: 22)
 
-        let reloaded = UserDefaultsKnownHostsStore(defaults: defaults)
+        let reloaded = try #require(UserDefaultsKnownHostsStore(suiteName: suiteName))
         #expect(await reloaded.fingerprint(host: "a.example", port: 22) == fingerprint)
         #expect(await reloaded.fingerprint(host: "a.example", port: 2222) == nil)
     }
@@ -38,11 +47,72 @@ struct KnownHostsStoreTests {
         let suiteName = "hm-known-hosts-\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        let store = UserDefaultsKnownHostsStore(defaults: defaults)
+        let store = try #require(UserDefaultsKnownHostsStore(suiteName: suiteName))
 
         await store.setFingerprint(fingerprint, host: "a.example", port: 22)
         await store.setFingerprint(otherFingerprint, host: "a.example", port: 22)
 
         #expect(await store.fingerprint(host: "a.example", port: 22) == otherFingerprint)
+    }
+
+    @Test func oneEndpointRetainsFingerprintsForMultipleAlgorithms() async throws {
+        let store = InMemoryKnownHostsStore()
+        let ed25519 = fingerprint(algorithm: "ssh-ed25519", marker: "ed")
+        let ecdsa = fingerprint(algorithm: "ecdsa-sha2-nistp256", marker: "ec")
+
+        await store.setFingerprint(ed25519, host: "a.example", port: 22)
+        await store.setFingerprint(ecdsa, host: "a.example", port: 22)
+
+        #expect(
+            await store.fingerprint(
+                host: "a.example", port: 22, algorithm: "ssh-ed25519") == ed25519)
+        #expect(
+            await store.fingerprint(
+                host: "a.example", port: 22, algorithm: "ecdsa-sha2-nistp256") == ecdsa)
+    }
+
+    @Test func persistentStoreRetainsMultipleAlgorithmsAcrossInstances() async throws {
+        let suiteName = "hm-known-hosts-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let original = try #require(UserDefaultsKnownHostsStore(suiteName: suiteName))
+        let ed25519 = fingerprint(algorithm: "ssh-ed25519", marker: "ed")
+        let ecdsa = fingerprint(algorithm: "ecdsa-sha2-nistp256", marker: "ec")
+
+        await original.setFingerprint(ed25519, host: "a.example", port: 22)
+        await original.setFingerprint(ecdsa, host: "a.example", port: 22)
+
+        let reloaded = try #require(UserDefaultsKnownHostsStore(suiteName: suiteName))
+        #expect(
+            await reloaded.fingerprint(
+                host: "a.example", port: 22, algorithm: "ssh-ed25519") == ed25519)
+        #expect(
+            await reloaded.fingerprint(
+                host: "a.example", port: 22, algorithm: "ecdsa-sha2-nistp256") == ecdsa)
+    }
+
+    @Test func concurrentPersistentWritesDoNotLoseOtherHosts() async throws {
+        let suiteName = "hm-known-hosts-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = try #require(UserDefaultsKnownHostsStore(suiteName: suiteName))
+
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0..<50 {
+                group.addTask {
+                    let fingerprint = fingerprint(
+                        algorithm: "ssh-ed25519", marker: "host-\(index)")
+                    await store.setFingerprint(
+                        fingerprint, host: "host-\(index).example", port: 22)
+                }
+            }
+        }
+
+        for index in 0..<50 {
+            #expect(
+                await store.fingerprint(
+                    host: "host-\(index).example", port: 22,
+                    algorithm: "ssh-ed25519") != nil)
+        }
     }
 }

--- a/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
@@ -42,6 +42,20 @@ struct ObserveTerminalStoreTests {
         return nil
     }
 
+    private func show(_ host: UIViewController, frame: CGRect) async -> UIWindow {
+        let window = UIWindow(frame: frame)
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        try? await Task.sleep(for: .milliseconds(20))
+        return window
+    }
+
+    private func hide(_ window: UIWindow) async {
+        window.isHidden = true
+        try? await Task.sleep(for: .milliseconds(20))
+        window.rootViewController = nil
+    }
+
     /// Polls until `condition` holds, yielding so the store's tasks progress.
     private func waitUntil(
         _ comment: Comment, timeout: Duration = .seconds(5),
@@ -132,17 +146,14 @@ struct ObserveTerminalStoreTests {
         await store.stop()
     }
 
-    @Test func observeUsesEnoughColumnsToLimitWidePaneReflow() throws {
+    @Test func observeUsesEnoughColumnsToLimitWidePaneReflow() async throws {
         // A 393-point iPhone showing the default 12-point terminal only fits
         // about 52 columns. A 185-column desktop line then expands to four
         // mobile rows, which makes the transcript unnecessarily tall.
         let host = UIHostingController(
             rootView: TerminalScreenView(feed: TerminalByteFeed(), style: .observe))
         let frame = CGRect(x: 0, y: 0, width: 393, height: 600)
-        let window = UIWindow(frame: frame)
-        window.rootViewController = host
-        window.makeKeyAndVisible()
-        defer { window.isHidden = true }
+        let window = await show(host, frame: frame)
         host.view.frame = frame
         host.view.layoutIfNeeded()
 
@@ -155,6 +166,7 @@ struct ObserveTerminalStoreTests {
         let rowsForDesktopLine = (185 + columns - 1) / columns
         #expect(columns >= 64)
         #expect(rowsForDesktopLine <= 3)
+        await hide(window)
     }
 
     @Test func replacingObserveSnapshotKeepsScrollExtentAndViewportStable() async throws {
@@ -162,10 +174,7 @@ struct ObserveTerminalStoreTests {
         let host = UIHostingController(
             rootView: TerminalScreenView(feed: feed, style: .observe))
         let frame = CGRect(x: 0, y: 0, width: 393, height: 600)
-        let window = UIWindow(frame: frame)
-        window.rootViewController = host
-        window.makeKeyAndVisible()
-        defer { window.isHidden = true }
+        let window = await show(host, frame: frame)
         host.view.frame = frame
         host.view.layoutIfNeeded()
 
@@ -191,6 +200,7 @@ struct ObserveTerminalStoreTests {
         }
         #expect(terminal.contentSize.height > originalExtent)
         #expect(terminal.scrollPosition == 1)
+        await hide(window)
     }
 
     @Test func reachingTheTopLoadsEarlierHistoryWithoutMovingTheViewport() async throws {
@@ -204,10 +214,7 @@ struct ObserveTerminalStoreTests {
                     return true
                 }))
         let frame = CGRect(x: 0, y: 0, width: 393, height: 600)
-        let window = UIWindow(frame: frame)
-        window.rootViewController = host
-        window.makeKeyAndVisible()
-        defer { window.isHidden = true }
+        let window = await show(host, frame: frame)
         host.view.frame = frame
         host.view.layoutIfNeeded()
 
@@ -239,6 +246,7 @@ struct ObserveTerminalStoreTests {
 
         while terminal.accessibilityScroll(.up) {}
         #expect(loadRequests == 2)
+        await hide(window)
     }
 
     @Test func loadingEarlierExpandsTheReadWindowUntilHistoryEnds() async throws {

--- a/Tests/HerdrMobileTests/PreflightReportTests.swift
+++ b/Tests/HerdrMobileTests/PreflightReportTests.swift
@@ -21,6 +21,7 @@ struct PreflightReportTests {
             .socatMissing(path: "/usr/bin/socat"), authMethod: .deviceKey)
 
         #expect(report[.connection] == .passed)
+        #expect(report[.remoteEnvironment] == .passed)
         guard case .failed(let hint) = report[.socat] else {
             Issue.record("socat check should fail")
             return
@@ -43,7 +44,7 @@ struct PreflightReportTests {
         (.eventsChannelAlreadyOpen, .connection),
         (.socatMissing(path: "/usr/bin/socat"), .socat),
         (.socketNotFound(path: "/home/dev/.config/herdr/herdr.sock"), .herdrInstalled),
-        (.homeDirectoryUnresolvable(detail: "no $HOME"), .herdrInstalled),
+        (.homeDirectoryUnresolvable(detail: "no $HOME"), .remoteEnvironment),
         (.serverNotRunning(path: "/home/dev/.config/herdr/herdr.sock"), .serverRunning),
         (.protocolVersionMismatch(server: 17, supported: 16), .protocolCompatible),
         (.malformedResponse("junk"), .protocolCompatible),

--- a/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
@@ -250,6 +250,57 @@ struct SSHTransportE2ETests {
         try await transport.close()
     }
 
+    @Test func sessionDiscoveryRejectsNamesOutsideHerdrsGrammar() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let scriptURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herdr-session-list-\(UUID().uuidString).sh")
+        let script = """
+            #!/bin/sh
+            printf '%s' '{"sessions":[{"name":"work; false","default":false,"running":true}]}'
+            """
+        try Data(script.utf8).write(to: scriptURL, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700], ofItemAtPath: scriptURL.path)
+        defer { try? FileManager.default.removeItem(at: scriptURL) }
+        var settings = environment.makeSettings(
+            socket: .absolutePath("/tmp/herdr-irrelevant.sock"))
+        settings.sessionListCommand = scriptURL.path
+        let transport = try await SSHTransport.connect(settings: settings)
+        await #expect(throws: TransportError.self) {
+            _ = try await transport.listSessions()
+        }
+        try await transport.close()
+    }
+
+    @Test func socketAndSocatPathsWithSpacesRoundTripSafely() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let directory = URL(
+            fileURLWithPath: "/tmp/hm paths \(UUID().uuidString.prefix(8))", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let socketPath = directory.appendingPathComponent("herdr socket.sock").path
+        let socatPath = directory.appendingPathComponent("socat binary").path
+        try FileManager.default.createSymbolicLink(
+            atPath: socatPath, withDestinationPath: environment.socatPath)
+        let server = try FakeHerdrServer(socketPath: socketPath) { request in
+            [#"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9-fake","protocol":16}}"#]
+        }
+        defer { server.stop() }
+        let transport = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .absolutePath(socketPath), socatPath: socatPath))
+        do {
+            let info = try await transport.ping()
+
+            #expect(info.protocolVersion == SSHTransport.supportedProtocolVersion)
+            #expect(server.receivedRequests.map(\.method) == ["ping"])
+        } catch {
+            try? await transport.close()
+            throw error
+        }
+        try await transport.close()
+    }
+
     @Test func namedSessionSocketPathResolvesOverRemoteHome() async throws {
         // The transport is given only a session name; it must resolve the
         // remote home directory over exec and find the socket at

--- a/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
@@ -341,6 +341,58 @@ struct SSHTransportE2ETests {
         try await transport.close()
     }
 
+    @Test func homeResolutionIgnoresLoginShellStdoutNoise() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let home = "/tmp/hm home \(UUID().uuidString.prefix(8))"
+        let sessionName = "work"
+        let sessionDirectory = "\(home)/.config/herdr/sessions/\(sessionName)"
+        try FileManager.default.createDirectory(
+            atPath: sessionDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let server = try FakeHerdrServer(socketPath: "\(sessionDirectory)/herdr.sock") { request in
+            [#"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9-fake","protocol":16}}"#]
+        }
+        defer { server.stop() }
+        let homeCommand =
+            "printf 'login banner\\n__HERDR_MOBILE_HOME__=%s\\nlast login\\n' '\(home)'"
+        let transport = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .namedSession(sessionName), homeCommand: homeCommand))
+
+        let info = try await transport.ping()
+
+        #expect(info.protocolVersion == SSHTransport.supportedProtocolVersion)
+        try await transport.close()
+    }
+
+    @Test func firstHomeRelativeRequestUsesOneTotalDeadline() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let home = "/tmp/hm-deadline-\(UUID().uuidString.prefix(8))"
+        let sessionName = "work"
+        let sessionDirectory = "\(home)/.config/herdr/sessions/\(sessionName)"
+        try FileManager.default.createDirectory(
+            atPath: sessionDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: home) }
+        let server = try FakeHerdrServer(socketPath: "\(sessionDirectory)/herdr.sock") { _ in nil }
+        defer { server.stop() }
+        let homeCommand =
+            "sleep 0.6; printf '__HERDR_MOBILE_HOME__=%s\\n' '\(home)'"
+        let transport = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .namedSession(sessionName), requestTimeout: .seconds(1),
+                homeCommand: homeCommand))
+        let clock = ContinuousClock()
+        let started = clock.now
+
+        await #expect(throws: TransportError.timedOut) {
+            try await transport.ping()
+        }
+
+        let elapsed = started.duration(to: clock.now)
+        #expect(elapsed < .milliseconds(1_400))
+        try await transport.close()
+    }
+
     /// Boots a fake herdr server plus a real SSH connection to localhost and
     /// tears both down afterwards. The transport is handed to `body` as the
     /// concrete actor; assertions go through its public Transport surface.

--- a/Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift
+++ b/Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift
@@ -77,6 +77,7 @@ struct LocalSSHTestEnvironment: Sendable {
         socatPath: String? = nil,
         wakeCommand: String? = nil,
         requestTimeout: Duration? = nil,
+        homeCommand: String? = nil,
         credentials: SSHCredentials? = nil,
         hostKeyPolicy: HostKeyPolicy? = nil
     ) -> SSHTransportSettings {
@@ -91,6 +92,7 @@ struct LocalSSHTestEnvironment: Sendable {
             socatPath: socatPath ?? self.socatPath)
         if let wakeCommand { settings.wakeCommand = wakeCommand }
         if let requestTimeout { settings.requestTimeout = requestTimeout }
+        if let homeCommand { settings.homeCommand = homeCommand }
         return settings
     }
 

--- a/Tests/HerdrMobileTests/TransportConcurrencyE2ETests.swift
+++ b/Tests/HerdrMobileTests/TransportConcurrencyE2ETests.swift
@@ -53,7 +53,9 @@ struct TransportConcurrencyE2ETests {
     }
 
     @Test func requestsAfterATimeoutStillSucceed() async throws {
-        // A timed-out request must not wedge the queue: afterwards, a full
+        // Citadel upgrade guard: its inbound stream must resume when the
+        // request task is cancelled. A timed-out request must therefore
+        // close its channel and release its slot; afterwards, a full
         // queue-width burst still completes.
         try await withTransport(requestTimeout: .seconds(2)) { request in
             switch request.method {


### PR DESCRIPTION
## Summary

- validate herdr session names and safely quote remote socat and socket paths before invoking the login shell
- version the Host catalog, migrate legacy records, and preserve unreadable data instead of silently overwriting it
- enforce one total request deadline, parse remote HOME output robustly, and keep Preflight results ordered correctly
- stop retrying action-required connection failures, surface specific guidance, and serialize terminal teardown and agent input
- store TOFU fingerprints per SSH key algorithm and serialize persistent known-host writes
- require credentials when creating or switching to password authentication
- strengthen real-SSH cancellation coverage and balance UIKit hosting-controller test lifecycles

## Testing

- `scripts/generate-wire-types.py --check --schema scripts/herdr-schema.json`
- `xcodebuild test -quiet -project HerdrMobile.xcodeproj -scheme HerdrMobile -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'`

Final result: 285 tests passed, 0 failed, 0 skipped, with the localhost SSH E2E suites enabled.
