### PR TITLE
refactor(terminal): migrate to libghostty

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Native iOS companion app for herdr (https://herdr.dev): an agent console over SS
 
 ## Architecture
 
-- **Stack**: SwiftUI, iOS 26+, iPhone + iPad. SSH via Citadel, terminal rendering via SwiftTerm. See ADR 0001 (stack) and ADR 0003 (iOS 26 target raise).
+- **Stack**: SwiftUI, iOS 26+, iPhone + iPad. SSH via Citadel, terminal rendering via the pinned libghostty-spm `GhosttyTerminal` product. See ADR 0001 (native stack), ADR 0003 (iOS 26 target raise), and ADR 0004 (terminal engine).
 - **Transport**: herdr's JSON API (NDJSON over a remote Unix socket) reached through SSH exec channels running `socat - UNIX-CONNECT:<sock>`. Interactive terminals use a PTY exec channel running `herdr agent attach`. See ADR 0002.
 - The UI layer must depend on a transport abstraction (protocol), never on Citadel types directly.
 
@@ -26,6 +26,7 @@ Rediscovering these is expensive; they were verified against herdr 0.7.4 source 
 - Swift 6 strict concurrency. No force unwraps or `try!` outside tests.
 - Secrets never leave the Keychain; private keys are generated on device (CryptoKit Ed25519) where possible. Host key policy is TOFU with fingerprint confirmation.
 - Pin Citadel exactly in `Package.resolved` and review updates: Citadel 0.12.1 depends on a third-party fork of swift-nio-ssh (Wellz26), not Apple's repo.
+- Pin libghostty-spm exactly and review both its Swift sources and prebuilt XCFramework checksum before updating.
 - Tracker is GitHub issues in this repo (`gh issue ...`). Reference issues from commits with `refs #<n>`.
 - Update `CONTEXT.md` when domain terms change; add an ADR only for hard-to-reverse, surprising trade-offs.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,9 @@ _Avoid_: dashboard, home
 The Agent detail surface: full interactive terminal control of the pane through
 the embedded terminal. The normal terminal buffer uses native local scrollback.
 Alternate-screen TUIs map vertical touch drags and momentum to terminal wheel rows.
+Touching the terminal never opens the software keyboard; the keyboard toolbar
+button is the only entry point, so a scroll gesture cannot be interrupted by a
+keyboard-driven viewport resize.
 _Avoid_: takeover (that's herdr's flag, not our surface), connect
 
 **Terminal Keyboard**:

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -42,12 +42,13 @@
 		693B0173C07DAF4BFC89B094 /* SecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567573855DCC8571BC02096D /* SecretStore.swift */; };
 		6CBE7E0961FFD970A614ED4B /* AgentCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3FA15CCDC83C72DDA81BEB /* AgentCardView.swift */; };
 		6F3B8F2DEC6CA5991BB267E5 /* HostOnboardingStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DD3828DAEF46DBA7038B0A /* HostOnboardingStoreTests.swift */; };
-		718719DA8913E787FA68BD45 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 9BC475AC7E033D8BE525AB1D /* SwiftTerm */; };
+		718719DA8913E787FA68BD45 /* GhosttyTerminal in Frameworks */ = {isa = PBXBuildFile; productRef = 168EBAF199220582EB0C49F7 /* GhosttyTerminal */; };
 		724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */; };
 		782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */; };
 		7EEB41E5CD728587D7DCEC96 /* StartAgentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18AE2DC88A745FB457350957 /* StartAgentView.swift */; };
 		86C5F3E2D17523948343DF09 /* GeneratedWireTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87B816CE7206B37622287C4 /* GeneratedWireTypesTests.swift */; };
 		8C514AFC85DAED69A4988C13 /* SSHCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90875ADAF6E348E186C8125A /* SSHCredentials.swift */; };
+		8DF99F3257BCC6AE08595A45 /* TerminalKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DB204D5F25D5375D5B2974 /* TerminalKeyboard.swift */; };
 		91833D21F64358A8E82A0D34 /* HostOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E538BF75AE58E16C58782F7 /* HostOnboardingView.swift */; };
 		93851E040C292A16F5ECB10D /* ConsoleStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079394F4C6AC8FE4D7B0779C /* ConsoleStoreTests.swift */; };
 		950D74A1B92239CDB2DDE5DC /* EventsSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C3ACB2A319C5C1298A29F3F /* EventsSession.swift */; };
@@ -80,13 +81,13 @@
 		E8E50DCA9F56799E022F9252 /* TerminalAttachE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83F34B22988623AD8E2093C /* TerminalAttachE2ETests.swift */; };
 		E908289DF03C6732F7D91328 /* HerdrEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */; };
 		EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */; };
+		EDFEE058F85AF41DBFE351A7 /* TerminalTextSelectionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786B2BA8A0683BB9DC71D797 /* TerminalTextSelectionPresenter.swift */; };
 		EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */; };
 		F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */; };
 		F62A9CD06CFB784550AF4977 /* DeviceKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558159B2AF61C28F6B1391A2 /* DeviceKeyTests.swift */; };
 		F96C5D15E14B947BE426B2F3 /* TerminalScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597ACEE9D688E433B20108D7 /* TerminalScreenView.swift */; };
-		B22D1E4F9C015A48B3D8E612 /* TerminalKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0D3E8B904F37A2C7D501 /* TerminalKeyboard.swift */; };
 		FE4ADC78CA6113FFFBCEC693 /* EventsSessionE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9291334E33C85C7588F86281 /* EventsSessionE2ETests.swift */; };
-		FEDD78DD422954EEBA415E8E /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 1A747BD14B4EC28AE6E73458 /* SwiftTerm */; };
+		FEDD78DD422954EEBA415E8E /* GhosttyTerminal in Frameworks */ = {isa = PBXBuildFile; productRef = 3A53219005FF960DB8CAB247 /* GhosttyTerminal */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -123,7 +124,6 @@
 		5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHHostKeyE2ETests.swift; sourceTree = "<group>"; };
 		567573855DCC8571BC02096D /* SecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretStore.swift; sourceTree = "<group>"; };
 		597ACEE9D688E433B20108D7 /* TerminalScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalScreenView.swift; sourceTree = "<group>"; };
-		A11C0D3E8B904F37A2C7D501 /* TerminalKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeyboard.swift; sourceTree = "<group>"; };
 		5ADF336771A3F757F2AD441D /* AgentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetailView.swift; sourceTree = "<group>"; };
 		641088A470B51F40C898830F /* EventsSessionBufferingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionBufferingTests.swift; sourceTree = "<group>"; };
 		6434D31A79422C0BAE80993F /* HostStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStoreTests.swift; sourceTree = "<group>"; };
@@ -131,7 +131,9 @@
 		6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHAuthE2ETests.swift; sourceTree = "<group>"; };
 		6CA5E9DDE1AB0F68F6EC56EB /* EventsSessionSubscriptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionSubscriptionsTests.swift; sourceTree = "<group>"; };
 		6F7C6974BD9BE77000016FCA /* TerminalByteFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalByteFeed.swift; sourceTree = "<group>"; };
+		73DB204D5F25D5375D5B2974 /* TerminalKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeyboard.swift; sourceTree = "<group>"; };
 		78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrMobileApp.swift; sourceTree = "<group>"; };
+		786B2BA8A0683BB9DC71D797 /* TerminalTextSelectionPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTextSelectionPresenter.swift; sourceTree = "<group>"; };
 		7AFE5C640586747D567E1CF1 /* ScriptedTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptedTransport.swift; sourceTree = "<group>"; };
 		7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransport.swift; sourceTree = "<group>"; };
 		7D95D580BCF4FE792AEFE974 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -187,7 +189,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */,
-				FEDD78DD422954EEBA415E8E /* SwiftTerm in Frameworks */,
+				FEDD78DD422954EEBA415E8E /* GhosttyTerminal in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -195,7 +197,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				718719DA8913E787FA68BD45 /* SwiftTerm in Frameworks */,
+				718719DA8913E787FA68BD45 /* GhosttyTerminal in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -247,8 +249,9 @@
 			isa = PBXGroup;
 			children = (
 				6F7C6974BD9BE77000016FCA /* TerminalByteFeed.swift */,
-				A11C0D3E8B904F37A2C7D501 /* TerminalKeyboard.swift */,
+				73DB204D5F25D5375D5B2974 /* TerminalKeyboard.swift */,
 				597ACEE9D688E433B20108D7 /* TerminalScreenView.swift */,
+				786B2BA8A0683BB9DC71D797 /* TerminalTextSelectionPresenter.swift */,
 			);
 			path = Terminal;
 			sourceTree = "<group>";
@@ -392,7 +395,7 @@
 			name = HerdrMobile;
 			packageProductDependencies = (
 				03BEAFDD98C535CDCE9AE335 /* Citadel */,
-				1A747BD14B4EC28AE6E73458 /* SwiftTerm */,
+				3A53219005FF960DB8CAB247 /* GhosttyTerminal */,
 			);
 			productName = HerdrMobile;
 			productReference = B383994C2C8492694D5F3690 /* HerdrMobile.app */;
@@ -412,7 +415,7 @@
 			);
 			name = HerdrMobileTests;
 			packageProductDependencies = (
-				9BC475AC7E033D8BE525AB1D /* SwiftTerm */,
+				168EBAF199220582EB0C49F7 /* GhosttyTerminal */,
 			);
 			productName = HerdrMobileTests;
 			productReference = F3D159C84E98A59AA47EBE6C /* HerdrMobileTests.xctest */;
@@ -440,7 +443,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				A5BAC52972885D4D487901C1 /* XCRemoteSwiftPackageReference "Citadel" */,
-				EEB0F61C1AFE903B668B0AA0 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
+				C7978977B3798596C05BD5DF /* XCRemoteSwiftPackageReference "libghostty-spm" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 55902E0ABDF1F168FA193448 /* Products */;
@@ -495,8 +498,9 @@
 				1F4B065DFCAF8E6656600F1E /* TOFUHostKeyValidator.swift in Sources */,
 				41BBA40C97BAE65E56D0E3B5 /* TerminalAttach.swift in Sources */,
 				BAC9F51A72EA9774DEDBC193 /* TerminalByteFeed.swift in Sources */,
-				B22D1E4F9C015A48B3D8E612 /* TerminalKeyboard.swift in Sources */,
+				8DF99F3257BCC6AE08595A45 /* TerminalKeyboard.swift in Sources */,
 				F96C5D15E14B947BE426B2F3 /* TerminalScreenView.swift in Sources */,
+				EDFEE058F85AF41DBFE351A7 /* TerminalTextSelectionPresenter.swift in Sources */,
 				49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */,
 				B31E16D56EE1F19A3802625B /* TransportConnector.swift in Sources */,
 			);
@@ -563,6 +567,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "herdr uses the microphone to transcribe your spoken reply into the message box. Audio is processed on device and never leaves your phone.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -602,6 +607,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "herdr uses the microphone to transcribe your spoken reply into the message box. Audio is processed on device and never leaves your phone.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -796,13 +802,12 @@
 				version = 0.12.1;
 			};
 		};
-		EEB0F61C1AFE903B668B0AA0 /* XCRemoteSwiftPackageReference "SwiftTerm" */ = {
+		C7978977B3798596C05BD5DF /* XCRemoteSwiftPackageReference "libghostty-spm" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/migueldeicaza/SwiftTerm.git";
+			repositoryURL = "https://github.com/lakr233/libghostty-spm.git";
 			requirement = {
-				kind = versionRange;
-				maximumVersion = 2.0.0;
-				minimumVersion = 1.2.0;
+				kind = exactVersion;
+				version = 1.3.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -813,15 +818,15 @@
 			package = A5BAC52972885D4D487901C1 /* XCRemoteSwiftPackageReference "Citadel" */;
 			productName = Citadel;
 		};
-		1A747BD14B4EC28AE6E73458 /* SwiftTerm */ = {
+		168EBAF199220582EB0C49F7 /* GhosttyTerminal */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = EEB0F61C1AFE903B668B0AA0 /* XCRemoteSwiftPackageReference "SwiftTerm" */;
-			productName = SwiftTerm;
+			package = C7978977B3798596C05BD5DF /* XCRemoteSwiftPackageReference "libghostty-spm" */;
+			productName = GhosttyTerminal;
 		};
-		9BC475AC7E033D8BE525AB1D /* SwiftTerm */ = {
+		3A53219005FF960DB8CAB247 /* GhosttyTerminal */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = EEB0F61C1AFE903B668B0AA0 /* XCRemoteSwiftPackageReference "SwiftTerm" */;
-			productName = SwiftTerm;
+			package = C7978977B3798596C05BD5DF /* XCRemoteSwiftPackageReference "libghostty-spm" */;
+			productName = GhosttyTerminal;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		B31E16D56EE1F19A3802625B /* TransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4476B101AA4B13190C7A7B7C /* TransportConnector.swift */; };
 		B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCA39340517CEF3DAA35A09B /* Preflight.swift */; };
 		B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C232163905675760F37FD7A0 /* KnownHostsStore.swift */; };
+		B8ACB86B152D44FC0C80DADA /* TerminalTouchScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB521B35951ABDA186FAFCF /* TerminalTouchScroll.swift */; };
 		BAC9F51A72EA9774DEDBC193 /* TerminalByteFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7C6974BD9BE77000016FCA /* TerminalByteFeed.swift */; };
 		BC107519427157CF5191E34F /* FakeTransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14983BD8988E4AAE79DC46A /* FakeTransportConnector.swift */; };
 		C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB59377D34D0C652DF70F01 /* UnixSockets.swift */; };
@@ -180,6 +181,7 @@
 		F3D159C84E98A59AA47EBE6C /* HerdrMobileTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HerdrMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWire.swift; sourceTree = "<group>"; };
 		F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransportE2ETests.swift; sourceTree = "<group>"; };
+		FCB521B35951ABDA186FAFCF /* TerminalTouchScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTouchScroll.swift; sourceTree = "<group>"; };
 		FCB59377D34D0C652DF70F01 /* UnixSockets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnixSockets.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -252,6 +254,7 @@
 				73DB204D5F25D5375D5B2974 /* TerminalKeyboard.swift */,
 				597ACEE9D688E433B20108D7 /* TerminalScreenView.swift */,
 				786B2BA8A0683BB9DC71D797 /* TerminalTextSelectionPresenter.swift */,
+				FCB521B35951ABDA186FAFCF /* TerminalTouchScroll.swift */,
 			);
 			path = Terminal;
 			sourceTree = "<group>";
@@ -501,6 +504,7 @@
 				8DF99F3257BCC6AE08595A45 /* TerminalKeyboard.swift in Sources */,
 				F96C5D15E14B947BE426B2F3 /* TerminalScreenView.swift in Sources */,
 				EDFEE058F85AF41DBFE351A7 /* TerminalTextSelectionPresenter.swift in Sources */,
+				B8ACB86B152D44FC0C80DADA /* TerminalTouchScroll.swift in Sources */,
 				49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */,
 				B31E16D56EE1F19A3802625B /* TransportConnector.swift in Sources */,
 			);

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		1BAA5950B7FDE0E6F09811F9 /* DeviceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC995A571D7659F3307B6E54 /* DeviceKey.swift */; };
 		1BBEEF5478D91222F48C2048 /* ReconnectPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66B41C393D38FA09388E3E2 /* ReconnectPolicyTests.swift */; };
 		1BF53C7A5E6402747F26096A /* HostCredentialsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC07C7B3772EEED1EB8BA9C /* HostCredentialsProvider.swift */; };
+		1E26593A1B05B0ACEE9AC557 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B5EBF6C4EC88361E91CA2C /* SettingsView.swift */; };
 		1F4B065DFCAF8E6656600F1E /* TOFUHostKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */; };
 		225ECBDC69A7785559BC4D20 /* AttachTerminalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97970F4D535CC80592333995 /* AttachTerminalStore.swift */; };
 		27C44B69FBE155A397F54B77 /* HostStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AECAD39A269D97DAB4ED194 /* HostStore.swift */; };
@@ -37,6 +38,7 @@
 		4C80E23F09C8CFB3A93101B8 /* JSONValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3E2308A50D4744A24A874B /* JSONValue.swift */; };
 		535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */; };
 		5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */; };
