### PR TITLE
fix: harden console lifecycle and session isolation

### DIFF
--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -1,5 +1,31 @@
 import SwiftUI
 
+/// Owns Dictation for one Agent detail and translates every surface-level
+/// interruption into the same discard-and-release behavior. Keeping these
+/// events together prevents a shared microphone engine from surviving a
+/// navigation, Attach handover, or app background transition.
+@MainActor
+final class AgentDetailDictationSession {
+    enum Interruption: CaseIterable, Sendable {
+        case detailDisappeared
+        case openingAttach
+        case appBackgrounded
+    }
+
+    let dictation: DictationStore
+
+    init(dictation: DictationStore) {
+        self.dictation = dictation
+    }
+
+    func handle(_ interruption: Interruption) {
+        switch interruption {
+        case .detailDisappeared, .openingAttach, .appBackgrounded:
+            dictation.cancelDictation()
+        }
+    }
+}
+
 /// The Agent detail screen (#9, #10): scrollback plus live output in a real
 /// terminal, read-only (Observe semantics per CONTEXT.md), with a native
 /// input bar below it (#10) for answering a Blocked agent without Attach,
@@ -15,13 +41,14 @@ struct AgentDetailView: View {
     private let transport: @Sendable () async -> (any Transport)?
     @State private var store: ObserveTerminalStore
     @State private var input: AgentInputStore
-    @State private var dictation: DictationStore
+    @State private var dictationSession: AgentDetailDictationSession
     @State private var attach: AttachTerminalStore?
     @State private var close: ClosePaneStore
     @State private var isConfirmingClose = false
     @State private var closeErrorMessage: String?
     @State private var isShowingSettings = false
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
 
     init(
         agent: ConsoleAgent, console: ConsoleStore,
@@ -37,10 +64,11 @@ struct AgentDetailView: View {
                 target: agent.agent.paneID, transport: transport))
         let inputStore = AgentInputStore(target: agent.agent.paneID, transport: transport)
         _input = State(initialValue: inputStore)
-        _dictation = State(
-            initialValue: DictationStore(
-                engine: dictationEngine, draft: inputStore,
-                language: { dictationSettings.selectedLanguage }))
+        _dictationSession = State(
+            initialValue: AgentDetailDictationSession(
+                dictation: DictationStore(
+                    engine: dictationEngine, draft: inputStore,
+                    language: { dictationSettings.selectedLanguage })))
         _close = State(
             initialValue: ClosePaneStore(paneTitle: Self.displayTitle(for: agent)) {
                 try await console.closePane(agent.agent.paneID, on: agent.hostID)
@@ -72,7 +100,7 @@ struct AgentDetailView: View {
             .overlay { statusOverlay }
 
             AgentInputBar(
-                store: input, dictation: dictation,
+                store: input, dictation: dictationSession.dictation,
                 onOpenSettings: { isShowingSettings = true })
         }
         .navigationTitle(title)
@@ -133,7 +161,15 @@ struct AgentDetailView: View {
             guard generation != nil, attach == nil else { return }
             reconnectObserve()
         }
+        .onChange(of: scenePhase) {
+            // First-use microphone permission can make the scene inactive; only
+            // actual backgrounding should cancel that same startup attempt.
+            if scenePhase == .background {
+                dictationSession.handle(.appBackgrounded)
+            }
+        }
         .onDisappear {
+            dictationSession.handle(.detailDisappeared)
             // Explicit close, never abandonment: a live exec channel ignores
             // task cancellation (ADR 0002). Registering with the Console is
             // synchronous, so the next detail waits for this channel close.
@@ -148,6 +184,7 @@ struct AgentDetailView: View {
     /// terminal channel, so Observe must be fully stopped (channel torn
     /// down) before the Attach screen appears and opens its own.
     private func openAttach() {
+        dictationSession.handle(.openingAttach)
         let observe = store
         let attachStore = AttachTerminalStore(target: agent.agent.paneID, transport: transport)
         Task {

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -129,6 +129,10 @@ struct AgentDetailView: View {
             // model-not-ready hint routes here to download the model (#34).
             SettingsView(store: dictationSettings)
         }
+        .onChange(of: console.hostConnectionGenerations[agent.hostID]) { _, generation in
+            guard generation != nil, attach == nil else { return }
+            reconnectObserve()
+        }
         .onDisappear {
             // Explicit close, never abandonment: a live exec channel ignores
             // task cancellation (ADR 0002). Registering with the Console is
@@ -157,7 +161,23 @@ struct AgentDetailView: View {
     /// resuming means a fresh store; the `.id` above rebuilds the terminal
     /// view around it.
     private func resumeObserve() {
-        store = ObserveTerminalStore(target: agent.agent.paneID, transport: transport)
+        let previous = store
+        let replacement = ObserveTerminalStore(
+            target: agent.agent.paneID, transport: transport)
+        replacement.reuseViewSize(from: previous)
+        store = replacement
+    }
+
+    /// A real Host reconnect means the old terminal stream is permanently
+    /// closed. Register its teardown before minting the replacement; the new
+    /// store's transport provider waits for that task before taking the Host's
+    /// single terminal channel.
+    private func reconnectObserve() {
+        let observe = store
+        console.scheduleTerminalTeardown(for: agent.hostID) {
+            await observe.stop()
+        }
+        resumeObserve()
     }
 
     /// Confirmed close: fire `pane.close`, and only on success stop Observe

--- a/Sources/HerdrMobile/Console/AgentInputBar.swift
+++ b/Sources/HerdrMobile/Console/AgentInputBar.swift
@@ -31,6 +31,8 @@ struct AgentInputBar: View {
                     axis: .vertical
                 )
                 .textFieldStyle(.roundedBorder)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
                 .lineLimit(1...5)
                 .focused($messageFocused)
                 .submitLabel(.send)

--- a/Sources/HerdrMobile/Console/ConsoleStore.swift
+++ b/Sources/HerdrMobile/Console/ConsoleStore.swift
@@ -27,6 +27,9 @@ final class ConsoleStore {
     /// Snapshot failures are separate from connection state: an events
     /// channel can remain connected while the Console data RPC is failing.
     private(set) var hostSyncErrors: [Host.ID: String] = [:]
+    /// Monotonic reconnect epochs per Host. Initial connection is generation
+    /// zero; only a return to connected after a real disconnect advances it.
+    private(set) var hostConnectionGenerations: [Host.ID: UInt64] = [:]
 
     @ObservationIgnored private var feeds: [Host.ID: HostFeed] = [:]
     @ObservationIgnored private let makeSession:
@@ -62,6 +65,7 @@ final class ConsoleStore {
             feeds[id] = nil
             hostStatuses[id] = nil
             hostSyncErrors[id] = nil
+            hostConnectionGenerations[id] = nil
         }
         for host in hosts where feeds[host.id] == nil {
             startFeed(for: host)
@@ -89,6 +93,7 @@ final class ConsoleStore {
         let session = makeSession(host, Self.subscriptions(paneIDs: []))
         let feed = HostFeed(host: host, session: session)
         feeds[host.id] = feed
+        hostConnectionGenerations[host.id] = 0
         feed.consumeTask = Task { [weak self] in
             for await update in session.updates {
                 guard let self else { return }
@@ -115,6 +120,15 @@ final class ConsoleStore {
         guard feeds[feed.host.id] === feed else { return }
         switch update {
         case .status(let status):
+            if status == .connected {
+                if feed.hasConnected, feed.connectionWasInterrupted {
+                    hostConnectionGenerations[feed.host.id, default: 0] &+= 1
+                }
+                feed.hasConnected = true
+                feed.connectionWasInterrupted = false
+            } else if feed.hasConnected {
+                feed.connectionWasInterrupted = true
+            }
             hostStatuses[feed.host.id] = status
             if status == .connected {
                 scheduleResync(feed: feed)
@@ -470,6 +484,8 @@ private final class HostFeed {
     var resyncTask: Task<Void, Never>?
     var resyncRetryTask: Task<Void, Never>?
     var resyncPending = false
+    var hasConnected = false
+    var connectionWasInterrupted = false
     var byPane: [String: ConsoleAgent] = [:]
     /// Latest status deltas by pane, versioned so a snapshot only preserves
     /// events that arrived after that snapshot request began.

--- a/Sources/HerdrMobile/Console/ConsoleStore.swift
+++ b/Sources/HerdrMobile/Console/ConsoleStore.swift
@@ -147,6 +147,7 @@ final class ConsoleStore {
     }
 
     private func runResync(feed: HostFeed) async {
+        let statusRevisionBeforeSnapshot = feed.statusChangeRevision
         guard let transport = await feed.session.currentTransport else { return }
         do {
             let snapshot = try await transport.sessionSnapshot()
@@ -154,7 +155,9 @@ final class ConsoleStore {
             feed.resyncRetryTask?.cancel()
             feed.resyncRetryTask = nil
             hostSyncErrors[feed.host.id] = nil
-            apply(snapshot, to: feed)
+            apply(
+                snapshot, to: feed,
+                preservingStatusChangesAfter: statusRevisionBeforeSnapshot)
             await feed.session.updateSubscriptions(
                 Self.subscriptions(paneIDs: feed.byPane.keys))
             refreshSnippets(feed: feed, transport: transport)
@@ -194,7 +197,11 @@ final class ConsoleStore {
         }
     }
 
-    private func apply(_ snapshot: SessionSnapshot, to feed: HostFeed) {
+    private func apply(
+        _ snapshot: SessionSnapshot,
+        to feed: HostFeed,
+        preservingStatusChangesAfter snapshotStartRevision: UInt64
+    ) {
         let workspaces = Dictionary(
             snapshot.workspaces.map { ($0.workspaceID, $0) }) { first, _ in first }
         var byPane: [String: ConsoleAgent] = [:]
@@ -209,6 +216,13 @@ final class ConsoleStore {
                 repoName: workspace?.worktree?.repoName,
                 lastOutputSnippet: feed.byPane[agent.paneID]?.lastOutputSnippet)
         }
+        for (paneID, change) in feed.latestStatusChanges
+        where change.revision > snapshotStartRevision {
+            guard var row = byPane[paneID] else { continue }
+            row.agent.status = change.status
+            byPane[paneID] = row
+        }
+        feed.latestStatusChanges.removeAll(keepingCapacity: true)
         feed.byPane = byPane
         feed.workspaces = snapshot.workspaces
             .map { ConsoleWorkspace(id: $0.workspaceID, label: $0.label) }
@@ -222,7 +236,10 @@ final class ConsoleStore {
             let rawStatus = data["agent_status"]?.stringValue,
             var row = feed.byPane[paneID]
         else { return }
-        row.agent.status = AgentStatus(rawValue: rawStatus)
+        let status = AgentStatus(rawValue: rawStatus)
+        feed.statusChangeRevision &+= 1
+        feed.latestStatusChanges[paneID] = (feed.statusChangeRevision, status)
+        row.agent.status = status
         feed.byPane[paneID] = row
         rebuild()
         // A status flip usually means fresh output worth showing — for
@@ -445,6 +462,10 @@ private final class HostFeed {
     var resyncRetryTask: Task<Void, Never>?
     var resyncPending = false
     var byPane: [String: ConsoleAgent] = [:]
+    /// Latest status deltas by pane, versioned so a snapshot only preserves
+    /// events that arrived after that snapshot request began.
+    var statusChangeRevision: UInt64 = 0
+    var latestStatusChanges: [String: (revision: UInt64, status: AgentStatus)] = [:]
     /// Workspaces from this Host's latest snapshot, for the new-agent picker.
     var workspaces: [ConsoleWorkspace] = []
     var snippetFetchesInFlight: Set<String> = []

--- a/Sources/HerdrMobile/Console/ConsoleStore.swift
+++ b/Sources/HerdrMobile/Console/ConsoleStore.swift
@@ -247,12 +247,12 @@ final class ConsoleStore {
     private func applyStatusChange(_ data: JSONValue, feed: HostFeed) {
         guard
             let paneID = data["pane_id"]?.stringValue,
-            let rawStatus = data["agent_status"]?.stringValue,
-            var row = feed.byPane[paneID]
+            let rawStatus = data["agent_status"]?.stringValue
         else { return }
         let status = AgentStatus(rawValue: rawStatus)
         feed.statusChangeRevision &+= 1
         feed.latestStatusChanges[paneID] = (feed.statusChangeRevision, status)
+        guard var row = feed.byPane[paneID] else { return }
         row.agent.status = status
         feed.byPane[paneID] = row
         rebuild()

--- a/Sources/HerdrMobile/Console/ConsoleStore.swift
+++ b/Sources/HerdrMobile/Console/ConsoleStore.swift
@@ -269,7 +269,10 @@ final class ConsoleStore {
     private func refreshSnippet(feed: HostFeed, paneID: String, transport: any Transport) {
         // One in-flight read per pane; a burst of status flips must not pile
         // requests onto the slot queue.
-        guard feed.snippetFetchesInFlight.insert(paneID).inserted else { return }
+        guard feed.snippetFetchesInFlight.insert(paneID).inserted else {
+            feed.pendingSnippetRefreshes.insert(paneID)
+            return
+        }
         Task { [weak self] in
             let read = try? await transport.readPane(
                 PaneReadParams(
@@ -277,13 +280,19 @@ final class ConsoleStore {
                     stripANSI: true))
             guard let self else { return }
             feed.snippetFetchesInFlight.remove(paneID)
+            guard self.feeds[feed.host.id] === feed else { return }
+            if let read, var row = feed.byPane[paneID] {
+                row.lastOutputSnippet = Self.snippet(fromPaneText: read.text)
+                feed.byPane[paneID] = row
+                self.rebuild()
+            }
             guard
-                let read, self.feeds[feed.host.id] === feed,
-                var row = feed.byPane[paneID]
+                feed.pendingSnippetRefreshes.remove(paneID) != nil,
+                feed.byPane[paneID] != nil,
+                let currentTransport = await feed.session.currentTransport,
+                self.feeds[feed.host.id] === feed
             else { return }
-            row.lastOutputSnippet = Self.snippet(fromPaneText: read.text)
-            feed.byPane[paneID] = row
-            self.rebuild()
+            self.refreshSnippet(feed: feed, paneID: paneID, transport: currentTransport)
         }
     }
 
@@ -469,6 +478,8 @@ private final class HostFeed {
     /// Workspaces from this Host's latest snapshot, for the new-agent picker.
     var workspaces: [ConsoleWorkspace] = []
     var snippetFetchesInFlight: Set<String> = []
+    /// Coalesced follow-up reads for panes refreshed while a read was active.
+    var pendingSnippetRefreshes: Set<String> = []
 
     init(host: Host, session: EventsSession) {
         self.host = host

--- a/Sources/HerdrMobile/Console/ConsoleView.swift
+++ b/Sources/HerdrMobile/Console/ConsoleView.swift
@@ -172,6 +172,8 @@ struct ConsoleView: View {
         switch failure {
         case .authenticationFailed:
             "Authentication failed. Update the credentials in Hosts."
+        case .deviceKeyCorrupt:
+            "The Device Key is corrupted. Edit this Host, replace the Device Key, then install its new public key on every Device Key Host."
         case .hostKeyRejected:
             "The host key is not trusted. Verify it in Hosts."
         case .hostKeyMismatch:

--- a/Sources/HerdrMobile/Console/ObserveTerminalStore.swift
+++ b/Sources/HerdrMobile/Console/ObserveTerminalStore.swift
@@ -70,6 +70,14 @@ final class ObserveTerminalStore {
         self.transport = transport
     }
 
+    /// Starts a replacement pipeline with the geometry already reported by
+    /// the same on-screen terminal. SwiftUI can replace its representable
+    /// without another layout pass when the bounds have not changed.
+    func reuseViewSize(from previous: ObserveTerminalStore) {
+        guard let cols = previous.cols, let rows = previous.rows else { return }
+        viewDidResize(cols: cols, rows: rows)
+    }
+
     /// The terminal view's geometry, reported on first layout and on every
     /// change (rotation, split view). The first report starts the pipeline;
     /// a change restarts the live-follow with the new size.

--- a/Sources/HerdrMobile/Console/ObserveTerminalStore.swift
+++ b/Sources/HerdrMobile/Console/ObserveTerminalStore.swift
@@ -52,6 +52,8 @@ final class ObserveTerminalStore {
     private var hasLoadedTranscript = false
     private var stopRequested = false
     private var restartRequested = false
+    private var isAwaitingTransport = false
+    private var activeTransport: (any Transport)?
     private var liveStream: TerminalFrameStream?
     private var runTask: Task<Void, Never>?
     private var transcriptRefreshTask: Task<Void, Never>?
@@ -112,7 +114,12 @@ final class ObserveTerminalStore {
         if let stream = liveStream {
             await stream.end()
         }
-        if let task = runTask {
+        // A run waiting for Console's teardown barrier owns no terminal
+        // resource yet. Waiting for that run here can make the barrier wait
+        // on itself during back-to-back replacements. `stopRequested` makes
+        // the run exit before backfill or stream creation once its provider
+        // is released.
+        if !isAwaitingTransport, let task = runTask {
             await task.value
         }
         if let task = transcriptRefreshTask {
@@ -131,6 +138,7 @@ final class ObserveTerminalStore {
     @discardableResult
     func loadEarlier() -> Bool {
         guard case .live = status else { return false }
+        guard let activeTransport else { return false }
         guard hasLoadedTranscript, canLoadEarlier, !isLoadingEarlier else { return false }
         guard transcriptLineLimit < Self.maximumTranscriptLines else {
             canLoadEarlier = false
@@ -143,27 +151,30 @@ final class ObserveTerminalStore {
         transcriptLineLimit = requestedLimit
         isLoadingEarlier = true
         historyLoadTask = Task {
-            await self.runHistoryLoad(previousLimit: previousLimit, requestedLimit: requestedLimit)
+            await self.runHistoryLoad(
+                transport: activeTransport, previousLimit: previousLimit,
+                requestedLimit: requestedLimit)
         }
         return true
     }
 
-    private func runHistoryLoad(previousLimit: Int, requestedLimit: Int) async {
-        let succeeded: Bool
-        if let transport = await transport() {
-            succeeded = await refreshTranscript(
-                transport: transport, replacing: true, requestedLines: requestedLimit)
-        } else {
-            succeeded = false
+    private func runHistoryLoad(
+        transport: any Transport, previousLimit: Int, requestedLimit: Int
+    ) async {
+        defer {
+            isLoadingEarlier = false
+            historyLoadTask = nil
         }
+        guard !stopRequested, !Task.isCancelled else { return }
+        let succeeded = await refreshTranscript(
+            transport: transport, replacing: true, requestedLines: requestedLimit)
+        guard !stopRequested, !Task.isCancelled else { return }
 
         if !succeeded, loadedTranscriptLineLimit < requestedLimit,
             transcriptLineLimit == requestedLimit
         {
             transcriptLineLimit = previousLimit
         }
-        isLoadingEarlier = false
-        historyLoadTask = nil
     }
 
     private func start() {
@@ -182,12 +193,21 @@ final class ObserveTerminalStore {
     /// One pipeline lifetime: backfill once, then observe/consume/restart
     /// until stopped or failed. Exactly one run loop exists at a time.
     private func run() async {
-        defer { runTask = nil }
+        defer {
+            activeTransport = nil
+            runTask = nil
+        }
         while !stopRequested {
-            guard let transport = await transport() else {
+            activeTransport = nil
+            isAwaitingTransport = true
+            let currentTransport = await transport()
+            isAwaitingTransport = false
+            guard !stopRequested else { return }
+            guard let transport = currentTransport else {
                 status = .failed("The Host is not connected.")
                 return
             }
+            activeTransport = transport
             if !didLoadInitialTranscript {
                 didLoadInitialTranscript = true
                 _ = await refreshTranscript(transport: transport, replacing: false)

--- a/Sources/HerdrMobile/Dictation/DictationEngine.swift
+++ b/Sources/HerdrMobile/Dictation/DictationEngine.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+/// Identifies one owner's recording attempt across asynchronous startup and
+/// teardown. A stop for an older screen must never affect a newer session on
+/// the app-wide shared engine.
+struct DictationSessionID: Hashable, Sendable {
+    private let rawValue = UUID()
+}
+
 /// One transcription update from a `DictationEngine`. `text` is the best
 /// transcription of the current utterance so far: the engine revises it as
 /// more audio arrives (volatile partials), then emits a last value with
@@ -56,13 +63,14 @@ protocol DictationEngine: Sendable {
     /// partial→final transcripts. Ensures microphone permission and resolves
     /// the on-device model; throws a `DictationEngineError` before yielding if
     /// the session cannot start (permission denied, model not installed,
-    /// unsupported locale). The stream finishes normally after `stop()` flushes
-    /// the final transcript, and finishes throwing if capture fails
-    /// mid-recording.
-    func start(language: DictationLanguage) async throws
+    /// unsupported locale). The stream finishes normally after the matching
+    /// `stop(sessionID:)` flushes the final transcript, and finishes throwing
+    /// if capture fails mid-recording.
+    func start(sessionID: DictationSessionID, language: DictationLanguage) async throws
         -> AsyncThrowingStream<DictationTranscript, any Error>
 
-    /// Stops capture and finalizes the current utterance: the stream yields
-    /// its final transcript, then finishes. A no-op if no session is active.
-    func stop() async
+    /// Stops capture and finalizes the matching utterance: the stream yields
+    /// its final transcript, then finishes. A no-op when `sessionID` is stale
+    /// or no matching session is active.
+    func stop(sessionID: DictationSessionID) async
 }

--- a/Sources/HerdrMobile/Dictation/DictationStore.swift
+++ b/Sources/HerdrMobile/Dictation/DictationStore.swift
@@ -94,6 +94,17 @@ final class DictationStore {
     /// The live session's consume task; non-nil exactly while a session is in
     /// flight. Doubles as the in-flight guard.
     private var sessionTask: Task<Void, Never>?
+    /// The generation handed to every engine call for the current hold. The
+    /// shared engine ignores teardown from older detail screens.
+    private var sessionID: DictationSessionID?
+    /// True only after the engine has finished its asynchronous startup and
+    /// returned a transcript stream. A release during startup cancels the
+    /// session task; a release after this point lets the stream flush its final.
+    private var engineDidStart = false
+    /// The one stop request for this session. Keeping the task lets startup
+    /// wait for an early no-op stop, then issue a second stop if the engine
+    /// nevertheless returned a late stream.
+    private var stopTask: Task<Void, Never>?
     /// Set by `cancelDictation()` so the consume loop stops touching the draft
     /// and the session ends at `idle` even if the engine still flushes a final.
     private var isCancelled = false
@@ -151,24 +162,31 @@ final class DictationStore {
         captureBase()
         latestTranscript = ""
         isCancelled = false
+        engineDidStart = false
+        stopTask = nil
         // Snapshot the selected language now so a change in Settings mid-hold
         // never swaps the engine's locale under a live recording.
         sessionLanguage = currentLanguage()
+        let sessionID = DictationSessionID()
+        self.sessionID = sessionID
         // Light the button immediately on touch-down; a first-use permission
         // or model-readiness check happens inside the engine's `start()`.
         state = .recording
-        sessionTask = Task { await self.runSession() }
+        sessionTask = Task { await self.runSession(sessionID: sessionID) }
     }
 
     /// Button release: stop recording. Moves to `finishing` and asks the
     /// engine to flush its final transcript, which ends the stream. Ignored if
     /// no session is active.
     func stopDictation() {
-        guard sessionTask != nil else { return }
+        guard sessionTask != nil, let sessionID else { return }
         if state == .recording {
             state = .finishing
         }
-        Task { await engine.stop() }
+        if !engineDidStart {
+            sessionTask?.cancel()
+        }
+        requestEngineStop(sessionID: sessionID)
     }
 
     /// Slide-off cancel: discard everything this session streamed in and
@@ -176,12 +194,23 @@ final class DictationStore {
     /// then wind the engine down. A botched take never pollutes the draft
     /// (User Story 5). Ignored if no session is active.
     func cancelDictation() {
-        guard sessionTask != nil else { return }
+        guard sessionTask != nil, let sessionID else { return }
+        switch state {
+        case .recording, .finishing:
+            break
+        case .idle, .failed:
+            // A failed session can still be tearing down. A rejected retry's
+            // slide-off must not discard partial text retained by that failure.
+            return
+        }
         isCancelled = true
         draftTarget.draft = basePrefix + baseSuffix
         draftTarget.cursorOffset = basePrefix.count
         // Wind the engine down; any final it flushes is ignored by the loop.
-        Task { await engine.stop() }
+        if !engineDidStart {
+            sessionTask?.cancel()
+        }
+        requestEngineStop(sessionID: sessionID)
     }
 
     /// Dismiss the permission-denied alert and return to idle. The mic button
@@ -210,25 +239,56 @@ final class DictationStore {
         baseSuffix = String(text[caret...])
     }
 
-    private func runSession() async {
+    private func runSession(sessionID: DictationSessionID) async {
         do {
-            let transcripts = try await engine.start(language: sessionLanguage)
+            let transcripts = try await engine.start(
+                sessionID: sessionID, language: sessionLanguage)
+            engineDidStart = true
+            if Task.isCancelled {
+                // An early stop can reach an engine while `start()` is still
+                // suspended and therefore be a no-op. Once a late start
+                // returns, stop again before exposing a live session.
+                await stopTask?.value
+                await engine.stop(sessionID: sessionID)
+                endSession(.idle, sessionID: sessionID)
+                return
+            }
             for try await transcript in transcripts {
                 guard !isCancelled else { continue }
                 latestTranscript = transcript.text
                 applyToDraft()
             }
-            endSession(.idle)
+            await stopTask?.value
+            endSession(.idle, sessionID: sessionID)
         } catch {
             // A cancel that races the stream still ends clean; otherwise keep
             // whatever partial already landed in the draft (User Story 16) and
             // report why it stopped.
-            endSession(isCancelled ? .idle : .failed(Self.failure(for: error)))
+            if isCancelled || Task.isCancelled {
+                await stopTask?.value
+                await engine.stop(sessionID: sessionID)
+                endSession(.idle, sessionID: sessionID)
+            } else {
+                let finalState = State.failed(Self.failure(for: error))
+                state = finalState
+                requestEngineStop(sessionID: sessionID)
+                await stopTask?.value
+                endSession(finalState, sessionID: sessionID)
+            }
         }
     }
 
-    private func endSession(_ finalState: State) {
+    private func requestEngineStop(sessionID: DictationSessionID) {
+        guard self.sessionID == sessionID, stopTask == nil else { return }
+        stopTask = Task { await engine.stop(sessionID: sessionID) }
+    }
+
+    private func endSession(_ finalState: State, sessionID: DictationSessionID) {
+        guard self.sessionID == sessionID else { return }
         sessionTask = nil
+        self.sessionID = nil
+        engineDidStart = false
+        stopTask = nil
         isCancelled = false
         state = finalState
     }

--- a/Sources/HerdrMobile/Dictation/SpeechDictationEngine.swift
+++ b/Sources/HerdrMobile/Dictation/SpeechDictationEngine.swift
@@ -15,13 +15,26 @@ import Speech
 /// exercised manually on device; stores test against a scripted engine
 /// (ADR 0003).
 actor SpeechDictationEngine: DictationEngine {
-    private let audioEngine = AVAudioEngine()
-    private let converter = BufferConverter()
+    private enum SessionPhase {
+        case idle
+        case starting
+        case active
+        case stopping
+    }
 
+    private let microphone: MicrophoneCapture
+
+    private var phase: SessionPhase = .idle
+    private var sessionID: DictationSessionID?
+    private var stopRequestedDuringStart = false
     private var analyzer: SpeechAnalyzer?
     private var transcriber: SpeechTranscriber?
     private var inputContinuation: AsyncStream<AnalyzerInput>.Continuation?
     private var resultsTask: Task<Void, Never>?
+
+    init(microphone: MicrophoneCapture = MicrophoneCapture()) {
+        self.microphone = microphone
+    }
 
     func modelStatus(for language: DictationLanguage) async -> DictationModelStatus {
         guard let resolved = await Self.resolvedLocale(for: language) else {
@@ -73,112 +86,180 @@ actor SpeechDictationEngine: DictationEngine {
         }
     }
 
-    func start(language: DictationLanguage) async throws
+    func start(sessionID: DictationSessionID, language: DictationLanguage) async throws
         -> AsyncThrowingStream<DictationTranscript, any Error>
     {
-        guard await Self.ensureMicrophonePermission() else {
-            throw DictationEngineError.microphonePermissionDenied
+        guard self.sessionID == nil else {
+            throw DictationEngineError.captureFailed("another dictation session is active")
         }
+        self.sessionID = sessionID
+        phase = .starting
+        stopRequestedDuringStart = false
 
-        // Locale identity is unreliable across the Speech framework's own
-        // canonicalization, so resolve through its equivalence lookup (ADR
-        // 0003); a nil result means no on-device support (also the Simulator).
-        guard let resolvedLocale = await Self.resolvedLocale(for: language) else {
-            throw DictationEngineError.localeUnsupported
-        }
-
-        // Downloads happen from Settings, not mid-gesture: if the model is not
-        // installed, fail fast and let the store route the user to Settings.
-        guard await Self.isInstalled(resolvedLocale) else {
-            throw DictationEngineError.modelUnavailable
-        }
-
-        let transcriber = SpeechTranscriber(
-            locale: resolvedLocale,
-            transcriptionOptions: [],
-            reportingOptions: [.volatileResults, .fastResults],
-            attributeOptions: [])
-        self.transcriber = transcriber
-
-        let analyzer = SpeechAnalyzer(modules: [transcriber])
-        self.analyzer = analyzer
-
-        guard let targetFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
-            compatibleWith: [transcriber])
-        else {
-            throw DictationEngineError.captureFailed("no compatible audio format")
-        }
-        try await analyzer.prepareToAnalyze(in: targetFormat)
-
-        let inputStream = AsyncStream<AnalyzerInput> { continuation in
-            self.inputContinuation = continuation
-        }
-        try await analyzer.start(inputSequence: inputStream)
-
-        let (transcripts, continuation) = AsyncThrowingStream<
+        var startupAnalyzer: SpeechAnalyzer?
+        var transcriptContinuation: AsyncThrowingStream<
             DictationTranscript, any Error
-        >.makeStream()
+        >.Continuation?
 
-        // Bridge the transcriber's results onto our transcript stream, then
-        // tear the audio session down once results end.
-        resultsTask = Task { [weak self] in
-            do {
-                for try await result in transcriber.results {
-                    continuation.yield(
-                        DictationTranscript(
-                            text: String(result.text.characters), isFinal: result.isFinal))
-                }
-                continuation.finish()
-            } catch {
-                continuation.finish(throwing: error)
+        do {
+            try checkStartupStillRequested(sessionID: sessionID)
+            guard await Self.ensureMicrophonePermission() else {
+                throw DictationEngineError.microphonePermissionDenied
             }
-            await self?.deactivateAudioSession()
-        }
+            try checkStartupStillRequested(sessionID: sessionID)
 
-        try startCapturingAudio(into: targetFormat)
-        return transcripts
+            // Locale identity is unreliable across the Speech framework's own
+            // canonicalization, so resolve through its equivalence lookup (ADR
+            // 0003); a nil result means no on-device support (also the Simulator).
+            guard let resolvedLocale = await Self.resolvedLocale(for: language) else {
+                throw DictationEngineError.localeUnsupported
+            }
+            try checkStartupStillRequested(sessionID: sessionID)
+
+            // Downloads happen from Settings, not mid-gesture: if the model is
+            // not installed, fail fast and route the user to Settings.
+            guard await Self.isInstalled(resolvedLocale) else {
+                throw DictationEngineError.modelUnavailable
+            }
+            try checkStartupStillRequested(sessionID: sessionID)
+
+            let transcriber = SpeechTranscriber(
+                locale: resolvedLocale,
+                transcriptionOptions: [],
+                reportingOptions: [.volatileResults, .fastResults],
+                attributeOptions: [])
+            self.transcriber = transcriber
+
+            let analyzer = SpeechAnalyzer(modules: [transcriber])
+            startupAnalyzer = analyzer
+            self.analyzer = analyzer
+
+            guard let targetFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+                compatibleWith: [transcriber])
+            else {
+                throw DictationEngineError.captureFailed("no compatible audio format")
+            }
+            try checkStartupStillRequested(sessionID: sessionID)
+            try await analyzer.prepareToAnalyze(in: targetFormat)
+            try checkStartupStillRequested(sessionID: sessionID)
+
+            let inputStream = AsyncStream<AnalyzerInput> { continuation in
+                self.inputContinuation = continuation
+            }
+            try await analyzer.start(inputSequence: inputStream)
+            try checkStartupStillRequested(sessionID: sessionID)
+
+            let (transcripts, continuation) = AsyncThrowingStream<
+                DictationTranscript, any Error
+            >.makeStream()
+            transcriptContinuation = continuation
+
+            let inputContinuation = inputContinuation
+            try microphone.start(into: targetFormat) { buffer in
+                inputContinuation?.yield(AnalyzerInput(buffer: buffer))
+            }
+            // A stop can arrive at any earlier suspension point. This final
+            // check prevents a microphone that started late from escaping.
+            try checkStartupStillRequested(sessionID: sessionID)
+
+            phase = .active
+            resultsTask = Task { [weak self] in
+                do {
+                    for try await result in transcriber.results {
+                        continuation.yield(
+                            DictationTranscript(
+                                text: String(result.text.characters), isFinal: result.isFinal))
+                    }
+                    await self?.finishActiveSession(
+                        sessionID: sessionID, analyzer: analyzer)
+                    continuation.finish()
+                } catch {
+                    await self?.finishActiveSession(
+                        sessionID: sessionID, analyzer: analyzer)
+                    continuation.finish(throwing: error)
+                }
+            }
+            return transcripts
+        } catch {
+            transcriptContinuation?.finish(throwing: error)
+            await rollBackStartup(sessionID: sessionID, analyzer: startupAnalyzer)
+            throw error
+        }
     }
 
-    func stop() async {
-        // Stop the mic first so no further audio queues, then finalize the
-        // analyzer so it flushes the last (final) result and ends the results
-        // stream — which finishes the transcript stream.
-        audioEngine.inputNode.removeTap(onBus: 0)
-        audioEngine.stop()
+    func stop(sessionID: DictationSessionID) async {
+        guard self.sessionID == sessionID else { return }
+        switch phase {
+        case .idle:
+            return
+        case .starting:
+            // Keep the startup claim until its task observes this request and
+            // rolls back. A second caller cannot start against half-torn-down
+            // Speech resources in the meantime.
+            stopRequestedDuringStart = true
+            microphone.stop()
+            inputContinuation?.finish()
+            inputContinuation = nil
+            let analyzer = analyzer
+            await analyzer?.cancelAndFinishNow()
+        case .active:
+            // Stop the mic first so no further audio queues, then finalize the
+            // analyzer so it flushes the last result and ends the stream. The
+            // stopping phase keeps this generation claimed across the await.
+            phase = .stopping
+            microphone.stop()
+            inputContinuation?.finish()
+            inputContinuation = nil
+            let analyzer = analyzer
+            try? await analyzer?.finalizeAndFinishThroughEndOfInput()
+            clearSession(sessionID: sessionID)
+        case .stopping:
+            return
+        }
+    }
+
+    private func checkStartupStillRequested(sessionID: DictationSessionID) throws {
+        if self.sessionID != sessionID || stopRequestedDuringStart {
+            throw CancellationError()
+        }
+        try Task.checkCancellation()
+    }
+
+    private func rollBackStartup(
+        sessionID: DictationSessionID, analyzer: SpeechAnalyzer?
+    ) async {
+        guard self.sessionID == sessionID else { return }
+        microphone.stop()
         inputContinuation?.finish()
         inputContinuation = nil
-        try? await analyzer?.finalizeAndFinishThroughEndOfInput()
+        resultsTask?.cancel()
+        resultsTask = nil
+        await analyzer?.cancelAndFinishNow()
+        clearSession(sessionID: sessionID)
+    }
+
+    private func finishActiveSession(
+        sessionID: DictationSessionID, analyzer: SpeechAnalyzer
+    ) {
+        guard
+            self.sessionID == sessionID,
+            phase == .active,
+            self.analyzer === analyzer
+        else { return }
+        microphone.stop()
+        inputContinuation?.finish()
+        inputContinuation = nil
+        clearSession(sessionID: sessionID)
+    }
+
+    private func clearSession(sessionID: DictationSessionID) {
+        guard self.sessionID == sessionID else { return }
         analyzer = nil
         transcriber = nil
         resultsTask = nil
-    }
-
-    private func startCapturingAudio(into targetFormat: AVAudioFormat) throws {
-        let session = AVAudioSession.sharedInstance()
-        try session.setCategory(.record, mode: .spokenAudio)
-        try session.setActive(true, options: .notifyOthersOnDeactivation)
-
-        let inputNode = audioEngine.inputNode
-        let hardwareFormat = inputNode.outputFormat(forBus: 0)
-        // Capture at the hardware format and convert to the analyzer's format
-        // per buffer; the tap runs on a realtime audio thread, so it captures
-        // only Sendable values (never the actor).
-        let converter = self.converter
-        let continuation = inputContinuation
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: hardwareFormat) { buffer, _ in
-            guard let converted = try? converter.convertBuffer(buffer, to: targetFormat) else {
-                return
-            }
-            continuation?.yield(AnalyzerInput(buffer: converted))
-        }
-
-        audioEngine.prepare()
-        try audioEngine.start()
-    }
-
-    private func deactivateAudioSession() {
-        try? AVAudioSession.sharedInstance().setActive(
-            false, options: .notifyOthersOnDeactivation)
+        stopRequestedDuringStart = false
+        phase = .idle
+        self.sessionID = nil
     }
 
     /// Resolves a language to an on-device-supported locale via the Speech
@@ -212,6 +293,117 @@ actor SpeechDictationEngine: DictationEngine {
     }
 }
 
+/// The narrow AVFoundation boundary used by `MicrophoneCapture`. Tests replace
+/// it with deterministic hardware while production owns the real audio engine
+/// and shared audio session here.
+protocol MicrophoneCaptureHardware: Sendable {
+    func activateSession() throws
+    func installTap(_ receive: @escaping @Sendable (AVAudioPCMBuffer) -> Void)
+    func prepareEngine()
+    func startEngine() throws
+    func removeTap()
+    func stopEngine()
+    func deactivateSession()
+}
+
+/// Owns microphone startup as one transaction. Once the tap has been installed,
+/// every later failure removes it, stops the engine, and deactivates the audio
+/// session before the error escapes, leaving the same instance safe to retry.
+final class MicrophoneCapture: @unchecked Sendable {
+    private let hardware: any MicrophoneCaptureHardware
+    private var isTapInstalled = false
+
+    init(hardware: any MicrophoneCaptureHardware = AVFoundationMicrophoneCaptureHardware()) {
+        self.hardware = hardware
+    }
+
+    func start(
+        into targetFormat: AVAudioFormat,
+        receive: @escaping @Sendable (AVAudioPCMBuffer) -> Void
+    ) throws {
+        // Input formats may change with the audio route between sessions. A
+        // converter is valid only for this tap's input/output format pair.
+        let converter = BufferConverter()
+        do {
+            try hardware.activateSession()
+            hardware.installTap { buffer in
+                guard let converted = try? converter.convertBuffer(buffer, to: targetFormat) else {
+                    return
+                }
+                receive(converted)
+            }
+            isTapInstalled = true
+            hardware.prepareEngine()
+            try hardware.startEngine()
+        } catch {
+            cleanUp()
+            throw error
+        }
+    }
+
+    func stop() {
+        cleanUp()
+    }
+
+    private func cleanUp() {
+        if isTapInstalled {
+            hardware.removeTap()
+            isTapInstalled = false
+        }
+        hardware.stopEngine()
+        hardware.deactivateSession()
+    }
+}
+
+private final class AVFoundationMicrophoneCaptureHardware: MicrophoneCaptureHardware,
+    @unchecked Sendable
+{
+    private let audioEngine: AVAudioEngine
+    private let audioSession: AVAudioSession
+
+    init(
+        audioEngine: AVAudioEngine = AVAudioEngine(),
+        audioSession: AVAudioSession = .sharedInstance()
+    ) {
+        self.audioEngine = audioEngine
+        self.audioSession = audioSession
+    }
+
+    func activateSession() throws {
+        try audioSession.setCategory(.record, mode: .spokenAudio)
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+    }
+
+    func installTap(_ receive: @escaping @Sendable (AVAudioPCMBuffer) -> Void) {
+        let inputFormat = audioEngine.inputNode.outputFormat(forBus: 0)
+        audioEngine.inputNode.installTap(
+            onBus: 0, bufferSize: 4096, format: inputFormat
+        ) { buffer, _ in
+            receive(buffer)
+        }
+    }
+
+    func prepareEngine() {
+        audioEngine.prepare()
+    }
+
+    func startEngine() throws {
+        try audioEngine.start()
+    }
+
+    func removeTap() {
+        audioEngine.inputNode.removeTap(onBus: 0)
+    }
+
+    func stopEngine() {
+        audioEngine.stop()
+    }
+
+    func deactivateSession() {
+        try? audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+    }
+}
+
 /// Converts captured microphone buffers to the analyzer's requested format.
 /// Adapted from Apple's SpeechAnalyzer sample; the tap thread is realtime, so
 /// this is `@unchecked Sendable` and holds no actor state.
@@ -230,7 +422,10 @@ private final class BufferConverter: @unchecked Sendable {
         let inputFormat = buffer.format
         guard inputFormat != format else { return buffer }
 
-        if converter == nil || converter?.outputFormat != format {
+        if converter == nil
+            || converter?.inputFormat != inputFormat
+            || converter?.outputFormat != format
+        {
             converter = AVAudioConverter(from: inputFormat, to: format)
             // Sacrifice the first samples' quality to avoid timestamp drift.
             converter?.primeMethod = .none

--- a/Sources/HerdrMobile/Hosts/HostListView.swift
+++ b/Sources/HerdrMobile/Hosts/HostListView.swift
@@ -1,10 +1,30 @@
 import Observation
 import SwiftUI
 
+struct HostRemovalRequest: Equatable {
+    let hosts: [Host]
+
+    var title: String {
+        if hosts.count == 1, let host = hosts.first {
+            return "Remove \(host.displayName)?"
+        }
+        return "Remove \(hosts.count) Hosts?"
+    }
+
+    var actionTitle: String {
+        hosts.count == 1 ? "Remove Host" : "Remove Hosts"
+    }
+
+    let message =
+        "This permanently deletes the Host configuration and any saved password "
+        + "from the Keychain. This cannot be undone."
+}
+
 @MainActor
 @Observable
 final class HostRemovalStore {
     private(set) var errorMessage: String?
+    private(set) var pendingRequest: HostRemovalRequest?
 
     @ObservationIgnored
     private let store: HostStore
@@ -13,10 +33,22 @@ final class HostRemovalStore {
         self.store = store
     }
 
-    func remove(_ ids: [Host.ID]) {
-        for id in ids {
+    func requestRemoval(_ ids: [Host.ID]) {
+        let requestedIDs = Set(ids)
+        let hosts = store.hosts.filter { requestedIDs.contains($0.id) }
+        guard !hosts.isEmpty else { return }
+        pendingRequest = HostRemovalRequest(hosts: hosts)
+    }
+
+    func cancelRemoval() {
+        pendingRequest = nil
+    }
+
+    func confirmRemoval(_ request: HostRemovalRequest) {
+        pendingRequest = nil
+        for host in request.hosts {
             do {
-                try store.remove(id)
+                try store.remove(host.id)
             } catch {
                 errorMessage = "The Host could not be removed. Its saved credentials may still be in the Keychain."
                 return
@@ -96,6 +128,20 @@ struct HostListView: View {
                 }
             }
             .alert(
+                removal.pendingRequest?.title ?? "Remove Host?",
+                isPresented: removalConfirmationPresented,
+                presenting: removal.pendingRequest
+            ) { request in
+                Button(request.actionTitle, role: .destructive) {
+                    removal.confirmRemoval(request)
+                }
+                Button("Cancel", role: .cancel) {
+                    removal.cancelRemoval()
+                }
+            } message: { request in
+                Text(request.message)
+            }
+            .alert(
                 "Could Not Remove Host",
                 isPresented: Binding(
                     get: { removal.errorMessage != nil },
@@ -115,8 +161,14 @@ struct HostListView: View {
         }
     }
 
+    private var removalConfirmationPresented: Binding<Bool> {
+        Binding(
+            get: { removal.pendingRequest != nil },
+            set: { if !$0 { removal.cancelRemoval() } })
+    }
+
     private func removeHosts(at offsets: IndexSet) {
-        removal.remove(offsets.map { store.hosts[$0].id })
+        removal.requestRemoval(offsets.map { store.hosts[$0].id })
     }
 }
 

--- a/Sources/HerdrMobile/Hosts/HostOnboardingStore.swift
+++ b/Sources/HerdrMobile/Hosts/HostOnboardingStore.swift
@@ -76,6 +76,9 @@ final class HostOnboardingStore {
                 check: .connection,
                 hint: "No password is saved for this Host. Edit the Host and enter one.")
             return
+        } catch DeviceKeyStoreError.storedKeyCorrupt {
+            report = .failure(.deviceKeyCorrupt, authMethod: host.authMethod)
+            return
         } catch {
             report = .failure(
                 check: .connection,

--- a/Sources/HerdrMobile/Hosts/Preflight.swift
+++ b/Sources/HerdrMobile/Hosts/Preflight.swift
@@ -75,6 +75,11 @@ struct PreflightReport: Equatable, Sendable {
             case .password:
                 hint = "The Host rejected the login. Check the username and password."
             }
+        case .deviceKeyCorrupt:
+            check = .connection
+            hint =
+                "The Device Key is corrupted. Edit this Host and choose Replace Device Key, "
+                + "then add the new public key to ~/.ssh/authorized_keys on every Device Key Host."
         case .hostKeyRejected:
             check = .connection
             hint = "The host key was not confirmed. Run the checks again and confirm the fingerprint."

--- a/Sources/HerdrMobile/Transport/EventsSession.swift
+++ b/Sources/HerdrMobile/Transport/EventsSession.swift
@@ -433,6 +433,12 @@ actor EventsSession {
     }
 
     private static func transportFailure(_ error: any Error) -> TransportError {
-        (error as? TransportError) ?? .channelFailed(detail: String(describing: error))
+        if let failure = error as? TransportError {
+            return failure
+        }
+        if case DeviceKeyStoreError.storedKeyCorrupt = error {
+            return .deviceKeyCorrupt
+        }
+        return .channelFailed(detail: String(describing: error))
     }
 }

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -909,7 +909,9 @@ actor SSHTransport: Transport {
 
     /// Runs the wake command over a slot-gated no-PTY exec channel with
     /// stdin at EOF from the start (`< /dev/null`). `HERDR_SOCKET_PATH` pins
-    /// the bridge and the server it spawns to this Host's configured socket.
+    /// the bridge and the server it spawns to this Host's configured socket;
+    /// named locations also set `HERDR_SESSION` so the spawned server uses
+    /// that session's state directory instead of the default session's state.
     /// The path rides as a positional argument so only the outer shell ever
     /// quotes it. The bridge's entry point ensures the server is running
     /// (spawn + wait for socket) before it starts bridging; the bridge then
@@ -918,7 +920,7 @@ actor SSHTransport: Transport {
     /// anything mid-flight.
     private func runWakeCommand(socketPath: String) async throws {
         let command = try Self.wakeExecCommand(
-            wakeCommand: wakeCommand, socketPath: socketPath)
+            wakeCommand: wakeCommand, socketPath: socketPath, socketLocation: socketLocation)
         try await acquireExecChannelSlot()
         defer { releaseExecChannelSlot() }
         _ = try await client.executeCommand(command)
@@ -926,15 +928,30 @@ actor SSHTransport: Transport {
 
     /// The full remote command for waking this Host's configured herdr
     /// server. It runs under POSIX sh because login shells such as fish do
-    /// not share assignment syntax, and passes the socket as an argument so
-    /// the wrapper script never interpolates path bytes.
-    static func wakeExecCommand(wakeCommand: String, socketPath: String) throws -> String {
+    /// not share assignment syntax, and passes the socket and optional named
+    /// session as arguments so the wrapper script never interpolates their
+    /// bytes.
+    static func wakeExecCommand(
+        wakeCommand: String, socketPath: String, socketLocation: HerdrSocketLocation
+    ) throws -> String {
         guard let quotedSocketPath = RemoteShellPath.quotedAbsolute(socketPath) else {
             throw TransportError.channelFailed(
                 detail: "The remote socket path cannot be quoted safely.")
         }
-        let command = "/bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
-            + "\(wakeCommand) < /dev/null' wake \(quotedSocketPath)"
+        let command: String
+        switch socketLocation {
+        case .namedSession(let sessionName):
+            guard HerdrSessionName.isValid(sessionName) else {
+                throw TransportError.channelFailed(
+                    detail: "The herdr session name is invalid.")
+            }
+            command = "/bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
+                + "export HERDR_SESSION=\"$2\"; \(wakeCommand) < /dev/null' wake "
+                + "\(quotedSocketPath) \(sessionName)"
+        case .defaultSession, .absolutePath:
+            command = "/bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
+                + "\(wakeCommand) < /dev/null' wake \(quotedSocketPath)"
+        }
         return cLocaleCommand(command)
     }
 

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -277,6 +277,9 @@ enum TransportError: Error, Sendable, Equatable {
     /// The Host rejected our credentials (key not authorized, wrong
     /// password, or the offered auth method is unavailable).
     case authenticationFailed
+    /// The device's stored Ed25519 private key cannot be decoded. Reconnecting
+    /// cannot repair it; the user must explicitly replace the Device Key.
+    case deviceKeyCorrupt
     /// First connect to an unknown Host and the user declined its key
     /// fingerprint; nothing was stored.
     case hostKeyRejected(presented: HostKeyFingerprint)
@@ -323,7 +326,7 @@ enum TransportError: Error, Sendable, Equatable {
         switch self {
         case .sshUnreachable, .serverNotRunning, .timedOut, .cancelled, .channelFailed:
             true
-        case .authenticationFailed, .hostKeyRejected, .hostKeyMismatch,
+        case .authenticationFailed, .deviceKeyCorrupt, .hostKeyRejected, .hostKeyMismatch,
             .socketNotFound, .socatMissing, .protocolVersionMismatch,
             .homeDirectoryUnresolvable, .eventsChannelAlreadyOpen,
             .terminalChannelAlreadyOpen, .malformedResponse:

--- a/Tests/HerdrMobileTests/ColdStartE2ETests.swift
+++ b/Tests/HerdrMobileTests/ColdStartE2ETests.swift
@@ -16,6 +16,54 @@ import Testing
         "requires localhost sshd, socat, and an authorized Ed25519 test key"),
     .timeLimit(.minutes(1)))
 struct ColdStartE2ETests {
+    @Test func namedSessionWakeScopesStateAndRetriesRequest() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let sessionName = "testloop"
+        // Resolve the named session under an isolated fake home so this test
+        // never reads or writes the user's real herdr session state.
+        let fakeHome = "/tmp/hm-wake-\(UUID().uuidString.prefix(8))"
+        let sessionDirectory = "\(fakeHome)/.config/herdr/sessions/\(sessionName)"
+        try FileManager.default.createDirectory(
+            atPath: sessionDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: fakeHome) }
+
+        let socketPath = "\(sessionDirectory)/herdr.sock"
+        let stale = try StaleUnixSocket(path: socketPath)
+        defer { stale.remove() }
+        let server = try FakeHerdrServer { request in
+            [
+                #"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9-fake","protocol":16}}"#
+            ]
+        }
+        defer { server.stop() }
+        let wake = try WakeScript(commands: [
+            "test \"$HERDR_SESSION\" = '\(sessionName)' || exit 1",
+            "test \"$HERDR_SOCKET_PATH\" = '\(socketPath)' || exit 1",
+            "rm -f '\(socketPath)'",
+            "ln -s '\(server.socketPath)' '\(socketPath)'",
+        ])
+        defer { wake.remove() }
+        let homeCommand =
+            "printf '__HERDR_MOBILE_HOME__=%s\\n' '\(fakeHome)'"
+        let transport = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .namedSession(sessionName), wakeCommand: wake.command,
+                homeCommand: homeCommand))
+        do {
+            let info = try await transport.ping()
+
+            #expect(info == ServerInfo(version: "9.9.9-fake", protocolVersion: 16))
+        } catch {
+            try? await transport.close()
+            throw error
+        }
+        try await transport.close()
+
+        #expect(wake.invocationCount == 1)
+        #expect(server.receivedRequests.map(\.method) == ["ping"])
+        #expect(server.connectionCount == 1)
+    }
+
     @Test func wakeReceivesConfiguredSocketAndRetriedRequestSucceeds() async throws {
         // Server "stopped": stale socket at the configured path. The wake
         // script brings the fake server online at that path, exactly like

--- a/Tests/HerdrMobileTests/ColdStartE2ETests.swift
+++ b/Tests/HerdrMobileTests/ColdStartE2ETests.swift
@@ -188,22 +188,57 @@ struct WakeCommandTests {
         #expect(settings.wakeCommand == "herdr remote-client-bridge")
     }
 
-    @Test func scopesWakeCommandToConfiguredSocket() throws {
+    @Test func scopesNamedSessionWakeCommandToSessionState() throws {
         let command = try SSHTransport.wakeExecCommand(
             wakeCommand: "herdr remote-client-bridge",
-            socketPath: "/home/u/My Config/herdr.sock")
+            socketPath: "/home/u/.config/herdr/sessions/testloop/herdr.sock",
+            socketLocation: .namedSession("testloop"))
 
         #expect(
             command == "LC_ALL=C /bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
-                + "herdr remote-client-bridge < /dev/null' wake "
+                + "export HERDR_SESSION=\"$2\"; herdr remote-client-bridge < /dev/null' wake "
+                + "'/home/u/.config/herdr/sessions/testloop/herdr.sock' testloop")
+    }
+
+    @Test func defaultSessionWakeCommandDoesNotOverrideSessionState() throws {
+        let command = try SSHTransport.wakeExecCommand(
+            wakeCommand: "/opt/herdr-wake --foreground",
+            socketPath: "/home/u/.config/herdr/herdr.sock",
+            socketLocation: .defaultSession)
+
+        #expect(
+            command == "LC_ALL=C /bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
+                + "/opt/herdr-wake --foreground < /dev/null' wake "
+                + "'/home/u/.config/herdr/herdr.sock'")
+    }
+
+    @Test func absolutePathWakeCommandDoesNotOverrideSessionState() throws {
+        let command = try SSHTransport.wakeExecCommand(
+            wakeCommand: "/opt/herdr-wake --foreground",
+            socketPath: "/home/u/My Config/herdr.sock",
+            socketLocation: .absolutePath("/home/u/My Config/herdr.sock"))
+
+        #expect(
+            command == "LC_ALL=C /bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
+                + "/opt/herdr-wake --foreground < /dev/null' wake "
                 + "'/home/u/My Config/herdr.sock'")
+    }
+
+    @Test func refusesInvalidNamedSession() {
+        #expect(throws: TransportError.self) {
+            _ = try SSHTransport.wakeExecCommand(
+                wakeCommand: "herdr remote-client-bridge",
+                socketPath: "/home/u/.config/herdr/sessions/work session/herdr.sock",
+                socketLocation: .namedSession("work session"))
+        }
     }
 
     @Test func refusesUnquotableSocketPath() {
         #expect(throws: TransportError.self) {
             _ = try SSHTransport.wakeExecCommand(
                 wakeCommand: "herdr remote-client-bridge",
-                socketPath: "/tmp/it's-a.sock")
+                socketPath: "/tmp/it's-a.sock",
+                socketLocation: .absolutePath("/tmp/it's-a.sock"))
         }
     }
 }

--- a/Tests/HerdrMobileTests/ConsoleStoreTests.swift
+++ b/Tests/HerdrMobileTests/ConsoleStoreTests.swift
@@ -15,7 +15,10 @@ struct ConsoleStoreTests {
 
     /// A store whose session factory routes each Host to its scripted
     /// transport; unknown Hosts fail the connect.
-    private func makeStore(transports: [Host.ID: ScriptedTransport]) -> ConsoleStore {
+    private func makeStore(
+        transports: [Host.ID: ScriptedTransport],
+        reconnectPolicy: ReconnectPolicy = Self.fastPolicy
+    ) -> ConsoleStore {
         ConsoleStore(snapshotRetryDelay: .milliseconds(10)) { host, subscriptions in
             EventsSession(
                 subscriptions: subscriptions,
@@ -25,7 +28,7 @@ struct ConsoleStoreTests {
                     }
                     return transport
                 },
-                reconnectPolicy: Self.fastPolicy,
+                reconnectPolicy: reconnectPolicy,
                 keepalive: nil)
         }
     }
@@ -186,6 +189,42 @@ struct ConsoleStoreTests {
         await snapshotGate.open()
         try await waitUntil("the stale snapshot response should finish applying") {
             await transport.paneReadParams.count > readsBeforeRace
+        }
+        #expect(store.agents.first?.agent.status == .blocked)
+
+        store.setHosts([])
+    }
+
+    @Test func statusChangeForNewPaneDuringInitialSnapshotSurvives() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: .fixture(agents: [.fixture(paneID: "w1:p1", status: .idle)]))
+        let snapshotGate = ScriptedTransportCallGate()
+        await transport.gateNextSnapshot(using: snapshotGate)
+        let store = makeStore(
+            transports: [host.id: transport],
+            reconnectPolicy: ReconnectPolicy(
+                initialDelay: .seconds(30), multiplier: 1, maxDelay: .seconds(30)))
+
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the initial stale snapshot should be in flight") {
+            await snapshotGate.entryCount == 1
+        }
+        #expect(store.agents.isEmpty)
+
+        #expect(
+            await transport.emit(.agentStatusChanged(paneID: "w1:p1", status: .blocked))
+                == true)
+        await transport.failEventStream(.channelFailed(detail: "test ordering barrier"))
+        try await waitUntil("the status event should be consumed before the disconnect") {
+            guard case .reconnecting = store.hostStatuses[host.id] else { return false }
+            return true
+        }
+
+        await snapshotGate.open()
+        try await waitUntil("the initial snapshot should create the Agent row") {
+            store.agents.count == 1
         }
         #expect(store.agents.first?.agent.status == .blocked)
 

--- a/Tests/HerdrMobileTests/ConsoleStoreTests.swift
+++ b/Tests/HerdrMobileTests/ConsoleStoreTests.swift
@@ -149,6 +149,49 @@ struct ConsoleStoreTests {
         store.setHosts([])
     }
 
+    @Test func statusChangeDuringSnapshotSurvivesTheStaleResponse() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: .fixture(agents: [.fixture(paneID: "w1:p1", status: .idle)]))
+        let store = makeStore(transports: [host.id: transport])
+
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the pane subscription should settle") {
+            let paneReads = await transport.paneReadParams
+            let subscriptions = await transport.capturedSubscriptions
+            return paneReads.count >= 2
+                && subscriptions.last?.contains(
+                    .pane(.agentStatusChanged, paneID: "w1:p1")) == true
+        }
+
+        let snapshotGate = ScriptedTransportCallGate()
+        await transport.gateNextSnapshot(using: snapshotGate)
+        let readsBeforeRace = await transport.paneReadParams.count
+        #expect(
+            await transport.emit(
+                HerdrEvent(kind: GlobalEventKind.paneAgentDetected.kind, data: .object([:])))
+                == true)
+        try await waitUntil("the stale snapshot should be in flight") {
+            await snapshotGate.entryCount == 1
+        }
+
+        #expect(
+            await transport.emit(.agentStatusChanged(paneID: "w1:p1", status: .blocked))
+                == true)
+        try await waitUntil("the live status event should land first") {
+            store.agents.first?.agent.status == .blocked
+        }
+
+        await snapshotGate.open()
+        try await waitUntil("the stale snapshot response should finish applying") {
+            await transport.paneReadParams.count > readsBeforeRace
+        }
+        #expect(store.agents.first?.agent.status == .blocked)
+
+        store.setHosts([])
+    }
+
     @Test func snapshotPushesPaneSubscriptionsIntoTheSession() async throws {
         let host = Host.fixture()
         let transport = ScriptedTransport(

--- a/Tests/HerdrMobileTests/ConsoleStoreTests.swift
+++ b/Tests/HerdrMobileTests/ConsoleStoreTests.swift
@@ -462,11 +462,13 @@ struct ConsoleStoreTests {
         store.setHosts([hostA, hostB])
         await store.resume()
         try await waitUntil("both agents should arrive") { store.agents.count == 2 }
+        #expect(store.hostConnectionGenerations[hostB.id] == 0)
 
         store.setHosts([hostA])
 
         #expect(store.agents.map(\.agent.paneID) == ["w1:p1"])
         #expect(store.hostStatuses[hostB.id] == nil)
+        #expect(store.hostConnectionGenerations[hostB.id] == nil)
         try await waitUntil("the removed Host's transport should close") {
             await transports[hostB.id]?.isClosed == true
         }
@@ -681,6 +683,69 @@ struct ConsoleStoreTests {
         try await waitUntil("the Host should report suspended") {
             store.hostStatuses[host.id] == .suspended
         }
+
+        store.setHosts([])
+    }
+
+    @Test func realReconnectAdvancesHostConnectionGeneration() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: .fixture(agents: [.fixture(paneID: "w1:p1")]))
+        let store = makeStore(transports: [host.id: transport])
+
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the initial subscribe cycle should settle") {
+            let subscriptions = await transport.capturedSubscriptions
+            return subscriptions.count >= 2
+                && store.hostStatuses[host.id] == .connected
+        }
+        #expect(store.hostConnectionGenerations[host.id] == 0)
+
+        await transport.failEventStream(.channelFailed(detail: "connection dropped"))
+        try await waitUntil("the real reconnect should advance the generation") {
+            let subscriptions = await transport.capturedSubscriptions
+            return subscriptions.count >= 3
+                && store.hostConnectionGenerations[host.id] == 1
+                && store.hostStatuses[host.id] == .connected
+        }
+
+        store.setHosts([])
+    }
+
+    @Test func subscriptionResubscribeDoesNotAdvanceConnectionGeneration() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: .fixture(agents: [.fixture(paneID: "w1:p1")]))
+        let store = makeStore(transports: [host.id: transport])
+
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the initial subscribe cycle should settle") {
+            let snapshotCount = await transport.snapshotFetchCount
+            let subscriptions = await transport.capturedSubscriptions
+            return snapshotCount >= 2 && subscriptions.count >= 2
+        }
+        let snapshotsBeforeMembershipChange = await transport.snapshotFetchCount
+
+        await transport.setSnapshot(
+            .fixture(agents: [
+                .fixture(paneID: "w1:p1"),
+                .fixture(paneID: "w1:p2"),
+            ]))
+        #expect(
+            await transport.emit(
+                HerdrEvent(kind: GlobalEventKind.paneAgentDetected.kind, data: .object([:])))
+                == true)
+        try await waitUntil("the changed pane subscription should reconnect its event stream") {
+            let subscriptions = await transport.capturedSubscriptions
+            let snapshotCount = await transport.snapshotFetchCount
+            return snapshotCount >= snapshotsBeforeMembershipChange + 2
+                && subscriptions.last?.contains(
+                    .pane(.agentStatusChanged, paneID: "w1:p2")) == true
+                && store.hostStatuses[host.id] == .connected
+        }
+        #expect(store.hostConnectionGenerations[host.id] == 0)
 
         store.setHosts([])
     }

--- a/Tests/HerdrMobileTests/ConsoleStoreTests.swift
+++ b/Tests/HerdrMobileTests/ConsoleStoreTests.swift
@@ -397,6 +397,57 @@ struct ConsoleStoreTests {
         store.setHosts([])
     }
 
+    @Test func blockedStatusDuringSnippetFetchSchedulesAFollowUpRead() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: .fixture(agents: [.fixture(paneID: "w1:p1", status: .working)]))
+        await transport.setPaneText("Ready", paneID: "w1:p1")
+        let store = makeStore(transports: [host.id: transport])
+
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the initial snapshot cycle should settle") {
+            let reads = await transport.paneReadParams
+            let subscriptions = await transport.capturedSubscriptions
+            return reads.count >= 2
+                && subscriptions.last?.contains(
+                    .pane(.agentStatusChanged, paneID: "w1:p1")) == true
+                && store.agents.first?.lastOutputSnippet == "Ready"
+        }
+
+        let staleReadGate = ScriptedTransportCallGate()
+        await transport.setPaneText("Still working", paneID: "w1:p1")
+        await transport.gateNextPaneRead(using: staleReadGate)
+        #expect(
+            await transport.emit(.agentStatusChanged(paneID: "w1:p1", status: .working))
+                == true)
+        try await waitUntil("the stale snippet read should be in flight") {
+            await staleReadGate.entryCount == 1
+        }
+
+        let followUpReadGate = ScriptedTransportCallGate()
+        await transport.setPaneText("Allow this command?", paneID: "w1:p1")
+        await transport.gateNextPaneRead(using: followUpReadGate)
+        #expect(
+            await transport.emit(.agentStatusChanged(paneID: "w1:p1", status: .blocked))
+                == true)
+        try await waitUntil("the Blocked status should land during the stale read") {
+            store.agents.first?.agent.status == .blocked
+        }
+        for _ in 0..<10 { await Task.yield() }
+
+        await staleReadGate.open()
+        try await waitUntil("the Blocked refresh should start a follow-up read") {
+            await followUpReadGate.entryCount == 1
+        }
+        await followUpReadGate.open()
+        try await waitUntil("the Blocked prompt should replace the stale snippet") {
+            store.agents.first?.lastOutputSnippet == "Allow this command?"
+        }
+
+        store.setHosts([])
+    }
+
     @Test func removingAHostDropsItsAgentsAndEndsItsSession() async throws {
         let hostA = Host.fixture(name: "alpha", address: "a.example")
         let hostB = Host.fixture(name: "beta", address: "b.example")

--- a/Tests/HerdrMobileTests/DictationStoreTests.swift
+++ b/Tests/HerdrMobileTests/DictationStoreTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 import Testing
 
@@ -84,6 +85,33 @@ struct DictationStoreTests {
         #expect(!store.isRecording)
     }
 
+    @Test func releaseWhileStartIsSuspendedDoesNotLeaveALateRecording() async throws {
+        let engine = ScriptedDictationEngine()
+        await engine.suspendNextStart()
+        let input = makeInput()
+        input.draft = "keep this"
+        let store = DictationStore(engine: engine, draft: input)
+
+        store.startDictation()
+        try await waitUntil("start should reach its asynchronous setup point") {
+            await engine.isStartSuspended
+        }
+
+        store.stopDictation()
+        #expect(store.state == .finishing)
+        try await waitUntil("stop should reach the engine before setup resumes") {
+            await engine.stopCount == 1
+        }
+        await engine.resumeSuspendedStart()
+
+        try await waitUntil("release during setup should finish without a live stream") {
+            guard store.state == .idle else { return false }
+            return !(await engine.hasLiveStream)
+        }
+        #expect(input.draft == "keep this")
+        #expect(!store.isRecording)
+    }
+
     @Test func dictationAppendsOntoExistingDraftWithoutOverwriting() async throws {
         let engine = ScriptedDictationEngine()
         let input = makeInput()
@@ -160,6 +188,61 @@ struct DictationStoreTests {
         #expect(!store.isRecording)
     }
 
+    @Test func cancelWhileStartIsSuspendedDiscardsAndClosesALateStream() async throws {
+        let engine = ScriptedDictationEngine()
+        await engine.suspendNextStart()
+        let input = makeInput()
+        input.draft = "keep this"
+        input.cursorOffset = input.draft.count
+        let store = DictationStore(engine: engine, draft: input)
+
+        store.startDictation()
+        try await waitUntil("start should reach its asynchronous setup point") {
+            await engine.isStartSuspended
+        }
+
+        store.cancelDictation()
+        try await waitUntil("cancel should reach the engine before setup resumes") {
+            await engine.stopCount == 1
+        }
+        await engine.resumeSuspendedStart()
+
+        try await waitUntil("cancel during setup should close any late stream") {
+            guard store.state == .idle else { return false }
+            return !(await engine.hasLiveStream)
+        }
+        #expect(input.draft == "keep this")
+        #expect(input.cursorOffset == "keep this".count)
+        #expect(!store.isRecording)
+    }
+
+    @Test(arguments: AgentDetailDictationSession.Interruption.allCases)
+    func agentDetailInterruptionsCancelTheSharedEngine(
+        _ interruption: AgentDetailDictationSession.Interruption
+    ) async throws {
+        let engine = ScriptedDictationEngine()
+        let input = makeInput()
+        input.draft = "keep this"
+        input.cursorOffset = input.draft.count
+        let dictation = DictationStore(engine: engine, draft: input)
+        let session = AgentDetailDictationSession(dictation: dictation)
+
+        try await startAndAwaitLiveStream(dictation, engine)
+        await engine.emitPartial("discard me")
+        try await waitUntil("the partial should reach the draft before interruption") {
+            input.draft == "keep this discard me"
+        }
+
+        session.handle(interruption)
+
+        try await waitUntil("the interruption should release the shared engine") {
+            guard dictation.state == .idle else { return false }
+            return !(await engine.hasLiveStream)
+        }
+        #expect(input.draft == "keep this")
+        #expect(!dictation.isRecording)
+    }
+
     @Test func dictationInsertsAtTheCursorWithinExistingDraft() async throws {
         // With the caret in the middle of a typed draft, dictation inserts
         // there; text on both sides of the caret is preserved (User Story 6).
@@ -207,6 +290,112 @@ struct DictationStoreTests {
         // offers no remedy — it is not a missing-model, download-in-Settings case.
         #expect(store.errorRowMessage == "Dictation stopped unexpectedly. Try again.")
         #expect(store.errorRowRemedy == nil)
+    }
+
+    @Test func releaseFailureWaitsForStopBeforeAllowingRetry() async throws {
+        let engine = ScriptedDictationEngine()
+        let input = makeInput()
+        let store = DictationStore(engine: engine, draft: input)
+
+        try await startAndAwaitLiveStream(store, engine)
+        await engine.suspendNextStop()
+        store.stopDictation()
+        try await waitUntil("stop should be in flight") {
+            await engine.isStopSuspended
+        }
+
+        await engine.failStream(TranscriptionFailure.engineDied)
+        try await waitUntil("the stream failure should be visible while teardown waits") {
+            if case .failed = store.state { return true }
+            return false
+        }
+        store.startDictation()
+        let retryWasBlocked: Bool
+        if case .failed = store.state {
+            retryWasBlocked = true
+        } else {
+            retryWasBlocked = false
+        }
+
+        await engine.resumeSuspendedStop()
+        #expect(retryWasBlocked)
+        guard retryWasBlocked else { return }
+
+        store.startDictation()
+        try await waitUntil("a retry should start after teardown completes") {
+            store.startDictation()
+            return await engine.startCount == 2
+        }
+    }
+
+    @Test func rejectedRetryDuringFailureTeardownCannotDiscardPartial() async throws {
+        let engine = ScriptedDictationEngine()
+        let input = makeInput()
+        input.draft = "typed"
+        let store = DictationStore(engine: engine, draft: input)
+
+        try await startAndAwaitLiveStream(store, engine)
+        await engine.emitPartial("dictated")
+        try await waitUntil("the partial should land before teardown") {
+            input.draft == "typed dictated"
+        }
+
+        await engine.suspendNextStop()
+        store.stopDictation()
+        try await waitUntil("stop should be in flight") {
+            await engine.isStopSuspended
+        }
+        await engine.failStream(TranscriptionFailure.engineDied)
+        try await waitUntil("the failure should be visible while teardown waits") {
+            if case .failed = store.state { return true }
+            return false
+        }
+
+        store.startDictation()
+        store.cancelDictation()
+        #expect(input.draft == "typed dictated")
+
+        await engine.resumeSuspendedStop()
+        try await waitUntil("the failed session should finish teardown") {
+            store.clearErrorRow()
+            return store.state == .idle
+        }
+        #expect(input.draft == "typed dictated")
+    }
+
+    @Test func staleStopFromPreviousStoreDoesNotCloseNewSharedSession() async throws {
+        let engine = ScriptedDictationEngine()
+        let firstInput = makeInput()
+        let secondInput = makeInput()
+        let firstStore = DictationStore(engine: engine, draft: firstInput)
+        let secondStore = DictationStore(engine: engine, draft: secondInput)
+
+        try await startAndAwaitLiveStream(firstStore, engine)
+        await engine.suspendNextStop()
+        firstStore.stopDictation()
+        try await waitUntil("the previous session's stop should be suspended") {
+            await engine.isStopSuspended
+        }
+
+        secondStore.startDictation()
+        try await waitUntil("the new store should open its own session") {
+            await engine.startCount == 2
+        }
+        await engine.resumeSuspendedStop()
+
+        try await waitUntil("the previous store should complete its teardown") {
+            firstStore.state == .idle
+        }
+        #expect(await engine.hasLiveStream)
+        #expect(await engine.emitPartial("new session"))
+        try await waitUntil("the delayed stop must not silence the new store") {
+            secondInput.draft == "new session"
+        }
+
+        secondStore.cancelDictation()
+        try await waitUntil("the new session should still clean up normally") {
+            secondStore.state == .idle
+        }
     }
 
     @Test func permissionDeniedShowsAlertNotErrorRowAndDraftUntouched() async throws {
@@ -305,4 +494,147 @@ struct DictationStoreTests {
 /// A stand-in error for a mid-recording engine failure.
 private enum TranscriptionFailure: Error {
     case engineDied
+}
+
+@Suite("Microphone capture")
+struct MicrophoneCaptureTests {
+    @Test func failedEngineStartRollsBackResourcesAndAllowsRetry() throws {
+        let hardware = ScriptedMicrophoneCaptureHardware()
+        let capture = MicrophoneCapture(hardware: hardware)
+        let targetFormat = try #require(
+            AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1))
+
+        hardware.shouldFailStart = true
+        #expect(throws: ScriptedMicrophoneCaptureHardware.StartFailure.self) {
+            try capture.start(into: targetFormat) { _ in }
+        }
+        #expect(!hardware.isSessionActive)
+        #expect(!hardware.hasTap)
+        #expect(!hardware.isEngineRunning)
+
+        hardware.shouldFailStart = false
+        try capture.start(into: targetFormat) { _ in }
+        #expect(hardware.isSessionActive)
+        #expect(hardware.hasTap)
+        #expect(hardware.isEngineRunning)
+
+        capture.stop()
+        #expect(!hardware.isSessionActive)
+        #expect(!hardware.hasTap)
+        #expect(!hardware.isEngineRunning)
+    }
+
+    @Test func changedInputFormatOnTheNextSessionStillDeliversAudio() throws {
+        let hardware = ScriptedMicrophoneCaptureHardware()
+        let capture = MicrophoneCapture(hardware: hardware)
+        let received = LockedCounter()
+        let targetFormat = try #require(
+            AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1))
+        let firstInputFormat = try #require(
+            AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 1))
+        let secondInputFormat = try #require(
+            AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 1))
+
+        hardware.bufferOnStart = try makeBuffer(format: firstInputFormat)
+        try capture.start(into: targetFormat) { _ in received.increment() }
+        #expect(received.value == 1)
+        capture.stop()
+
+        hardware.bufferOnStart = try makeBuffer(format: secondInputFormat)
+        try capture.start(into: targetFormat) { _ in received.increment() }
+        #expect(received.value == 2)
+        capture.stop()
+    }
+
+    @Test func changedInputFormatWithinASessionRebuildsTheConverter() throws {
+        let hardware = ScriptedMicrophoneCaptureHardware()
+        let capture = MicrophoneCapture(hardware: hardware)
+        let received = LockedCounter()
+        let targetFormat = try #require(
+            AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1))
+        let firstInputFormat = try #require(
+            AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 1))
+        let secondInputFormat = try #require(
+            AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 1))
+
+        hardware.bufferOnStart = try makeBuffer(format: firstInputFormat)
+        try capture.start(into: targetFormat) { _ in received.increment() }
+        #expect(received.value == 1)
+
+        hardware.emit(try makeBuffer(format: secondInputFormat))
+        #expect(received.value == 2)
+        capture.stop()
+    }
+
+    private func makeBuffer(format: AVAudioFormat) throws -> AVAudioPCMBuffer {
+        let buffer = try #require(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 480))
+        buffer.frameLength = buffer.frameCapacity
+        return buffer
+    }
+}
+
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.withLock { count }
+    }
+
+    func increment() {
+        lock.withLock { count += 1 }
+    }
+}
+
+private final class ScriptedMicrophoneCaptureHardware: MicrophoneCaptureHardware,
+    @unchecked Sendable
+{
+    enum StartFailure: Error {
+        case scripted
+    }
+
+    var shouldFailStart = false
+    var bufferOnStart: AVAudioPCMBuffer?
+    private(set) var isSessionActive = false
+    private(set) var hasTap = false
+    private(set) var isEngineRunning = false
+    private var receive: (@Sendable (AVAudioPCMBuffer) -> Void)?
+
+    func activateSession() throws {
+        isSessionActive = true
+    }
+
+    func installTap(_ receive: @escaping @Sendable (AVAudioPCMBuffer) -> Void) {
+        hasTap = true
+        self.receive = receive
+    }
+
+    func prepareEngine() {}
+
+    func emit(_ buffer: AVAudioPCMBuffer) {
+        receive?(buffer)
+    }
+
+    func startEngine() throws {
+        if shouldFailStart {
+            throw StartFailure.scripted
+        }
+        isEngineRunning = true
+        if let bufferOnStart {
+            receive?(bufferOnStart)
+        }
+    }
+
+    func removeTap() {
+        hasTap = false
+        receive = nil
+    }
+
+    func stopEngine() {
+        isEngineRunning = false
+    }
+
+    func deactivateSession() {
+        isSessionActive = false
+    }
 }

--- a/Tests/HerdrMobileTests/EventsSessionSubscriptionsTests.swift
+++ b/Tests/HerdrMobileTests/EventsSessionSubscriptionsTests.swift
@@ -99,4 +99,26 @@ struct EventsSessionSubscriptionsTests {
 
         await session.end()
     }
+
+    @Test func corruptDeviceKeyStopsWithActionRequiredInsteadOfReconnecting() async throws {
+        let connectionAttempts = Mutex(0)
+        let session = EventsSession(
+            subscriptions: initial,
+            connect: { () async throws -> any Transport in
+                connectionAttempts.withLock { $0 += 1 }
+                throw DeviceKeyStoreError.storedKeyCorrupt
+            },
+            reconnectPolicy: ReconnectPolicy(
+                initialDelay: .milliseconds(1), multiplier: 1, maxDelay: .milliseconds(1)),
+            keepalive: nil)
+        var updates = session.updates.makeAsyncIterator()
+
+        await session.resume()
+
+        #expect(await updates.next() == .status(.failed(.deviceKeyCorrupt)))
+        try await Task.sleep(for: .milliseconds(30))
+        #expect(connectionAttempts.withLock { $0 } == 1)
+
+        await session.end()
+    }
 }

--- a/Tests/HerdrMobileTests/HostOnboardingStoreTests.swift
+++ b/Tests/HerdrMobileTests/HostOnboardingStoreTests.swift
@@ -101,6 +101,29 @@ struct HostOnboardingStoreTests {
         #expect(store.serverInfo == nil)
     }
 
+    @Test func corruptDeviceKeyExplainsTheReplacementRecovery() async throws {
+        let account = "corrupt-device-key"
+        let secrets = InMemorySecretStore()
+        try secrets.write(Data("not-an-ed25519-key".utf8), account: account)
+        let connector = FakeTransportConnector(outcome: .connects(pingResult: Self.healthyPing))
+        let store = HostOnboardingStore(
+            host: .fixture(authMethod: .deviceKey),
+            connector: connector,
+            knownHosts: InMemoryKnownHostsStore(),
+            credentials: HostCredentialsProvider(
+                deviceKeys: DeviceKeyStore(secrets: secrets, account: account), secrets: secrets))
+
+        await store.runChecks()
+
+        guard case .failed(let hint) = try #require(store.report)[.connection] else {
+            Issue.record("a corrupt Device Key should fail the connection check")
+            return
+        }
+        #expect(hint.contains("Replace Device Key"))
+        #expect(hint.contains("authorized_keys"))
+        #expect(await connector.capturedSettings.isEmpty)
+    }
+
     @Test func pingFailureFailsItsCheckAndStillClosesTheTransport() async throws {
         let (store, connector) = try makeStore(
             outcome: .connects(

--- a/Tests/HerdrMobileTests/HostStoreTests.swift
+++ b/Tests/HerdrMobileTests/HostStoreTests.swift
@@ -116,6 +116,36 @@ struct HostStoreTests {
         #expect(try store.password(for: host) == nil)
     }
 
+    @Test func removalRequestRequiresExplicitConfirmation() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let secrets = InMemorySecretStore()
+        let store = HostStore(defaults: defaults, secrets: secrets)
+        let host = Host.fixture(name: "Workbox", authMethod: .password)
+        try store.add(host, password: "hunter2")
+        let removal = HostRemovalStore(store: store)
+
+        removal.requestRemoval([host.id])
+
+        #expect(store.hosts == [host])
+        #expect(try store.password(for: host) == "hunter2")
+        let request = try #require(removal.pendingRequest)
+        #expect(request.title == "Remove Workbox?")
+        #expect(request.message.contains("Keychain"))
+        #expect(request.message.contains("cannot be undone"))
+
+        removal.cancelRemoval()
+        #expect(removal.pendingRequest == nil)
+        #expect(store.hosts == [host])
+
+        removal.requestRemoval([host.id])
+        removal.confirmRemoval(try #require(removal.pendingRequest))
+
+        #expect(removal.pendingRequest == nil)
+        #expect(store.hosts.isEmpty)
+        #expect(try store.password(for: host) == nil)
+    }
+
     @Test func passwordRoundTripsThroughTheSecretStore() throws {
         let (defaults, cleanup) = try makeDefaults()
         defer { cleanup() }
@@ -166,7 +196,8 @@ struct HostStoreTests {
         secrets.failRemovals()
         let removal = HostRemovalStore(store: store)
 
-        removal.remove([host.id])
+        removal.requestRemoval([host.id])
+        removal.confirmRemoval(try #require(removal.pendingRequest))
 
         #expect(store.hosts == [host])
         #expect(removal.errorMessage != nil)

--- a/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
@@ -456,6 +456,75 @@ struct ObserveTerminalStoreTests {
         #expect(store.status == .stopped)
     }
 
+    @Test func detailReobservesAfterHostSuspendsAndResumes() async throws {
+        let host = Host.fixture()
+        let firstTransport = ScriptedTransport(
+            snapshot: .fixture(agents: [.fixture(paneID: "w1:p1")]))
+        let resumedTransport = ScriptedTransport(
+            snapshot: .fixture(agents: [.fixture(paneID: "w1:p1")]))
+        let transports = ObserveTransportSequence([firstTransport, resumedTransport])
+        let console = ConsoleStore(snapshotRetryDelay: .milliseconds(10)) {
+            _, subscriptions in
+            EventsSession(
+                subscriptions: subscriptions,
+                connect: { try await transports.next() },
+                reconnectPolicy: ReconnectPolicy(
+                    initialDelay: .milliseconds(10), multiplier: 2,
+                    maxDelay: .milliseconds(50)),
+                keepalive: nil)
+        }
+        console.setHosts([host])
+        await console.resume()
+        try await waitUntil("the Host and Agent should be ready") {
+            console.hostStatuses[host.id] == .connected && console.agents.count == 1
+        }
+
+        let agent = try #require(console.agents.first)
+        let defaultsName = "ObserveTerminalStoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsName))
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+        let dictationEngine = ScriptedDictationEngine()
+        let dictationSettings = DictationSettingsStore(
+            engine: dictationEngine, defaults: defaults)
+        let controller = UIHostingController(
+            rootView: NavigationStack {
+                AgentDetailView(
+                    agent: agent, console: console,
+                    dictationSettings: dictationSettings,
+                    dictationEngine: dictationEngine)
+            })
+        let window = await show(
+            controller, frame: CGRect(x: 0, y: 0, width: 393, height: 852))
+        controller.view.frame = window.bounds
+        controller.view.layoutIfNeeded()
+        try await waitUntil("the detail should open its first Observe stream") {
+            let requestCount = await firstTransport.observeRequests.count
+            let hasLiveStream = await firstTransport.hasLiveFrameStream
+            return requestCount == 1 && hasLiveStream
+        }
+
+        await console.suspend()
+        try await waitUntil("the Host should finish suspending") {
+            let hasLiveStream = await firstTransport.hasLiveFrameStream
+            return console.hostStatuses[host.id] == .suspended && !hasLiveStream
+        }
+        await console.resume()
+        try await waitUntil("the Host should reconnect") {
+            console.hostStatuses[host.id] == .connected
+        }
+        try await waitUntil(
+            "the visible detail should Observe again after foregrounding",
+            timeout: .seconds(1)
+        ) {
+            let requestCount = await resumedTransport.observeRequests.count
+            let hasLiveStream = await resumedTransport.hasLiveFrameStream
+            return requestCount == 1 && hasLiveStream
+        }
+
+        await hide(window)
+        console.setHosts([])
+    }
+
     @Test func feedBuffersBytesUntilASinkAttaches() {
         // The terminal view attaches after layout; backfill written before
         // that must not be lost.
@@ -465,5 +534,20 @@ struct ObserveTerminalStoreTests {
         feed.attach { seen.append($0) }
         feed.write(Data("late".utf8))
         #expect(seen == [Data("early".utf8), Data("late".utf8)])
+    }
+}
+
+private actor ObserveTransportSequence {
+    private var transports: [ScriptedTransport]
+
+    init(_ transports: [ScriptedTransport]) {
+        self.transports = transports
+    }
+
+    func next() throws -> any Transport {
+        guard !transports.isEmpty else {
+            throw TransportError.sshUnreachable(detail: "no scripted transport remains")
+        }
+        return transports.removeFirst()
     }
 }

--- a/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/ObserveTerminalStoreTests.swift
@@ -525,6 +525,155 @@ struct ObserveTerminalStoreTests {
         console.setHosts([])
     }
 
+    @Test func backToBackReconnectReplacementsStartOnlyTheLatestObserve() async throws {
+        // Model two reconnect generations at their shared teardown seam.
+        // The middle replacement waits for the second teardown, while that
+        // teardown stops the middle replacement. The latest Observe must be
+        // released after the stop without letting the stopped store open.
+        let transport = ScriptedTransport()
+        let replacementProviderGate = ScriptedTransportCallGate()
+        let teardownBarrier = ScriptedTransportCallGate()
+        let replacement = ObserveTerminalStore(target: "w1:p1") {
+            await replacementProviderGate.waitUntilOpen()
+            await teardownBarrier.waitUntilOpen()
+            return transport
+        }
+        replacement.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the replacement should wait to acquire its transport") {
+            await replacementProviderGate.entryCount == 1
+        }
+
+        let teardown = Task {
+            await replacement.stop()
+        }
+        let releaseAfterTeardown = Task {
+            await teardown.value
+            await teardownBarrier.open()
+        }
+        let latest = ObserveTerminalStore(target: "w1:p1") {
+            await teardownBarrier.waitUntilOpen()
+            return transport
+        }
+        latest.reuseViewSize(from: replacement)
+        try await waitUntil("the latest Observe should wait for teardown") {
+            await teardownBarrier.entryCount == 1
+        }
+
+        await replacementProviderGate.open()
+        try await waitUntil("both Observe runs should be in the teardown chain") {
+            await teardownBarrier.entryCount == 2
+        }
+
+        try await waitUntil(
+            "the latest replacement should Observe after teardown",
+            timeout: .seconds(1)
+        ) {
+            latest.status == .live
+        }
+        #expect(replacement.status == .stopped)
+        #expect(await transport.observeRequests.count == 1)
+        #expect(await transport.paneReadParams.count == 1)
+
+        // Opens only on the pre-fix failure path, breaking the deliberately
+        // constructed cycle so the red test also exits without leaked tasks.
+        if latest.status != .live {
+            await teardownBarrier.open()
+        }
+        await teardown.value
+        await releaseAfterTeardown.value
+        try await waitUntil("cleanup should release the latest Observe") {
+            latest.status == .live
+        }
+        await latest.stop()
+    }
+
+    @Test func loadingEarlierReusesTheLiveTransportAcrossTeardown() async throws {
+        let transport = ScriptedTransport()
+        let repeatedCallGate = ScriptedTransportCallGate()
+        let provider = ObserveCountingTransportProvider(
+            transport: transport, repeatedCallGate: repeatedCallGate)
+        let store = ObserveTerminalStore(target: "w1:p1") {
+            await provider.next()
+        }
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("Observe should be live") { store.status == .live }
+        #expect(await provider.callCount == 1)
+
+        #expect(store.loadEarlier())
+        try await waitUntil(
+            "history should finish without re-entering the transport provider",
+            timeout: .seconds(1)
+        ) {
+            let providerCallCount = await provider.callCount
+            return !store.isLoadingEarlier || providerCallCount > 1
+        }
+
+        let stopCompletion = ObserveCompletion()
+        let stop = Task {
+            await store.stop()
+            await stopCompletion.finish()
+        }
+        try await waitUntil(
+            "teardown should not wait on a history-provider cycle",
+            timeout: .seconds(1)
+        ) {
+            await stopCompletion.isFinished
+        }
+        #expect(await provider.callCount == 1)
+        #expect(await transport.paneReadParams.count == 2)
+
+        // Releases only the old provider-reentry behavior, so a red run is
+        // bounded and leaves no history or stop task behind.
+        await repeatedCallGate.open()
+        await stop.value
+    }
+
+    @Test func attachHandoverStopsObserveWhileItsTransportIsPending() async throws {
+        let transport = ScriptedTransport()
+        let providerGate = ScriptedTransportCallGate()
+        let observe = ObserveTerminalStore(target: "w1:p1") {
+            await providerGate.waitUntilOpen()
+            return transport
+        }
+        observe.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("Observe should wait for its transport") {
+            await providerGate.entryCount == 1
+        }
+
+        let stopCompletion = ObserveCompletion()
+        let stop = Task {
+            await observe.stop()
+            await stopCompletion.finish()
+        }
+        let attach = AttachTerminalStore(target: "w1:p1") {
+            await providerGate.waitUntilOpen()
+            return transport
+        }
+        attach.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("Attach should wait behind the same teardown") {
+            await providerGate.entryCount == 2
+        }
+        try await waitUntil(
+            "Observe stop should finish before the transport is released",
+            timeout: .seconds(1)
+        ) {
+            await stopCompletion.isFinished
+        }
+
+        // Also releases the old behavior after its bounded failure, allowing
+        // the stop and Attach tasks to finish instead of leaking into later tests.
+        await providerGate.open()
+        await stop.value
+        try await waitUntil("Attach should own the terminal channel") {
+            attach.status == .live
+        }
+        #expect(observe.status == .stopped)
+        #expect(await transport.observeRequests.isEmpty)
+        #expect(await transport.attachRequests.count == 1)
+        await attach.stop()
+    }
+
     @Test func feedBuffersBytesUntilASinkAttaches() {
         // The terminal view attaches after layout; backfill written before
         // that must not be lost.
@@ -549,5 +698,32 @@ private actor ObserveTransportSequence {
             throw TransportError.sshUnreachable(detail: "no scripted transport remains")
         }
         return transports.removeFirst()
+    }
+}
+
+private actor ObserveCountingTransportProvider {
+    private let transport: any Transport
+    private let repeatedCallGate: ScriptedTransportCallGate
+    private(set) var callCount = 0
+
+    init(transport: any Transport, repeatedCallGate: ScriptedTransportCallGate) {
+        self.transport = transport
+        self.repeatedCallGate = repeatedCallGate
+    }
+
+    func next() async -> (any Transport)? {
+        callCount += 1
+        if callCount > 1 {
+            await repeatedCallGate.waitUntilOpen()
+        }
+        return transport
+    }
+}
+
+private actor ObserveCompletion {
+    private(set) var isFinished = false
+
+    func finish() {
+        isFinished = true
     }
 }

--- a/Tests/HerdrMobileTests/PreflightReportTests.swift
+++ b/Tests/HerdrMobileTests/PreflightReportTests.swift
@@ -36,6 +36,7 @@ struct PreflightReportTests {
     @Test(arguments: [
         (TransportError.sshUnreachable(detail: "refused"), PreflightCheck.connection),
         (.authenticationFailed, .connection),
+        (.deviceKeyCorrupt, .connection),
         (.hostKeyRejected(
             presented: HostKeyFingerprint(publicKeyBlob: Data("blob-a".utf8))), .connection),
         (.timedOut, .connection),

--- a/Tests/HerdrMobileTests/Support/ScriptedDictationEngine.swift
+++ b/Tests/HerdrMobileTests/Support/ScriptedDictationEngine.swift
@@ -14,9 +14,21 @@ final actor ScriptedDictationEngine: DictationEngine {
     /// assert the store forwards the persisted selection (#38).
     private(set) var lastStartLanguage: DictationLanguage?
 
-    private var continuation: AsyncThrowingStream<DictationTranscript, any Error>.Continuation?
+    private var continuations: [
+        DictationSessionID: AsyncThrowingStream<DictationTranscript, any Error>.Continuation
+    ] = [:]
+    /// The newest session receives scripted partials. Older streams remain
+    /// addressable by ID so a delayed stop can close only its own generation.
+    private var latestSessionID: DictationSessionID?
     /// If set, the next `start()` throws it instead of opening a stream.
     private var startError: (any Error)?
+    /// A deterministic suspension point before `start()` opens its stream.
+    /// This deliberately ignores task cancellation so store tests also cover
+    /// engines that only notice cancellation after an asynchronous setup step.
+    private var shouldSuspendNextStart = false
+    private var suspendedStart: CheckedContinuation<Void, Never>?
+    private var shouldSuspendNextStop = false
+    private var suspendedStop: CheckedContinuation<Void, Never>?
     /// If set, `stop()` yields this final transcript before ending the stream,
     /// standing in for the analyzer flushing its last result on finalize.
     private var finalOnStop: DictationTranscript?
@@ -33,6 +45,38 @@ final actor ScriptedDictationEngine: DictationEngine {
     /// missing, unsupported locale) instead of opening a stream.
     func setStartError(_ error: (any Error)?) {
         startError = error
+    }
+
+    /// Holds the next `start()` immediately before it opens the transcript
+    /// stream. The test resumes it explicitly after issuing stop or cancel.
+    func suspendNextStart() {
+        shouldSuspendNextStart = true
+    }
+
+    /// Whether `start()` is currently parked at the scripted suspension point.
+    var isStartSuspended: Bool {
+        suspendedStart != nil
+    }
+
+    /// Releases a `start()` parked by `suspendNextStart()`.
+    func resumeSuspendedStart() {
+        suspendedStart?.resume()
+        suspendedStart = nil
+    }
+
+    /// Holds the next `stop()` after it has reached the engine but before it
+    /// finishes the transcript stream.
+    func suspendNextStop() {
+        shouldSuspendNextStop = true
+    }
+
+    var isStopSuspended: Bool {
+        suspendedStop != nil
+    }
+
+    func resumeSuspendedStop() {
+        suspendedStop?.resume()
+        suspendedStop = nil
     }
 
     /// Scripts the model status `modelStatus(for:)` reports for a language.
@@ -74,7 +118,7 @@ final actor ScriptedDictationEngine: DictationEngine {
     /// Pushes a volatile partial onto the live stream; false if none is live.
     @discardableResult
     func emitPartial(_ text: String) -> Bool {
-        guard let continuation else { return false }
+        guard let continuation = latestContinuation else { return false }
         continuation.yield(DictationTranscript(text: text, isFinal: false))
         return true
     }
@@ -82,7 +126,7 @@ final actor ScriptedDictationEngine: DictationEngine {
     /// Pushes a final transcript onto the live stream without ending it.
     @discardableResult
     func emitFinal(_ text: String) -> Bool {
-        guard let continuation else { return false }
+        guard let continuation = latestContinuation else { return false }
         continuation.yield(DictationTranscript(text: text, isFinal: true))
         return true
     }
@@ -90,13 +134,14 @@ final actor ScriptedDictationEngine: DictationEngine {
     /// Kills the live stream with `failure`, as a mid-recording engine failure
     /// would.
     func failStream(_ failure: any Error) {
-        continuation?.finish(throwing: failure)
-        continuation = nil
+        guard let latestSessionID else { return }
+        continuations.removeValue(forKey: latestSessionID)?.finish(throwing: failure)
+        self.latestSessionID = nil
     }
 
     /// Whether a recording stream is currently live.
     var hasLiveStream: Bool {
-        continuation != nil
+        latestContinuation != nil
     }
 
     // MARK: DictationEngine
@@ -114,27 +159,50 @@ final actor ScriptedDictationEngine: DictationEngine {
         return stream
     }
 
-    func start(language: DictationLanguage) async throws
+    func start(sessionID: DictationSessionID, language: DictationLanguage) async throws
         -> AsyncThrowingStream<DictationTranscript, any Error>
     {
         startCount += 1
         lastStartLanguage = language
+        if shouldSuspendNextStart {
+            shouldSuspendNextStart = false
+            await withCheckedContinuation { continuation in
+                suspendedStart = continuation
+            }
+        }
         if let startError {
             throw startError
         }
         let (stream, continuation) = AsyncThrowingStream<
             DictationTranscript, any Error
         >.makeStream()
-        self.continuation = continuation
+        continuations[sessionID] = continuation
+        latestSessionID = sessionID
         return stream
     }
 
-    func stop() async {
+    func stop(sessionID: DictationSessionID) async {
         stopCount += 1
-        if let finalOnStop {
-            continuation?.yield(finalOnStop)
+        if shouldSuspendNextStop {
+            shouldSuspendNextStop = false
+            await withCheckedContinuation { continuation in
+                suspendedStop = continuation
+            }
         }
-        continuation?.finish()
-        continuation = nil
+        guard let continuation = continuations.removeValue(forKey: sessionID) else { return }
+        if let finalOnStop {
+            continuation.yield(finalOnStop)
+        }
+        continuation.finish()
+        if latestSessionID == sessionID {
+            latestSessionID = nil
+        }
+    }
+
+    private var latestContinuation:
+        AsyncThrowingStream<DictationTranscript, any Error>.Continuation?
+    {
+        guard let latestSessionID else { return nil }
+        return continuations[latestSessionID]
     }
 }

--- a/Tests/HerdrMobileTests/Support/ScriptedTransport.swift
+++ b/Tests/HerdrMobileTests/Support/ScriptedTransport.swift
@@ -41,6 +41,7 @@ final actor ScriptedTransport: Transport {
     private var serverInfo: ServerInfo
     private var snapshot: SessionSnapshot
     private var snapshotFailure: TransportError?
+    private var nextSnapshotGate: ScriptedTransportCallGate?
     private var paneTexts: [String: String] = [:]
     private var paneReadFailure: TransportError?
     private var nextStreamID: UInt64 = 0
@@ -72,6 +73,12 @@ final actor ScriptedTransport: Transport {
     /// Makes every subsequent `sessionSnapshot` throw `failure`.
     func setSnapshotFailure(_ failure: TransportError?) {
         snapshotFailure = failure
+    }
+
+    /// Pauses the next snapshot after capturing its response, so tests can
+    /// deterministically deliver events while that stale response is in flight.
+    func gateNextSnapshot(using gate: ScriptedTransportCallGate) {
+        nextSnapshotGate = gate
     }
 
     /// Scripts the text `readPane` returns for `paneID`.
@@ -184,8 +191,13 @@ final actor ScriptedTransport: Transport {
 
     func sessionSnapshot() async throws -> SessionSnapshot {
         snapshotFetchCount += 1
-        if let snapshotFailure { throw snapshotFailure }
-        return snapshot
+        let response = snapshot
+        let failure = snapshotFailure
+        let gate = nextSnapshotGate
+        nextSnapshotGate = nil
+        await gate?.waitUntilOpen()
+        if let failure { throw failure }
+        return response
     }
 
     func readPane(_ params: PaneReadParams) async throws -> PaneReadResult {
@@ -328,6 +340,27 @@ final actor ScriptedTransport: Transport {
         attachContinuation?.finish()
         attachContinuation = nil
         liveAttachID = nil
+    }
+}
+
+/// A one-shot test gate that exposes when a scripted transport call has
+/// captured its response, then holds that response until the test releases it.
+actor ScriptedTransportCallGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private(set) var entryCount = 0
+
+    func waitUntilOpen() async {
+        entryCount += 1
+        if isOpen { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        let resuming = waiters
+        waiters.removeAll()
+        for waiter in resuming { waiter.resume() }
     }
 }
 

--- a/Tests/HerdrMobileTests/Support/ScriptedTransport.swift
+++ b/Tests/HerdrMobileTests/Support/ScriptedTransport.swift
@@ -44,6 +44,7 @@ final actor ScriptedTransport: Transport {
     private var nextSnapshotGate: ScriptedTransportCallGate?
     private var paneTexts: [String: String] = [:]
     private var paneReadFailure: TransportError?
+    private var nextPaneReadGate: ScriptedTransportCallGate?
     private var nextStreamID: UInt64 = 0
     private var liveStreamID: UInt64?
     private var eventContinuation: AsyncThrowingStream<HerdrEvent, any Error>.Continuation?
@@ -89,6 +90,11 @@ final actor ScriptedTransport: Transport {
     /// Makes every subsequent `readPane` throw `failure`.
     func setPaneReadFailure(_ failure: TransportError?) {
         paneReadFailure = failure
+    }
+
+    /// Pauses the next pane read after capturing its response.
+    func gateNextPaneRead(using gate: ScriptedTransportCallGate) {
+        nextPaneReadGate = gate
     }
 
     /// Makes every subsequent `sendInput`/`sendKeys` throw `failure`.
@@ -202,12 +208,15 @@ final actor ScriptedTransport: Transport {
 
     func readPane(_ params: PaneReadParams) async throws -> PaneReadResult {
         paneReadParams.append(params)
-        if let paneReadFailure {
-            throw paneReadFailure
-        }
+        let responseText = paneTexts[params.paneID] ?? ""
+        let failure = paneReadFailure
+        let gate = nextPaneReadGate
+        nextPaneReadGate = nil
+        await gate?.waitUntilOpen()
+        if let failure { throw failure }
         return PaneReadResult(
             format: .text, paneID: params.paneID, revision: 0,
-            source: params.source, tabID: "t", text: paneTexts[params.paneID] ?? "",
+            source: params.source, tabID: "t", text: responseText,
             truncated: false, workspaceID: "w")
     }
 

--- a/Tests/HerdrMobileTests/Support/UnixSockets.swift
+++ b/Tests/HerdrMobileTests/Support/UnixSockets.swift
@@ -32,13 +32,13 @@ enum UnixSockets {
 struct StaleUnixSocket {
     let path: String
 
-    init() throws {
-        path = "/tmp/herdr-stale-\(UUID().uuidString.prefix(8)).sock"
+    init(path: String? = nil) throws {
+        self.path = path ?? "/tmp/herdr-stale-\(UUID().uuidString.prefix(8)).sock"
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { throw UnixSockets.SetupError.failed(step: "socket", errno: errno) }
         // Bind creates the file; closing without listening or unlinking
         // leaves it stale.
-        let bindResult = UnixSockets.withSockaddr(path: path) { bind(fd, $0, $1) }
+        let bindResult = UnixSockets.withSockaddr(path: self.path) { bind(fd, $0, $1) }
         close(fd)
         guard bindResult == 0 else {
             throw UnixSockets.SetupError.failed(step: "bind", errno: errno)


### PR DESCRIPTION
## Summary

- preserve exact command text in the Agent reply field
- reconcile Console snapshots and event deltas without losing newer statuses or pending snippets
- restore Observe after Host reconnects and prevent teardown cycles across rapid reconnect, history loading, and Attach handover
- isolate named-session cold-start wake state from the default herdr session
- require explicit Host removal confirmation and stop retrying corrupt Device Keys
- harden Dictation startup, cancellation, teardown ownership, and microphone cleanup

## Validation

- `scripts/generate-wire-types.py --check --schema scripts/herdr-schema.json`
- full iPhone 17 Simulator suite: 336 test functions, 360 executions, 0 failures, 0 skipped
- `xcodebuild analyze` on iPhone 17 Simulator
- Debug build for iPad Pro 11-inch Simulator
- Computer Use acceptance on iPhone: exact reply, quick keys, Attach, New Agent, Agent close cancel/confirm, Host removal cancel, rapid background/foreground reconnects, and named-session cold start
- Computer Use smoke on iPad in portrait and landscape
- real localhost SSH, socat, and herdr 0.7.4 verification, including named-session state and log isolation from the default session

## Known limitation

The real SpeechAnalyzer microphone, permission prompt, and audio-route behavior still require a physical iOS 26 device. Store, lifecycle, and microphone-boundary behavior are covered by deterministic tests.

Refs #18
Refs #20
Refs #34
Refs #40
