### PR TITLE
feat(console): label agents by the wire's display_agent/name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,17 @@ Rediscovering these is expensive; they were verified against herdr 0.7.4 source 
 - Pin Citadel exactly in `Package.resolved` and review updates: Citadel 0.12.1 depends on a third-party fork of swift-nio-ssh (Wellz26), not Apple's repo.
 - Tracker is GitHub issues in this repo (`gh issue ...`). Reference issues from commits with `refs #<n>`.
 - Update `CONTEXT.md` when domain terms change; add an ADR only for hard-to-reverse, surprising trade-offs.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in this repo's GitHub Issues (`gh` CLI). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage roles map 1:1 to repo labels. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/Sources/HerdrMobile/Console/AgentCardView.swift
+++ b/Sources/HerdrMobile/Console/AgentCardView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// One Console card (#8): agent kind and status up front, Host, pane
+/// One Console card (#8): agent name and status up front, Host, pane
 /// address, and workspace as context, plus the last-output snippet.
 struct AgentCardView: View {
     let agent: ConsoleAgent
@@ -8,7 +8,7 @@ struct AgentCardView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .firstTextBaseline) {
-                Text(agent.agent.kind)
+                Text(agent.agent.displayName)
                     .font(.headline)
                 AgentStatusBadge(status: agent.agent.status)
                 Spacer()

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -203,6 +203,6 @@ struct AgentDetailView: View {
     /// The Agent's screen title, shared with the close store's dialog copy so
     /// both name the same thing.
     private static func displayTitle(for agent: ConsoleAgent) -> String {
-        agent.agent.title.isEmpty ? agent.agent.kind : agent.agent.title
+        agent.agent.title.isEmpty ? agent.agent.displayName : agent.agent.title
     }
 }

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -178,8 +178,12 @@ enum RemoteShellPath {
 /// notifications.
 struct Agent: Sendable, Equatable {
     let terminalID: String
-    /// The agent program herdr detected: "claude", "codex", ...
+    /// The agent program herdr detected: "claude", "codex", ... Behavior
+    /// stays keyed off this; labels prefer `displayName`.
     let kind: String
+    /// The server-reported agent name the herdr TUI shows (`display_agent`,
+    /// falling back to `name`); nil when the server reports neither.
+    let name: String?
     /// Terminal title with spinner/status glyphs stripped.
     let title: String
     /// Mutable: the Console applies `pane.agent_status_changed` deltas in
@@ -192,12 +196,18 @@ struct Agent: Sendable, Equatable {
     let cwd: String
     let revision: Int
 
+    /// The card's primary label (#41): the server-reported name when present,
+    /// otherwise the detected kind.
+    var displayName: String { name ?? kind }
+
     init(
         terminalID: String, kind: String, title: String, status: AgentStatus,
-        workspaceID: String, tabID: String, paneID: String, cwd: String, revision: Int
+        workspaceID: String, tabID: String, paneID: String, cwd: String, revision: Int,
+        name: String? = nil
     ) {
         self.terminalID = terminalID
         self.kind = kind
+        self.name = name
         self.title = title
         self.status = status
         self.workspaceID = workspaceID
@@ -220,8 +230,15 @@ struct Agent: Sendable, Equatable {
             tabID: info.tabID,
             paneID: info.paneID,
             cwd: info.cwd ?? "",
-            revision: info.revision
+            revision: info.revision,
+            name: Self.nonEmpty(info.displayAgent) ?? Self.nonEmpty(info.name)
         )
+    }
+
+    /// An empty wire string carries no name; treating it as missing keeps the
+    /// fallback chain from rendering a blank card label.
+    private static func nonEmpty(_ value: String?) -> String? {
+        value.flatMap { $0.isEmpty ? nil : $0 }
     }
 }
 

--- a/Tests/HerdrMobileTests/HerdrWireTests.swift
+++ b/Tests/HerdrMobileTests/HerdrWireTests.swift
@@ -59,10 +59,47 @@ import Testing
         let agent = Agent(try JSONDecoder().decode(AgentInfo.self, from: Data(json.utf8)))
 
         #expect(agent.kind == "unknown")
+        #expect(agent.name == nil)
+        #expect(agent.displayName == "unknown")
         #expect(agent.title == "")
         #expect(agent.cwd == "")
         // An unrecognized status survives with its raw value intact.
         #expect(agent.status == AgentStatus(rawValue: "haunted"))
+    }
+
+    @Test func agentMappingResolvesNameWithDisplayAgentPrecedence() throws {
+        // `herdr agent start testbash` shape: unrecognized program, but the
+        // server reports a meaningful name (#41).
+        let json = #"{"terminal_id":"t","display_agent":"testbash","name":"agent-3","agent_status":"working","workspace_id":"w","tab_id":"w:t","pane_id":"w:p","focused":false,"revision":1}"#
+
+        let agent = Agent(try JSONDecoder().decode(AgentInfo.self, from: Data(json.utf8)))
+
+        #expect(agent.name == "testbash")
+        #expect(agent.displayName == "testbash")
+        #expect(agent.kind == "unknown")
+    }
+
+    @Test func agentMappingFallsBackToWireNameThenKind() throws {
+        let named = #"{"terminal_id":"t","name":"agent-3","agent_status":"working","workspace_id":"w","tab_id":"w:t","pane_id":"w:p","focused":false,"revision":1}"#
+        let detectedOnly = #"{"terminal_id":"t","agent":"claude","agent_status":"working","workspace_id":"w","tab_id":"w:t","pane_id":"w:p","focused":false,"revision":1}"#
+
+        let namedAgent = Agent(try JSONDecoder().decode(AgentInfo.self, from: Data(named.utf8)))
+        let detectedAgent = Agent(
+            try JSONDecoder().decode(AgentInfo.self, from: Data(detectedOnly.utf8)))
+
+        #expect(namedAgent.displayName == "agent-3")
+        // A recognized agent without a server-reported name renders as today.
+        #expect(detectedAgent.name == nil)
+        #expect(detectedAgent.displayName == "claude")
+    }
+
+    @Test func agentMappingTreatsEmptyWireNamesAsMissing() throws {
+        let json = #"{"terminal_id":"t","agent":"codex","display_agent":"","name":"","agent_status":"working","workspace_id":"w","tab_id":"w:t","pane_id":"w:p","focused":false,"revision":1}"#
+
+        let agent = Agent(try JSONDecoder().decode(AgentInfo.self, from: Data(json.utf8)))
+
+        #expect(agent.name == nil)
+        #expect(agent.displayName == "codex")
     }
 
     @Test func agentMappingFallsBackToUnstrippedTitle() throws {

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Closes #41

## What

Console cards labeled agents by the detected agent program only, so any pane herdr does not recognize rendered as `unknown` even when the server reports a meaningful name (e.g. `herdr agent start testbash`).

The card's primary label now resolves with precedence `display_agent` → `name` → detected kind → `"unknown"`:

- `Agent` gains `name: String?` (the server-reported name, `display_agent ?? name`, empty wire strings treated as missing) and a computed `displayName` (`name ?? kind`). The detected `kind` is kept as-is; nothing keyed off it changes behavior.
- `AgentCardView` renders `displayName` as the headline.
- `AgentDetailView`'s empty-title fallback also uses `displayName` so the detail screen and close dialog name the agent consistently (small step beyond the card, called out here on purpose).

## Tests

- New `HerdrWireTests` cases cover the precedence chain (`display_agent` wins, `name` fallback, kind fallback), empty-string normalization, and the extended missing-field degradation case.
- Full suite (309 tests, including local sshd/socat e2e) passes on the iPhone 17 simulator.