+		5D1B735C72D551ADE0D82D44 /* TerminalThemeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A961D26EDEAA03AFB0F9C408 /* TerminalThemeSettings.swift */; };
 		6092F63FF2DE77AD7D087A7C /* ClosePaneStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC2552636663F92A55D1DFF1 /* ClosePaneStoreTests.swift */; };
 		6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */; };
 		693B0173C07DAF4BFC89B094 /* SecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567573855DCC8571BC02096D /* SecretStore.swift */; };
@@ -66,9 +68,11 @@
 		C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB59377D34D0C652DF70F01 /* UnixSockets.swift */; };
 		C60E8E0398665C36520DDA8E /* HerdrEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABFC5E35C19F809355619E7 /* HerdrEvents.swift */; };
 		C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 03BEAFDD98C535CDCE9AE335 /* Citadel */; };
+		C70B492B9C358FDAFF7876CF /* GhosttyTheme in Frameworks */ = {isa = PBXBuildFile; productRef = 6AB21852B18619F247B07907 /* GhosttyTheme */; };
 		CC20BAD2AC1A725889F82A20 /* ClosePaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13921A61B4E4F17CDE47C96 /* ClosePaneStore.swift */; };
 		CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D95D580BCF4FE792AEFE974 /* ContentView.swift */; };
 		D11D524FCF49C49763C9F9D7 /* Host.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806A90DBCA99FD02E76D68C6 /* Host.swift */; };
+		D51F828E0AC4A2F6C23A0CBE /* TerminalThemeSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */; };
 		D6E9D6545089932306C4704F /* HostKeyFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CBE401E4A5FA5871809E540 /* HostKeyFingerprint.swift */; };
 		D818864671292BE9F965CAA6 /* AttachTerminalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A549DEB5B5CE8FDD29CE2A28 /* AttachTerminalStoreTests.swift */; };
 		DBB9FF4BC72D3AA244E2ECE0 /* HostFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278668F4D5B3EB85E6CDA16A /* HostFormView.swift */; };
@@ -147,6 +151,7 @@
 		904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSSHTestEnvironment.swift; sourceTree = "<group>"; };
 		90875ADAF6E348E186C8125A /* SSHCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHCredentials.swift; sourceTree = "<group>"; };
 		9291334E33C85C7588F86281 /* EventsSessionE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionE2ETests.swift; sourceTree = "<group>"; };
+		95B5EBF6C4EC88361E91CA2C /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		97970F4D535CC80592333995 /* AttachTerminalStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachTerminalStore.swift; sourceTree = "<group>"; };
 		9AECAD39A269D97DAB4ED194 /* HostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStore.swift; sourceTree = "<group>"; };
 		9B106E427EE5358088B615CE /* InMemorySecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemorySecretStore.swift; sourceTree = "<group>"; };
@@ -154,6 +159,7 @@
 		A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrEventsTests.swift; sourceTree = "<group>"; };
 		A71CE71D20ABB90D7E94264E /* StartAgentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStoreTests.swift; sourceTree = "<group>"; };
 		A95E62CA572C71B2C746E972 /* ConsoleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleStore.swift; sourceTree = "<group>"; };
+		A961D26EDEAA03AFB0F9C408 /* TerminalThemeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemeSettings.swift; sourceTree = "<group>"; };
 		A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConcurrencyE2ETests.swift; sourceTree = "<group>"; };
 		B383994C2C8492694D5F3690 /* HerdrMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HerdrMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B66B41C393D38FA09388E3E2 /* ReconnectPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectPolicyTests.swift; sourceTree = "<group>"; };
@@ -176,6 +182,7 @@
 		DDC07C7B3772EEED1EB8BA9C /* HostCredentialsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostCredentialsProvider.swift; sourceTree = "<group>"; };
 		DE12859365BC7A57B9EC256A /* HostDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostDraft.swift; sourceTree = "<group>"; };
 		E87B816CE7206B37622287C4 /* GeneratedWireTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedWireTypesTests.swift; sourceTree = "<group>"; };
+		EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemeSettingsTests.swift; sourceTree = "<group>"; };
 		EF9B76E2DA818DAB4259286C /* HostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostListView.swift; sourceTree = "<group>"; };
 		F13921A61B4E4F17CDE47C96 /* ClosePaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosePaneStore.swift; sourceTree = "<group>"; };
 		F3D159C84E98A59AA47EBE6C /* HerdrMobileTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HerdrMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -192,6 +199,7 @@
 			files = (
 				C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */,
 				FEDD78DD422954EEBA415E8E /* GhosttyTerminal in Frameworks */,
+				C70B492B9C358FDAFF7876CF /* GhosttyTheme in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -206,6 +214,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		076C8448389275EA5E67DA9F /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				95B5EBF6C4EC88361E91CA2C /* SettingsView.swift */,
+				A961D26EDEAA03AFB0F9C408 /* TerminalThemeSettings.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
 		1E109F809AACADFF5FCB7385 /* Generated */ = {
 			isa = PBXGroup;
 			children = (
@@ -290,6 +307,7 @@
 				A71CE71D20ABB90D7E94264E /* StartAgentStoreTests.swift */,
 				D83F34B22988623AD8E2093C /* TerminalAttachE2ETests.swift */,
 				BE8796AB629EF68A90C96B3D /* TerminalAttachTests.swift */,
+				EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */,
 				A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */,
 				02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */,
 				CB45F25667AE3C5C2EFD76CB /* Support */,
@@ -354,6 +372,7 @@
 				78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */,
 				AEEB5E7751FD30413560D58D /* Console */,
 				85F7BECB72876852AAA885F2 /* Hosts */,
+				076C8448389275EA5E67DA9F /* Settings */,
 				758C1B00FCD3935541ADA64F /* Terminal */,
 				41C75ABDF8DC22F0282957C5 /* Transport */,
 			);
@@ -399,6 +418,7 @@
 			packageProductDependencies = (
 				03BEAFDD98C535CDCE9AE335 /* Citadel */,
 				3A53219005FF960DB8CAB247 /* GhosttyTerminal */,
+				6AB21852B18619F247B07907 /* GhosttyTheme */,
 			);
 			productName = HerdrMobile;
 			productReference = B383994C2C8492694D5F3690 /* HerdrMobile.app */;
@@ -495,6 +515,7 @@
 				8C514AFC85DAED69A4988C13 /* SSHCredentials.swift in Sources */,
 				073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */,
 				693B0173C07DAF4BFC89B094 /* SecretStore.swift in Sources */,
+				1E26593A1B05B0ACEE9AC557 /* SettingsView.swift in Sources */,
 				DC564E76486D243AD1741F7E /* SharedAsyncOperation.swift in Sources */,
 				9C1C00F36A178BF1BEE6C0A5 /* StartAgentStore.swift in Sources */,
 				7EEB41E5CD728587D7DCEC96 /* StartAgentView.swift in Sources */,
@@ -504,6 +525,7 @@
 				8DF99F3257BCC6AE08595A45 /* TerminalKeyboard.swift in Sources */,
 				F96C5D15E14B947BE426B2F3 /* TerminalScreenView.swift in Sources */,
 				EDFEE058F85AF41DBFE351A7 /* TerminalTextSelectionPresenter.swift in Sources */,
+				5D1B735C72D551ADE0D82D44 /* TerminalThemeSettings.swift in Sources */,
 				B8ACB86B152D44FC0C80DADA /* TerminalTouchScroll.swift in Sources */,
 				49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */,
 				B31E16D56EE1F19A3802625B /* TransportConnector.swift in Sources */,
@@ -547,6 +569,7 @@
 				488EF0DD844658122800A1A7 /* StartAgentStoreTests.swift in Sources */,
 				E8E50DCA9F56799E022F9252 /* TerminalAttachE2ETests.swift in Sources */,
 				0CF1AA5AF7F2357186A5E486 /* TerminalAttachTests.swift in Sources */,
+				D51F828E0AC4A2F6C23A0CBE /* TerminalThemeSettingsTests.swift in Sources */,
 				E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */,
 				782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */,
 				C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */,
@@ -831,6 +854,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C7978977B3798596C05BD5DF /* XCRemoteSwiftPackageReference "libghostty-spm" */;
 			productName = GhosttyTerminal;
+		};
+		6AB21852B18619F247B07907 /* GhosttyTheme */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C7978977B3798596C05BD5DF /* XCRemoteSwiftPackageReference "libghostty-spm" */;
+			productName = GhosttyTheme;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/HerdrMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HerdrMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "47cd49417d767965e2f16dba29ebd67ea7e7e40e2652e748f8a09020e452b23d",
+  "originHash" : "408454893d857f99027fd8be8bc6124d70ae71595e7aa6aecda764ea663b25ac",
   "pins" : [
     {
       "identity" : "bigint",
@@ -20,12 +20,21 @@
       }
     },
     {
-      "identity" : "swift-argument-parser",
+      "identity" : "libghostty-spm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
+      "location" : "https://github.com/lakr233/libghostty-spm.git",
       "state" : {
-        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
-        "version" : "1.8.2"
+        "revision" : "5530721e8e975178ac8293708f23815281f16f72",
+        "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "msdisplaylink",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Lakr233/MSDisplayLink.git",
+      "state" : {
+        "revision" : "1ba3e769b734e456317fa7e45321fa7f53eefb67",
+        "version" : "2.1.0"
       }
     },
     {
@@ -98,15 +107,6 @@
       "state" : {
         "revision" : "b5544ba79a70a0cb3563e75bf26dc198d6b40ed3",
         "version" : "1.7.4"
-      }
-    },
-    {
-      "identity" : "swiftterm",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/migueldeicaza/SwiftTerm.git",
-      "state" : {
-        "revision" : "849e8a4f3d6f79ddee07152400137f1370c32621",
-        "version" : "1.14.0"
       }
     }
   ],

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ herdr-mobile is an **agent console**: a native dashboard of every coding agent r
 The app speaks herdr's JSON API (newline-delimited JSON over a Unix socket) through SSH:
 
 - **RPC + events**: a no-PTY SSH exec channel running `socat - UNIX-CONNECT:<herdr.sock>` per request, plus one long-lived channel for `events.subscribe`.
-- **Interactive terminal**: the Agent detail screen opens an SSH PTY shell channel bootstrapped with an injection-safe `exec herdr agent attach <pane>` line, then rendered by SwiftTerm with native normal-buffer scrolling and alternate-screen wheel gestures.
+- **Interactive terminal**: the Agent detail screen opens an SSH PTY shell channel bootstrapped with an injection-safe `exec herdr agent attach <pane>` line, then renders it through a host-managed libghostty-spm session with Metal output, IME input, native touch scrolling, and long-press text selection.
 
 No herdr server changes required. The only remote prerequisite is `socat` installed on the host.
 
