### PR TITLE
fix(transport): scope wake command to host socket

### DIFF
--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -879,7 +879,7 @@ actor SSHTransport: Transport {
             return try await operation()
         } catch TransportError.serverNotRunning(let path) {
             do {
-                try await wakeServer()
+                try await wakeServer(socketPath: path)
             } catch TransportError.cancelled {
                 throw TransportError.cancelled
             } catch TransportError.timedOut {
@@ -899,25 +899,43 @@ actor SSHTransport: Transport {
     /// is deadline-bounded: a hung wake command cannot be ended client-side
     /// (sshd holds the channel until the command exits), so waiters abandon
     /// it with `.timedOut` while it keeps its slot until it really ends.
-    private func wakeServer() async throws {
+    private func wakeServer(socketPath: String) async throws {
         try await Self.withRequestDeadline(requestTimeout) {
             try await self.wake.value {
-                try await self.runWakeCommand()
+                try await self.runWakeCommand(socketPath: socketPath)
             }
         }
     }
 
     /// Runs the wake command over a slot-gated no-PTY exec channel with
-    /// stdin at EOF from the start (`< /dev/null`). The bridge's entry point
-    /// ensures the server is running (spawn + wait for socket) before it
-    /// starts bridging; the bridge then reads EOF and exits — so the command
-    /// completing implies a live socket, and its own lifetime bounds the
-    /// channel without writing or closing anything mid-flight.
-    private func runWakeCommand() async throws {
+    /// stdin at EOF from the start (`< /dev/null`). `HERDR_SOCKET_PATH` pins
+    /// the bridge and the server it spawns to this Host's configured socket.
+    /// The path rides as a positional argument so only the outer shell ever
+    /// quotes it. The bridge's entry point ensures the server is running
+    /// (spawn + wait for socket) before it starts bridging; the bridge then
+    /// reads EOF and exits — so the command completing implies a live socket,
+    /// and its own lifetime bounds the channel without writing or closing
+    /// anything mid-flight.
+    private func runWakeCommand(socketPath: String) async throws {
+        let command = try Self.wakeExecCommand(
+            wakeCommand: wakeCommand, socketPath: socketPath)
         try await acquireExecChannelSlot()
         defer { releaseExecChannelSlot() }
-        _ = try await client.executeCommand(
-            Self.cLocaleCommand("\(wakeCommand) < /dev/null"))
+        _ = try await client.executeCommand(command)
+    }
+
+    /// The full remote command for waking this Host's configured herdr
+    /// server. It runs under POSIX sh because login shells such as fish do
+    /// not share assignment syntax, and passes the socket as an argument so
+    /// the wrapper script never interpolates path bytes.
+    static func wakeExecCommand(wakeCommand: String, socketPath: String) throws -> String {
+        guard let quotedSocketPath = RemoteShellPath.quotedAbsolute(socketPath) else {
+            throw TransportError.channelFailed(
+                detail: "The remote socket path cannot be quoted safely.")
+        }
+        let command = "/bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
+            + "\(wakeCommand) < /dev/null' wake \(quotedSocketPath)"
+        return cLocaleCommand(command)
     }
 
     /// One no-PTY exec channel per request, raced against the per-request

--- a/Tests/HerdrMobileTests/ColdStartE2ETests.swift
+++ b/Tests/HerdrMobileTests/ColdStartE2ETests.swift
@@ -16,7 +16,7 @@ import Testing
         "requires localhost sshd, socat, and an authorized Ed25519 test key"),
     .timeLimit(.minutes(1)))
 struct ColdStartE2ETests {
-    @Test func wakeStartsServerAndRetriedRequestSucceeds() async throws {
+    @Test func wakeReceivesConfiguredSocketAndRetriedRequestSucceeds() async throws {
         // Server "stopped": stale socket at the configured path. The wake
         // script brings the fake server online at that path, exactly like
         // the bridge entry point ensures a live socket before returning.
@@ -29,6 +29,7 @@ struct ColdStartE2ETests {
         }
         defer { server.stop() }
         let wake = try WakeScript(commands: [
+            "test \"$HERDR_SOCKET_PATH\" = '\(stale.path)' || exit 1",
             "rm -f '\(stale.path)'",
             "ln -s '\(server.socketPath)' '\(stale.path)'",
         ])
@@ -185,5 +186,24 @@ struct WakeCommandDefaultTests {
             socatPath: "/opt/homebrew/bin/socat")
 
         #expect(settings.wakeCommand == "herdr remote-client-bridge")
+    }
+
+    @Test func scopesWakeCommandToConfiguredSocket() throws {
+        let command = try SSHTransport.wakeExecCommand(
+            wakeCommand: "herdr remote-client-bridge",
+            socketPath: "/home/u/My Config/herdr.sock")
+
+        #expect(
+            command == "LC_ALL=C /bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
+                + "herdr remote-client-bridge < /dev/null' wake "
+                + "'/home/u/My Config/herdr.sock'")
+    }
+
+    @Test func refusesUnquotableSocketPath() {
+        #expect(throws: TransportError.self) {
+            _ = try SSHTransport.wakeExecCommand(
+                wakeCommand: "herdr remote-client-bridge",
+                socketPath: "/tmp/it's-a.sock")
+        }
     }
 }

--- a/Tests/HerdrMobileTests/ColdStartE2ETests.swift
+++ b/Tests/HerdrMobileTests/ColdStartE2ETests.swift
@@ -173,8 +173,8 @@ private struct WakeScript {
 
 // The default wake command is the real herdr invocation from spec #16: the
 // remote bridge's entry point ensures the server is running before bridging.
-@Suite("Wake command default")
-struct WakeCommandDefaultTests {
+@Suite("Wake command")
+struct WakeCommandTests {
     @Test func defaultsToHerdrRemoteClientBridge() {
         let settings = SSHTransportSettings(
             host: "example.invalid",

--- a/Tests/HerdrMobileTests/TransportFailureModesE2ETests.swift
+++ b/Tests/HerdrMobileTests/TransportFailureModesE2ETests.swift
@@ -25,11 +25,14 @@ struct TransportFailureModesE2ETests {
     }
 
     @Test func staleSocketMapsToServerNotRunning() async throws {
-        // socat exits with stderr `E connect(...): Connection refused`.
+        // socat exits with stderr `E connect(...): Connection refused`, and
+        // an ineffective wake leaves the configured server stopped.
         let stale = try StaleUnixSocket()
         defer { stale.remove() }
 
-        try await withFailingTransport(socketPath: stale.path) { transport in
+        try await withFailingTransport(
+            socketPath: stale.path, wakeCommand: "false"
+        ) { transport in
             await #expect(throws: TransportError.serverNotRunning(path: stale.path)) {
                 try await transport.ping()
             }
@@ -56,12 +59,14 @@ struct TransportFailureModesE2ETests {
     private func withFailingTransport(
         socketPath: String,
         socatPath: String? = nil,
+        wakeCommand: String? = nil,
         body: (SSHTransport) async throws -> Void
     ) async throws {
         let environment = try #require(LocalSSHTestEnvironment.current)
         let transport = try await SSHTransport.connect(
             settings: environment.makeSettings(
-                socket: .absolutePath(socketPath), socatPath: socatPath))
+                socket: .absolutePath(socketPath), socatPath: socatPath,
+                wakeCommand: wakeCommand))
         do {
             try await body(transport)
         } catch {


### PR DESCRIPTION
## Summary

- pin the cold-start wake command to the Host configured socket with HERDR_SOCKET_PATH
- pass the already resolved failing socket path through the bounded wake flow
- cover command construction, unsafe path rejection, real SSH cold-start behavior, and ineffective wake failures

## Verification

- verified with herdr 0.7.4 that remote-client-bridge starts the server on the supplied API and client socket paths without starting the default session
- scripts/generate-wire-types.py --check --schema scripts/herdr-schema.json
- xcodebuild test -project HerdrMobile.xcodeproj -scheme HerdrMobile -destination platform=iOS\ Simulator,name=iPhone\ 17,OS=latest (311 tests passed)
- two-axis code review: Standards 0 findings, Spec 0 findings

Closes #40