### PR TITLE
fix: agent detail crash and named-session terminal channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ DerivedData/
 
 # Local-only notes and experiments
 .local/
+
+# testloop scratch artifacts
+.testloop/

--- a/Sources/HerdrMobile/Console/AgentInputBar.swift
+++ b/Sources/HerdrMobile/Console/AgentInputBar.swift
@@ -111,6 +111,11 @@ struct AgentInputBar: View {
         let text = store.draft
         switch selection.indices {
         case .selection(let range) where range.isEmpty:
+            // The field can publish a selection indexed into text the draft no
+            // longer holds (observed trapping on first render with an empty
+            // draft); measuring a foreign index traps, so treat out-of-bounds
+            // as "selection unknown".
+            guard range.lowerBound <= text.endIndex else { return nil }
             return text.distance(from: text.startIndex, to: range.lowerBound)
         case .selection, .multiSelection:
             return nil

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -525,13 +525,15 @@ actor SSHTransport: Transport {
     private var nextTerminalReaderID: UInt64 = 0
 
     func observeTerminal(_ request: TerminalObserveRequest) async throws -> TerminalFrameStream {
+        let socketPath = try await resolvedSocketPath()
         guard terminalChannelState == .idle else {
             throw TransportError.terminalChannelAlreadyOpen
         }
-        let command = Self.observeChannelCommand(
+        let command = try Self.observeChannelCommand(
             observeCommand: observeCommand,
             handlesStdinEOF: observeCommandHandlesStdinEOF,
-            request: request)
+            request: request,
+            socketPath: socketPath)
         // Bounded like the events path (#22): a shed frame leaves a hole in
         // the `seq` counter, and the observe consumer already treats any
         // seq gap as "re-observe for a fresh full repaint" — local drops
@@ -564,8 +566,15 @@ actor SSHTransport: Transport {
     /// kills the command instead.
     ///
     /// Runs under `/bin/sh` explicitly because the login shell owning the
-    /// exec command line may not speak POSIX (fish). The target rides as a
-    /// positional argument so only the outer shell ever quotes it.
+    /// exec command line may not speak POSIX (fish). The target and socket
+    /// path ride as positional arguments so only the outer shell ever quotes
+    /// them.
+    ///
+    /// `HERDR_SOCKET_PATH` pins the herdr CLI to this Host's configured
+    /// socket: without it the CLI resolves the default session, and a
+    /// named-session terminal id is "not found" there — the channel dies
+    /// instantly with nothing on stderr (the CLI reports the close reason on
+    /// stdout).
     ///
     /// In the fallback stdin dance, POSIX hands `/dev/null` to backgrounded
     /// (`&`) commands, so the real stdin is saved to fd 3 first and the
@@ -575,19 +584,25 @@ actor SSHTransport: Transport {
     static func observeChannelCommand(
         observeCommand: String,
         handlesStdinEOF: Bool,
-        request: TerminalObserveRequest
-    ) -> String {
+        request: TerminalObserveRequest,
+        socketPath: String
+    ) throws -> String {
+        guard let quotedSocketPath = RemoteShellPath.quotedAbsolute(socketPath) else {
+            throw TransportError.channelFailed(
+                detail: "The remote socket path cannot be quoted safely.")
+        }
         let quotedTarget =
             "'" + request.target.replacingOccurrences(of: "'", with: #"'\''"#) + "'"
         let observe = "\(observeCommand) \"$1\" --cols \(request.cols) --rows \(request.rows)"
+        let scope = "export HERDR_SOCKET_PATH=\"$2\"; "
         if handlesStdinEOF {
-            return "/bin/sh -c 'exec \(observe)' observe \(quotedTarget)"
+            return "/bin/sh -c '\(scope)exec \(observe)' observe \(quotedTarget) \(quotedSocketPath)"
         }
         let wrapper =
-            "exec 3<&0 0</dev/null; \(observe) & p=$!; "
+            scope + "exec 3<&0 0</dev/null; \(observe) & p=$!; "
             + "(cat <&3 >/dev/null 2>&1 3<&-; kill $p 2>/dev/null) & w=$!; "
             + "wait $p; kill $w 2>/dev/null; exit 0"
-        return "/bin/sh -c '\(wrapper)' observe \(quotedTarget)"
+        return "/bin/sh -c '\(wrapper)' observe \(quotedTarget) \(quotedSocketPath)"
     }
 
     /// The terminal channel's read loop: yields every complete frame line
@@ -662,11 +677,12 @@ actor SSHTransport: Transport {
     // ends attach promptly (verified against localhost sshd in the #11 e2e).
 
     func attachTerminal(_ request: TerminalAttachRequest) async throws -> TerminalAttachSession {
+        let socketPath = try await resolvedSocketPath()
         guard terminalChannelState == .idle else {
             throw TransportError.terminalChannelAlreadyOpen
         }
         let bootstrapLine = try Self.attachBootstrapLine(
-            attachCommand: attachCommand, request: request)
+            attachCommand: attachCommand, request: request, socketPath: socketPath)
         // Deliberately unbounded (#22): raw PTY bytes have no framing, no
         // seq, and no snapshot to resync from, so a shed chunk would corrupt
         // the escape stream for the rest of the session. Volume is
@@ -702,8 +718,14 @@ actor SSHTransport: Transport {
     /// no quote, backslash, or control characters, so targets are restricted
     /// to exactly that (a Pane id that violates it could only come from a
     /// hostile server, and refusing beats handing it a shell).
+    ///
+    /// The attach process runs under `/bin/sh` so `HERDR_SOCKET_PATH` can pin
+    /// the herdr CLI to this Host's configured socket (fish parses prefix
+    /// assignments differently, so the login shell cannot set it portably);
+    /// without it the CLI resolves the default session and a named-session
+    /// target is "not found" there.
     static func attachBootstrapLine(
-        attachCommand: String, request: TerminalAttachRequest
+        attachCommand: String, request: TerminalAttachRequest, socketPath: String
     ) throws -> String {
         let unquotable: (Character) -> Bool = { character in
             character == "'" || character == "\\"
@@ -715,8 +737,14 @@ actor SSHTransport: Transport {
             throw TransportError.channelFailed(
                 detail: "attach target cannot be quoted for the remote shell")
         }
+        guard let quotedSocketPath = RemoteShellPath.quotedAbsolute(socketPath) else {
+            throw TransportError.channelFailed(
+                detail: "The remote socket path cannot be quoted safely.")
+        }
         let takeover = request.takeover ? " --takeover" : ""
-        return "exec \(attachCommand) '\(request.target)'\(takeover)\n"
+        return "exec /bin/sh -c 'export HERDR_SOCKET_PATH=\"$2\"; "
+            + "exec \(attachCommand) \"$1\"\(takeover)' attach "
+            + "'\(request.target)' \(quotedSocketPath)\n"
     }
 
     /// The attach channel's lifetime: opens the PTY, types the bootstrap

--- a/Tests/HerdrMobileTests/TerminalAttachTests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachTests.swift
@@ -5,22 +5,32 @@ import Testing
 
 /// The attach bootstrap line (#11): the command typed into the PTY channel's
 /// login shell. It must `exec` the attach process (so its exit ends the
-/// channel), quote the target safely for POSIX shells and fish alike, and
-/// refuse targets that cannot be quoted safely for both.
+/// channel), pin the herdr CLI to the Host's socket via `HERDR_SOCKET_PATH`
+/// (a named-session target is "not found" on the default socket), quote the
+/// target and socket safely for POSIX shells and fish alike, and refuse
+/// targets that cannot be quoted safely for both.
 @Suite("Terminal attach bootstrap line")
 struct TerminalAttachTests {
-    @Test func execsTheAttachCommandWithQuotedTarget() throws {
+    @Test func execsTheAttachCommandWithQuotedTargetAndSocketScope() throws {
         let line = try SSHTransport.attachBootstrapLine(
             attachCommand: "herdr agent attach",
-            request: TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24))
-        #expect(line == "exec herdr agent attach 'w1:p1'\n")
+            request: TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24),
+            socketPath: "/home/u/.config/herdr/sessions/dev/herdr.sock")
+        #expect(
+            line == "exec /bin/sh -c 'export HERDR_SOCKET_PATH=\"$2\"; "
+                + "exec herdr agent attach \"$1\"' attach "
+                + "'w1:p1' '/home/u/.config/herdr/sessions/dev/herdr.sock'\n")
     }
 
     @Test func takeoverAppendsHerdrsFlag() throws {
         let line = try SSHTransport.attachBootstrapLine(
             attachCommand: "herdr agent attach",
-            request: TerminalAttachRequest(target: "w1:p1", takeover: true, cols: 80, rows: 24))
-        #expect(line == "exec herdr agent attach 'w1:p1' --takeover\n")
+            request: TerminalAttachRequest(target: "w1:p1", takeover: true, cols: 80, rows: 24),
+            socketPath: "/home/u/.config/herdr/herdr.sock")
+        #expect(
+            line == "exec /bin/sh -c 'export HERDR_SOCKET_PATH=\"$2\"; "
+                + "exec herdr agent attach \"$1\" --takeover' attach "
+                + "'w1:p1' '/home/u/.config/herdr/herdr.sock'\n")
     }
 
     @Test func injectableAttachCommandRidesThrough() throws {
@@ -28,8 +38,12 @@ struct TerminalAttachTests {
         // wake and observe commands.
         let line = try SSHTransport.attachBootstrapLine(
             attachCommand: "/bin/sh /tmp/fake-attach.sh",
-            request: TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24))
-        #expect(line == "exec /bin/sh /tmp/fake-attach.sh 'w1:p1'\n")
+            request: TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24),
+            socketPath: "/tmp/fake.sock")
+        #expect(
+            line == "exec /bin/sh -c 'export HERDR_SOCKET_PATH=\"$2\"; "
+                + "exec /bin/sh /tmp/fake-attach.sh \"$1\"' attach "
+                + "'w1:p1' '/tmp/fake.sock'\n")
     }
 
     @Test(arguments: [
@@ -41,7 +55,17 @@ struct TerminalAttachTests {
         #expect(throws: TransportError.self) {
             _ = try SSHTransport.attachBootstrapLine(
                 attachCommand: "herdr agent attach",
-                request: TerminalAttachRequest(target: target, cols: 80, rows: 24))
+                request: TerminalAttachRequest(target: target, cols: 80, rows: 24),
+                socketPath: "/tmp/fake.sock")
+        }
+    }
+
+    @Test func unquotableSocketPathsAreRefused() {
+        #expect(throws: TransportError.self) {
+            _ = try SSHTransport.attachBootstrapLine(
+                attachCommand: "herdr agent attach",
+                request: TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24),
+                socketPath: "/tmp/it's-a.sock")
         }
     }
 


### PR DESCRIPTION
Two bugs found and fixed during a driven GUI test session against a live localhost herdr host (Simulator + real SSH + herdr 0.7.4).

## Agent detail crash (3d082a4)

Opening an agent's detail screen trapped in `AgentInputBar.cursorOffset(of:)`: the `TextSelection` bound to the reply field can carry `String.Index` values into text the draft no longer holds (reproduced deterministically on first render with an empty draft), and measuring a foreign index with `String.distance` asserts. Two matching crash reports confirmed the signature.

Fix: treat an out-of-bounds caret as "selection unknown" (`nil`), which already has defined semantics — dictation composes at the end. Same defensive style as the existing clamp in `DictationStore`.

## Named-session hosts could not Observe or Attach (423aed4)

The observe (`herdr terminal session control`) and attach (`herdr agent attach`) remote commands ran without any session scoping, so the remote herdr CLI always resolved the **default** session's socket. For a host configured with a named session, the terminal target is "not found" there and the channel dies instantly — surfacing as `channelFailed(... Already closed)` with empty stderr (the CLI reports the close reason on stdout). Verified over raw SSH: unscoped → `terminal target ... not found`; with `HERDR_SOCKET_PATH` pointing at the named session's socket → clean attach/detach.

Fix: both channels now `export HERDR_SOCKET_PATH` inside their `/bin/sh` wrapper, with the socket path riding as a quoted positional argument (`RemoteShellPath.quotedAbsolute`). The attach bootstrap line previously ran through the login shell directly; it is now wrapped in `/bin/sh` too, since fish parses prefix assignments differently.

## Testing

- `TerminalAttachTests` (6 tests, including new socket-scoping and unquotable-socket assertions)
- `TerminalObserveE2ETests` + `TerminalAttachE2ETests` (13 tests against real localhost sshd)
- Full GUI regression: onboarding, TOFU, preflight, session discovery/selection, Console, Start Agent, live Observe, native replies + quick keys, Attach (`pwd` round-trip), background/foreground reconnect, Close Agent — all green on the fixed build.

Follow-ups filed separately: #40 (wake command scoping), #41 (agent name on Console cards), #42 (socat default path on macOS hosts).