@@ -17,7 +17,7 @@ No herdr server changes required. The only remote prerequisite is `socat` instal
 
 - SwiftUI, iOS 26+, iPhone + iPad
 - [Citadel](https://github.com/orlandos-nl/Citadel) for SSH
-- [SwiftTerm](https://github.com/migueldeicaza/SwiftTerm) for terminal rendering
+- [libghostty-spm](https://github.com/lakr233/libghostty-spm) for terminal emulation and Metal rendering
 
 See `docs/adr/` for why these choices were made (the transport story in particular is not obvious).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ herdr-mobile is an **agent console**: a native dashboard of every coding agent r
 The app speaks herdr's JSON API (newline-delimited JSON over a Unix socket) through SSH:
 
 - **RPC + events**: a no-PTY SSH exec channel running `socat - UNIX-CONNECT:<herdr.sock>` per request, plus one long-lived channel for `events.subscribe`.
-- **Interactive terminal**: the Agent detail screen opens an SSH PTY shell channel bootstrapped with an injection-safe `exec herdr agent attach <pane>` line, then renders it through a host-managed libghostty-spm session with Metal output, IME input, long-press text selection, and app-routed touch scrolling for both local scrollback and remote TUIs.
+- **Interactive terminal**: the Agent detail screen opens an SSH PTY shell channel bootstrapped with an injection-safe `exec herdr agent attach <pane>` line, then renders it through a host-managed libghostty-spm session with Metal output, input-row keyboard activation, IME input, long-press text selection, and app-routed touch scrolling for both local scrollback and remote TUIs.
 
 No herdr server changes required. The only remote prerequisite is `socat` installed on the host.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ herdr-mobile is an **agent console**: a native dashboard of every coding agent r
 The app speaks herdr's JSON API (newline-delimited JSON over a Unix socket) through SSH:
 
 - **RPC + events**: a no-PTY SSH exec channel running `socat - UNIX-CONNECT:<herdr.sock>` per request, plus one long-lived channel for `events.subscribe`.
-- **Interactive terminal**: the Agent detail screen opens an SSH PTY shell channel bootstrapped with an injection-safe `exec herdr agent attach <pane>` line, then renders it through a host-managed libghostty-spm session with Metal output, IME input, native touch scrolling, and long-press text selection.
+- **Interactive terminal**: the Agent detail screen opens an SSH PTY shell channel bootstrapped with an injection-safe `exec herdr agent attach <pane>` line, then renders it through a host-managed libghostty-spm session with Metal output, IME input, long-press text selection, and app-routed touch scrolling for both local scrollback and remote TUIs.
 
 No herdr server changes required. The only remote prerequisite is `socat` installed on the host.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ herdr-mobile is an **agent console**: a native dashboard of every coding agent r
 The app speaks herdr's JSON API (newline-delimited JSON over a Unix socket) through SSH:
 
 - **RPC + events**: a no-PTY SSH exec channel running `socat - UNIX-CONNECT:<herdr.sock>` per request, plus one long-lived channel for `events.subscribe`.
-- **Interactive terminal**: the Agent detail screen opens an SSH PTY shell channel bootstrapped with an injection-safe `exec herdr agent attach <pane>` line, then renders it through a host-managed libghostty-spm session with Metal output, input-row keyboard activation, IME input, long-press text selection, and app-routed touch scrolling for both local scrollback and remote TUIs.
+- **Interactive terminal**: the Agent detail screen opens an SSH PTY shell channel bootstrapped with an injection-safe `exec herdr agent attach <pane>` line, then renders it through a host-managed libghostty-spm session with Metal output, persistent appearance-aware themes, input-row keyboard activation, IME input, long-press text selection, and app-routed touch scrolling for both local scrollback and remote TUIs.
 
 No herdr server changes required. The only remote prerequisite is `socat` installed on the host.
 

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -6,16 +6,23 @@ import SwiftUI
 struct AgentDetailView: View {
     let agent: ConsoleAgent
     private let console: ConsoleStore
+    private let terminalThemes: TerminalThemeSettings
     private let transport: @Sendable () async -> (any Transport)?
     @State private var store: AttachTerminalStore
     @State private var close: ClosePaneStore
     @State private var isConfirmingClose = false
+    @State private var isShowingSettings = false
     @State private var closeErrorMessage: String?
     @Environment(\.dismiss) private var dismiss
 
-    init(agent: ConsoleAgent, console: ConsoleStore) {
+    init(
+        agent: ConsoleAgent,
+        console: ConsoleStore,
+        terminalThemes: TerminalThemeSettings
+    ) {
         self.agent = agent
         self.console = console
+        self.terminalThemes = terminalThemes
         let transport = console.transportProvider(for: agent.hostID)
         self.transport = transport
         _store = State(
@@ -33,7 +40,8 @@ struct AgentDetailView: View {
             onSizeChanged: { cols, rows in
                 store.viewDidResize(cols: cols, rows: rows)
             },
-            onSend: { keystrokes in store.send(keystrokes) }
+            onSend: { keystrokes in store.send(keystrokes) },
+            theme: terminalThemes.theme
         )
         .id(ObjectIdentifier(store))
         .overlay { statusOverlay }
@@ -45,6 +53,9 @@ struct AgentDetailView: View {
             }
             ToolbarItem(placement: .primaryAction) {
                 Menu {
+                    Button("Terminal Theme", systemImage: "paintpalette") {
+                        isShowingSettings = true
+                    }
                     Button("Close Agent", systemImage: "trash", role: .destructive) {
                         isConfirmingClose = true
                     }
@@ -52,6 +63,9 @@ struct AgentDetailView: View {
                     Label("More", systemImage: "ellipsis.circle")
                 }
             }
+        }
+        .sheet(isPresented: $isShowingSettings) {
+            SettingsView(terminalThemes: terminalThemes)
         }
         .confirmationDialog(
             "Close \(title)?", isPresented: $isConfirmingClose, titleVisibility: .visible

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-/// The Agent detail screen: one interactive Attach terminal with the iOS
-/// system keyboard. Ghostty owns local scrollback, touch scrolling, IME, and
-/// alternate-screen mouse reporting for the host-managed terminal session.
+/// The Agent detail screen: one interactive Attach terminal with an explicitly
+/// activated iOS keyboard. Ghostty owns local scrollback, touch scrolling, IME,
+/// and alternate-screen mouse reporting for the host-managed terminal session.
 struct AgentDetailView: View {
     let agent: ConsoleAgent
     private let console: ConsoleStore
@@ -11,6 +11,7 @@ struct AgentDetailView: View {
     @State private var close: ClosePaneStore
     @State private var isConfirmingClose = false
     @State private var closeErrorMessage: String?
+    @State private var keyboardRequestID = 0
     @Environment(\.dismiss) private var dismiss
 
     init(agent: ConsoleAgent, console: ConsoleStore) {
@@ -33,7 +34,8 @@ struct AgentDetailView: View {
             onSizeChanged: { cols, rows in
                 store.viewDidResize(cols: cols, rows: rows)
             },
-            onSend: { keystrokes in store.send(keystrokes) }
+            onSend: { keystrokes in store.send(keystrokes) },
+            keyboardRequestID: keyboardRequestID
         )
         .id(ObjectIdentifier(store))
         .overlay { statusOverlay }
@@ -42,6 +44,13 @@ struct AgentDetailView: View {
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 AgentStatusBadge(status: agent.agent.status)
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    keyboardRequestID &+= 1
+                } label: {
+                    Label("Keyboard", systemImage: "keyboard")
+                }
             }
             ToolbarItem(placement: .primaryAction) {
                 Menu {

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 /// The Agent detail screen: one interactive Attach terminal with the iOS
-/// system keyboard. The normal terminal buffer scrolls locally; full-screen
-/// alternate buffers translate vertical drags into continuous wheel events.
+/// system keyboard. Ghostty owns local scrollback, touch scrolling, IME, and
+/// alternate-screen mouse reporting for the host-managed terminal session.
 struct AgentDetailView: View {
     let agent: ConsoleAgent
     private let console: ConsoleStore

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 /// The Agent detail screen: one interactive Attach terminal with an explicitly
-/// activated iOS keyboard. Ghostty owns local scrollback, touch scrolling, IME,
-/// and alternate-screen mouse reporting for the host-managed terminal session.
+/// activated iOS keyboard. Ghostty owns rendering, scrollback, and IME; the
+/// adapter routes touch scrolling to local history or the remote TUI.
 struct AgentDetailView: View {
     let agent: ConsoleAgent
     private let console: ConsoleStore

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-/// The Agent detail screen: one interactive Attach terminal with an explicitly
-/// activated iOS keyboard. Ghostty owns rendering, scrollback, and IME; the
-/// adapter routes touch scrolling to local history or the remote TUI.
+/// The Agent detail screen: one interactive Attach terminal. Ghostty owns
+/// rendering, scrollback, and IME; the adapter routes input-row taps and touch
+/// scrolling without adding separate terminal chrome.
 struct AgentDetailView: View {
     let agent: ConsoleAgent
     private let console: ConsoleStore
@@ -11,7 +11,6 @@ struct AgentDetailView: View {
     @State private var close: ClosePaneStore
     @State private var isConfirmingClose = false
     @State private var closeErrorMessage: String?
-    @State private var keyboardRequestID = 0
     @Environment(\.dismiss) private var dismiss
 
     init(agent: ConsoleAgent, console: ConsoleStore) {
@@ -34,8 +33,7 @@ struct AgentDetailView: View {
             onSizeChanged: { cols, rows in
                 store.viewDidResize(cols: cols, rows: rows)
             },
-            onSend: { keystrokes in store.send(keystrokes) },
-            keyboardRequestID: keyboardRequestID
+            onSend: { keystrokes in store.send(keystrokes) }
         )
         .id(ObjectIdentifier(store))
         .overlay { statusOverlay }
@@ -44,13 +42,6 @@ struct AgentDetailView: View {
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 AgentStatusBadge(status: agent.agent.status)
-            }
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    keyboardRequestID &+= 1
-                } label: {
-                    Label("Keyboard", systemImage: "keyboard")
-                }
             }
             ToolbarItem(placement: .primaryAction) {
                 Menu {

--- a/Sources/HerdrMobile/Console/ConsoleView.swift
+++ b/Sources/HerdrMobile/Console/ConsoleView.swift
@@ -5,8 +5,10 @@ import SwiftUI
 struct ConsoleView: View {
     let hosts: HostStore
     let console: ConsoleStore
+    let terminalThemes: TerminalThemeSettings
     @State private var isManagingHosts = false
     @State private var isStartingAgent = false
+    @State private var isShowingSettings = false
 
     var body: some View {
         NavigationStack {
@@ -16,7 +18,10 @@ struct ConsoleView: View {
                 // Agent detail screen is pushed.
                 .navigationDestination(for: ConsoleAgent.ID.self) { id in
                     if let agent = console.agents.first(where: { $0.id == id }) {
-                        AgentDetailView(agent: agent, console: console)
+                        AgentDetailView(
+                            agent: agent,
+                            console: console,
+                            terminalThemes: terminalThemes)
                     } else {
                         ContentUnavailableView(
                             "Agent Gone", systemImage: "rectangle.on.rectangle.slash",
@@ -28,6 +33,11 @@ struct ConsoleView: View {
                     ToolbarItem(placement: .primaryAction) {
                         Button("Hosts", systemImage: "server.rack") {
                             isManagingHosts = true
+                        }
+                    }
+                    ToolbarItem(placement: .primaryAction) {
+                        Button("Settings", systemImage: "gearshape") {
+                            isShowingSettings = true
                         }
                     }
                     if !hosts.hosts.isEmpty {
@@ -48,6 +58,9 @@ struct ConsoleView: View {
                 .sheet(isPresented: $isStartingAgent) {
                     // StartAgentView brings its own NavigationStack.
                     StartAgentView(hosts: hosts.hosts, console: console)
+                }
+                .sheet(isPresented: $isShowingSettings) {
+                    SettingsView(terminalThemes: terminalThemes)
                 }
         }
     }

--- a/Sources/HerdrMobile/ContentView.swift
+++ b/Sources/HerdrMobile/ContentView.swift
@@ -6,10 +6,11 @@ import SwiftUI
 struct ContentView: View {
     @State private var hostStore = HostStore()
     @State private var console = ConsoleStore()
+    @State private var terminalThemes = TerminalThemeSettings()
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
-        ConsoleView(hosts: hostStore, console: console)
+        ConsoleView(hosts: hostStore, console: console, terminalThemes: terminalThemes)
             .task {
                 console.setHosts(hostStore.hosts)
                 await console.resume()

--- a/Sources/HerdrMobile/Settings/SettingsView.swift
+++ b/Sources/HerdrMobile/Settings/SettingsView.swift
@@ -1,0 +1,138 @@
+import GhosttyTerminal
+import SwiftUI
+import UIKit
+
+struct SettingsView: View {
+    let terminalThemes: TerminalThemeSettings
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TerminalThemePreview(theme: terminalThemes.theme)
+                        .frame(height: 180)
+                        .clipShape(.rect(cornerRadius: 16))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 16)
+                                .stroke(
+                                    Color(uiColor: .separator).opacity(0.45),
+                                    lineWidth: 0.5)
+                        }
+                        .listRowInsets(EdgeInsets())
+                        .listRowBackground(Color.clear)
+                        .accessibilityLabel("Terminal theme preview")
+                } header: {
+                    Text("Preview")
+                } footer: {
+                    Text(
+                        "Changes apply instantly to current and future Attach terminals without reconnecting."
+                    )
+                }
+
+                Section("Terminal Theme") {
+                    ForEach(TerminalThemeOption.allCases) { option in
+                        themeButton(option)
+                    }
+                }
+            }
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func themeButton(_ option: TerminalThemeOption) -> some View {
+        let isSelected = terminalThemes.selection == option
+        return Button {
+            terminalThemes.select(option)
+        } label: {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(option.title)
+                        .foregroundStyle(.primary)
+                    Text(option.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 12)
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.tint)
+                        .accessibilityHidden(true)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityValue(isSelected ? "Selected" : "")
+    }
+}
+
+private struct TerminalThemePreview: UIViewRepresentable {
+    let theme: TerminalTheme
+
+    func makeUIView(context _: Context) -> TerminalThemePreviewView {
+        TerminalThemePreviewView(theme: theme)
+    }
+
+    func updateUIView(_ view: TerminalThemePreviewView, context _: Context) {
+        view.applyTheme(theme)
+    }
+}
+
+@MainActor
+private final class TerminalThemePreviewView: UITerminalView {
+    private static let previewLines: [String] = [
+        "\u{1B}[2J\u{1B}[H\u{1B}[1;36mherdr-mobile\u{1B}[0m",
+        "\u{1B}[32m● connected\u{1B}[0m  mac-studio",
+        "",
+        "\u{1B}[34m~/Projects/herdr\u{1B}[0m",
+        "\u{1B}[35m›\u{1B}[0m codex --continue",
+        "\u{1B}[2mReady for input\u{1B}[0m",
+    ]
+    private static let preview = Data(previewLines.joined(separator: "\r\n").utf8)
+
+    private let previewSession: InMemoryTerminalSession
+    private let themeController: TerminalController
+    private var hasLoadedPreview = false
+
+    init(theme: TerminalTheme) {
+        let session = InMemoryTerminalSession(write: { _ in }, resize: { _ in })
+        previewSession = session
+        themeController = TerminalController(theme: theme) { builder in
+            builder.withWindowPaddingX(12)
+            builder.withWindowPaddingY(10)
+        }
+        super.init(frame: .zero)
+        inputAccessoryItems = []
+        configuration = TerminalSurfaceOptions(
+            backend: .inMemory(session),
+            fontSize: 13)
+        controller = themeController
+        isUserInteractionEnabled = false
+        isAccessibilityElement = true
+        accessibilityLabel = "Terminal theme preview"
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is unavailable")
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        guard window != nil, !hasLoadedPreview else { return }
+        hasLoadedPreview = true
+        previewSession.receive(Self.preview)
+    }
+
+    func applyTheme(_ theme: TerminalTheme) {
+        _ = themeController.setTheme(theme)
+    }
+}

--- a/Sources/HerdrMobile/Settings/TerminalThemeSettings.swift
+++ b/Sources/HerdrMobile/Settings/TerminalThemeSettings.swift
@@ -1,0 +1,112 @@
+import Foundation
+import GhosttyTerminal
+import GhosttyTheme
+import Observation
+
+enum TerminalThemeOption: String, CaseIterable, Identifiable, Sendable {
+    case followSystem = "follow-system"
+    case vesper
+    case appleSystemColors = "apple-system-colors"
+    case dracula
+    case solarized
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .followSystem: "Follow System"
+        case .vesper: "Vesper"
+        case .appleSystemColors: "Apple System Colors"
+        case .dracula: "Dracula"
+        case .solarized: "Solarized"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .followSystem: "Alabaster in Light Mode, Afterglow in Dark Mode"
+        case .vesper: "A warm, low-contrast dark theme"
+        case .appleSystemColors: "Apple's terminal palette for each appearance"
+        case .dracula: "The classic high-contrast dark palette"
+        case .solarized: "Paired iTerm2 Solarized light and dark themes"
+        }
+    }
+
+    var terminalTheme: TerminalTheme {
+        switch self {
+        case .followSystem:
+            .default
+        case .vesper:
+            Self.singleTheme(named: "Vesper")
+        case .appleSystemColors:
+            Self.pairedTheme(
+                light: "Apple System Colors Light",
+                dark: "Apple System Colors")
+        case .dracula:
+            Self.singleTheme(named: "Dracula")
+        case .solarized:
+            Self.pairedTheme(
+                light: "iTerm2 Solarized Light",
+                dark: "iTerm2 Solarized Dark")
+        }
+    }
+
+    static let requiredCatalogThemeNames = [
+        "Vesper",
+        "Apple System Colors Light",
+        "Apple System Colors",
+        "Dracula",
+        "iTerm2 Solarized Light",
+        "iTerm2 Solarized Dark",
+    ]
+
+    static var missingCatalogThemeNames: [String] {
+        requiredCatalogThemeNames.filter { definitions[$0] == nil }
+    }
+
+    private static let definitions: [String: GhosttyThemeDefinition] =
+        GhosttyThemeCatalog.allThemes.reduce(into: [:]) { result, definition in
+            result[definition.name] = definition
+        }
+
+    private static func singleTheme(named name: String) -> TerminalTheme {
+        let configuration = configuration(named: name)
+        return TerminalTheme(light: configuration, dark: configuration)
+    }
+
+    private static func pairedTheme(light: String, dark: String) -> TerminalTheme {
+        TerminalTheme(
+            light: configuration(named: light),
+            dark: configuration(named: dark))
+    }
+
+    private static func configuration(named name: String) -> TerminalConfiguration {
+        definitions[name]?.toTerminalConfiguration() ?? .default
+    }
+}
+
+@MainActor
+@Observable
+final class TerminalThemeSettings {
+    private static let defaultsKey = "terminal-theme"
+
+    private(set) var selection: TerminalThemeOption
+    @ObservationIgnored private nonisolated(unsafe) let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        selection =
+            defaults.string(forKey: Self.defaultsKey)
+            .flatMap(TerminalThemeOption.init(rawValue:)) ?? .followSystem
+    }
+
+    var theme: TerminalTheme {
+        selection.terminalTheme
+    }
+
+    func select(_ selection: TerminalThemeOption) {
+        guard selection != self.selection else { return }
+        self.selection = selection
+        defaults.set(selection.rawValue, forKey: Self.defaultsKey)
+    }
+}

--- a/Sources/HerdrMobile/Settings/TerminalThemeSettings.swift
+++ b/Sources/HerdrMobile/Settings/TerminalThemeSettings.swift
@@ -9,6 +9,11 @@ enum TerminalThemeOption: String, CaseIterable, Identifiable, Sendable {
     case appleSystemColors = "apple-system-colors"
     case dracula
     case solarized
+    case catppuccin
+    case tokyoNight = "tokyo-night"
+    case gruvbox
+    case nord
+    case monokaiPro = "monokai-pro"
 
     var id: Self { self }
 
@@ -19,6 +24,11 @@ enum TerminalThemeOption: String, CaseIterable, Identifiable, Sendable {
         case .appleSystemColors: "Apple System Colors"
         case .dracula: "Dracula"
         case .solarized: "Solarized"
+        case .catppuccin: "Catppuccin"
+        case .tokyoNight: "Tokyo Night"
+        case .gruvbox: "Gruvbox"
+        case .nord: "Nord"
+        case .monokaiPro: "Monokai Pro"
         }
     }
 
@@ -29,6 +39,11 @@ enum TerminalThemeOption: String, CaseIterable, Identifiable, Sendable {
         case .appleSystemColors: "Apple's terminal palette for each appearance"
         case .dracula: "The classic high-contrast dark palette"
         case .solarized: "Paired iTerm2 Solarized light and dark themes"
+        case .catppuccin: "Latte in Light Mode, Mocha in Dark Mode"
+        case .tokyoNight: "Day in Light Mode, Night in Dark Mode"
+        case .gruvbox: "A warm retro palette for both appearances"
+        case .nord: "A calm arctic palette for both appearances"
+        case .monokaiPro: "The popular editor palette for both appearances"
         }
     }
 
@@ -48,6 +63,26 @@ enum TerminalThemeOption: String, CaseIterable, Identifiable, Sendable {
             Self.pairedTheme(
                 light: "iTerm2 Solarized Light",
                 dark: "iTerm2 Solarized Dark")
+        case .catppuccin:
+            Self.pairedTheme(
+                light: "Catppuccin Latte",
+                dark: "Catppuccin Mocha")
+        case .tokyoNight:
+            Self.pairedTheme(
+                light: "TokyoNight Day",
+                dark: "TokyoNight Night")
+        case .gruvbox:
+            Self.pairedTheme(
+                light: "Gruvbox Light",
+                dark: "Gruvbox Dark")
+        case .nord:
+            Self.pairedTheme(
+                light: "Nord Light",
+                dark: "Nord")
+        case .monokaiPro:
+            Self.pairedTheme(
+                light: "Monokai Pro Light",
+                dark: "Monokai Pro")
         }
     }
 
@@ -58,6 +93,16 @@ enum TerminalThemeOption: String, CaseIterable, Identifiable, Sendable {
         "Dracula",
         "iTerm2 Solarized Light",
         "iTerm2 Solarized Dark",
+        "Catppuccin Latte",
+        "Catppuccin Mocha",
+        "TokyoNight Day",
+        "TokyoNight Night",
+        "Gruvbox Light",
+        "Gruvbox Dark",
+        "Nord Light",
+        "Nord",
+        "Monokai Pro Light",
+        "Monokai Pro",
     ]
 
     static var missingCatalogThemeNames: [String] {

--- a/Sources/HerdrMobile/Terminal/TerminalByteFeed.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalByteFeed.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// The byte pipe between an Attach store and its SwiftTerm view. Bytes that
+/// The byte pipe between an Attach store and its terminal view. Bytes that
 /// arrive before the view exists are buffered, so opening output is never lost.
 @MainActor
 final class TerminalByteFeed {

--- a/Sources/HerdrMobile/Terminal/TerminalKeyboard.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalKeyboard.swift
@@ -1,5 +1,25 @@
-import SwiftTerm
 import UIKit
+
+private enum TerminalEscapeSequences {
+    static let escape: [UInt8] = [0x1B]
+    static let tab: [UInt8] = [0x09]
+    static let homeNormal: [UInt8] = [0x1B, 0x5B, 0x48]
+    static let homeApplication: [UInt8] = [0x1B, 0x4F, 0x48]
+    static let pageUp: [UInt8] = [0x1B, 0x5B, 0x35, 0x7E]
+    static let upNormal: [UInt8] = [0x1B, 0x5B, 0x41]
+    static let upApplication: [UInt8] = [0x1B, 0x4F, 0x41]
+    static let pageDown: [UInt8] = [0x1B, 0x5B, 0x36, 0x7E]
+    static let endNormal: [UInt8] = [0x1B, 0x5B, 0x46]
+    static let endApplication: [UInt8] = [0x1B, 0x4F, 0x46]
+    static let backspace: [UInt8] = [0x7F]
+    static let leftNormal: [UInt8] = [0x1B, 0x5B, 0x44]
+    static let leftApplication: [UInt8] = [0x1B, 0x4F, 0x44]
+    static let downNormal: [UInt8] = [0x1B, 0x5B, 0x42]
+    static let downApplication: [UInt8] = [0x1B, 0x4F, 0x42]
+    static let rightNormal: [UInt8] = [0x1B, 0x5B, 0x43]
+    static let rightApplication: [UInt8] = [0x1B, 0x4F, 0x43]
+    static let enter: [UInt8] = [0x0D]
+}
 
 enum TerminalKeyboardMode: Int {
     case text
@@ -87,27 +107,33 @@ enum TerminalControlKey: Equatable {
 
     func bytes(applicationCursor: Bool) -> [UInt8] {
         switch self {
-        case .escape: EscapeSequences.cmdEsc
-        case .tab: EscapeSequences.cmdTab
+        case .escape: TerminalEscapeSequences.escape
+        case .tab: TerminalEscapeSequences.tab
         case .controlC: [0x03]
         case .controlD: [0x04]
         case .controlZ: [0x1A]
         case .home:
-            applicationCursor ? EscapeSequences.moveHomeApp : EscapeSequences.moveHomeNormal
-        case .pageUp: EscapeSequences.cmdPageUp
+            applicationCursor
+                ? TerminalEscapeSequences.homeApplication : TerminalEscapeSequences.homeNormal
+        case .pageUp: TerminalEscapeSequences.pageUp
         case .up:
-            applicationCursor ? EscapeSequences.moveUpApp : EscapeSequences.moveUpNormal
-        case .pageDown: EscapeSequences.cmdPageDown
+            applicationCursor
+                ? TerminalEscapeSequences.upApplication : TerminalEscapeSequences.upNormal
+        case .pageDown: TerminalEscapeSequences.pageDown
         case .end:
-            applicationCursor ? EscapeSequences.moveEndApp : EscapeSequences.moveEndNormal
-        case .backspace: EscapeSequences.cmdDel
+            applicationCursor
+                ? TerminalEscapeSequences.endApplication : TerminalEscapeSequences.endNormal
+        case .backspace: TerminalEscapeSequences.backspace
         case .left:
-            applicationCursor ? EscapeSequences.moveLeftApp : EscapeSequences.moveLeftNormal
+            applicationCursor
+                ? TerminalEscapeSequences.leftApplication : TerminalEscapeSequences.leftNormal
         case .down:
-            applicationCursor ? EscapeSequences.moveDownApp : EscapeSequences.moveDownNormal
+            applicationCursor
+                ? TerminalEscapeSequences.downApplication : TerminalEscapeSequences.downNormal
         case .right:
-            applicationCursor ? EscapeSequences.moveRightApp : EscapeSequences.moveRightNormal
-        case .enter: EscapeSequences.cmdRet
+            applicationCursor
+                ? TerminalEscapeSequences.rightApplication : TerminalEscapeSequences.rightNormal
+        case .enter: TerminalEscapeSequences.enter
         }
     }
 }
@@ -115,10 +141,10 @@ enum TerminalControlKey: Equatable {
 final class TerminalKeyboardAccessory: UIInputView {
     static let preferredHeight: CGFloat = 48
 
-    private weak var terminalView: SizeReportingTerminalView?
+    private weak var terminalView: HerdrTerminalView?
     private let modeControl = UISegmentedControl(items: ["Text", "Keys"])
 
-    init(frame: CGRect, terminalView: SizeReportingTerminalView) {
+    init(frame: CGRect, terminalView: HerdrTerminalView) {
         self.terminalView = terminalView
         super.init(frame: frame, inputViewStyle: .keyboard)
         allowsSelfSizing = true
@@ -192,12 +218,12 @@ final class TerminalKeyboardAccessory: UIInputView {
 final class TerminalControlKeyboardView: UIInputView, UIInputViewAudioFeedback {
     static let defaultHeight: CGFloat = 224
 
-    private weak var terminalView: SizeReportingTerminalView?
+    private weak var terminalView: HerdrTerminalView?
     private let keyboardHeight: CGFloat
 
     var enableInputClicksWhenVisible: Bool { true }
 
-    init(frame: CGRect, keyboardHeight: CGFloat, terminalView: SizeReportingTerminalView) {
+    init(frame: CGRect, keyboardHeight: CGFloat, terminalView: HerdrTerminalView) {
         self.terminalView = terminalView
         self.keyboardHeight = keyboardHeight
         super.init(frame: frame, inputViewStyle: .keyboard)
@@ -335,7 +361,7 @@ private final class TerminalKeyButton: UIButton {
     }
 }
 
-extension SizeReportingTerminalView {
+extension HerdrTerminalView {
     var keyboardMode: TerminalKeyboardMode {
         inputView is TerminalControlKeyboardView ? .controls : .text
     }
@@ -343,11 +369,7 @@ extension SizeReportingTerminalView {
     func installKeyboardSwitcher() {
         inputAssistantItem.leadingBarButtonGroups = []
         inputAssistantItem.trailingBarButtonGroups = []
-        inputAccessoryView = TerminalKeyboardAccessory(
-            frame: CGRect(
-                x: 0, y: 0, width: bounds.width,
-                height: TerminalKeyboardAccessory.preferredHeight),
-            terminalView: self)
+        _ = inputAccessoryView
         NotificationCenter.default.addObserver(
             self, selector: #selector(textKeyboardFrameDidChange(_:)),
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil)
@@ -358,12 +380,13 @@ extension SizeReportingTerminalView {
 
         switch mode {
         case .text:
-            inputView = nil
+            setTerminalInputView(nil)
         case .controls:
-            inputView = TerminalControlKeyboardView(
-                frame: CGRect(
-                    x: 0, y: 0, width: bounds.width, height: controlKeyboardHeight),
-                keyboardHeight: controlKeyboardHeight, terminalView: self)
+            setTerminalInputView(
+                TerminalControlKeyboardView(
+                    frame: CGRect(
+                        x: 0, y: 0, width: bounds.width, height: controlKeyboardHeight),
+                    keyboardHeight: controlKeyboardHeight, terminalView: self))
         }
         (inputAccessoryView as? TerminalKeyboardAccessory)?.update(mode: mode)
         UIView.performWithoutAnimation {
@@ -372,7 +395,8 @@ extension SizeReportingTerminalView {
     }
 
     func sendControlKey(_ key: TerminalControlKey) {
-        send(key.bytes(applicationCursor: getTerminal().applicationCursor))
+        terminalSession.sendInput(
+            Data(key.bytes(applicationCursor: usesApplicationCursorKeys)))
     }
 
     func recordTextKeyboardHeight(totalHeight: CGFloat, accessoryHeight: CGFloat) {

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -20,6 +20,7 @@ struct TerminalScreenView: UIViewRepresentable {
     let feed: TerminalByteFeed
     var onSizeChanged: ((_ cols: Int, _ rows: Int) -> Void)?
     var onSend: ((Data) -> Void)?
+    var keyboardRequestID = 0
     @Environment(\.openURL) private var openURL
 
     func makeUIView(context: Context) -> HerdrTerminalView {
@@ -50,10 +51,16 @@ struct TerminalScreenView: UIViewRepresentable {
     func updateUIView(_ view: HerdrTerminalView, context: Context) {
         view.updateCallbacks(onSizeChanged: onSizeChanged, onSend: onSend)
         context.coordinator.onOpenLink = { url in openURL(url) }
+        if context.coordinator.keyboardRequestID != keyboardRequestID {
+            context.coordinator.keyboardRequestID = keyboardRequestID
+            view.requestKeyboard()
+        }
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onOpenLink: { url in openURL(url) })
+        Coordinator(
+            keyboardRequestID: keyboardRequestID,
+            onOpenLink: { url in openURL(url) })
     }
 
     @MainActor
@@ -61,9 +68,11 @@ struct TerminalScreenView: UIViewRepresentable {
         TerminalSurfaceTextSelectionRequestDelegate
     {
         weak var terminalView: HerdrTerminalView?
+        var keyboardRequestID: Int
         var onOpenLink: ((URL) -> Void)?
 
-        init(onOpenLink: ((URL) -> Void)? = nil) {
+        init(keyboardRequestID: Int, onOpenLink: ((URL) -> Void)? = nil) {
+            self.keyboardRequestID = keyboardRequestID
             self.onOpenLink = onOpenLink
         }
 
@@ -115,6 +124,7 @@ final class HerdrTerminalView: UITerminalView {
     private var terminalInputView: UIView?
     private var cursorMode = TerminalCursorModeTracker()
     private var lastInputWindowSize: CGSize?
+    private var allowsKeyboardActivation = false
     var controlKeyboardHeight = TerminalControlKeyboardView.defaultHeight
 
     private lazy var terminalKeyboardAccessory = TerminalKeyboardAccessory(
@@ -131,6 +141,10 @@ final class HerdrTerminalView: UITerminalView {
 
     override var inputAccessoryView: UIView? {
         terminalKeyboardAccessory
+    }
+
+    override var canBecomeFirstResponder: Bool {
+        allowsKeyboardActivation
     }
 
     init(
@@ -173,11 +187,16 @@ final class HerdrTerminalView: UITerminalView {
         terminalSession.receive(data)
     }
 
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
-        if window != nil {
-            _ = becomeFirstResponder()
-        }
+    func requestKeyboard() {
+        allowsKeyboardActivation = true
+        _ = becomeFirstResponder()
+    }
+
+    @discardableResult
+    override func resignFirstResponder() -> Bool {
+        let resigned = super.resignFirstResponder()
+        allowsKeyboardActivation = false
+        return resigned
     }
 
     override func layoutSubviews() {

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -1,277 +1,188 @@
-import SwiftTerm
+import GhosttyTerminal
 import SwiftUI
 import UIKit
 
 /// Remote terminal output is untrusted. Only ordinary web links cross from
-/// SwiftTerm into the system URL opener; local files and executable schemes do not.
+/// Ghostty into the system URL opener; local files and executable schemes do not.
 enum TerminalLinkPolicy {
     static func url(for link: String) -> URL? {
         guard let url = URL(string: link), let scheme = url.scheme?.lowercased() else {
             return nil
         }
-        guard (scheme == "http" || scheme == "https"), url.host != nil else { return nil }
+        guard scheme == "http" || scheme == "https", url.host != nil else { return nil }
         return url
     }
 }
 
-/// The interactive SwiftTerm surface. PTY bytes flow into the view, geometry
-/// changes flow to the remote PTY, and keystrokes flow back to Attach.
+/// The interactive Ghostty surface. PTY bytes flow into an in-memory Ghostty
+/// session, while its write and resize callbacks flow back to Attach.
 struct TerminalScreenView: UIViewRepresentable {
     let feed: TerminalByteFeed
     var onSizeChanged: ((_ cols: Int, _ rows: Int) -> Void)?
     var onSend: ((Data) -> Void)?
     @Environment(\.openURL) private var openURL
 
-    func makeUIView(context: Context) -> SizeReportingTerminalView {
-        let view = Self.makeConfiguredTerminal()
-        view.terminalDelegate = context.coordinator
-        view.onSizeReport = { [weak coordinator = context.coordinator] cols, rows in
-            coordinator?.onSizeChanged?(cols, rows)
-        }
+    func makeUIView(context: Context) -> HerdrTerminalView {
+        let view = Self.makeConfiguredTerminal(
+            onSizeChanged: onSizeChanged,
+            onSend: onSend)
+        view.delegate = context.coordinator
+        context.coordinator.terminalView = view
         feed.attach { [weak view] data in
-            view?.feed(byteArray: ArraySlice([UInt8](data)))
+            view?.receive(data)
         }
         return view
     }
 
     @MainActor
-    static func makeConfiguredTerminal() -> SizeReportingTerminalView {
-        let view = SizeReportingTerminalView(frame: .zero, font: nil)
+    static func makeConfiguredTerminal(
+        onSizeChanged: ((_ cols: Int, _ rows: Int) -> Void)? = nil,
+        onSend: ((Data) -> Void)? = nil
+    ) -> HerdrTerminalView {
+        let view = HerdrTerminalView(
+            frame: .zero,
+            onSizeChanged: onSizeChanged,
+            onSend: onSend)
         view.installKeyboardSwitcher()
-        view.keyboardDismissMode = .interactive
-        view.installAlternateScreenScrolling()
         return view
     }
 
-    func updateUIView(_ view: SizeReportingTerminalView, context: Context) {
-        context.coordinator.onSizeChanged = onSizeChanged
-        context.coordinator.onSend = onSend
+    func updateUIView(_ view: HerdrTerminalView, context: Context) {
+        view.updateCallbacks(onSizeChanged: onSizeChanged, onSend: onSend)
         context.coordinator.onOpenLink = { url in openURL(url) }
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(
-            onSizeChanged: onSizeChanged, onSend: onSend,
-            onOpenLink: { url in openURL(url) })
+        Coordinator(onOpenLink: { url in openURL(url) })
     }
 
     @MainActor
-    final class Coordinator: TerminalViewDelegate {
-        var onSizeChanged: ((Int, Int) -> Void)?
-        var onSend: ((Data) -> Void)?
+    final class Coordinator: NSObject, TerminalSurfaceOpenURLDelegate,
+        TerminalSurfaceTextSelectionRequestDelegate
+    {
+        weak var terminalView: HerdrTerminalView?
         var onOpenLink: ((URL) -> Void)?
 
-        init(
-            onSizeChanged: ((Int, Int) -> Void)?, onSend: ((Data) -> Void)?,
-            onOpenLink: ((URL) -> Void)? = nil
-        ) {
-            self.onSizeChanged = onSizeChanged
-            self.onSend = onSend
+        init(onOpenLink: ((URL) -> Void)? = nil) {
             self.onOpenLink = onOpenLink
         }
 
-        nonisolated func sizeChanged(source: TerminalView, newCols: Int, newRows: Int) {
-            MainActor.assumeIsolated { onSizeChanged?(newCols, newRows) }
+        func terminalDidRequestOpenURL(_ url: String, kind _: TerminalOpenURLKind) {
+            guard let url = TerminalLinkPolicy.url(for: url) else { return }
+            onOpenLink?(url)
         }
 
-        nonisolated func send(source: TerminalView, data: ArraySlice<UInt8>) {
-            let bytes = Data(data)
-            MainActor.assumeIsolated { onSend?(bytes) }
+        func terminalDidRequestTextSelection(_ request: TerminalTextSelectionRequest) {
+            guard let terminalView else { return }
+            TerminalTextSelectionPresenter.present(request, from: terminalView)
         }
-
-        nonisolated func setTerminalTitle(source: TerminalView, title: String) {}
-        nonisolated func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
-        nonisolated func scrolled(source: TerminalView, position: Double) {}
-        nonisolated func requestOpenLink(
-            source: TerminalView, link: String, params: [String: String]
-        ) {
-            guard let url = TerminalLinkPolicy.url(for: link) else { return }
-            MainActor.assumeIsolated { onOpenLink?(url) }
-        }
-        nonisolated func rangeChanged(source: TerminalView, startY: Int, endY: Int) {}
     }
 }
 
-/// Reports initial terminal geometry and adds direct touch scrolling for
-/// alternate-screen TUIs. SwiftTerm's native UIScrollView remains untouched
-/// for the normal buffer and its local scrollback.
-final class SizeReportingTerminalView: TerminalView, UIGestureRecognizerDelegate {
-    var onSizeReport: ((_ cols: Int, _ rows: Int) -> Void)?
-    var controlKeyboardHeight = TerminalControlKeyboardView.defaultHeight
-    private var lastReported: (cols: Int, rows: Int)?
+/// Bridges Ghostty's sendable session callbacks onto the UI's main-actor
+/// closures without making the transport layer depend on Ghostty types.
+@MainActor
+private final class TerminalSessionCallbackBridge {
+    var onSizeChanged: ((Int, Int) -> Void)?
+    var onSend: ((Data) -> Void)?
+
+    init(
+        onSizeChanged: ((Int, Int) -> Void)?,
+        onSend: ((Data) -> Void)?
+    ) {
+        self.onSizeChanged = onSizeChanged
+        self.onSend = onSend
+    }
+
+    nonisolated func send(_ data: Data) {
+        Task { @MainActor [weak self] in
+            self?.onSend?(data)
+        }
+    }
+
+    nonisolated func resize(_ viewport: InMemoryTerminalViewport) {
+        Task { @MainActor [weak self] in
+            self?.onSizeChanged?(Int(viewport.columns), Int(viewport.rows))
+        }
+    }
+}
+
+/// The app-owned seam around libghostty-spm. It keeps keyboard policy and the
+/// host-managed session lifecycle out of the SwiftUI screen.
+final class HerdrTerminalView: UITerminalView {
+    private let callbackBridge: TerminalSessionCallbackBridge
+    let terminalSession: InMemoryTerminalSession
+    private var terminalInputView: UIView?
+    private var cursorMode = TerminalCursorModeTracker()
     private var lastInputWindowSize: CGSize?
-    private var installedAlternateScreenScrolling = false
-    private var alternateScrollRemainder: CGFloat = 0
-    private var scrollMomentumDisplayLink: CADisplayLink?
-    private var scrollMomentumVelocityY: CGFloat = 0
-    private var scrollMomentumTimestamp: CFTimeInterval = 0
-    private lazy var alternateScreenPan = UIPanGestureRecognizer(
-        target: self, action: #selector(handleAlternateScreenPan(_:)))
+    var controlKeyboardHeight = TerminalControlKeyboardView.defaultHeight
 
-    var alternateScrollStep: CGFloat {
-        max(1, font.lineHeight)
+    private lazy var terminalKeyboardAccessory = TerminalKeyboardAccessory(
+        frame: CGRect(
+            x: 0,
+            y: 0,
+            width: bounds.width,
+            height: TerminalKeyboardAccessory.preferredHeight),
+        terminalView: self)
+
+    override var inputView: UIView? {
+        terminalInputView
     }
 
-    func installAlternateScreenScrolling() {
-        guard !installedAlternateScreenScrolling else { return }
-        installedAlternateScreenScrolling = true
-        alternateScreenPan.delegate = self
-        alternateScreenPan.cancelsTouchesInView = false
-        addGestureRecognizer(alternateScreenPan)
+    override var inputAccessoryView: UIView? {
+        terminalKeyboardAccessory
     }
 
-    /// Converts finger travel into terminal wheel rows. Alternate buffers do
-    /// not own local scrollback, so the remote TUI remains the source of truth.
-    @discardableResult
-    func scrollAlternateScreen(translationY: CGFloat) -> Int {
-        let terminal = getTerminal()
-        guard terminal.isCurrentBufferAlternate, !hasActiveSelection else {
-            alternateScrollRemainder = 0
-            return 0
-        }
-        if alternateScrollRemainder * translationY < 0 {
-            alternateScrollRemainder = 0
-        }
-        alternateScrollRemainder += translationY
-        let lineCount = Int(abs(alternateScrollRemainder) / alternateScrollStep)
-        guard lineCount > 0 else { return 0 }
-        let movesTowardOlderContent = alternateScrollRemainder > 0
-        alternateScrollRemainder.formTruncatingRemainder(dividingBy: alternateScrollStep)
-        sendScrollRows(lineCount, towardOlderContent: movesTowardOlderContent)
-        return lineCount
+    init(
+        frame: CGRect,
+        onSizeChanged: ((Int, Int) -> Void)?,
+        onSend: ((Data) -> Void)?
+    ) {
+        let callbackBridge = TerminalSessionCallbackBridge(
+            onSizeChanged: onSizeChanged,
+            onSend: onSend)
+        self.callbackBridge = callbackBridge
+        terminalSession = InMemoryTerminalSession(
+            write: { [weak callbackBridge] data in
+                callbackBridge?.send(data)
+            },
+            resize: { [weak callbackBridge] viewport in
+                callbackBridge?.resize(viewport)
+            })
+        super.init(frame: frame)
+        inputAccessoryItems = []
+        configuration = TerminalSurfaceOptions(backend: .inMemory(terminalSession))
+        controller = TerminalController()
     }
 
-    @objc private func handleAlternateScreenPan(_ gesture: UIPanGestureRecognizer) {
-        switch gesture.state {
-        case .began:
-            stopScrollMomentum()
-            alternateScrollRemainder = 0
-        case .changed:
-            _ = scrollAlternateScreen(translationY: gesture.translation(in: self).y)
-            gesture.setTranslation(.zero, in: self)
-        case .ended:
-            startScrollMomentum(velocityY: gesture.velocity(in: self).y)
-        case .cancelled, .failed:
-            stopScrollMomentum()
-            alternateScrollRemainder = 0
-        default:
-            break
-        }
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is unavailable")
     }
 
-    private func sendScrollRows(_ count: Int, towardOlderContent: Bool) {
-        let terminal = getTerminal()
-        switch terminal.mouseMode {
-        case .off:
-            let bytes =
-                towardOlderContent
-                ? (terminal.applicationCursor
-                    ? EscapeSequences.moveUpApp : EscapeSequences.moveUpNormal)
-                : (terminal.applicationCursor
-                    ? EscapeSequences.moveDownApp : EscapeSequences.moveDownNormal)
-            for _ in 0..<count {
-                send(bytes)
-            }
-        default:
-            let button = towardOlderContent ? 4 : 5
-            let buttonFlags = terminal.encodeButton(
-                button: button, release: false, shift: false, meta: false, control: false)
-            let column = max(0, (terminal.cols - 1) / 2)
-            let row = max(0, (terminal.rows - 1) / 2)
-            let scale = window?.screen.scale ?? traitCollection.displayScale
-            let pixelX = Int(bounds.midX * scale)
-            let pixelY = Int(bounds.midY * scale)
-            for _ in 0..<count {
-                terminal.sendEvent(
-                    buttonFlags: buttonFlags, x: column, y: row,
-                    pixelX: pixelX, pixelY: pixelY)
-            }
-        }
+    func updateCallbacks(
+        onSizeChanged: ((Int, Int) -> Void)?,
+        onSend: ((Data) -> Void)?
+    ) {
+        callbackBridge.onSizeChanged = onSizeChanged
+        callbackBridge.onSend = onSend
     }
 
-    private func startScrollMomentum(velocityY: CGFloat) {
-        guard abs(velocityY) >= 80, getTerminal().isCurrentBufferAlternate else {
-            alternateScrollRemainder = 0
-            return
-        }
-        stopScrollMomentum()
-        scrollMomentumVelocityY = max(-4_000, min(4_000, velocityY))
-        scrollMomentumTimestamp = 0
-        let displayLink = CADisplayLink(target: self, selector: #selector(advanceScrollMomentum(_:)))
-        scrollMomentumDisplayLink = displayLink
-        displayLink.add(to: .main, forMode: .common)
-    }
-
-    @objc private func advanceScrollMomentum(_ displayLink: CADisplayLink) {
-        guard getTerminal().isCurrentBufferAlternate, abs(scrollMomentumVelocityY) >= 20 else {
-            stopScrollMomentum()
-            alternateScrollRemainder = 0
-            return
-        }
-        guard scrollMomentumTimestamp > 0 else {
-            scrollMomentumTimestamp = displayLink.timestamp
-            return
-        }
-        let elapsed = min(1.0 / 30.0, displayLink.timestamp - scrollMomentumTimestamp)
-        scrollMomentumTimestamp = displayLink.timestamp
-        _ = scrollAlternateScreen(translationY: scrollMomentumVelocityY * elapsed)
-        scrollMomentumVelocityY *= pow(0.998, elapsed * 1_000)
-    }
-
-    private func stopScrollMomentum() {
-        scrollMomentumDisplayLink?.invalidate()
-        scrollMomentumDisplayLink = nil
-        scrollMomentumVelocityY = 0
-        scrollMomentumTimestamp = 0
-    }
-
-    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        guard gestureRecognizer === alternateScreenPan else { return true }
-        let velocity = alternateScreenPan.velocity(in: self)
-        return getTerminal().isCurrentBufferAlternate
-            && !hasActiveSelection
-            && abs(velocity.y) > abs(velocity.x)
-    }
-
-    func gestureRecognizer(
-        _ gestureRecognizer: UIGestureRecognizer,
-        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
-    ) -> Bool {
-        (gestureRecognizer === alternateScreenPan && otherGestureRecognizer === panGestureRecognizer)
-            || (otherGestureRecognizer === alternateScreenPan
-                && gestureRecognizer === panGestureRecognizer)
-    }
-
-    override func mouseModeChanged(source: Terminal) {
-        super.mouseModeChanged(source: source)
-        prioritizeAlternateScreenScrollGesture()
-    }
-
-    private func prioritizeAlternateScreenScrollGesture() {
-        for case let gesture as UIPanGestureRecognizer in gestureRecognizers ?? []
-        where gesture !== alternateScreenPan && gesture !== panGestureRecognizer {
-            gesture.require(toFail: alternateScreenPan)
-        }
+    func receive(_ data: Data) {
+        cursorMode.receive(data)
+        terminalSession.receive(data)
     }
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
         if window != nil {
             _ = becomeFirstResponder()
-        } else {
-            stopScrollMomentum()
         }
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
         reloadInputViewsAfterWindowResize()
-        guard bounds.width > 0, bounds.height > 0 else { return }
-        let terminal = getTerminal()
-        let size = (cols: terminal.cols, rows: terminal.rows)
-        if let lastReported, lastReported == size { return }
-        lastReported = size
-        onSizeReport?(size.cols, size.rows)
     }
 
     private func reloadInputViewsAfterWindowResize() {
@@ -286,6 +197,55 @@ final class SizeReportingTerminalView: TerminalView, UIGestureRecognizerDelegate
             UIView.performWithoutAnimation {
                 self.reloadInputViews()
             }
+        }
+    }
+
+    var usesApplicationCursorKeys: Bool {
+        cursorMode.usesApplicationCursorKeys
+    }
+
+    func setTerminalInputView(_ inputView: UIView?) {
+        terminalInputView = inputView
+    }
+}
+
+struct TerminalCursorModeTracker {
+    private static let enableSequence = Data([0x1B, 0x5B, 0x3F, 0x31, 0x68])
+    private static let disableSequence = Data([0x1B, 0x5B, 0x3F, 0x31, 0x6C])
+    private static let retainedByteCount = max(enableSequence.count, disableSequence.count) - 1
+
+    private var pending = Data()
+    private(set) var usesApplicationCursorKeys = false
+
+    mutating func receive(_ data: Data) {
+        pending.append(data)
+
+        while true {
+            let enableRange = pending.range(of: Self.enableSequence)
+            let disableRange = pending.range(of: Self.disableSequence)
+            let next: (range: Range<Data.Index>, enabled: Bool)?
+
+            switch (enableRange, disableRange) {
+            case (.some(let enable), .some(let disable)):
+                next =
+                    enable.lowerBound < disable.lowerBound
+                    ? (enable, true)
+                    : (disable, false)
+            case (.some(let enable), .none):
+                next = (enable, true)
+            case (.none, .some(let disable)):
+                next = (disable, false)
+            case (.none, .none):
+                next = nil
+            }
+
+            guard let next else { break }
+            usesApplicationCursorKeys = next.enabled
+            pending.removeSubrange(pending.startIndex..<next.range.upperBound)
+        }
+
+        if pending.count > Self.retainedByteCount {
+            pending = Data(pending.suffix(Self.retainedByteCount))
         }
     }
 }

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -94,6 +94,7 @@ struct TerminalScreenView: UIViewRepresentable {
 private final class TerminalSessionCallbackBridge {
     var onSizeChanged: ((Int, Int) -> Void)?
     var onSend: ((Data) -> Void)?
+    var onViewport: ((InMemoryTerminalViewport) -> Void)?
 
     init(
         onSizeChanged: ((Int, Int) -> Void)?,
@@ -111,6 +112,7 @@ private final class TerminalSessionCallbackBridge {
 
     nonisolated func resize(_ viewport: InMemoryTerminalViewport) {
         Task { @MainActor [weak self] in
+            self?.onViewport?(viewport)
             self?.onSizeChanged?(Int(viewport.columns), Int(viewport.rows))
         }
     }
@@ -122,10 +124,20 @@ final class HerdrTerminalView: UITerminalView {
     private let callbackBridge: TerminalSessionCallbackBridge
     let terminalSession: InMemoryTerminalSession
     private var terminalInputView: UIView?
-    private var cursorMode = TerminalCursorModeTracker()
+    private var modeTracker = TerminalModeTracker()
     private var lastInputWindowSize: CGSize?
     private var allowsKeyboardActivation = false
+    private var terminalGridSize = (columns: 80, rows: 24)
+    private var touchScrollPointsPerRow: CGFloat = 16
+    private var touchScrollAccumulator = TerminalTouchScrollAccumulator()
+    private var touchScrollMomentumDisplayLink: CADisplayLink?
+    private var touchScrollMomentumVelocityY: CGFloat = 0
+    private var touchScrollMomentumTimestamp: CFTimeInterval = 0
     var controlKeyboardHeight = TerminalControlKeyboardView.defaultHeight
+
+    private lazy var touchScrollGesture = UIPanGestureRecognizer(
+        target: self,
+        action: #selector(handleHerdrTouchScrollGesture(_:)))
 
     private lazy var terminalKeyboardAccessory = TerminalKeyboardAccessory(
         frame: CGRect(
@@ -167,6 +179,10 @@ final class HerdrTerminalView: UITerminalView {
         inputAccessoryItems = []
         configuration = TerminalSurfaceOptions(backend: .inMemory(terminalSession))
         controller = TerminalController()
+        callbackBridge.onViewport = { [weak self] viewport in
+            self?.updateTouchScrollMetrics(viewport)
+        }
+        installTouchScrolling()
     }
 
     @available(*, unavailable)
@@ -183,7 +199,7 @@ final class HerdrTerminalView: UITerminalView {
     }
 
     func receive(_ data: Data) {
-        cursorMode.receive(data)
+        modeTracker.receive(data)
         terminalSession.receive(data)
     }
 
@@ -204,6 +220,23 @@ final class HerdrTerminalView: UITerminalView {
         reloadInputViewsAfterWindowResize()
     }
 
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window == nil {
+            stopTouchScrollMomentum()
+        }
+    }
+
+    override func gestureRecognizerShouldBegin(
+        _ gestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        if gestureRecognizer === touchScrollGesture {
+            let velocity = touchScrollGesture.velocity(in: self)
+            return abs(velocity.y) > abs(velocity.x)
+        }
+        return super.gestureRecognizerShouldBegin(gestureRecognizer)
+    }
+
     private func reloadInputViewsAfterWindowResize() {
         guard let windowSize = window?.bounds.size else { return }
         defer { lastInputWindowSize = windowSize }
@@ -220,51 +253,113 @@ final class HerdrTerminalView: UITerminalView {
     }
 
     var usesApplicationCursorKeys: Bool {
-        cursorMode.usesApplicationCursorKeys
+        modeTracker.usesApplicationCursorKeys
     }
 
     func setTerminalInputView(_ inputView: UIView?) {
         terminalInputView = inputView
     }
-}
 
-struct TerminalCursorModeTracker {
-    private static let enableSequence = Data([0x1B, 0x5B, 0x3F, 0x31, 0x68])
-    private static let disableSequence = Data([0x1B, 0x5B, 0x3F, 0x31, 0x6C])
-    private static let retainedByteCount = max(enableSequence.count, disableSequence.count) - 1
+    @discardableResult
+    func scrollTouch(translationY: CGFloat) -> Int {
+        let rows = touchScrollAccumulator.rows(
+            for: translationY,
+            pointsPerRow: touchScrollPointsPerRow)
+        guard rows != 0 else { return 0 }
 
-    private var pending = Data()
-    private(set) var usesApplicationCursorKeys = false
-
-    mutating func receive(_ data: Data) {
-        pending.append(data)
-
-        while true {
-            let enableRange = pending.range(of: Self.enableSequence)
-            let disableRange = pending.range(of: Self.disableSequence)
-            let next: (range: Range<Data.Index>, enabled: Bool)?
-
-            switch (enableRange, disableRange) {
-            case (.some(let enable), .some(let disable)):
-                next =
-                    enable.lowerBound < disable.lowerBound
-                    ? (enable, true)
-                    : (disable, false)
-            case (.some(let enable), .none):
-                next = (enable, true)
-            case (.none, .some(let disable)):
-                next = (disable, false)
-            case (.none, .none):
-                next = nil
+        let towardOlderContent = rows > 0
+        let rowCount = abs(rows)
+        if let sequence = modeTracker.remoteScrollSequence(
+            towardOlderContent: towardOlderContent,
+            columns: terminalGridSize.columns,
+            rows: terminalGridSize.rows)
+        {
+            for _ in 0..<rowCount {
+                terminalSession.sendInput(sequence)
             }
+        } else {
+            let localRows = towardOlderContent ? -rowCount : rowCount
+            _ = performBindingAction("scroll_page_lines:\(localRows)")
+        }
+        return rows
+    }
 
-            guard let next else { break }
-            usesApplicationCursorKeys = next.enabled
-            pending.removeSubrange(pending.startIndex..<next.range.upperBound)
+    private func installTouchScrolling() {
+        let directTouch = NSNumber(value: UITouch.TouchType.direct.rawValue)
+        for case let pan as UIPanGestureRecognizer in gestureRecognizers ?? []
+        where pan.allowedTouchTypes.contains(directTouch) {
+            pan.isEnabled = false
         }
 
-        if pending.count > Self.retainedByteCount {
-            pending = Data(pending.suffix(Self.retainedByteCount))
+        touchScrollGesture.allowedTouchTypes = [directTouch]
+        touchScrollGesture.maximumNumberOfTouches = 1
+        touchScrollGesture.cancelsTouchesInView = false
+        touchScrollGesture.delegate = self
+        addGestureRecognizer(touchScrollGesture)
+    }
+
+    @objc private func handleHerdrTouchScrollGesture(_ gesture: UIPanGestureRecognizer) {
+        switch gesture.state {
+        case .began:
+            stopTouchScrollMomentum()
+            touchScrollAccumulator.reset()
+        case .changed:
+            _ = scrollTouch(translationY: gesture.translation(in: self).y)
+            gesture.setTranslation(.zero, in: self)
+        case .ended:
+            startTouchScrollMomentum(velocityY: gesture.velocity(in: self).y)
+        case .cancelled, .failed:
+            stopTouchScrollMomentum()
+            touchScrollAccumulator.reset()
+        default:
+            break
         }
+    }
+
+    private func updateTouchScrollMetrics(_ viewport: InMemoryTerminalViewport) {
+        terminalGridSize = (Int(viewport.columns), Int(viewport.rows))
+        guard viewport.cellHeightPixels > 0 else { return }
+        let scale = window?.screen.nativeScale ?? traitCollection.displayScale
+        guard scale > 0 else { return }
+        touchScrollPointsPerRow = max(8, CGFloat(viewport.cellHeightPixels) / scale)
+    }
+
+    private func startTouchScrollMomentum(velocityY: CGFloat) {
+        guard abs(velocityY) >= 80 else {
+            touchScrollAccumulator.reset()
+            return
+        }
+        stopTouchScrollMomentum()
+        touchScrollMomentumVelocityY = max(-4_000, min(4_000, velocityY))
+        touchScrollMomentumTimestamp = 0
+        let displayLink = CADisplayLink(
+            target: self,
+            selector: #selector(advanceTouchScrollMomentum(_:)))
+        touchScrollMomentumDisplayLink = displayLink
+        displayLink.add(to: .main, forMode: .common)
+    }
+
+    @objc private func advanceTouchScrollMomentum(_ displayLink: CADisplayLink) {
+        guard abs(touchScrollMomentumVelocityY) >= 20 else {
+            stopTouchScrollMomentum()
+            touchScrollAccumulator.reset()
+            return
+        }
+        guard touchScrollMomentumTimestamp > 0 else {
+            touchScrollMomentumTimestamp = displayLink.timestamp
+            return
+        }
+
+        let elapsed = min(1.0 / 30.0, displayLink.timestamp - touchScrollMomentumTimestamp)
+        touchScrollMomentumTimestamp = displayLink.timestamp
+        _ = scrollTouch(translationY: touchScrollMomentumVelocityY * elapsed)
+        touchScrollMomentumVelocityY *= pow(0.998, elapsed * 1_000)
+    }
+
+    private func stopTouchScrollMomentum() {
+        touchScrollMomentumDisplayLink?.invalidate()
+        touchScrollMomentumDisplayLink = nil
+        touchScrollMomentumVelocityY = 0
+        touchScrollMomentumTimestamp = 0
     }
 }

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -20,12 +20,14 @@ struct TerminalScreenView: UIViewRepresentable {
     let feed: TerminalByteFeed
     var onSizeChanged: ((_ cols: Int, _ rows: Int) -> Void)?
     var onSend: ((Data) -> Void)?
+    var theme: TerminalTheme = .default
     @Environment(\.openURL) private var openURL
 
     func makeUIView(context: Context) -> HerdrTerminalView {
         let view = Self.makeConfiguredTerminal(
             onSizeChanged: onSizeChanged,
-            onSend: onSend)
+            onSend: onSend,
+            theme: theme)
         view.delegate = context.coordinator
         context.coordinator.terminalView = view
         feed.attach { [weak view] data in
@@ -37,18 +39,21 @@ struct TerminalScreenView: UIViewRepresentable {
     @MainActor
     static func makeConfiguredTerminal(
         onSizeChanged: ((_ cols: Int, _ rows: Int) -> Void)? = nil,
-        onSend: ((Data) -> Void)? = nil
+        onSend: ((Data) -> Void)? = nil,
+        theme: TerminalTheme = .default
     ) -> HerdrTerminalView {
         let view = HerdrTerminalView(
             frame: .zero,
             onSizeChanged: onSizeChanged,
-            onSend: onSend)
+            onSend: onSend,
+            theme: theme)
         view.installKeyboardSwitcher()
         return view
     }
 
     func updateUIView(_ view: HerdrTerminalView, context: Context) {
         view.updateCallbacks(onSizeChanged: onSizeChanged, onSend: onSend)
+        view.applyTheme(theme)
         context.coordinator.onOpenLink = { url in openURL(url) }
     }
 
@@ -113,7 +118,9 @@ private final class TerminalSessionCallbackBridge {
 /// host-managed session lifecycle out of the SwiftUI screen.
 final class HerdrTerminalView: UITerminalView {
     private let callbackBridge: TerminalSessionCallbackBridge
+    private let terminalController: TerminalController
     let terminalSession: InMemoryTerminalSession
+    private(set) var appliedTheme: TerminalTheme
     private var terminalInputView: UIView?
     private var modeTracker = TerminalModeTracker()
     private var lastInputWindowSize: CGSize?
@@ -157,7 +164,8 @@ final class HerdrTerminalView: UITerminalView {
     init(
         frame: CGRect,
         onSizeChanged: ((Int, Int) -> Void)?,
-        onSend: ((Data) -> Void)?
+        onSend: ((Data) -> Void)?,
+        theme: TerminalTheme
     ) {
         let callbackBridge = TerminalSessionCallbackBridge(
             onSizeChanged: onSizeChanged,
@@ -170,10 +178,12 @@ final class HerdrTerminalView: UITerminalView {
             resize: { [weak callbackBridge] viewport in
                 callbackBridge?.resize(viewport)
             })
+        terminalController = TerminalController(theme: theme)
+        appliedTheme = theme
         super.init(frame: frame)
         inputAccessoryItems = []
         configuration = TerminalSurfaceOptions(backend: .inMemory(terminalSession))
-        controller = TerminalController()
+        controller = terminalController
         callbackBridge.onViewport = { [weak self] viewport in
             self?.updateTouchScrollMetrics(viewport)
         }
@@ -191,6 +201,15 @@ final class HerdrTerminalView: UITerminalView {
     ) {
         callbackBridge.onSizeChanged = onSizeChanged
         callbackBridge.onSend = onSend
+    }
+
+    @discardableResult
+    func applyTheme(_ theme: TerminalTheme) -> Bool {
+        guard theme != appliedTheme, terminalController.setTheme(theme) else {
+            return false
+        }
+        appliedTheme = theme
+        return true
     }
 
     func receive(_ data: Data) {

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -20,7 +20,6 @@ struct TerminalScreenView: UIViewRepresentable {
     let feed: TerminalByteFeed
     var onSizeChanged: ((_ cols: Int, _ rows: Int) -> Void)?
     var onSend: ((Data) -> Void)?
-    var keyboardRequestID = 0
     @Environment(\.openURL) private var openURL
 
     func makeUIView(context: Context) -> HerdrTerminalView {
@@ -51,16 +50,10 @@ struct TerminalScreenView: UIViewRepresentable {
     func updateUIView(_ view: HerdrTerminalView, context: Context) {
         view.updateCallbacks(onSizeChanged: onSizeChanged, onSend: onSend)
         context.coordinator.onOpenLink = { url in openURL(url) }
-        if context.coordinator.keyboardRequestID != keyboardRequestID {
-            context.coordinator.keyboardRequestID = keyboardRequestID
-            view.requestKeyboard()
-        }
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(
-            keyboardRequestID: keyboardRequestID,
-            onOpenLink: { url in openURL(url) })
+        Coordinator(onOpenLink: { url in openURL(url) })
     }
 
     @MainActor
@@ -68,11 +61,9 @@ struct TerminalScreenView: UIViewRepresentable {
         TerminalSurfaceTextSelectionRequestDelegate
     {
         weak var terminalView: HerdrTerminalView?
-        var keyboardRequestID: Int
         var onOpenLink: ((URL) -> Void)?
 
-        init(keyboardRequestID: Int, onOpenLink: ((URL) -> Void)? = nil) {
-            self.keyboardRequestID = keyboardRequestID
+        init(onOpenLink: ((URL) -> Void)? = nil) {
             self.onOpenLink = onOpenLink
         }
 
@@ -138,6 +129,10 @@ final class HerdrTerminalView: UITerminalView {
     private lazy var touchScrollGesture = UIPanGestureRecognizer(
         target: self,
         action: #selector(handleHerdrTouchScrollGesture(_:)))
+
+    private lazy var keyboardActivationTapGesture = UITapGestureRecognizer(
+        target: self,
+        action: #selector(handleKeyboardActivationTap(_:)))
 
     private lazy var terminalKeyboardAccessory = TerminalKeyboardAccessory(
         frame: CGRect(
@@ -234,6 +229,10 @@ final class HerdrTerminalView: UITerminalView {
             let velocity = touchScrollGesture.velocity(in: self)
             return abs(velocity.y) > abs(velocity.x)
         }
+        if gestureRecognizer === keyboardActivationTapGesture {
+            return keyboardActivationRegion.contains(
+                keyboardActivationTapGesture.location(in: self))
+        }
         return super.gestureRecognizerShouldBegin(gestureRecognizer)
     }
 
@@ -258,6 +257,11 @@ final class HerdrTerminalView: UITerminalView {
 
     func setTerminalInputView(_ inputView: UIView?) {
         terminalInputView = inputView
+    }
+
+    var keyboardActivationRegion: CGRect {
+        let caret = caretRect(for: endOfDocument)
+        return TerminalKeyboardTapTarget.region(caretRect: caret, in: bounds)
     }
 
     @discardableResult
@@ -296,6 +300,17 @@ final class HerdrTerminalView: UITerminalView {
         touchScrollGesture.cancelsTouchesInView = false
         touchScrollGesture.delegate = self
         addGestureRecognizer(touchScrollGesture)
+
+        keyboardActivationTapGesture.allowedTouchTypes = [directTouch]
+        keyboardActivationTapGesture.numberOfTouchesRequired = 1
+        keyboardActivationTapGesture.cancelsTouchesInView = false
+        keyboardActivationTapGesture.delegate = self
+        addGestureRecognizer(keyboardActivationTapGesture)
+    }
+
+    @objc private func handleKeyboardActivationTap(_ gesture: UITapGestureRecognizer) {
+        guard gesture.state == .ended else { return }
+        requestKeyboard()
     }
 
     @objc private func handleHerdrTouchScrollGesture(_ gesture: UIPanGestureRecognizer) {

--- a/Sources/HerdrMobile/Terminal/TerminalTextSelectionPresenter.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalTextSelectionPresenter.swift
@@ -1,0 +1,121 @@
+import GhosttyTerminal
+import UIKit
+
+@MainActor
+enum TerminalTextSelectionPresenter {
+    static func present(_ request: TerminalTextSelectionRequest, from sourceView: UIView) {
+        guard let presentingViewController = sourceView.nearestPresentingViewController else {
+            return
+        }
+
+        let selection = TerminalTextSelectionViewController(
+            text: request.text,
+            anchorRange: request.anchorRange)
+        let navigation = UINavigationController(rootViewController: selection)
+        navigation.modalPresentationStyle = .pageSheet
+        navigation.sheetPresentationController?.detents = [.large()]
+        presentingViewController.present(navigation, animated: true)
+    }
+}
+
+@MainActor
+final class TerminalTextSelectionViewController: UIViewController {
+    private let text: String
+    private let anchorRange: NSRange?
+    private let textView = UITextView()
+
+    init(text: String, anchorRange: NSRange?) {
+        self.text = text
+        self.anchorRange = anchorRange
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is unavailable")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Select Text"
+        view.backgroundColor = .systemBackground
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: self,
+            action: #selector(dismissSelection))
+
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.backgroundColor = .systemBackground
+        textView.textColor = .label
+        textView.font = .monospacedSystemFont(ofSize: 14, weight: .regular)
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.alwaysBounceVertical = true
+        textView.textContainerInset = UIEdgeInsets(top: 16, left: 12, bottom: 16, right: 12)
+        textView.text = text
+        textView.accessibilityIdentifier = "terminal.text-selection"
+        view.addSubview(textView)
+
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            textView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            textView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        textView.selectedRange = Self.normalizedSelectionRange(
+            anchorRange,
+            textLength: (text as NSString).length)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        textView.scrollRangeToVisible(textView.selectedRange)
+    }
+
+    static func normalizedSelectionRange(_ range: NSRange?, textLength: Int) -> NSRange {
+        guard let range,
+            range.location <= textLength,
+            range.length <= textLength - range.location
+        else {
+            return NSRange(location: 0, length: textLength)
+        }
+        return range
+    }
+
+    @objc private func dismissSelection() {
+        dismiss(animated: true)
+    }
+}
+
+extension UIView {
+    fileprivate var nearestPresentingViewController: UIViewController? {
+        var responder: UIResponder? = self
+        while let current = responder {
+            if let viewController = current as? UIViewController {
+                return viewController.topmostPresentedViewController
+            }
+            responder = current.next
+        }
+        return window?.rootViewController?.topmostPresentedViewController
+    }
+}
+
+extension UIViewController {
+    fileprivate var topmostPresentedViewController: UIViewController {
+        if let presentedViewController {
+            return presentedViewController.topmostPresentedViewController
+        }
+        if let navigation = self as? UINavigationController,
+            let visible = navigation.visibleViewController
+        {
+            return visible.topmostPresentedViewController
+        }
+        if let tab = self as? UITabBarController,
+            let selected = tab.selectedViewController
+        {
+            return selected.topmostPresentedViewController
+        }
+        return self
+    }
+}

--- a/Sources/HerdrMobile/Terminal/TerminalTouchScroll.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalTouchScroll.swift
@@ -1,0 +1,146 @@
+import CoreGraphics
+import Foundation
+
+struct TerminalModeTracker {
+    private static let privateModePrefix: [UInt8] = [0x1B, 0x5B, 0x3F]
+
+    private var pending: [UInt8] = []
+    private var mouseTrackingModes: Set<Int> = []
+    private(set) var usesApplicationCursorKeys = false
+    private(set) var isAlternateScreen = false
+    private(set) var usesSGRMouseEncoding = false
+
+    var tracksMouse: Bool {
+        !mouseTrackingModes.isEmpty
+    }
+
+    mutating func receive(_ data: Data) {
+        pending.append(contentsOf: data)
+
+        while let prefixIndex = nextPrivateModePrefixIndex() {
+            if prefixIndex > 0 {
+                pending.removeFirst(prefixIndex)
+            }
+
+            guard let terminatorIndex = privateModeTerminatorIndex() else {
+                retainIncompletePrefix()
+                return
+            }
+
+            let terminator = pending[terminatorIndex]
+            let modeBytes = pending[Self.privateModePrefix.count..<terminatorIndex]
+            if let modeList = String(bytes: modeBytes, encoding: .ascii) {
+                let enabled = terminator == 0x68
+                for mode in modeList.split(separator: ";").compactMap({ Int($0) }) {
+                    update(mode: mode, enabled: enabled)
+                }
+            }
+            pending.removeFirst(terminatorIndex + 1)
+        }
+
+        retainIncompletePrefix()
+    }
+
+    func remoteScrollSequence(
+        towardOlderContent: Bool,
+        columns: Int,
+        rows: Int
+    ) -> Data? {
+        if tracksMouse {
+            let button = towardOlderContent ? 64 : 65
+            let column = max(1, columns / 2)
+            let row = max(1, rows / 2)
+
+            if usesSGRMouseEncoding {
+                return Data("\u{1B}[<\(button);\(column);\(row)M".utf8)
+            }
+
+            let legacyColumn = UInt8(clamping: min(column, 223) + 32)
+            let legacyRow = UInt8(clamping: min(row, 223) + 32)
+            return Data([0x1B, 0x5B, 0x4D, UInt8(button + 32), legacyColumn, legacyRow])
+        }
+
+        guard isAlternateScreen else { return nil }
+        if towardOlderContent {
+            return Data(
+                usesApplicationCursorKeys
+                    ? [0x1B, 0x4F, 0x41]
+                    : [0x1B, 0x5B, 0x41])
+        }
+        return Data(
+            usesApplicationCursorKeys
+                ? [0x1B, 0x4F, 0x42]
+                : [0x1B, 0x5B, 0x42])
+    }
+
+    private mutating func update(mode: Int, enabled: Bool) {
+        switch mode {
+        case 1:
+            usesApplicationCursorKeys = enabled
+        case 47, 1047, 1049:
+            isAlternateScreen = enabled
+        case 1000, 1002, 1003:
+            if enabled {
+                mouseTrackingModes.insert(mode)
+            } else {
+                mouseTrackingModes.remove(mode)
+            }
+        case 1006:
+            usesSGRMouseEncoding = enabled
+        default:
+            break
+        }
+    }
+
+    private func nextPrivateModePrefixIndex() -> Int? {
+        guard pending.count >= Self.privateModePrefix.count else { return nil }
+        return pending.indices.dropLast(Self.privateModePrefix.count - 1).first { index in
+            pending[index] == Self.privateModePrefix[0]
+                && pending[index + 1] == Self.privateModePrefix[1]
+                && pending[index + 2] == Self.privateModePrefix[2]
+        }
+    }
+
+    private func privateModeTerminatorIndex() -> Int? {
+        guard pending.count > Self.privateModePrefix.count else { return nil }
+        for index in Self.privateModePrefix.count..<pending.count {
+            let byte = pending[index]
+            if byte == 0x68 || byte == 0x6C {
+                return index
+            }
+            if byte != 0x3B && !(0x30...0x39).contains(byte) {
+                return index
+            }
+        }
+        return nil
+    }
+
+    private mutating func retainIncompletePrefix() {
+        if pending.suffix(2) == Self.privateModePrefix.prefix(2) {
+            pending = Array(pending.suffix(2))
+        } else if pending.last == Self.privateModePrefix.first {
+            pending = [Self.privateModePrefix[0]]
+        } else if nextPrivateModePrefixIndex() == nil {
+            pending.removeAll(keepingCapacity: true)
+        }
+    }
+}
+
+struct TerminalTouchScrollAccumulator {
+    private(set) var remainder: CGFloat = 0
+
+    mutating func reset() {
+        remainder = 0
+    }
+
+    mutating func rows(for translationY: CGFloat, pointsPerRow: CGFloat) -> Int {
+        guard pointsPerRow > 0 else { return 0 }
+        if remainder * translationY < 0 {
+            remainder = 0
+        }
+        remainder += translationY
+        let rows = Int(remainder / pointsPerRow)
+        remainder -= CGFloat(rows) * pointsPerRow
+        return rows
+    }
+}

--- a/Sources/HerdrMobile/Terminal/TerminalTouchScroll.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalTouchScroll.swift
@@ -1,6 +1,21 @@
 import CoreGraphics
 import Foundation
 
+enum TerminalKeyboardTapTarget {
+    static let minimumHeight: CGFloat = 44
+
+    static func region(caretRect: CGRect, in bounds: CGRect) -> CGRect {
+        guard caretRect.height > 0, !bounds.isEmpty else { return .null }
+        let height = max(caretRect.height, minimumHeight)
+        let region = CGRect(
+            x: bounds.minX,
+            y: caretRect.midY - height / 2,
+            width: bounds.width,
+            height: height)
+        return region.intersection(bounds)
+    }
+}
+
 struct TerminalModeTracker {
     private static let privateModePrefix: [UInt8] = [0x1B, 0x5B, 0x3F]
 

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -80,7 +80,7 @@ struct AttachTerminalStoreTests {
         try await waitUntil("store should go live") { store.status == .live }
 
         store.send(Data("y".utf8))
-        store.send(Data([0x1B, 0x5B, 0x41]))  // Up arrow, as SwiftTerm emits it.
+        store.send(Data([0x1B, 0x5B, 0x41]))  // Up arrow from the terminal emulator.
         await store.stop()
 
         #expect(

--- a/Tests/HerdrMobileTests/TerminalAttachE2ETests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachE2ETests.swift
@@ -41,7 +41,7 @@ struct TerminalAttachE2ETests {
             session.send(Data("ping-1\n".utf8))
             try await expectOutput(&iterator, accumulated: &seen, contains: "GOT:ping-1")
 
-            // An Up-arrow escape sequence followed by text, as SwiftTerm
+            // An Up-arrow escape sequence followed by text, as the terminal
             // would emit while navigating a TUI menu.
             session.send(Data("\u{1B}[Aok\n".utf8))
             try await expectOutput(&iterator, accumulated: &seen, contains: "GOT:\u{1B}[Aok")

--- a/Tests/HerdrMobileTests/TerminalAttachTests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachTests.swift
@@ -40,6 +40,30 @@ struct TerminalAttachTests {
     }
 
     @MainActor
+    @Test func terminalTouchPanEmitsRemoteTUIMouseWheelInput() async {
+        var sent = Data()
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            onSend: { sent.append($0) })
+        let directTouch = NSNumber(value: UITouch.TouchType.direct.rawValue)
+        let enabledTouchPans: [UIPanGestureRecognizer] =
+            terminal.gestureRecognizers?.compactMap { gesture in
+                guard let pan = gesture as? UIPanGestureRecognizer,
+                    pan.isEnabled,
+                    pan.allowedTouchTypes.contains(directTouch)
+                else { return nil }
+                return pan
+            } ?? []
+        #expect(enabledTouchPans.count == 1)
+
+        terminal.receive(Data("\u{1B}[?1049h\u{1B}[?1000;1006h".utf8))
+        #expect(terminal.scrollTouch(translationY: 32) == 2)
+        await Task.yield()
+
+        #expect(
+            sent == Data("\u{1B}[<64;40;12M\u{1B}[<64;40;12M".utf8))
+    }
+
+    @MainActor
     @Test func attachSwitchesBetweenTextAndTerminalKeys() {
         let terminal = TerminalScreenView.makeConfiguredTerminal()
 
@@ -106,8 +130,8 @@ struct TerminalAttachTests {
         #expect(sent == Data([0x1B, 0x4F, 0x41]))
     }
 
-    @Test func cursorModeTrackerHandlesSplitAndRepeatedModeChanges() {
-        var tracker = TerminalCursorModeTracker()
+    @Test func terminalModeTrackerHandlesSplitAndRepeatedModeChanges() {
+        var tracker = TerminalModeTracker()
         tracker.receive(Data([0x1B, 0x5B]))
         tracker.receive(Data([0x3F, 0x31, 0x68]))
         #expect(tracker.usesApplicationCursorKeys)
@@ -117,6 +141,47 @@ struct TerminalAttachTests {
 
         tracker.receive(Data("\u{1B}[?1l".utf8))
         #expect(!tracker.usesApplicationCursorKeys)
+    }
+
+    @Test func terminalModeTrackerEncodesMouseAndAlternateScreenScrolling() {
+        var tracker = TerminalModeTracker()
+        tracker.receive(Data("\u{1B}[?1049h\u{1B}[?1002;1006h".utf8))
+
+        #expect(tracker.isAlternateScreen)
+        #expect(tracker.tracksMouse)
+        #expect(tracker.usesSGRMouseEncoding)
+        #expect(
+            tracker.remoteScrollSequence(
+                towardOlderContent: true,
+                columns: 80,
+                rows: 24)
+                == Data("\u{1B}[<64;40;12M".utf8))
+
+        tracker.receive(Data("\u{1B}[?1002;1006l".utf8))
+        #expect(!tracker.tracksMouse)
+        #expect(!tracker.usesSGRMouseEncoding)
+        #expect(
+            tracker.remoteScrollSequence(
+                towardOlderContent: false,
+                columns: 80,
+                rows: 24)
+                == Data([0x1B, 0x5B, 0x42]))
+
+        tracker.receive(Data("\u{1B}[?1049l".utf8))
+        #expect(
+            tracker.remoteScrollSequence(
+                towardOlderContent: true,
+                columns: 80,
+                rows: 24) == nil)
+    }
+
+    @Test func touchScrollAccumulatorPreservesSubrowMovementAndDirectionChanges() {
+        var accumulator = TerminalTouchScrollAccumulator()
+
+        #expect(accumulator.rows(for: 7, pointsPerRow: 16) == 0)
+        #expect(accumulator.rows(for: 10, pointsPerRow: 16) == 1)
+        #expect(accumulator.rows(for: -15, pointsPerRow: 16) == 0)
+        #expect(accumulator.rows(for: -2, pointsPerRow: 16) == -1)
     }
 
     @MainActor

--- a/Tests/HerdrMobileTests/TerminalAttachTests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachTests.swift
@@ -10,7 +10,7 @@ import UIKit
 /// (a named-session target is "not found" on the default socket), quote the
 /// target and socket safely for POSIX shells and fish alike, and refuse
 /// targets that cannot be quoted safely for both.
-@Suite("Terminal attach bootstrap line")
+@Suite("Terminal attach")
 struct TerminalAttachTests {
     @MainActor
     @Test func attachStartsWithTheIOSInputMethodAndKeyboardSwitcher() {
@@ -18,7 +18,6 @@ struct TerminalAttachTests {
         #expect(terminal.keyboardMode == .text)
         #expect(terminal.inputView == nil)
         #expect(terminal.inputAccessoryView is TerminalKeyboardAccessory)
-        #expect(terminal.keyboardDismissMode == .interactive)
     }
 
     @MainActor
@@ -47,11 +46,12 @@ struct TerminalAttachTests {
     }
 
     @Test func terminalControlKeyboardContainsOnlyUsefulMobileKeys() {
-        #expect(TerminalControlKey.rows == [
-            [.escape, .tab, .controlC, .controlD, .controlZ],
-            [.home, .pageUp, .up, .pageDown, .end],
-            [.backspace, .left, .down, .right, .enter],
-        ])
+        #expect(
+            TerminalControlKey.rows == [
+                [.escape, .tab, .controlC, .controlD, .controlZ],
+                [.home, .pageUp, .up, .pageDown, .end],
+                [.backspace, .left, .down, .right, .enter],
+            ])
     }
 
     @Test func terminalControlKeysEncodeExpectedBytes() {
@@ -64,59 +64,56 @@ struct TerminalAttachTests {
         #expect(TerminalControlKey.enter.bytes(applicationCursor: false) == [0x0D])
         #expect(TerminalControlKey.up.bytes(applicationCursor: false) == [0x1B, 0x5B, 0x41])
         #expect(TerminalControlKey.up.bytes(applicationCursor: true) == [0x1B, 0x4F, 0x41])
-        #expect(TerminalControlKey.pageUp.bytes(applicationCursor: false) == [
-            0x1B, 0x5B, 0x35, 0x7E,
-        ])
+        #expect(
+            TerminalControlKey.pageUp.bytes(applicationCursor: false) == [
+                0x1B, 0x5B, 0x35, 0x7E,
+            ])
     }
 
     @MainActor
-    @Test func terminalControlKeysFlowThroughTheAttachDelegate() {
-        let terminal = TerminalScreenView.makeConfiguredTerminal()
+    @Test func terminalControlKeysFlowThroughTheGhosttySession() async {
         var sent = Data()
-        let coordinator = TerminalScreenView.Coordinator(
-            onSizeChanged: nil,
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
             onSend: { sent.append($0) })
-        terminal.terminalDelegate = coordinator
 
         terminal.sendControlKey(.controlC)
+        await Task.yield()
         #expect(sent == Data([0x03]))
 
         sent.removeAll()
-        terminal.feed(text: "\u{1B}[?1h")
+        terminal.receive(Data("\u{1B}[?1h".utf8))
         terminal.sendControlKey(.up)
+        await Task.yield()
         #expect(sent == Data([0x1B, 0x4F, 0x41]))
     }
 
+    @Test func cursorModeTrackerHandlesSplitAndRepeatedModeChanges() {
+        var tracker = TerminalCursorModeTracker()
+        tracker.receive(Data([0x1B, 0x5B]))
+        tracker.receive(Data([0x3F, 0x31, 0x68]))
+        #expect(tracker.usesApplicationCursorKeys)
+
+        tracker.receive(Data("noise\u{1B}[?1lmore\u{1B}[?1h".utf8))
+        #expect(tracker.usesApplicationCursorKeys)
+
+        tracker.receive(Data("\u{1B}[?1l".utf8))
+        #expect(!tracker.usesApplicationCursorKeys)
+    }
+
     @MainActor
-    @Test func alternateScreenVerticalDragSendsContinuousWheelEvents() {
-        let terminal = TerminalScreenView.makeConfiguredTerminal()
-        terminal.bounds = CGRect(x: 0, y: 0, width: 390, height: 800)
-        var sent = Data()
-        let coordinator = TerminalScreenView.Coordinator(
-            onSizeChanged: nil,
-            onSend: { sent.append($0) })
-        terminal.terminalDelegate = coordinator
-
-        terminal.feed(text: "\u{1B}[?1049h\u{1B}[?1000h\u{1B}[?1006h")
+    @Test func terminalSelectionRejectsOutOfBoundsAnchorRanges() {
         #expect(
-            terminal.scrollAlternateScreen(
-                translationY: terminal.alternateScrollStep * 3.2) == 3)
-        let olderEvents = String(decoding: sent, as: UTF8.self)
-        #expect(olderEvents.filter { $0 == "M" }.count == 3)
-        #expect(olderEvents.contains("\u{1B}[<64;"))
-
-        sent.removeAll()
+            TerminalTextSelectionViewController.normalizedSelectionRange(
+                NSRange(location: 2, length: 3), textLength: 8)
+                == NSRange(location: 2, length: 3))
         #expect(
-            terminal.scrollAlternateScreen(
-                translationY: -terminal.alternateScrollStep * 2.2) == 2)
-        let newerEvents = String(decoding: sent, as: UTF8.self)
-        #expect(newerEvents.filter { $0 == "M" }.count == 2)
-        #expect(newerEvents.contains("\u{1B}[<65;"))
-
-        sent.removeAll()
-        terminal.feed(text: "\u{1B}[?1000l\u{1B}[?1049l")
-        #expect(terminal.scrollAlternateScreen(translationY: 160) == 0)
-        #expect(sent.isEmpty)
+            TerminalTextSelectionViewController.normalizedSelectionRange(
+                NSRange(location: 7, length: 4), textLength: 8)
+                == NSRange(location: 0, length: 8))
+        #expect(
+            TerminalTextSelectionViewController.normalizedSelectionRange(
+                nil, textLength: 8)
+                == NSRange(location: 0, length: 8))
     }
 
     @Test func execsTheAttachCommandWithQuotedTargetAndSocketScope() throws {

--- a/Tests/HerdrMobileTests/TerminalAttachTests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachTests.swift
@@ -21,15 +21,21 @@ struct TerminalAttachTests {
     }
 
     @MainActor
-    @Test func terminalTouchPolicyPreservesScrollingUntilExplicitKeyboardActivation() {
+    @Test func terminalTouchPolicyKeepsKeyboardBehindTheCurrentInputRow() {
         let terminal = TerminalScreenView.makeConfiguredTerminal()
+        let directTouch = NSNumber(value: UITouch.TouchType.direct.rawValue)
 
         #expect(!terminal.canBecomeFirstResponder)
         #expect(
             terminal.gestureRecognizers?.contains { gesture in
                 guard let pan = gesture as? UIPanGestureRecognizer else { return false }
                 return pan.allowedTouchTypes.contains(
-                    NSNumber(value: UITouch.TouchType.direct.rawValue))
+                    directTouch)
+            } == true)
+        #expect(
+            terminal.gestureRecognizers?.contains { gesture in
+                guard let tap = gesture as? UITapGestureRecognizer else { return false }
+                return tap.isEnabled && tap.allowedTouchTypes.contains(directTouch)
             } == true)
 
         terminal.requestKeyboard()
@@ -37,6 +43,39 @@ struct TerminalAttachTests {
 
         _ = terminal.resignFirstResponder()
         #expect(!terminal.canBecomeFirstResponder)
+    }
+
+    @Test func keyboardTapTargetCoversOnlyTheCurrentInputRow() {
+        let bounds = CGRect(x: 0, y: 0, width: 390, height: 720)
+        let region = TerminalKeyboardTapTarget.region(
+            caretRect: CGRect(x: 72, y: 650, width: 9, height: 20),
+            in: bounds)
+
+        #expect(region == CGRect(x: 0, y: 638, width: 390, height: 44))
+        #expect(region.contains(CGPoint(x: 20, y: 660)))
+        #expect(!region.contains(CGPoint(x: 20, y: 500)))
+    }
+
+    @MainActor
+    @Test func ghosttyCursorProvidesAVisibleKeyboardTapTarget() async throws {
+        let terminal = TerminalScreenView.makeConfiguredTerminal()
+        terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 720)
+        let controller = UIViewController()
+        controller.view = terminal
+        let windowScene = try #require(
+            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
+        let window = UIWindow(windowScene: windowScene)
+        window.frame = terminal.bounds
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        terminal.receive(Data("$ ".utf8))
+        terminal.layoutIfNeeded()
+        await Task.yield()
+
+        #expect(!terminal.keyboardActivationRegion.isNull)
+        #expect(terminal.bounds.contains(terminal.keyboardActivationRegion))
     }
 
     @MainActor

--- a/Tests/HerdrMobileTests/TerminalAttachTests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachTests.swift
@@ -21,6 +21,25 @@ struct TerminalAttachTests {
     }
 
     @MainActor
+    @Test func terminalTouchPolicyPreservesScrollingUntilExplicitKeyboardActivation() {
+        let terminal = TerminalScreenView.makeConfiguredTerminal()
+
+        #expect(!terminal.canBecomeFirstResponder)
+        #expect(
+            terminal.gestureRecognizers?.contains { gesture in
+                guard let pan = gesture as? UIPanGestureRecognizer else { return false }
+                return pan.allowedTouchTypes.contains(
+                    NSNumber(value: UITouch.TouchType.direct.rawValue))
+            } == true)
+
+        terminal.requestKeyboard()
+        #expect(terminal.canBecomeFirstResponder)
+
+        _ = terminal.resignFirstResponder()
+        #expect(!terminal.canBecomeFirstResponder)
+    }
+
+    @MainActor
     @Test func attachSwitchesBetweenTextAndTerminalKeys() {
         let terminal = TerminalScreenView.makeConfiguredTerminal()
 

--- a/Tests/HerdrMobileTests/TerminalThemeSettingsTests.swift
+++ b/Tests/HerdrMobileTests/TerminalThemeSettingsTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+@MainActor
+@Suite("Terminal theme settings")
+struct TerminalThemeSettingsTests {
+    private func makeDefaults() throws -> (UserDefaults, cleanup: () -> Void) {
+        let suiteName = "hm-terminal-theme-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        return (defaults, { defaults.removePersistentDomain(forName: suiteName) })
+    }
+
+    @Test func defaultsToFollowingTheSystem() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+
+        #expect(TerminalThemeSettings(defaults: defaults).selection == .followSystem)
+    }
+
+    @Test func selectionPersistsAcrossStoreInstances() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let settings = TerminalThemeSettings(defaults: defaults)
+
+        settings.select(.dracula)
+
+        #expect(TerminalThemeSettings(defaults: defaults).selection == .dracula)
+    }
+
+    @Test func unknownPersistedSelectionFallsBackToTheSystem() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        defaults.set("removed-theme", forKey: "terminal-theme")
+
+        #expect(TerminalThemeSettings(defaults: defaults).selection == .followSystem)
+    }
+
+    @Test func curatedCatalogEntriesExistInThePinnedPackage() {
+        #expect(TerminalThemeOption.missingCatalogThemeNames.isEmpty)
+    }
+
+    @Test func changingThemeKeepsTheExistingTerminalSession() {
+        let terminal = TerminalScreenView.makeConfiguredTerminal()
+        let session = terminal.terminalSession
+        let theme = TerminalThemeOption.vesper.terminalTheme
+
+        #expect(terminal.applyTheme(theme))
+        #expect(terminal.appliedTheme == theme)
+        #expect(terminal.terminalSession === session)
+    }
+}

--- a/docs/adr/0001-native-swift-stack.md
+++ b/docs/adr/0001-native-swift-stack.md
@@ -1,5 +1,8 @@
 # Native Swift stack (SwiftUI + Citadel + SwiftTerm), iOS-only
 
+Status: Partially superseded by ADR 0004. The native Swift and Citadel choices
+remain active; libghostty-spm replaced SwiftTerm as the terminal engine.
+
 We build natively in Swift for iOS 18+ (iPhone + iPad) with Citadel for SSH and SwiftTerm for terminal rendering, and accept dropping Android. The embedded terminal is a core UX surface, and SwiftTerm is the most mature mobile terminal component in any ecosystem, while the alternatives' terminal stories are structurally weaker.
 
 ## Considered Options

--- a/docs/adr/0004-libghostty-terminal.md
+++ b/docs/adr/0004-libghostty-terminal.md
@@ -1,0 +1,42 @@
+# Replace SwiftTerm with libghostty-spm
+
+We use the `GhosttyTerminal` product from libghostty-spm for the interactive
+Agent terminal. The app supplies an `InMemoryTerminalSession`: incoming SSH PTY
+bytes enter through `receive(_:)`, while Ghostty's write and resize callbacks
+feed the existing Attach transport. The transport layer remains independent of
+the terminal engine.
+
+libghostty-spm owns terminal parsing, Metal rendering, CoreText font handling,
+IME integration, scrollback, touch scrolling, and mouse reporting. herdr-mobile
+continues to own its two-mode keyboard UI, URL policy, Attach lifecycle, and the
+native text-selection presentation requested by Ghostty's iOS delegate.
+
+## Considered Options
+
+- **Keep SwiftTerm** — rejected. It required app-owned gesture translation for
+  alternate-screen TUIs and did not provide the rendering and selection path we
+  want to build on long term.
+- **Embed official libghostty directly** — rejected. The C API supplies the
+  terminal engine, not a complete UIKit surface. Owning the Metal renderer,
+  CoreText integration, IME bridge, and touch input layer would duplicate the
+  work already maintained by libghostty-spm.
+- **Use libghostty-spm** — chosen. Its UIKit `UITerminalView` and
+  `InMemoryTerminalSession` match the app's host-managed SSH PTY boundary, so
+  the migration does not leak Ghostty into transport or domain code.
+
+## Consequences
+
+- libghostty-spm is an unofficial wrapper and distributes libghostty as a
+  prebuilt XCFramework. Pin its exact version, retain SwiftPM's checksum
+  verification, and review supply-chain changes before every update.
+- libghostty's embedding API is still evolving. Keep all package-specific code
+  behind `HerdrTerminalView` and the terminal selection presenter.
+- The custom control keyboard sends raw terminal sequences. A small incremental
+  DEC cursor-mode tracker preserves application-cursor sequences because the
+  wrapper does not expose its internal synthetic-key path publicly.
+- Long-press selection is intentionally presented in a native selectable text
+  sheet. The wrapper supplies a viewport snapshot and anchor range; it does not
+  present selection handles on behalf of the host app.
+- Xcode may retain an empty binary-artifact directory after an interrupted
+  first download. Resolving packages with fresh DerivedData repairs that cache
+  state without changing the pinned dependency.

--- a/docs/adr/0004-libghostty-terminal.md
+++ b/docs/adr/0004-libghostty-terminal.md
@@ -38,9 +38,10 @@ the native text-selection presentation requested by Ghostty's iOS delegate.
   sheet. The wrapper supplies a viewport snapshot and anchor range; it does not
   present selection handles on behalf of the host app.
 - libghostty-spm normally makes every direct terminal touch request first
-  responder status. herdr-mobile gates that behavior behind the navigation-bar
-  keyboard button so touch scrolling cannot be interrupted by keyboard-driven
-  viewport resizing.
+  responder status. herdr-mobile instead gates first-responder eligibility on
+  taps within the current IME cursor row. The full-width target is at least 44
+  points tall, while pans and long presses remain dedicated to scrolling and
+  selection.
 - libghostty-spm 1.3.2's internal iOS touch-scroll path does not emit remote TUI
   wheel input through an in-memory session, and its mouse-scroll API is not
   public. The adapter therefore owns one vertical Pan gesture: normal-buffer

--- a/docs/adr/0004-libghostty-terminal.md
+++ b/docs/adr/0004-libghostty-terminal.md
@@ -49,6 +49,10 @@ the native text-selection presentation requested by Ghostty's iOS delegate.
   encode SGR or legacy terminal wheel events through the session's public input
   seam. DEC private-mode tracking is incremental so split SSH packets remain
   correct.
+- Theme selection uses the package's `GhosttyTheme` catalog but exposes only a
+  small curated set. The persisted selection resolves to a light/dark
+  `TerminalTheme`; `TerminalController.setTheme` updates existing Attach
+  surfaces and the settings preview without rebuilding their in-memory session.
 - Xcode may retain an empty binary-artifact directory after an interrupted
   first download. Resolving packages with fresh DerivedData repairs that cache
   state without changing the pinned dependency.

--- a/docs/adr/0004-libghostty-terminal.md
+++ b/docs/adr/0004-libghostty-terminal.md
@@ -37,6 +37,10 @@ native text-selection presentation requested by Ghostty's iOS delegate.
 - Long-press selection is intentionally presented in a native selectable text
   sheet. The wrapper supplies a viewport snapshot and anchor range; it does not
   present selection handles on behalf of the host app.
+- libghostty-spm normally makes every direct terminal touch request first
+  responder status. herdr-mobile gates that behavior behind the navigation-bar
+  keyboard button so touch scrolling cannot be interrupted by keyboard-driven
+  viewport resizing.
 - Xcode may retain an empty binary-artifact directory after an interrupted
   first download. Resolving packages with fresh DerivedData repairs that cache
   state without changing the pinned dependency.

--- a/docs/adr/0004-libghostty-terminal.md
+++ b/docs/adr/0004-libghostty-terminal.md
@@ -7,9 +7,9 @@ feed the existing Attach transport. The transport layer remains independent of
 the terminal engine.
 
 libghostty-spm owns terminal parsing, Metal rendering, CoreText font handling,
-IME integration, scrollback, touch scrolling, and mouse reporting. herdr-mobile
-continues to own its two-mode keyboard UI, URL policy, Attach lifecycle, and the
-native text-selection presentation requested by Ghostty's iOS delegate.
+IME integration, and scrollback storage. herdr-mobile continues to own its
+two-mode keyboard UI, touch-scroll routing, URL policy, Attach lifecycle, and
+the native text-selection presentation requested by Ghostty's iOS delegate.
 
 ## Considered Options
 
@@ -41,6 +41,13 @@ native text-selection presentation requested by Ghostty's iOS delegate.
   responder status. herdr-mobile gates that behavior behind the navigation-bar
   keyboard button so touch scrolling cannot be interrupted by keyboard-driven
   viewport resizing.
+- libghostty-spm 1.3.2's internal iOS touch-scroll path does not emit remote TUI
+  wheel input through an in-memory session, and its mouse-scroll API is not
+  public. The adapter therefore owns one vertical Pan gesture: normal-buffer
+  drags invoke Ghostty scrollback actions, while tracked alternate-screen drags
+  encode SGR or legacy terminal wheel events through the session's public input
+  seam. DEC private-mode tracking is incremental so split SSH packets remain
+  correct.
 - Xcode may retain an empty binary-artifact directory after an interrupted
   first download. Resolving packages with fresh DerivedData repairs that cache
   state without changing the pinned dependency.

--- a/project.yml
+++ b/project.yml
@@ -18,11 +18,11 @@ packages:
   Citadel:
     url: https://github.com/orlandos-nl/Citadel.git
     exactVersion: "0.12.1"
-  # Added for the future Attach terminal; unused in M0.
-  SwiftTerm:
-    url: https://github.com/migueldeicaza/SwiftTerm.git
-    minVersion: "1.2.0"
-    maxVersion: "2.0.0"
+  # Pinned because this package embeds a prebuilt libghostty XCFramework and
+  # libghostty's public API is still evolving independently from Ghostty.
+  GhosttyTerminal:
+    url: https://github.com/lakr233/libghostty-spm.git
+    exactVersion: "1.3.2"
 
 targets:
   HerdrMobile:
@@ -48,7 +48,7 @@ targets:
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
     dependencies:
       - package: Citadel
-      - package: SwiftTerm
+      - package: GhosttyTerminal
 
   HerdrMobileTests:
     type: bundle.unit-test
@@ -61,8 +61,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.herdr.mobile.HerdrMobileTests
     dependencies:
       - target: HerdrMobile
-      # Terminal interaction tests exercise SwiftTerm directly.
-      - package: SwiftTerm
+      - package: GhosttyTerminal
 
 schemes:
   HerdrMobile:

--- a/project.yml
+++ b/project.yml
@@ -49,6 +49,8 @@ targets:
     dependencies:
       - package: Citadel
       - package: GhosttyTerminal
+      - package: GhosttyTerminal
+        product: GhosttyTheme
 
   HerdrMobileTests:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary

- replace SwiftTerm with libghostty-spm and an app-owned in-memory terminal session
- preserve Attach input, resize, scrolling, text selection, and system/control keyboard behavior through the new renderer
- add persistent terminal theme settings with a live Ghostty preview and curated light/dark theme pairs

## Testing

- `xcodebuild test -quiet -project HerdrMobile.xcodeproj -scheme HerdrMobile -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' -only-testing:HerdrMobileTests/TerminalThemeSettingsTests -only-testing:HerdrMobileTests/TerminalAttachTests`
- `scripts/generate-wire-types.py --check --schema scripts/herdr-schema.json`
- signed Debug build installed and launched on a physical iPhone
- Simulator interaction verified for touch scrolling, keyboard activation, text selection, keyboard switching, and live theme changes
