### PR TITLE
feat: add image attachments over SFTP

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,18 @@ _Avoid_: server, machine, connection
 A coding agent process (claude, codex, ...) running inside a herdr pane, as reported by herdr's detection. The primary object of the app.
 _Avoid_: bot, task, session
 
+**Staged Image**:
+A user-selected image that exists on a Host at a remote path, whether or not the Agent has accepted it into a prompt.
+_Avoid_: attachment, uploaded image
+
+**Image Attachment**:
+A Staged Image that the Agent has accepted into its current prompt as image input.
+_Avoid_: staged image, image path
+
+**Attach Image**:
+The Attach action that prepares one selected image, creates a Staged Image, and offers its path to the current terminal. The label expresses user intent; it does not assert that the Agent accepted an Image Attachment.
+_Avoid_: send image, upload image
+
 **Agent Status**:
 herdr's detected state of an Agent: Idle, Working, Blocked, Done, or Unknown. Blocked means the agent is waiting for human input and drives sort order and (later) notifications.
 _Avoid_: agent state, activity
@@ -40,6 +52,10 @@ replaces it with a compact terminal control pad for navigation and common contro
 signals.
 Both modes send directly to the Agent's pane.
 _Avoid_: desktop keyboard, reply keyboard
+
+**Terminal Paste**:
+A user-invoked insertion of plain text from the iOS clipboard into Attach. Single-line text proceeds directly; potentially executable multiline or control content requires review.
+_Avoid_: Control V, image paste
 
 **Transport**:
 The app-side abstraction that executes herdr API requests and delivers event streams over SSH. UI code talks to Transport, never to SSH primitives.

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */; };
 		2CE9115816E7CE945ABCF7A8 /* AgentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADF336771A3F757F2AD441D /* AgentDetailView.swift */; };
 		2E4C392847F96047AF0510DD /* PreflightReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB88AD0F4E9EE776B17FAFAA /* PreflightReportTests.swift */; };
+		30A69209EA01A8DF784ABC52 /* TerminalInputControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75316F4E6B80E442C365765 /* TerminalInputControllerTests.swift */; };
 		36B674DF605ECAE382E51196 /* HostOnboardingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCAF31058B6430B514B2188 /* HostOnboardingStore.swift */; };
 		3DC1B4DCC0E2CD73A0C13B64 /* SSHAuthE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */; };
 		3ECB4DD848A1C73AF0ED4B5F /* ConsoleAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498ECBCD631F9734C28861EA /* ConsoleAgent.swift */; };
@@ -55,6 +56,7 @@
 		93851E040C292A16F5ECB10D /* ConsoleStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079394F4C6AC8FE4D7B0779C /* ConsoleStoreTests.swift */; };
 		950D74A1B92239CDB2DDE5DC /* EventsSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C3ACB2A319C5C1298A29F3F /* EventsSession.swift */; };
 		969057C35F7E5F162B0CF41D /* JSONValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F86744BFAC66D732CE7833 /* JSONValueTests.swift */; };
+		98E83E883BCC8534910D7493 /* TerminalInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E727A9081269681AD7581B /* TerminalInputController.swift */; };
 		9C1C00F36A178BF1BEE6C0A5 /* StartAgentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E14A4298DB015E6477F789 /* StartAgentStore.swift */; };
 		9F3F748E722FD8059A59ECBD /* HostStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6434D31A79422C0BAE80993F /* HostStoreTests.swift */; };
 		A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */; };
@@ -146,6 +148,7 @@
 		7E538BF75AE58E16C58782F7 /* HostOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostOnboardingView.swift; sourceTree = "<group>"; };
 		8007AF9894BE8BAFFA7A6372 /* TerminalAttach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAttach.swift; sourceTree = "<group>"; };
 		806A90DBCA99FD02E76D68C6 /* Host.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Host.swift; sourceTree = "<group>"; };
+		80E727A9081269681AD7581B /* TerminalInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalInputController.swift; sourceTree = "<group>"; };
 		8323C68B13826B7388800B1F /* DeviceKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyStoreTests.swift; sourceTree = "<group>"; };
 		87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStoreTests.swift; sourceTree = "<group>"; };
 		904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSSHTestEnvironment.swift; sourceTree = "<group>"; };
@@ -163,6 +166,7 @@
 		A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConcurrencyE2ETests.swift; sourceTree = "<group>"; };
 		B383994C2C8492694D5F3690 /* HerdrMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HerdrMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B66B41C393D38FA09388E3E2 /* ReconnectPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectPolicyTests.swift; sourceTree = "<group>"; };
+		B75316F4E6B80E442C365765 /* TerminalInputControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalInputControllerTests.swift; sourceTree = "<group>"; };
 		BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOFUHostKeyValidator.swift; sourceTree = "<group>"; };
 		BC2552636663F92A55D1DFF1 /* ClosePaneStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosePaneStoreTests.swift; sourceTree = "<group>"; };
 		BC995A571D7659F3307B6E54 /* DeviceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKey.swift; sourceTree = "<group>"; };
@@ -268,6 +272,7 @@
 			isa = PBXGroup;
 			children = (
 				6F7C6974BD9BE77000016FCA /* TerminalByteFeed.swift */,
+				80E727A9081269681AD7581B /* TerminalInputController.swift */,
 				73DB204D5F25D5375D5B2974 /* TerminalKeyboard.swift */,
 				597ACEE9D688E433B20108D7 /* TerminalScreenView.swift */,
 				786B2BA8A0683BB9DC71D797 /* TerminalTextSelectionPresenter.swift */,
@@ -307,6 +312,7 @@
 				A71CE71D20ABB90D7E94264E /* StartAgentStoreTests.swift */,
 				D83F34B22988623AD8E2093C /* TerminalAttachE2ETests.swift */,
 				BE8796AB629EF68A90C96B3D /* TerminalAttachTests.swift */,
+				B75316F4E6B80E442C365765 /* TerminalInputControllerTests.swift */,
 				EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */,
 				A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */,
 				02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */,
@@ -522,6 +528,7 @@
 				1F4B065DFCAF8E6656600F1E /* TOFUHostKeyValidator.swift in Sources */,
 				41BBA40C97BAE65E56D0E3B5 /* TerminalAttach.swift in Sources */,
 				BAC9F51A72EA9774DEDBC193 /* TerminalByteFeed.swift in Sources */,
+				98E83E883BCC8534910D7493 /* TerminalInputController.swift in Sources */,
 				8DF99F3257BCC6AE08595A45 /* TerminalKeyboard.swift in Sources */,
 				F96C5D15E14B947BE426B2F3 /* TerminalScreenView.swift in Sources */,
 				EDFEE058F85AF41DBFE351A7 /* TerminalTextSelectionPresenter.swift in Sources */,
@@ -569,6 +576,7 @@
 				488EF0DD844658122800A1A7 /* StartAgentStoreTests.swift in Sources */,
 				E8E50DCA9F56799E022F9252 /* TerminalAttachE2ETests.swift in Sources */,
 				0CF1AA5AF7F2357186A5E486 /* TerminalAttachTests.swift in Sources */,
+				30A69209EA01A8DF784ABC52 /* TerminalInputControllerTests.swift in Sources */,
 				D51F828E0AC4A2F6C23A0CBE /* TerminalThemeSettingsTests.swift in Sources */,
 				E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */,
 				782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		9C1C00F36A178BF1BEE6C0A5 /* StartAgentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E14A4298DB015E6477F789 /* StartAgentStore.swift */; };
 		9F3F748E722FD8059A59ECBD /* HostStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6434D31A79422C0BAE80993F /* HostStoreTests.swift */; };
 		A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */; };
+		A14E6D20D1216F7764E3298B /* PhotosPickerImageSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89863F261DC0C6F317D75786 /* PhotosPickerImageSelection.swift */; };
 		B0D87D1783C80597B66EDDFC /* HerdrAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD390F4EE653187BCF20037F /* HerdrAPITypes.swift */; };
 		B31E16D56EE1F19A3802625B /* TransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4476B101AA4B13190C7A7B7C /* TransportConnector.swift */; };
 		B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCA39340517CEF3DAA35A09B /* Preflight.swift */; };
@@ -75,6 +76,7 @@
 		C60E8E0398665C36520DDA8E /* HerdrEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABFC5E35C19F809355619E7 /* HerdrEvents.swift */; };
 		C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 03BEAFDD98C535CDCE9AE335 /* Citadel */; };
 		C70B492B9C358FDAFF7876CF /* GhosttyTheme in Frameworks */ = {isa = PBXBuildFile; productRef = 6AB21852B18619F247B07907 /* GhosttyTheme */; };
+		C863E192DD66E3689C012342 /* ImageAttachStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCDC5144D5AA6403150431A /* ImageAttachStoreTests.swift */; };
 		CAFF027EF047D3AACE5F5243 /* ImagePreparerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29ABD9B1F458A3948086A16 /* ImagePreparerTests.swift */; };
 		CC20BAD2AC1A725889F82A20 /* ClosePaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13921A61B4E4F17CDE47C96 /* ClosePaneStore.swift */; };
 		CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D95D580BCF4FE792AEFE974 /* ContentView.swift */; };
@@ -90,6 +92,7 @@
 		E30244FD0231DD02EC9978D0 /* EventsSubscribeE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4076B0E816625CD09EB29F2E /* EventsSubscribeE2ETests.swift */; };
 		E37B688F0A59B1E4085C2C18 /* HostDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E3451A4ECA518B0AE43F93 /* HostDraftTests.swift */; };
 		E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */; };
+		E5950D24C4F647368C03853F /* ImageAttachStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4847B965ACCAC480398065 /* ImageAttachStore.swift */; };
 		E8E50DCA9F56799E022F9252 /* TerminalAttachE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83F34B22988623AD8E2093C /* TerminalAttachE2ETests.swift */; };
 		E908289DF03C6732F7D91328 /* HerdrEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */; };
 		EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */; };
@@ -129,6 +132,7 @@
 		25E3451A4ECA518B0AE43F93 /* HostDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostDraftTests.swift; sourceTree = "<group>"; };
 		278668F4D5B3EB85E6CDA16A /* HostFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostFormView.swift; sourceTree = "<group>"; };
 		29DD3828DAEF46DBA7038B0A /* HostOnboardingStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostOnboardingStoreTests.swift; sourceTree = "<group>"; };
+		3CCDC5144D5AA6403150431A /* ImageAttachStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachStoreTests.swift; sourceTree = "<group>"; };
 		3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedAsyncOperation.swift; sourceTree = "<group>"; };
 		4076B0E816625CD09EB29F2E /* EventsSubscribeE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSubscribeE2ETests.swift; sourceTree = "<group>"; };
 		4476B101AA4B13190C7A7B7C /* TransportConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConnector.swift; sourceTree = "<group>"; };
@@ -158,6 +162,7 @@
 		80E727A9081269681AD7581B /* TerminalInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalInputController.swift; sourceTree = "<group>"; };
 		8323C68B13826B7388800B1F /* DeviceKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyStoreTests.swift; sourceTree = "<group>"; };
 		87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStoreTests.swift; sourceTree = "<group>"; };
+		89863F261DC0C6F317D75786 /* PhotosPickerImageSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosPickerImageSelection.swift; sourceTree = "<group>"; };
 		904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSSHTestEnvironment.swift; sourceTree = "<group>"; };
 		90875ADAF6E348E186C8125A /* SSHCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHCredentials.swift; sourceTree = "<group>"; };
 		9291334E33C85C7588F86281 /* EventsSessionE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionE2ETests.swift; sourceTree = "<group>"; };
@@ -165,6 +170,7 @@
 		97970F4D535CC80592333995 /* AttachTerminalStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachTerminalStore.swift; sourceTree = "<group>"; };
 		9AECAD39A269D97DAB4ED194 /* HostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStore.swift; sourceTree = "<group>"; };
 		9B106E427EE5358088B615CE /* InMemorySecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemorySecretStore.swift; sourceTree = "<group>"; };
+		9B4847B965ACCAC480398065 /* ImageAttachStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachStore.swift; sourceTree = "<group>"; };
 		A32D737E753ABEB2809975EA /* ImageStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStagingTests.swift; sourceTree = "<group>"; };
 		A549DEB5B5CE8FDD29CE2A28 /* AttachTerminalStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachTerminalStoreTests.swift; sourceTree = "<group>"; };
 		A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrEventsTests.swift; sourceTree = "<group>"; };
@@ -311,6 +317,7 @@
 				25E3451A4ECA518B0AE43F93 /* HostDraftTests.swift */,
 				29DD3828DAEF46DBA7038B0A /* HostOnboardingStoreTests.swift */,
 				6434D31A79422C0BAE80993F /* HostStoreTests.swift */,
+				3CCDC5144D5AA6403150431A /* ImageAttachStoreTests.swift */,
 				F29ABD9B1F458A3948086A16 /* ImagePreparerTests.swift */,
 				EA18CA4EC57526EA84A6DEE8 /* ImageStagingE2ETests.swift */,
 				A32D737E753ABEB2809975EA /* ImageStagingTests.swift */,
@@ -402,8 +409,10 @@
 		B9BA381B5B296A3BE02F125E /* Images */ = {
 			isa = PBXGroup;
 			children = (
+				9B4847B965ACCAC480398065 /* ImageAttachStore.swift */,
 				7730887B9AF1CE45D9FB9AAB /* ImagePreparer.swift */,
 				127EB78F8CCC219F6C435626 /* ImageStaging.swift */,
+				89863F261DC0C6F317D75786 /* PhotosPickerImageSelection.swift */,
 			);
 			path = Images;
 			sourceTree = "<group>";
@@ -538,10 +547,12 @@
 				36B674DF605ECAE382E51196 /* HostOnboardingStore.swift in Sources */,
 				91833D21F64358A8E82A0D34 /* HostOnboardingView.swift in Sources */,
 				27C44B69FBE155A397F54B77 /* HostStore.swift in Sources */,
+				E5950D24C4F647368C03853F /* ImageAttachStore.swift in Sources */,
 				48C7F12EA8EF701E1F6D8649 /* ImagePreparer.swift in Sources */,
 				0B82C5F60B548ED11F8C3045 /* ImageStaging.swift in Sources */,
 				4C80E23F09C8CFB3A93101B8 /* JSONValue.swift in Sources */,
 				B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */,
+				A14E6D20D1216F7764E3298B /* PhotosPickerImageSelection.swift in Sources */,
 				B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */,
 				8C514AFC85DAED69A4988C13 /* SSHCredentials.swift in Sources */,
 				073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */,
@@ -587,6 +598,7 @@
 				E37B688F0A59B1E4085C2C18 /* HostDraftTests.swift in Sources */,
 				6F3B8F2DEC6CA5991BB267E5 /* HostOnboardingStoreTests.swift in Sources */,
 				9F3F748E722FD8059A59ECBD /* HostStoreTests.swift in Sources */,
+				C863E192DD66E3689C012342 /* ImageAttachStoreTests.swift in Sources */,
 				CAFF027EF047D3AACE5F5243 /* ImagePreparerTests.swift in Sources */,
 				68E0CF3B2078B4450366AF36 /* ImageStagingE2ETests.swift in Sources */,
 				213116D3248CE7DCEAA6EBB9 /* ImageStagingTests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		41BBA40C97BAE65E56D0E3B5 /* TerminalAttach.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8007AF9894BE8BAFFA7A6372 /* TerminalAttach.swift */; };
 		473F834A4C680F18BA303DB9 /* ScriptedTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFE5C640586747D567E1CF1 /* ScriptedTransport.swift */; };
 		488EF0DD844658122800A1A7 /* StartAgentStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71CE71D20ABB90D7E94264E /* StartAgentStoreTests.swift */; };
+		48C7F12EA8EF701E1F6D8649 /* ImagePreparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7730887B9AF1CE45D9FB9AAB /* ImagePreparer.swift */; };
 		49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E51D58B1094AC5B389EDA /* Transport.swift */; };
 		4C80E23F09C8CFB3A93101B8 /* JSONValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3E2308A50D4744A24A874B /* JSONValue.swift */; };
 		535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */; };
@@ -71,6 +72,7 @@
 		C60E8E0398665C36520DDA8E /* HerdrEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABFC5E35C19F809355619E7 /* HerdrEvents.swift */; };
 		C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 03BEAFDD98C535CDCE9AE335 /* Citadel */; };
 		C70B492B9C358FDAFF7876CF /* GhosttyTheme in Frameworks */ = {isa = PBXBuildFile; productRef = 6AB21852B18619F247B07907 /* GhosttyTheme */; };
+		CAFF027EF047D3AACE5F5243 /* ImagePreparerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29ABD9B1F458A3948086A16 /* ImagePreparerTests.swift */; };
 		CC20BAD2AC1A725889F82A20 /* ClosePaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13921A61B4E4F17CDE47C96 /* ClosePaneStore.swift */; };
 		CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D95D580BCF4FE792AEFE974 /* ContentView.swift */; };
 		D11D524FCF49C49763C9F9D7 /* Host.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806A90DBCA99FD02E76D68C6 /* Host.swift */; };
@@ -139,6 +141,7 @@
 		6CA5E9DDE1AB0F68F6EC56EB /* EventsSessionSubscriptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionSubscriptionsTests.swift; sourceTree = "<group>"; };
 		6F7C6974BD9BE77000016FCA /* TerminalByteFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalByteFeed.swift; sourceTree = "<group>"; };
 		73DB204D5F25D5375D5B2974 /* TerminalKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeyboard.swift; sourceTree = "<group>"; };
+		7730887B9AF1CE45D9FB9AAB /* ImagePreparer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreparer.swift; sourceTree = "<group>"; };
 		78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrMobileApp.swift; sourceTree = "<group>"; };
 		786B2BA8A0683BB9DC71D797 /* TerminalTextSelectionPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTextSelectionPresenter.swift; sourceTree = "<group>"; };
 		7AFE5C640586747D567E1CF1 /* ScriptedTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptedTransport.swift; sourceTree = "<group>"; };
@@ -189,6 +192,7 @@
 		EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemeSettingsTests.swift; sourceTree = "<group>"; };
 		EF9B76E2DA818DAB4259286C /* HostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostListView.swift; sourceTree = "<group>"; };
 		F13921A61B4E4F17CDE47C96 /* ClosePaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosePaneStore.swift; sourceTree = "<group>"; };
+		F29ABD9B1F458A3948086A16 /* ImagePreparerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreparerTests.swift; sourceTree = "<group>"; };
 		F3D159C84E98A59AA47EBE6C /* HerdrMobileTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HerdrMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWire.swift; sourceTree = "<group>"; };
 		F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransportE2ETests.swift; sourceTree = "<group>"; };
@@ -301,6 +305,7 @@
 				25E3451A4ECA518B0AE43F93 /* HostDraftTests.swift */,
 				29DD3828DAEF46DBA7038B0A /* HostOnboardingStoreTests.swift */,
 				6434D31A79422C0BAE80993F /* HostStoreTests.swift */,
+				F29ABD9B1F458A3948086A16 /* ImagePreparerTests.swift */,
 				17F86744BFAC66D732CE7833 /* JSONValueTests.swift */,
 				87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */,
 				DB88AD0F4E9EE776B17FAFAA /* PreflightReportTests.swift */,
@@ -378,11 +383,20 @@
 				78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */,
 				AEEB5E7751FD30413560D58D /* Console */,
 				85F7BECB72876852AAA885F2 /* Hosts */,
+				B9BA381B5B296A3BE02F125E /* Images */,
 				076C8448389275EA5E67DA9F /* Settings */,
 				758C1B00FCD3935541ADA64F /* Terminal */,
 				41C75ABDF8DC22F0282957C5 /* Transport */,
 			);
 			path = HerdrMobile;
+			sourceTree = "<group>";
+		};
+		B9BA381B5B296A3BE02F125E /* Images */ = {
+			isa = PBXGroup;
+			children = (
+				7730887B9AF1CE45D9FB9AAB /* ImagePreparer.swift */,
+			);
+			path = Images;
 			sourceTree = "<group>";
 		};
 		CB45F25667AE3C5C2EFD76CB /* Support */ = {
@@ -515,6 +529,7 @@
 				36B674DF605ECAE382E51196 /* HostOnboardingStore.swift in Sources */,
 				91833D21F64358A8E82A0D34 /* HostOnboardingView.swift in Sources */,
 				27C44B69FBE155A397F54B77 /* HostStore.swift in Sources */,
+				48C7F12EA8EF701E1F6D8649 /* ImagePreparer.swift in Sources */,
 				4C80E23F09C8CFB3A93101B8 /* JSONValue.swift in Sources */,
 				B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */,
 				B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */,
@@ -562,6 +577,7 @@
 				E37B688F0A59B1E4085C2C18 /* HostDraftTests.swift in Sources */,
 				6F3B8F2DEC6CA5991BB267E5 /* HostOnboardingStoreTests.swift in Sources */,
 				9F3F748E722FD8059A59ECBD /* HostStoreTests.swift in Sources */,
+				CAFF027EF047D3AACE5F5243 /* ImagePreparerTests.swift in Sources */,
 				0A0657501E1164D7672A8B39 /* InMemorySecretStore.swift in Sources */,
 				969057C35F7E5F162B0CF41D /* JSONValueTests.swift in Sources */,
 				2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0700F97FBF6A714C5D9EA5CD /* ColdStartE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */; };
 		073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */; };
 		0A0657501E1164D7672A8B39 /* InMemorySecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B106E427EE5358088B615CE /* InMemorySecretStore.swift */; };
+		0B82C5F60B548ED11F8C3045 /* ImageStaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127EB78F8CCC219F6C435626 /* ImageStaging.swift */; };
 		0CF1AA5AF7F2357186A5E486 /* TerminalAttachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE8796AB629EF68A90C96B3D /* TerminalAttachTests.swift */; };
 		1302E0DD26A3F6C629A753D8 /* HostKeyPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADA0E8C1DC6D30FCC6CEDC2 /* HostKeyPolicy.swift */; };
 		1BAA5950B7FDE0E6F09811F9 /* DeviceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC995A571D7659F3307B6E54 /* DeviceKey.swift */; };
@@ -21,6 +22,7 @@
 		1BF53C7A5E6402747F26096A /* HostCredentialsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC07C7B3772EEED1EB8BA9C /* HostCredentialsProvider.swift */; };
 		1E26593A1B05B0ACEE9AC557 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B5EBF6C4EC88361E91CA2C /* SettingsView.swift */; };
 		1F4B065DFCAF8E6656600F1E /* TOFUHostKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */; };
+		213116D3248CE7DCEAA6EBB9 /* ImageStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32D737E753ABEB2809975EA /* ImageStagingTests.swift */; };
 		225ECBDC69A7785559BC4D20 /* AttachTerminalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97970F4D535CC80592333995 /* AttachTerminalStore.swift */; };
 		27C44B69FBE155A397F54B77 /* HostStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AECAD39A269D97DAB4ED194 /* HostStore.swift */; };
 		29832666B5E02B0D33453DB1 /* EventsSessionBufferingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641088A470B51F40C898830F /* EventsSessionBufferingTests.swift */; };
@@ -43,6 +45,7 @@
 		5D1B735C72D551ADE0D82D44 /* TerminalThemeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A961D26EDEAA03AFB0F9C408 /* TerminalThemeSettings.swift */; };
 		6092F63FF2DE77AD7D087A7C /* ClosePaneStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC2552636663F92A55D1DFF1 /* ClosePaneStoreTests.swift */; };
 		6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */; };
+		68E0CF3B2078B4450366AF36 /* ImageStagingE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA18CA4EC57526EA84A6DEE8 /* ImageStagingE2ETests.swift */; };
 		693B0173C07DAF4BFC89B094 /* SecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567573855DCC8571BC02096D /* SecretStore.swift */; };
 		6CBE7E0961FFD970A614ED4B /* AgentCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3FA15CCDC83C72DDA81BEB /* AgentCardView.swift */; };
 		6F3B8F2DEC6CA5991BB267E5 /* HostOnboardingStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DD3828DAEF46DBA7038B0A /* HostOnboardingStoreTests.swift */; };
@@ -114,6 +117,7 @@
 		079394F4C6AC8FE4D7B0779C /* ConsoleStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleStoreTests.swift; sourceTree = "<group>"; };
 		08E14A4298DB015E6477F789 /* StartAgentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStore.swift; sourceTree = "<group>"; };
 		0B3FA15CCDC83C72DDA81BEB /* AgentCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentCardView.swift; sourceTree = "<group>"; };
+		127EB78F8CCC219F6C435626 /* ImageStaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStaging.swift; sourceTree = "<group>"; };
 		17F86744BFAC66D732CE7833 /* JSONValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueTests.swift; sourceTree = "<group>"; };
 		18AE2DC88A745FB457350957 /* StartAgentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentView.swift; sourceTree = "<group>"; };
 		1C3ACB2A319C5C1298A29F3F /* EventsSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSession.swift; sourceTree = "<group>"; };
@@ -161,6 +165,7 @@
 		97970F4D535CC80592333995 /* AttachTerminalStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachTerminalStore.swift; sourceTree = "<group>"; };
 		9AECAD39A269D97DAB4ED194 /* HostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStore.swift; sourceTree = "<group>"; };
 		9B106E427EE5358088B615CE /* InMemorySecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemorySecretStore.swift; sourceTree = "<group>"; };
+		A32D737E753ABEB2809975EA /* ImageStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStagingTests.swift; sourceTree = "<group>"; };
 		A549DEB5B5CE8FDD29CE2A28 /* AttachTerminalStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachTerminalStoreTests.swift; sourceTree = "<group>"; };
 		A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrEventsTests.swift; sourceTree = "<group>"; };
 		A71CE71D20ABB90D7E94264E /* StartAgentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStoreTests.swift; sourceTree = "<group>"; };
@@ -189,6 +194,7 @@
 		DDC07C7B3772EEED1EB8BA9C /* HostCredentialsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostCredentialsProvider.swift; sourceTree = "<group>"; };
 		DE12859365BC7A57B9EC256A /* HostDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostDraft.swift; sourceTree = "<group>"; };
 		E87B816CE7206B37622287C4 /* GeneratedWireTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedWireTypesTests.swift; sourceTree = "<group>"; };
+		EA18CA4EC57526EA84A6DEE8 /* ImageStagingE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStagingE2ETests.swift; sourceTree = "<group>"; };
 		EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemeSettingsTests.swift; sourceTree = "<group>"; };
 		EF9B76E2DA818DAB4259286C /* HostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostListView.swift; sourceTree = "<group>"; };
 		F13921A61B4E4F17CDE47C96 /* ClosePaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosePaneStore.swift; sourceTree = "<group>"; };
@@ -306,6 +312,8 @@
 				29DD3828DAEF46DBA7038B0A /* HostOnboardingStoreTests.swift */,
 				6434D31A79422C0BAE80993F /* HostStoreTests.swift */,
 				F29ABD9B1F458A3948086A16 /* ImagePreparerTests.swift */,
+				EA18CA4EC57526EA84A6DEE8 /* ImageStagingE2ETests.swift */,
+				A32D737E753ABEB2809975EA /* ImageStagingTests.swift */,
 				17F86744BFAC66D732CE7833 /* JSONValueTests.swift */,
 				87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */,
 				DB88AD0F4E9EE776B17FAFAA /* PreflightReportTests.swift */,
@@ -395,6 +403,7 @@
 			isa = PBXGroup;
 			children = (
 				7730887B9AF1CE45D9FB9AAB /* ImagePreparer.swift */,
+				127EB78F8CCC219F6C435626 /* ImageStaging.swift */,
 			);
 			path = Images;
 			sourceTree = "<group>";
@@ -530,6 +539,7 @@
 				91833D21F64358A8E82A0D34 /* HostOnboardingView.swift in Sources */,
 				27C44B69FBE155A397F54B77 /* HostStore.swift in Sources */,
 				48C7F12EA8EF701E1F6D8649 /* ImagePreparer.swift in Sources */,
+				0B82C5F60B548ED11F8C3045 /* ImageStaging.swift in Sources */,
 				4C80E23F09C8CFB3A93101B8 /* JSONValue.swift in Sources */,
 				B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */,
 				B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */,
@@ -578,6 +588,8 @@
 				6F3B8F2DEC6CA5991BB267E5 /* HostOnboardingStoreTests.swift in Sources */,
 				9F3F748E722FD8059A59ECBD /* HostStoreTests.swift in Sources */,
 				CAFF027EF047D3AACE5F5243 /* ImagePreparerTests.swift in Sources */,
+				68E0CF3B2078B4450366AF36 /* ImageStagingE2ETests.swift in Sources */,
+				213116D3248CE7DCEAA6EBB9 /* ImageStagingTests.swift in Sources */,
 				0A0657501E1164D7672A8B39 /* InMemorySecretStore.swift in Sources */,
 				969057C35F7E5F162B0CF41D /* JSONValueTests.swift in Sources */,
 				2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */,

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -1,3 +1,4 @@
+import PhotosUI
 import SwiftUI
 
 /// The Agent detail screen: one interactive Attach terminal. Ghostty owns
@@ -8,12 +9,16 @@ struct AgentDetailView: View {
     private let console: ConsoleStore
     private let terminalThemes: TerminalThemeSettings
     private let transport: @Sendable () async -> (any Transport)?
+    @State private var input: TerminalInputController
     @State private var store: AttachTerminalStore
+    @State private var imageAttach: ImageAttachStore
     @State private var close: ClosePaneStore
+    @State private var selectedPhoto: PhotosPickerItem?
     @State private var isConfirmingClose = false
     @State private var isShowingSettings = false
     @State private var closeErrorMessage: String?
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
 
     init(
         agent: ConsoleAgent,
@@ -24,10 +29,18 @@ struct AgentDetailView: View {
         self.console = console
         self.terminalThemes = terminalThemes
         let transport = console.transportProvider(for: agent.hostID)
+        let input = TerminalInputController()
         self.transport = transport
+        _input = State(initialValue: input)
         _store = State(
             initialValue: AttachTerminalStore(
-                target: agent.agent.paneID, transport: transport))
+                target: agent.agent.paneID,
+                input: input,
+                transport: transport))
+        _imageAttach = State(
+            initialValue: ImageAttachStore(
+                transport: transport,
+                input: input))
         _close = State(
             initialValue: ClosePaneStore(paneTitle: Self.displayTitle(for: agent)) {
                 try await console.closePane(agent.agent.paneID, on: agent.hostID)
@@ -41,13 +54,25 @@ struct AgentDetailView: View {
                 store.viewDidResize(cols: cols, rows: rows)
             },
             onSend: { keystrokes in store.send(keystrokes) },
+            onPaste: { text in _ = input.requestPaste(text) },
+            isLocalInputEnabled: !input.isPaused,
             theme: terminalThemes.theme
         )
         .id(ObjectIdentifier(store))
         .overlay { statusOverlay }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            imageAttachStatus
+        }
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                PhotosPicker(selection: $selectedPhoto, matching: .images) {
+                    Label("Attach Image", systemImage: "photo.badge.plus")
+                }
+                .disabled(store.status != .live || !imageAttach.canSelectImage)
+                .accessibilityLabel("Attach Image")
+            }
             ToolbarItem(placement: .primaryAction) {
                 AgentStatusBadge(status: agent.agent.status)
             }
@@ -66,6 +91,13 @@ struct AgentDetailView: View {
         }
         .sheet(isPresented: $isShowingSettings) {
             SettingsView(terminalThemes: terminalThemes)
+        }
+        .sheet(
+            isPresented: Binding(
+                get: { input.pendingPaste != nil },
+                set: { if !$0 { input.cancelPaste() } })
+        ) {
+            pasteReviewSheet
         }
         .confirmationDialog(
             "Close \(title)?", isPresented: $isConfirmingClose, titleVisibility: .visible
@@ -89,13 +121,44 @@ struct AgentDetailView: View {
         } message: {
             Text(closeErrorMessage ?? "")
         }
+        .alert(
+            "Paste Blocked",
+            isPresented: Binding(
+                get: { input.pasteErrorMessage != nil },
+                set: { if !$0 { input.clearPasteError() } })
+        ) {
+            Button("OK", role: .cancel) {
+                input.clearPasteError()
+            }
+        } message: {
+            Text(input.pasteErrorMessage ?? "")
+        }
+        .onChange(of: selectedPhoto) { _, item in
+            guard let item else { return }
+            selectedPhoto = nil
+            imageAttach.select(PhotosPickerImageSelection(item: item))
+        }
+        .onChange(of: scenePhase) { _, phase in
+            switch phase {
+            case .active:
+                imageAttach.didBecomeActive()
+            case .background:
+                imageAttach.didEnterBackground()
+            case .inactive:
+                break
+            @unknown default:
+                break
+            }
+        }
         .onChange(of: console.hostConnectionGenerations[agent.hostID]) { _, generation in
             guard generation != nil else { return }
             reconnect()
         }
         .onDisappear {
             let terminal = store
+            let imageAttach = imageAttach
             console.scheduleTerminalTeardown(for: agent.hostID) {
+                await imageAttach.leaveAttach()
                 await terminal.stop()
             }
         }
@@ -106,7 +169,10 @@ struct AgentDetailView: View {
         console.scheduleTerminalTeardown(for: agent.hostID) {
             await previous.stop()
         }
-        store = AttachTerminalStore(target: agent.agent.paneID, transport: transport)
+        store = AttachTerminalStore(
+            target: agent.agent.paneID,
+            input: input,
+            transport: transport)
     }
 
     private func performClose() async {
@@ -141,11 +207,135 @@ struct AgentDetailView: View {
         }
     }
 
+    @ViewBuilder
+    private var imageAttachStatus: some View {
+        switch imageAttach.state {
+        case .idle:
+            EmptyView()
+        case .preparing:
+            ImageAttachStatusBar(
+                icon: "photo",
+                title: "Preparing Image…",
+                accessibilityLabel: "Preparing Image"
+            ) {
+                Button("Cancel", role: .cancel) { imageAttach.cancel() }
+            }
+        case .uploading(let progress):
+            ImageAttachStatusBar(
+                icon: "arrow.up.circle",
+                title: "Uploading Image… \(Int(progress.fractionCompleted * 100))%",
+                accessibilityLabel:
+                    "Uploading Image, \(Int(progress.fractionCompleted * 100)) percent"
+            ) {
+                Button("Cancel", role: .cancel) { imageAttach.cancel() }
+            }
+        case .failed(let failure), .backgroundInterrupted(let failure):
+            ImageAttachStatusBar(
+                icon: "exclamationmark.triangle",
+                title: failure.message,
+                accessibilityLabel: failure.message
+            ) {
+                if failure.isRetryable {
+                    Button("Retry") { imageAttach.retry() }
+                }
+                Button("Dismiss", role: .cancel) { imageAttach.dismissResult() }
+            }
+        case .completed(let result):
+            ImageAttachStatusBar(
+                icon: result.copied && result.inserted ? "checkmark.circle" : "info.circle",
+                title: result.message,
+                accessibilityLabel: result.message
+            ) {
+                if !result.copied {
+                    Button("Copy Path") { imageAttach.copyPath() }
+                }
+                if !result.inserted {
+                    Button("Insert Path") { imageAttach.insertPath() }
+                }
+                Button("Done", role: .cancel) { imageAttach.dismissResult() }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var pasteReviewSheet: some View {
+        if let review = input.pendingPaste {
+            NavigationStack {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(
+                        "\(review.lineCount) lines, \(review.characterCount) characters")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    ScrollView {
+                        Text(review.preview)
+                            .font(.system(.body, design: .monospaced))
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .padding(12)
+                    .background(.quaternary, in: .rect(cornerRadius: 10))
+                }
+                .padding()
+                .navigationTitle("Review Paste")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel", role: .cancel) { input.cancelPaste() }
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Paste") { _ = input.confirmPaste() }
+                    }
+                }
+            }
+            .presentationDetents([.medium, .large])
+        }
+    }
+
     private var title: String {
         Self.displayTitle(for: agent)
     }
 
     private static func displayTitle(for agent: ConsoleAgent) -> String {
         agent.agent.title.isEmpty ? agent.agent.displayName : agent.agent.title
+    }
+}
+
+private struct ImageAttachStatusBar<Actions: View>: View {
+    let icon: String
+    let title: String
+    let accessibilityLabel: String
+    let actions: Actions
+
+    init(
+        icon: String,
+        title: String,
+        accessibilityLabel: String,
+        @ViewBuilder actions: () -> Actions
+    ) {
+        self.icon = icon
+        self.title = title
+        self.accessibilityLabel = accessibilityLabel
+        self.actions = actions()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(title, systemImage: icon)
+                .font(.subheadline)
+                .lineLimit(3)
+            HStack(spacing: 12) {
+                Spacer()
+                actions
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.regularMaterial)
+        .overlay(alignment: .top) { Divider() }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilityLabel)
     }
 }

--- a/Sources/HerdrMobile/Console/AttachTerminalStore.swift
+++ b/Sources/HerdrMobile/Console/AttachTerminalStore.swift
@@ -34,6 +34,7 @@ final class AttachTerminalStore {
 
     private let target: String
     private let takeover: Bool
+    private let input: TerminalInputController
     /// The Host's current transport, re-queried per (re)attach: the events
     /// session underneath may have reconnected onto a fresh one.
     private let transport: @Sendable () async -> (any Transport)?
@@ -42,14 +43,17 @@ final class AttachTerminalStore {
     private var rows: Int?
     private var stopRequested = false
     private var session: TerminalAttachSession?
+    private var inputGeneration: TerminalInputController.SessionGeneration?
     private var runTask: Task<Void, Never>?
 
     init(
         target: String, takeover: Bool = false,
+        input: TerminalInputController = TerminalInputController(),
         transport: @escaping @Sendable () async -> (any Transport)?
     ) {
         self.target = target
         self.takeover = takeover
+        self.input = input
         self.transport = transport
     }
 
@@ -73,7 +77,7 @@ final class AttachTerminalStore {
     /// Keystrokes from the terminal view, forwarded raw. Dropped while no
     /// session is live — there is nothing to type into yet.
     func send(_ keystrokes: Data) {
-        session?.send(keystrokes)
+        input.send(keystrokes)
     }
 
     /// Reattaches after the session ended remotely.
@@ -124,6 +128,10 @@ final class AttachTerminalStore {
             return
         }
         self.session = session
+        let inputGeneration = input.beginSession { data in
+            session.send(data)
+        }
+        self.inputGeneration = inputGeneration
         status = .live
         if let latestCols = self.cols, let latestRows = self.rows,
             latestCols != cols || latestRows != rows
@@ -142,6 +150,10 @@ final class AttachTerminalStore {
             failure = error
         }
         self.session = nil
+        input.endSession(inputGeneration)
+        if self.inputGeneration == inputGeneration {
+            self.inputGeneration = nil
+        }
         guard !stopRequested else { return }
         status = .ended(failure.map(Self.message(for:)) ?? "The session ended.")
     }

--- a/Sources/HerdrMobile/HerdrMobileApp.swift
+++ b/Sources/HerdrMobile/HerdrMobileApp.swift
@@ -4,6 +4,10 @@ import SwiftUI
 /// arrives in M1 once the Transport underneath it exists.
 @main
 struct HerdrMobileApp: App {
+    init() {
+        try? ImagePreparer.cleanupRemnants()
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/Sources/HerdrMobile/Images/ImageAttachStore.swift
+++ b/Sources/HerdrMobile/Images/ImageAttachStore.swift
@@ -1,0 +1,365 @@
+import Foundation
+import Observation
+import UniformTypeIdentifiers
+import UIKit
+
+@MainActor
+protocol ImageClipboard {
+    func copy(_ path: String) throws
+}
+
+@MainActor
+struct SystemImageClipboard: ImageClipboard {
+    static let lifetime: TimeInterval = 24 * 60 * 60
+
+    func copy(_ path: String) throws {
+        UIPasteboard.general.setItems(
+            [[UTType.plainText.identifier: path]],
+            options: [
+                .localOnly: true,
+                .expirationDate: Date().addingTimeInterval(Self.lifetime),
+            ])
+    }
+}
+
+struct ImageAttachFailure: Sendable, Equatable {
+    let message: String
+    let isRetryable: Bool
+}
+
+struct ImageAttachResult: Sendable, Equatable {
+    let stagedImage: StagedImage
+    var copied: Bool
+    var inserted: Bool
+
+    var message: String {
+        switch (copied, inserted) {
+        case (true, true):
+            "Image path inserted and copied."
+        case (true, false):
+            "Image path copied, but couldn't be inserted."
+        case (false, true):
+            "Image path inserted, but couldn't be copied."
+        case (false, false):
+            "Image uploaded, but its path couldn't be copied or inserted."
+        }
+    }
+}
+
+enum ImageAttachState: Sendable, Equatable {
+    case idle
+    case preparing
+    case uploading(ImageStageProgress)
+    case failed(ImageAttachFailure)
+    case backgroundInterrupted(ImageAttachFailure)
+    case completed(ImageAttachResult)
+
+    var isBusy: Bool {
+        switch self {
+        case .preparing, .uploading:
+            true
+        case .idle, .failed, .backgroundInterrupted, .completed:
+            false
+        }
+    }
+
+    var isCompleted: Bool {
+        if case .completed = self { true } else { false }
+    }
+
+    var completedResult: ImageAttachResult? {
+        if case .completed(let result) = self { result } else { nil }
+    }
+
+    var isFailed: Bool {
+        if case .failed = self { true } else { false }
+    }
+
+    var failedValue: ImageAttachFailure? {
+        if case .failed(let failure) = self { failure } else { nil }
+    }
+
+    var isBackgroundInterrupted: Bool {
+        if case .backgroundInterrupted = self { true } else { false }
+    }
+}
+
+/// Coordinates one selected image from Photos decoding through Host staging
+/// and terminal insertion. It owns only the app-local prepared file; completed
+/// Host files intentionally outlive this screen (ADR 0005).
+@MainActor
+@Observable
+final class ImageAttachStore {
+    private enum CancellationDisposition {
+        case user
+        case background
+        case leaving
+    }
+
+    private(set) var state: ImageAttachState = .idle
+
+    private let preparer: any ImagePreparing
+    private let transport: @Sendable () async -> (any Transport)?
+    private let clipboard: any ImageClipboard
+    private let input: TerminalInputController
+
+    private var preparedImage: PreparedImage?
+    private var operationTask: Task<Void, Never>?
+    private var operationID: UInt64 = 0
+    private var cancellationDisposition: CancellationDisposition?
+
+    init(
+        preparer: any ImagePreparing = ImagePreparer(),
+        transport: @escaping @Sendable () async -> (any Transport)?,
+        clipboard: any ImageClipboard = SystemImageClipboard(),
+        input: TerminalInputController
+    ) {
+        self.preparer = preparer
+        self.transport = transport
+        self.clipboard = clipboard
+        self.input = input
+    }
+
+    var canSelectImage: Bool {
+        !state.isBusy && input.liveGeneration != nil
+    }
+
+    func select(_ selection: any ImageSelection) {
+        guard operationTask == nil, let generation = input.liveGeneration else { return }
+        discardRetainedPreparedImage()
+        cancellationDisposition = nil
+        operationID &+= 1
+        let currentID = operationID
+        state = .preparing
+        input.pause()
+        operationTask = Task {
+            await runSelection(selection, generation: generation, operationID: currentID)
+        }
+    }
+
+    func retry() {
+        guard operationTask == nil, let preparedImage,
+            let generation = input.liveGeneration
+        else { return }
+        cancellationDisposition = nil
+        operationID &+= 1
+        let currentID = operationID
+        state = .uploading(
+            ImageStageProgress(transferredBytes: 0, totalBytes: preparedImage.byteCount))
+        input.pause()
+        operationTask = Task {
+            await runUpload(preparedImage, generation: generation, operationID: currentID)
+        }
+    }
+
+    func cancel() {
+        guard let operationTask else {
+            state = .idle
+            discardRetainedPreparedImage()
+            return
+        }
+        cancellationDisposition = .user
+        operationTask.cancel()
+    }
+
+    func didEnterBackground() {
+        guard let operationTask else { return }
+        cancellationDisposition = .background
+        operationTask.cancel()
+    }
+
+    /// Foregrounding never retries implicitly. The retained local file and
+    /// explicit retry action make the interruption visible and deterministic.
+    func didBecomeActive() {}
+
+    func copyPath() {
+        guard case .completed(var result) = state, !result.copied else { return }
+        do {
+            try clipboard.copy(result.stagedImage.path)
+            result.copied = true
+            state = .completed(result)
+        } catch {
+            // The completed result remains available for another explicit try.
+        }
+    }
+
+    func insertPath() {
+        guard case .completed(var result) = state, !result.inserted else { return }
+        result.inserted = input.insertPathIntoCurrentSession(result.stagedImage.path)
+        state = .completed(result)
+    }
+
+    func dismissResult() {
+        guard !state.isBusy else { return }
+        state = .idle
+    }
+
+    func leaveAttach() async {
+        if let task = operationTask {
+            cancellationDisposition = .leaving
+            task.cancel()
+            await task.value
+        }
+        discardRetainedPreparedImage()
+        input.resume()
+        state = .idle
+    }
+
+    private func runSelection(
+        _ selection: any ImageSelection,
+        generation: TerminalInputController.SessionGeneration,
+        operationID: UInt64
+    ) async {
+        do {
+            let image = try await preparer.prepare(selection)
+            try Task.checkCancellation()
+            guard operationID == self.operationID else {
+                try? image.remove()
+                return
+            }
+            preparedImage = image
+            state = .uploading(
+                ImageStageProgress(transferredBytes: 0, totalBytes: image.byteCount))
+            await runUploadBody(image, generation: generation, operationID: operationID)
+        } catch {
+            finish(error: error, operationID: operationID)
+        }
+    }
+
+    private func runUpload(
+        _ image: PreparedImage,
+        generation: TerminalInputController.SessionGeneration,
+        operationID: UInt64
+    ) async {
+        await runUploadBody(image, generation: generation, operationID: operationID)
+    }
+
+    private func runUploadBody(
+        _ image: PreparedImage,
+        generation: TerminalInputController.SessionGeneration,
+        operationID: UInt64
+    ) async {
+        do {
+            guard let transport = await transport() else {
+                throw ImageAttachStoreError.hostDisconnected
+            }
+            let staged = try await transport.stageImage(image) { [weak self] progress in
+                await self?.receive(progress: progress, operationID: operationID)
+            }
+            try Task.checkCancellation()
+            finishSuccess(staged, generation: generation, operationID: operationID)
+        } catch {
+            finish(error: error, operationID: operationID)
+        }
+    }
+
+    private func receive(progress: ImageStageProgress, operationID: UInt64) {
+        guard operationID == self.operationID, operationTask != nil else { return }
+        state = .uploading(progress)
+    }
+
+    private func finishSuccess(
+        _ stagedImage: StagedImage,
+        generation: TerminalInputController.SessionGeneration,
+        operationID: UInt64
+    ) {
+        guard operationID == self.operationID else { return }
+        operationTask = nil
+        cancellationDisposition = nil
+        discardRetainedPreparedImage()
+        input.resume()
+
+        var copied = false
+        do {
+            try clipboard.copy(stagedImage.path)
+            copied = true
+        } catch {}
+        let inserted = input.insertPath(stagedImage.path, matching: generation)
+        state = .completed(
+            ImageAttachResult(
+                stagedImage: stagedImage,
+                copied: copied,
+                inserted: inserted))
+    }
+
+    private func finish(error: any Error, operationID: UInt64) {
+        guard operationID == self.operationID else { return }
+        operationTask = nil
+        input.resume()
+
+        if Self.isCancellation(error) || cancellationDisposition != nil {
+            switch cancellationDisposition {
+            case .background:
+                state = .backgroundInterrupted(
+                    ImageAttachFailure(
+                        message: "Image upload paused when herdr moved to the background.",
+                        isRetryable: preparedImage != nil))
+            case .user, .leaving, .none:
+                discardRetainedPreparedImage()
+                state = .idle
+            }
+            cancellationDisposition = nil
+            return
+        }
+
+        let failure = Self.failure(for: error)
+        if !failure.isRetryable {
+            discardRetainedPreparedImage()
+        }
+        state = .failed(failure)
+    }
+
+    private func discardRetainedPreparedImage() {
+        try? preparedImage?.remove()
+        preparedImage = nil
+    }
+
+    private static func isCancellation(_ error: any Error) -> Bool {
+        error is CancellationError || (error as? ImageStagingError) == .cancelled
+    }
+
+    private static func failure(for error: any Error) -> ImageAttachFailure {
+        switch error {
+        case ImageAttachStoreError.hostDisconnected:
+            ImageAttachFailure(
+                message: "The Host is not connected. Reconnect, then retry the upload.",
+                isRetryable: true)
+        case ImageStagingError.sftpUnavailable:
+            ImageAttachFailure(
+                message: "SFTP is unavailable on this Host. Enable its SSH SFTP subsystem.",
+                isRetryable: false)
+        case let staging as ImageStagingError:
+            ImageAttachFailure(
+                message: "Image upload failed.",
+                isRetryable: staging.isRetryable)
+        case ImagePreparationError.selectionUnavailable:
+            ImageAttachFailure(
+                message: "The selected photo is no longer available.",
+                isRetryable: false)
+        case ImagePreparationError.sourceTooLarge:
+            ImageAttachFailure(
+                message: "The selected image is too large to decode safely.",
+                isRetryable: false)
+        case ImagePreparationError.invalidImage:
+            ImageAttachFailure(
+                message: "The selected item is not a readable image.",
+                isRetryable: false)
+        case ImagePreparationError.unableToProduceBoundedOutput:
+            ImageAttachFailure(
+                message: "The image could not be reduced below the 16 MiB upload limit.",
+                isRetryable: false)
+        case ImagePreparationError.localStorageFailed:
+            ImageAttachFailure(
+                message: "herdr could not prepare the image in protected local storage.",
+                isRetryable: false)
+        default:
+            ImageAttachFailure(
+                message: "Image preparation failed.",
+                isRetryable: false)
+        }
+    }
+}
+
+private enum ImageAttachStoreError: Error {
+    case hostDisconnected
+}

--- a/Sources/HerdrMobile/Images/ImageAttachStore.swift
+++ b/Sources/HerdrMobile/Images/ImageAttachStore.swift
@@ -210,18 +210,22 @@ final class ImageAttachStore {
         generation: TerminalInputController.SessionGeneration,
         operationID: UInt64
     ) async {
+        var unclaimedImage: PreparedImage?
         do {
             let image = try await preparer.prepare(selection)
+            unclaimedImage = image
             try Task.checkCancellation()
             guard operationID == self.operationID else {
                 try? image.remove()
                 return
             }
             preparedImage = image
+            unclaimedImage = nil
             state = .uploading(
                 ImageStageProgress(transferredBytes: 0, totalBytes: image.byteCount))
             await runUploadBody(image, generation: generation, operationID: operationID)
         } catch {
+            try? unclaimedImage?.remove()
             finish(error: error, operationID: operationID)
         }
     }

--- a/Sources/HerdrMobile/Images/ImageAttachStore.swift
+++ b/Sources/HerdrMobile/Images/ImageAttachStore.swift
@@ -191,6 +191,7 @@ final class ImageAttachStore {
 
     func dismissResult() {
         guard !state.isBusy else { return }
+        discardRetainedPreparedImage()
         state = .idle
     }
 

--- a/Sources/HerdrMobile/Images/ImagePreparer.swift
+++ b/Sources/HerdrMobile/Images/ImagePreparer.swift
@@ -1,0 +1,370 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+enum PreparedImageFormat: String, Sendable, Equatable {
+    case jpeg
+    case png
+
+    var fileExtension: String {
+        switch self {
+        case .jpeg: "jpg"
+        case .png: "png"
+        }
+    }
+
+    fileprivate var typeIdentifier: CFString {
+        switch self {
+        case .jpeg: UTType.jpeg.identifier as CFString
+        case .png: UTType.png.identifier as CFString
+        }
+    }
+}
+
+/// App-owned normalized image file ready for transport. The random local name
+/// carries no Photos filename or metadata.
+struct PreparedImage: Sendable, Equatable {
+    let fileURL: URL
+    let format: PreparedImageFormat
+    let pixelWidth: Int
+    let pixelHeight: Int
+    let byteCount: Int64
+
+    func remove(fileManager: FileManager = .default) throws {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return }
+        try fileManager.removeItem(at: fileURL)
+    }
+}
+
+protocol ImageSelection: Sendable {
+    func loadData() async throws -> Data
+}
+
+struct DataImageSelection: ImageSelection {
+    let data: Data
+
+    func loadData() async throws -> Data {
+        data
+    }
+}
+
+protocol ImagePreparing: Sendable {
+    func prepare(_ selection: any ImageSelection) async throws -> PreparedImage
+}
+
+enum ImagePreparationError: Error, Sendable, Equatable {
+    case selectionUnavailable
+    case invalidImage
+    case sourceTooLarge
+    case unableToProduceBoundedOutput
+    case localStorageFailed
+}
+
+/// Safely decodes into a bounded thumbnail, applies source orientation, strips
+/// metadata by re-encoding from pixels, and writes one protected app-owned file.
+actor ImagePreparer: ImagePreparing {
+    struct Configuration: Sendable, Equatable {
+        let maximumLongEdge: Int
+        let maximumEncodedByteCount: Int
+        let maximumSourcePixelCount: Int
+
+        init(
+            maximumLongEdge: Int,
+            maximumEncodedByteCount: Int,
+            maximumSourcePixelCount: Int
+        ) {
+            self.maximumLongEdge = maximumLongEdge
+            self.maximumEncodedByteCount = maximumEncodedByteCount
+            self.maximumSourcePixelCount = maximumSourcePixelCount
+        }
+    }
+
+    static let maximumEncodedByteCount = 16 * 1_024 * 1_024
+    static let defaultDirectory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("HerdrMobilePreparedImages", isDirectory: true)
+
+    private static let defaultConfiguration = Configuration(
+        maximumLongEdge: 4_096,
+        maximumEncodedByteCount: maximumEncodedByteCount,
+        maximumSourcePixelCount: 200_000_000)
+    private static let jpegQualities: [CGFloat] = [
+        0.90, 0.82, 0.74, 0.66, 0.58, 0.50, 0.42, 0.35,
+    ]
+    private static let minimumDimension = 16
+
+    private let configuration: Configuration
+    private let directory: URL
+    private let fileManager: FileManager
+
+    init(
+        configuration: Configuration = ImagePreparer.defaultConfiguration,
+        directory: URL = ImagePreparer.defaultDirectory,
+        fileManager: FileManager = .default
+    ) {
+        self.configuration = configuration
+        self.directory = directory
+        self.fileManager = fileManager
+    }
+
+    func prepare(_ selection: any ImageSelection) async throws -> PreparedImage {
+        try Task.checkCancellation()
+        let sourceData = try await selection.loadData()
+        guard !sourceData.isEmpty else { throw ImagePreparationError.selectionUnavailable }
+        try Task.checkCancellation()
+
+        do {
+            try Self.ensureDirectory(directory, fileManager: fileManager)
+        } catch {
+            throw ImagePreparationError.localStorageFailed
+        }
+        let sourceURL = directory.appendingPathComponent(
+            "\(UUID().uuidString.lowercased()).source")
+        do {
+            try Self.writeProtected(sourceData, to: sourceURL, fileManager: fileManager)
+        } catch {
+            throw ImagePreparationError.localStorageFailed
+        }
+        defer { try? fileManager.removeItem(at: sourceURL) }
+
+        let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard
+            let source = CGImageSourceCreateWithURL(sourceURL as CFURL, sourceOptions),
+            CGImageSourceGetCount(source) > 0
+        else {
+            throw ImagePreparationError.invalidImage
+        }
+        let dimensions = try Self.sourceDimensions(source)
+        guard Self.isSafelyBounded(dimensions, configuration: configuration) else {
+            throw ImagePreparationError.sourceTooLarge
+        }
+        try Task.checkCancellation()
+
+        let thumbnailOptions: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: configuration.maximumLongEdge,
+        ]
+        guard
+            let orientedImage = CGImageSourceCreateThumbnailAtIndex(
+                source, 0, thumbnailOptions as CFDictionary)
+        else {
+            throw ImagePreparationError.invalidImage
+        }
+        let format: PreparedImageFormat =
+            Self.hasAlpha(orientedImage) ? .png : .jpeg
+        let encoded = try Self.encodeBounded(
+            orientedImage,
+            format: format,
+            maximumByteCount: configuration.maximumEncodedByteCount)
+        try Task.checkCancellation()
+
+        let outputURL = directory.appendingPathComponent(
+            "\(UUID().uuidString.lowercased()).\(format.fileExtension)")
+        do {
+            try Self.writeProtected(encoded.data, to: outputURL, fileManager: fileManager)
+        } catch {
+            throw ImagePreparationError.localStorageFailed
+        }
+        return PreparedImage(
+            fileURL: outputURL,
+            format: format,
+            pixelWidth: encoded.image.width,
+            pixelHeight: encoded.image.height,
+            byteCount: Int64(encoded.data.count))
+    }
+
+    static func cleanupRemnants(
+        in directory: URL = defaultDirectory,
+        fileManager: FileManager = .default
+    ) throws {
+        guard fileManager.fileExists(atPath: directory.path) else { return }
+        for url in try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles])
+        {
+            try fileManager.removeItem(at: url)
+        }
+    }
+
+    private static func ensureDirectory(_ directory: URL, fileManager: FileManager) throws {
+        try fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.complete])
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        var mutableDirectory = directory
+        try mutableDirectory.setResourceValues(values)
+    }
+
+    private static func writeProtected(
+        _ data: Data,
+        to url: URL,
+        fileManager: FileManager
+    ) throws {
+        try data.write(to: url, options: .atomic)
+        try fileManager.setAttributes(
+            [.protectionKey: FileProtectionType.complete],
+            ofItemAtPath: url.path)
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        var mutableURL = url
+        try mutableURL.setResourceValues(values)
+    }
+
+    private static func sourceDimensions(_ source: CGImageSource) throws -> (Int, Int) {
+        guard
+            let properties = CGImageSourceCopyPropertiesAtIndex(
+                source,
+                0,
+                [kCGImageSourceShouldCache: false] as CFDictionary)
+                as? [CFString: Any],
+            let width = (properties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue,
+            let height = (properties[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue,
+            width > 0,
+            height > 0
+        else {
+            throw ImagePreparationError.invalidImage
+        }
+        return (width, height)
+    }
+
+    private static func isSafelyBounded(
+        _ dimensions: (Int, Int),
+        configuration: Configuration
+    ) -> Bool {
+        let (pixelCount, overflow) = dimensions.0.multipliedReportingOverflow(
+            by: dimensions.1)
+        return !overflow
+            && pixelCount <= configuration.maximumSourcePixelCount
+            && dimensions.0 <= 65_535
+            && dimensions.1 <= 65_535
+    }
+
+    private static func hasAlpha(_ image: CGImage) -> Bool {
+        switch image.alphaInfo {
+        case .first, .last, .premultipliedFirst, .premultipliedLast, .alphaOnly:
+            true
+        case .none, .noneSkipFirst, .noneSkipLast:
+            false
+        @unknown default:
+            true
+        }
+    }
+
+    private struct EncodedImage {
+        let image: CGImage
+        let data: Data
+    }
+
+    private static func encodeBounded(
+        _ image: CGImage,
+        format: PreparedImageFormat,
+        maximumByteCount: Int
+    ) throws -> EncodedImage {
+        guard maximumByteCount > 0 else {
+            throw ImagePreparationError.unableToProduceBoundedOutput
+        }
+        var candidate = image
+        while candidate.width >= minimumDimension, candidate.height >= minimumDimension {
+            switch format {
+            case .jpeg:
+                var smallestData: Data?
+                for quality in jpegQualities {
+                    let data = try encode(candidate, format: format, quality: quality)
+                    if data.count <= maximumByteCount {
+                        return EncodedImage(image: candidate, data: data)
+                    }
+                    smallestData = data
+                }
+                guard let smallestData else {
+                    throw ImagePreparationError.unableToProduceBoundedOutput
+                }
+                candidate = try scaledDown(
+                    candidate,
+                    currentByteCount: smallestData.count,
+                    maximumByteCount: maximumByteCount,
+                    preservesAlpha: false)
+            case .png:
+                let data = try encode(candidate, format: format, quality: nil)
+                if data.count <= maximumByteCount {
+                    return EncodedImage(image: candidate, data: data)
+                }
+                candidate = try scaledDown(
+                    candidate,
+                    currentByteCount: data.count,
+                    maximumByteCount: maximumByteCount,
+                    preservesAlpha: true)
+            }
+        }
+        throw ImagePreparationError.unableToProduceBoundedOutput
+    }
+
+    private static func encode(
+        _ image: CGImage,
+        format: PreparedImageFormat,
+        quality: CGFloat?
+    ) throws -> Data {
+        let data = NSMutableData()
+        guard
+            let destination = CGImageDestinationCreateWithData(
+                data,
+                format.typeIdentifier,
+                1,
+                nil)
+        else {
+            throw ImagePreparationError.unableToProduceBoundedOutput
+        }
+        let properties: CFDictionary?
+        if let quality {
+            properties = [
+                kCGImageDestinationLossyCompressionQuality: quality
+            ] as CFDictionary
+        } else {
+            properties = nil
+        }
+        CGImageDestinationAddImage(destination, image, properties)
+        guard CGImageDestinationFinalize(destination) else {
+            throw ImagePreparationError.unableToProduceBoundedOutput
+        }
+        return data as Data
+    }
+
+    private static func scaledDown(
+        _ image: CGImage,
+        currentByteCount: Int,
+        maximumByteCount: Int,
+        preservesAlpha: Bool
+    ) throws -> CGImage {
+        let estimated = sqrt(Double(maximumByteCount) / Double(currentByteCount)) * 0.9
+        let scale = min(0.8, max(0.25, estimated))
+        let width = max(minimumDimension, Int((Double(image.width) * scale).rounded(.down)))
+        let height = max(minimumDimension, Int((Double(image.height) * scale).rounded(.down)))
+        guard width < image.width || height < image.height else {
+            throw ImagePreparationError.unableToProduceBoundedOutput
+        }
+
+        let alphaInfo: CGImageAlphaInfo = preservesAlpha ? .premultipliedLast : .noneSkipLast
+        guard
+            let context = CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGBitmapInfo(rawValue: alphaInfo.rawValue).rawValue)
+        else {
+            throw ImagePreparationError.unableToProduceBoundedOutput
+        }
+        context.interpolationQuality = .high
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        guard let scaled = context.makeImage() else {
+            throw ImagePreparationError.unableToProduceBoundedOutput
+        }
+        return scaled
+    }
+}

--- a/Sources/HerdrMobile/Images/ImagePreparer.swift
+++ b/Sources/HerdrMobile/Images/ImagePreparer.swift
@@ -205,14 +205,19 @@ actor ImagePreparer: ImagePreparing {
         to url: URL,
         fileManager: FileManager
     ) throws {
-        try data.write(to: url, options: .atomic)
-        try fileManager.setAttributes(
-            [.protectionKey: FileProtectionType.complete],
-            ofItemAtPath: url.path)
-        var values = URLResourceValues()
-        values.isExcludedFromBackup = true
-        var mutableURL = url
-        try mutableURL.setResourceValues(values)
+        do {
+            try data.write(to: url, options: .atomic)
+            try fileManager.setAttributes(
+                [.protectionKey: FileProtectionType.complete],
+                ofItemAtPath: url.path)
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            var mutableURL = url
+            try mutableURL.setResourceValues(values)
+        } catch {
+            try? fileManager.removeItem(at: url)
+            throw error
+        }
     }
 
     private static func sourceDimensions(_ source: CGImageSource) throws -> (Int, Int) {
@@ -270,10 +275,12 @@ actor ImagePreparer: ImagePreparing {
         }
         var candidate = image
         while candidate.width >= minimumDimension, candidate.height >= minimumDimension {
+            try Task.checkCancellation()
             switch format {
             case .jpeg:
                 var smallestData: Data?
                 for quality in jpegQualities {
+                    try Task.checkCancellation()
                     let data = try encode(candidate, format: format, quality: quality)
                     if data.count <= maximumByteCount {
                         return EncodedImage(image: candidate, data: data)

--- a/Sources/HerdrMobile/Images/ImageStaging.swift
+++ b/Sources/HerdrMobile/Images/ImageStaging.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+struct ImageStageProgress: Sendable, Equatable {
+    let transferredBytes: Int64
+    let totalBytes: Int64
+
+    init(transferredBytes: Int, totalBytes: Int) {
+        self.init(transferredBytes: Int64(transferredBytes), totalBytes: Int64(totalBytes))
+    }
+
+    init(transferredBytes: Int64, totalBytes: Int64) {
+        self.transferredBytes = transferredBytes
+        self.totalBytes = totalBytes
+    }
+
+    var fractionCompleted: Double {
+        guard totalBytes > 0 else { return 0 }
+        return min(1, max(0, Double(transferredBytes) / Double(totalBytes)))
+    }
+}
+
+struct StagedImage: Sendable, Equatable {
+    let path: String
+
+    init(path: String) throws {
+        guard Self.isValidAbsoluteHostPath(path) else {
+            throw ImageStagingError.invalidRemotePath
+        }
+        self.path = path
+    }
+
+    /// Test and transport implementation convenience. UI code treats the path
+    /// as an opaque Host value and never opens it locally.
+    var fileURL: URL {
+        URL(fileURLWithPath: path)
+    }
+
+    private static func isValidAbsoluteHostPath(_ path: String) -> Bool {
+        guard path.hasPrefix("/"), path != "/" else { return false }
+        return path.unicodeScalars.allSatisfy { scalar in
+            scalar.value >= 0x20 && scalar.value != 0x7F
+                && scalar.properties.generalCategory != .control
+        }
+    }
+}
+
+enum ImageStagingError: Error, Sendable, Equatable {
+    case invalidRemotePath
+    case invalidPreparedImage
+    case localReadFailed
+    case remoteTemporaryDirectoryFailed
+    case sftpUnavailable
+    case permissionEnforcementFailed
+    case byteCountMismatch
+    case transferFailed
+    case cancelled
+
+    var isRetryable: Bool {
+        switch self {
+        case .transferFailed, .cancelled:
+            true
+        case .invalidRemotePath, .invalidPreparedImage, .localReadFailed,
+            .remoteTemporaryDirectoryFailed, .sftpUnavailable,
+            .permissionEnforcementFailed, .byteCountMismatch:
+            false
+        }
+    }
+}

--- a/Sources/HerdrMobile/Images/PhotosPickerImageSelection.swift
+++ b/Sources/HerdrMobile/Images/PhotosPickerImageSelection.swift
@@ -1,0 +1,14 @@
+import Foundation
+import PhotosUI
+import SwiftUI
+
+struct PhotosPickerImageSelection: ImageSelection {
+    let item: PhotosPickerItem
+
+    func loadData() async throws -> Data {
+        guard let data = try await item.loadTransferable(type: Data.self) else {
+            throw ImagePreparationError.selectionUnavailable
+        }
+        return data
+    }
+}

--- a/Sources/HerdrMobile/Terminal/TerminalInputController.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalInputController.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Observation
+
+/// The only application-level writer for Attach input. Keyboard input, terminal
+/// controls, reviewed Paste, and Staged Image paths all cross this boundary so
+/// pausing and session-generation checks apply consistently.
+@MainActor
+@Observable
+final class TerminalInputController {
+    struct SessionGeneration: Sendable, Hashable {
+        fileprivate let value: UInt64
+    }
+
+    struct PasteReview: Sendable, Equatable {
+        let lineCount: Int
+        let characterCount: Int
+        let preview: String
+    }
+
+    enum PasteRequestResult: Sendable, Equatable {
+        case inserted
+        case requiresReview(PasteReview)
+        case rejected
+        case blocked
+
+        var requiresReview: Bool {
+            if case .requiresReview = self { true } else { false }
+        }
+    }
+
+    private(set) var liveGeneration: SessionGeneration?
+    private(set) var isPaused = false
+    private(set) var pendingPaste: PasteReview?
+    private(set) var pasteErrorMessage: String?
+
+    private var nextGeneration: UInt64 = 0
+    private var writer: ((Data) -> Void)?
+    private var pendingPasteText: String?
+
+    @discardableResult
+    func beginSession(writer: @escaping (Data) -> Void) -> SessionGeneration {
+        nextGeneration &+= 1
+        let generation = SessionGeneration(value: nextGeneration)
+        liveGeneration = generation
+        self.writer = writer
+        return generation
+    }
+
+    func endSession(_ generation: SessionGeneration) {
+        guard generation == liveGeneration else { return }
+        liveGeneration = nil
+        writer = nil
+        cancelPaste()
+    }
+
+    func pause() {
+        isPaused = true
+        cancelPaste()
+    }
+
+    func resume() {
+        isPaused = false
+    }
+
+    /// Sends ordinary terminal bytes if a live, unpaused Attach session exists.
+    func send(_ data: Data) {
+        guard !data.isEmpty, !isPaused else { return }
+        writer?(data)
+    }
+
+    /// Inserts a staged path only into the session captured by an image
+    /// operation. Path and separator remain distinct writes and no submit byte
+    /// is ever synthesized.
+    @discardableResult
+    func insertPath(_ path: String, matching generation: SessionGeneration) -> Bool {
+        guard generation == liveGeneration else { return false }
+        return insertPathIntoCurrentSession(path)
+    }
+
+    /// Recovery action chosen by the user. It intentionally targets whichever
+    /// Attach session is live now, rather than the operation's old generation.
+    @discardableResult
+    func insertPathIntoCurrentSession(_ path: String) -> Bool {
+        guard !isPaused, writer != nil, Self.isValidAbsoluteHostPath(path) else {
+            return false
+        }
+        writer?(Data(path.utf8))
+        writer?(Data(" ".utf8))
+        return true
+    }
+
+    @discardableResult
+    func requestPaste(_ text: String) -> PasteRequestResult {
+        pasteErrorMessage = nil
+        guard !isPaused, writer != nil else { return .blocked }
+        guard Self.containsOnlySafePasteScalars(text) else {
+            cancelPaste()
+            pasteErrorMessage = "The clipboard contains unsafe terminal control characters."
+            return .rejected
+        }
+        guard Self.isMultiline(text) else {
+            if !text.isEmpty {
+                writer?(Data(text.utf8))
+            }
+            return .inserted
+        }
+
+        let review = PasteReview(
+            lineCount: Self.lineCount(text),
+            characterCount: text.count,
+            preview: Self.preview(text))
+        pendingPasteText = text
+        pendingPaste = review
+        return .requiresReview(review)
+    }
+
+    @discardableResult
+    func confirmPaste() -> Bool {
+        guard !isPaused, writer != nil, let text = pendingPasteText else {
+            cancelPaste()
+            return false
+        }
+        writer?(Data(text.utf8))
+        cancelPaste()
+        return true
+    }
+
+    func cancelPaste() {
+        pendingPasteText = nil
+        pendingPaste = nil
+    }
+
+    func clearPasteError() {
+        pasteErrorMessage = nil
+    }
+
+    private static func isValidAbsoluteHostPath(_ path: String) -> Bool {
+        path.hasPrefix("/") && path.unicodeScalars.allSatisfy { scalar in
+            scalar.value >= 0x20 && scalar.value != 0x7F
+                && scalar.properties.generalCategory != .control
+        }
+    }
+
+    private static func containsOnlySafePasteScalars(_ text: String) -> Bool {
+        text.unicodeScalars.allSatisfy { scalar in
+            switch scalar.value {
+            case 0x09, 0x0A, 0x0D:
+                true
+            default:
+                scalar.properties.generalCategory != .control
+            }
+        }
+    }
+
+    private static func isMultiline(_ text: String) -> Bool {
+        text.contains("\n") || text.contains("\r")
+    }
+
+    private static func lineCount(_ text: String) -> Int {
+        var count = 1
+        var previousWasCarriageReturn = false
+        for scalar in text.unicodeScalars {
+            if scalar.value == 0x0A {
+                if !previousWasCarriageReturn { count += 1 }
+            } else if scalar.value == 0x0D {
+                count += 1
+            }
+            previousWasCarriageReturn = scalar.value == 0x0D
+        }
+        return count
+    }
+
+    private static func preview(_ text: String) -> String {
+        let limit = 2_000
+        guard text.count > limit else { return text }
+        return String(text.prefix(limit)) + "…"
+    }
+}

--- a/Sources/HerdrMobile/Terminal/TerminalKeyboard.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalKeyboard.swift
@@ -143,6 +143,14 @@ final class TerminalKeyboardAccessory: UIInputView {
 
     private weak var terminalView: HerdrTerminalView?
     private let modeControl = UISegmentedControl(items: ["Text", "Keys"])
+    private(set) lazy var pasteControl: UIPasteControl = {
+        var configuration = UIPasteControl.Configuration()
+        configuration.displayMode = .iconOnly
+        let control = UIPasteControl(configuration: configuration)
+        control.target = terminalView
+        control.accessibilityLabel = "Paste"
+        return control
+    }()
 
     init(frame: CGRect, terminalView: HerdrTerminalView) {
         self.terminalView = terminalView
@@ -151,6 +159,7 @@ final class TerminalKeyboardAccessory: UIInputView {
         autoresizingMask = [.flexibleWidth]
         backgroundColor = .secondarySystemBackground
         configureModeControl()
+        configurePasteControl()
         configureDismissButton()
         update(mode: terminalView.keyboardMode)
     }
@@ -168,6 +177,10 @@ final class TerminalKeyboardAccessory: UIInputView {
         modeControl.selectedSegmentIndex = mode.rawValue
     }
 
+    func setPasteEnabled(_ isEnabled: Bool) {
+        pasteControl.isEnabled = isEnabled
+    }
+
     private func configureModeControl() {
         modeControl.translatesAutoresizingMaskIntoConstraints = false
         modeControl.selectedSegmentTintColor = .tertiarySystemBackground
@@ -182,6 +195,18 @@ final class TerminalKeyboardAccessory: UIInputView {
             modeControl.centerYAnchor.constraint(equalTo: centerYAnchor),
             modeControl.widthAnchor.constraint(equalToConstant: 184),
             modeControl.heightAnchor.constraint(equalToConstant: 32),
+        ])
+    }
+
+    private func configurePasteControl() {
+        pasteControl.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(pasteControl)
+
+        NSLayoutConstraint.activate([
+            pasteControl.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            pasteControl.centerYAnchor.constraint(equalTo: centerYAnchor),
+            pasteControl.widthAnchor.constraint(equalToConstant: 44),
+            pasteControl.heightAnchor.constraint(equalToConstant: 44),
         ])
     }
 
@@ -388,6 +413,8 @@ extension HerdrTerminalView {
                         x: 0, y: 0, width: bounds.width, height: controlKeyboardHeight),
                     keyboardHeight: controlKeyboardHeight, terminalView: self))
         }
+        inputView?.isUserInteractionEnabled = isLocalInputEnabled
+        inputView?.alpha = isLocalInputEnabled ? 1 : 0.5
         (inputAccessoryView as? TerminalKeyboardAccessory)?.update(mode: mode)
         UIView.performWithoutAnimation {
             reloadInputViews()
@@ -395,6 +422,7 @@ extension HerdrTerminalView {
     }
 
     func sendControlKey(_ key: TerminalControlKey) {
+        guard isLocalInputEnabled else { return }
         terminalSession.sendInput(
             Data(key.bytes(applicationCursor: usesApplicationCursorKeys)))
     }

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -20,6 +20,8 @@ struct TerminalScreenView: UIViewRepresentable {
     let feed: TerminalByteFeed
     var onSizeChanged: ((_ cols: Int, _ rows: Int) -> Void)?
     var onSend: ((Data) -> Void)?
+    var onPaste: ((String) -> Void)?
+    var isLocalInputEnabled = true
     var theme: TerminalTheme = .default
     @Environment(\.openURL) private var openURL
 
@@ -27,6 +29,7 @@ struct TerminalScreenView: UIViewRepresentable {
         let view = Self.makeConfiguredTerminal(
             onSizeChanged: onSizeChanged,
             onSend: onSend,
+            onPaste: onPaste,
             theme: theme)
         view.delegate = context.coordinator
         context.coordinator.terminalView = view
@@ -40,19 +43,25 @@ struct TerminalScreenView: UIViewRepresentable {
     static func makeConfiguredTerminal(
         onSizeChanged: ((_ cols: Int, _ rows: Int) -> Void)? = nil,
         onSend: ((Data) -> Void)? = nil,
+        onPaste: ((String) -> Void)? = nil,
         theme: TerminalTheme = .default
     ) -> HerdrTerminalView {
         let view = HerdrTerminalView(
             frame: .zero,
             onSizeChanged: onSizeChanged,
             onSend: onSend,
+            onPaste: onPaste,
             theme: theme)
         view.installKeyboardSwitcher()
         return view
     }
 
     func updateUIView(_ view: HerdrTerminalView, context: Context) {
-        view.updateCallbacks(onSizeChanged: onSizeChanged, onSend: onSend)
+        view.updateCallbacks(
+            onSizeChanged: onSizeChanged,
+            onSend: onSend,
+            onPaste: onPaste)
+        view.setLocalInputEnabled(isLocalInputEnabled)
         view.applyTheme(theme)
         context.coordinator.onOpenLink = { url in openURL(url) }
     }
@@ -90,14 +99,17 @@ struct TerminalScreenView: UIViewRepresentable {
 private final class TerminalSessionCallbackBridge {
     var onSizeChanged: ((Int, Int) -> Void)?
     var onSend: ((Data) -> Void)?
+    var onPaste: ((String) -> Void)?
     var onViewport: ((InMemoryTerminalViewport) -> Void)?
 
     init(
         onSizeChanged: ((Int, Int) -> Void)?,
-        onSend: ((Data) -> Void)?
+        onSend: ((Data) -> Void)?,
+        onPaste: ((String) -> Void)?
     ) {
         self.onSizeChanged = onSizeChanged
         self.onSend = onSend
+        self.onPaste = onPaste
     }
 
     nonisolated func send(_ data: Data) {
@@ -112,6 +124,10 @@ private final class TerminalSessionCallbackBridge {
             self?.onSizeChanged?(Int(viewport.columns), Int(viewport.rows))
         }
     }
+
+    func paste(_ text: String) {
+        onPaste?(text)
+    }
 }
 
 /// The app-owned seam around libghostty-spm. It keeps keyboard policy and the
@@ -125,6 +141,7 @@ final class HerdrTerminalView: UITerminalView {
     private var modeTracker = TerminalModeTracker()
     private var lastInputWindowSize: CGSize?
     private var allowsKeyboardActivation = false
+    private(set) var isLocalInputEnabled = true
     private var terminalGridSize = (columns: 80, rows: 24)
     private var touchScrollPointsPerRow: CGFloat = 16
     private var touchScrollAccumulator = TerminalTouchScrollAccumulator()
@@ -165,11 +182,13 @@ final class HerdrTerminalView: UITerminalView {
         frame: CGRect,
         onSizeChanged: ((Int, Int) -> Void)?,
         onSend: ((Data) -> Void)?,
+        onPaste: ((String) -> Void)?,
         theme: TerminalTheme
     ) {
         let callbackBridge = TerminalSessionCallbackBridge(
             onSizeChanged: onSizeChanged,
-            onSend: onSend)
+            onSend: onSend,
+            onPaste: onPaste)
         self.callbackBridge = callbackBridge
         terminalSession = InMemoryTerminalSession(
             write: { [weak callbackBridge] data in
@@ -181,6 +200,7 @@ final class HerdrTerminalView: UITerminalView {
         terminalController = TerminalController(theme: theme)
         appliedTheme = theme
         super.init(frame: frame)
+        pasteConfiguration = UIPasteConfiguration(forAccepting: String.self)
         inputAccessoryItems = []
         configuration = TerminalSurfaceOptions(backend: .inMemory(terminalSession))
         controller = terminalController
@@ -197,10 +217,12 @@ final class HerdrTerminalView: UITerminalView {
 
     func updateCallbacks(
         onSizeChanged: ((Int, Int) -> Void)?,
-        onSend: ((Data) -> Void)?
+        onSend: ((Data) -> Void)?,
+        onPaste: ((String) -> Void)?
     ) {
         callbackBridge.onSizeChanged = onSizeChanged
         callbackBridge.onSend = onSend
+        callbackBridge.onPaste = onPaste
     }
 
     @discardableResult
@@ -220,6 +242,50 @@ final class HerdrTerminalView: UITerminalView {
     func requestKeyboard() {
         allowsKeyboardActivation = true
         _ = becomeFirstResponder()
+    }
+
+    func setLocalInputEnabled(_ isEnabled: Bool) {
+        guard isLocalInputEnabled != isEnabled else { return }
+        isLocalInputEnabled = isEnabled
+        terminalKeyboardAccessory.setPasteEnabled(isEnabled)
+        terminalInputView?.isUserInteractionEnabled = isEnabled
+        terminalInputView?.alpha = isEnabled ? 1 : 0.5
+    }
+
+    func requestPaste(_ text: String?) {
+        guard isLocalInputEnabled, let text else { return }
+        callbackBridge.paste(text)
+    }
+
+    override func paste(_ sender: Any?) {
+        requestPaste(UIPasteboard.general.string)
+    }
+
+    override func paste(itemProviders: [NSItemProvider]) {
+        guard isLocalInputEnabled else { return }
+        for provider in itemProviders where provider.canLoadObject(ofClass: NSString.self) {
+            provider.loadObject(ofClass: NSString.self) { [weak self] object, _ in
+                guard let text = object as? String else { return }
+                Task { @MainActor [weak self] in
+                    self?.requestPaste(text)
+                }
+            }
+            return
+        }
+    }
+
+    override func canPaste(_ itemProviders: [NSItemProvider]) -> Bool {
+        isLocalInputEnabled
+            && itemProviders.contains {
+                $0.canLoadObject(ofClass: NSString.self)
+            }
+    }
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(paste(_:)) {
+            return isLocalInputEnabled && UIPasteboard.general.hasStrings
+        }
+        return super.canPerformAction(action, withSender: sender)
     }
 
     @discardableResult

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -3,6 +3,7 @@
 // otherwise be an error. The actor still serializes all access to the client.
 @preconcurrency import Citadel
 import Foundation
+import Logging
 import NIOCore
 @preconcurrency import NIOSSH
 
@@ -67,6 +68,13 @@ private struct HerdrSessionListResponse: Decodable {
 actor SSHTransport: Transport {
     /// The herdr wire protocol version this build speaks (herdr 0.7.5).
     static let supportedProtocolVersion = 17
+
+    /// Citadel logs full SFTP paths at info, debug, and trace levels. Staging
+    /// paths are private diagnostics data, so every SFTP channel uses a
+    /// per-instance sink rather than Citadel's stderr-backed default logger.
+    private static let restrictedSFTPLogger = Logger(
+        label: "dev.herdr.mobile.sftp",
+        factory: { _ in SwiftLogNoOpLogHandler() })
 
     /// Exec channels are SSH session channels, capped by sshd's MaxSessions
     /// (default 10) per connection. Bound at 8 to leave headroom for the
@@ -386,7 +394,7 @@ actor SSHTransport: Transport {
     ) async throws -> StagedImage {
         let sftp: SFTPClient
         do {
-            sftp = try await client.openSFTP()
+            sftp = try await client.openSFTP(logger: Self.restrictedSFTPLogger)
         } catch {
             if Task.isCancelled {
                 throw ImageStagingError.cancelled
@@ -517,7 +525,9 @@ actor SSHTransport: Transport {
     }
 
     private func bestEffortRemovePart(at path: String) async {
-        guard let sftp = try? await client.openSFTP() else { return }
+        guard
+            let sftp = try? await client.openSFTP(logger: Self.restrictedSFTPLogger)
+        else { return }
         try? await sftp.remove(at: path)
         try? await sftp.close()
     }

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -43,6 +43,13 @@ struct SSHTransportSettings: Sendable {
     /// Command used to print a marker-delimited remote home directory. It is
     /// injectable only at the environment boundary for real-SSH tests.
     var homeCommand: String = "printf '__HERDR_MOBILE_HOME__=%s\\n' \"$HOME\""
+    /// Creates one private directory beneath the Host operating system's
+    /// selected temporary root. The marker makes login-shell noise harmless;
+    /// callers never interpolate image names or paths into this command.
+    var stageDirectoryCommand: String =
+        "/bin/sh -c 'umask 077; "
+        + "directory=$(mktemp -d \"${TMPDIR:-/tmp}/herdr-mobile.XXXXXXXX\") || exit 1; "
+        + "printf \"__HERDR_MOBILE_STAGE_DIR__=%s\\n\" \"$directory\"'"
     /// Per-request deadline covering the queue wait and the exec exchange;
     /// on expiry the request fails with `.timedOut` and its channel is
     /// closed. Short in tests, generous by default: a hung host should
@@ -73,6 +80,7 @@ actor SSHTransport: Transport {
     private let sessionListCommand: String
     private let attachCommand: String
     private let homeCommand: String
+    private let stageDirectoryCommand: String
     private let requestTimeout: Duration
     /// Remote home directory resolution, resolved over exec once per Host:
     /// concurrent first requests share one in-flight run, success is cached
@@ -105,6 +113,10 @@ actor SSHTransport: Transport {
     private var cancelledSlotRequests: Set<UInt64> = []
     private var pendingSlotRequests: Set<UInt64> = []
     private var nextSlotRequestID: UInt64 = 0
+    /// Active SFTP channels keyed by staging operation. Cancellation closes
+    /// the exact channel so a blocked Citadel request cannot continue after
+    /// the app reports an interrupted upload.
+    private var imageStageClients: [UUID: SFTPClient] = [:]
 
     /// Waits for a free exec channel slot. Throws `CancellationError` without
     /// consuming a slot if the task is cancelled while queued.
@@ -155,7 +167,7 @@ actor SSHTransport: Transport {
     private init(
         client: SSHClient, socketLocation: HerdrSocketLocation, socatPath: String,
         wakeCommand: String, sessionListCommand: String, attachCommand: String,
-        homeCommand: String,
+        homeCommand: String, stageDirectoryCommand: String,
         requestTimeout: Duration
     ) {
         self.client = client
@@ -165,6 +177,7 @@ actor SSHTransport: Transport {
         self.sessionListCommand = sessionListCommand
         self.attachCommand = attachCommand
         self.homeCommand = homeCommand
+        self.stageDirectoryCommand = stageDirectoryCommand
         self.requestTimeout = requestTimeout
     }
 
@@ -196,6 +209,7 @@ actor SSHTransport: Transport {
             client: client, socketLocation: settings.socket, socatPath: settings.socatPath,
             wakeCommand: settings.wakeCommand, sessionListCommand: settings.sessionListCommand,
             attachCommand: settings.attachCommand, homeCommand: settings.homeCommand,
+            stageDirectoryCommand: settings.stageDirectoryCommand,
             requestTimeout: settings.requestTimeout)
     }
 
@@ -294,6 +308,213 @@ actor SSHTransport: Transport {
 
     func closePane(_ params: PaneTarget) async throws {
         _ = try await request(method: "pane.close", params: params, decoding: OkResponse.self)
+    }
+
+    // MARK: Image staging
+
+    func stageImage(
+        _ image: PreparedImage,
+        progress: @escaping @Sendable (ImageStageProgress) async -> Void
+    ) async throws -> StagedImage {
+        guard
+            image.byteCount > 0,
+            image.byteCount <= Int64(ImagePreparer.maximumEncodedByteCount),
+            let localSize = try? FileManager.default.attributesOfItem(
+                atPath: image.fileURL.path)[.size] as? NSNumber,
+            localSize.int64Value == image.byteCount
+        else {
+            throw ImageStagingError.invalidPreparedImage
+        }
+
+        do {
+            try await acquireExecChannelSlot()
+        } catch {
+            throw ImageStagingError.cancelled
+        }
+        defer { releaseExecChannelSlot() }
+
+        try Task.checkCancellation()
+        let remoteDirectory = try await createStageDirectory()
+        let operationID = UUID()
+        await progress(
+            ImageStageProgress(transferredBytes: 0, totalBytes: image.byteCount))
+
+        do {
+            return try await withTaskCancellationHandler {
+                try await performImageStage(
+                    image,
+                    remoteDirectory: remoteDirectory,
+                    operationID: operationID,
+                    progress: progress)
+            } onCancel: {
+                Task { await self.cancelImageStage(operationID) }
+            }
+        } catch let error as ImageStagingError {
+            throw error
+        } catch is CancellationError {
+            throw ImageStagingError.cancelled
+        } catch {
+            throw Task.isCancelled
+                ? ImageStagingError.cancelled : ImageStagingError.transferFailed
+        }
+    }
+
+    private func createStageDirectory() async throws -> String {
+        let output: ByteBuffer
+        do {
+            output = try await client.executeCommand(
+                Self.cLocaleCommand(stageDirectoryCommand))
+        } catch {
+            throw Task.isCancelled
+                ? ImageStagingError.cancelled
+                : ImageStagingError.remoteTemporaryDirectoryFailed
+        }
+        return try Self.parseStageDirectory(output)
+    }
+
+    private func performImageStage(
+        _ image: PreparedImage,
+        remoteDirectory: String,
+        operationID: UUID,
+        progress: @escaping @Sendable (ImageStageProgress) async -> Void
+    ) async throws -> StagedImage {
+        let sftp: SFTPClient
+        do {
+            sftp = try await client.openSFTP()
+        } catch {
+            throw Task.isCancelled
+                ? ImageStagingError.cancelled : ImageStagingError.sftpUnavailable
+        }
+        imageStageClients[operationID] = sftp
+
+        let randomName = UUID().uuidString.lowercased()
+        let finalPath = "\(remoteDirectory)/\(randomName).\(image.format.fileExtension)"
+        var partPath: String? = "\(finalPath).part"
+
+        do {
+            let directoryAttributes = try await sftp.getAttributes(at: remoteDirectory)
+            guard Self.permissionBits(directoryAttributes.permissions) == 0o700 else {
+                throw ImageStagingError.permissionEnforcementFailed
+            }
+            guard let currentPartPath = partPath else {
+                throw ImageStagingError.transferFailed
+            }
+            try await streamImage(
+                image,
+                to: currentPartPath,
+                over: sftp,
+                progress: progress)
+            try Task.checkCancellation()
+
+            let uploadedAttributes = try await sftp.getAttributes(at: currentPartPath)
+            guard
+                uploadedAttributes.size == UInt64(image.byteCount),
+                Self.permissionBits(uploadedAttributes.permissions) == 0o600
+            else {
+                throw ImageStagingError.byteCountMismatch
+            }
+            try await sftp.rename(at: currentPartPath, to: finalPath)
+            partPath = nil
+
+            let finalAttributes = try await sftp.getAttributes(at: finalPath)
+            guard
+                finalAttributes.size == UInt64(image.byteCount),
+                Self.permissionBits(finalAttributes.permissions) == 0o600
+            else {
+                // Rename completed, so ADR 0005 forbids deleting this final
+                // Host file even when the final verification response is bad.
+                throw ImageStagingError.byteCountMismatch
+            }
+            let staged = try StagedImage(path: finalPath)
+            imageStageClients[operationID] = nil
+            try await sftp.close()
+            return staged
+        } catch {
+            imageStageClients[operationID] = nil
+            try? await sftp.close()
+            if let partPath {
+                await bestEffortRemovePart(at: partPath)
+            }
+            if Task.isCancelled {
+                throw ImageStagingError.cancelled
+            }
+            if let stagingError = error as? ImageStagingError {
+                throw stagingError
+            }
+            throw ImageStagingError.transferFailed
+        }
+    }
+
+    private func streamImage(
+        _ image: PreparedImage,
+        to remotePath: String,
+        over sftp: SFTPClient,
+        progress: @escaping @Sendable (ImageStageProgress) async -> Void
+    ) async throws {
+        let localFile: FileHandle
+        do {
+            localFile = try FileHandle(forReadingFrom: image.fileURL)
+        } catch {
+            throw ImageStagingError.localReadFailed
+        }
+        defer { try? localFile.close() }
+
+        var creationAttributes = SFTPFileAttributes()
+        creationAttributes.permissions = 0o600
+        let remoteFile = try await sftp.openFile(
+            filePath: remotePath,
+            flags: [.write, .create, .forceCreate],
+            attributes: creationAttributes)
+        do {
+            let attributes = try await remoteFile.readAttributes()
+            guard Self.permissionBits(attributes.permissions) == 0o600 else {
+                throw ImageStagingError.permissionEnforcementFailed
+            }
+
+            let chunkSize = 64 * 1_024
+            var transferred: Int64 = 0
+            while transferred < image.byteCount {
+                try Task.checkCancellation()
+                let remaining = image.byteCount - transferred
+                let requested = min(chunkSize, Int(remaining))
+                guard
+                    let data = try localFile.read(upToCount: requested),
+                    !data.isEmpty
+                else {
+                    throw ImageStagingError.byteCountMismatch
+                }
+                var buffer = ByteBufferAllocator().buffer(capacity: data.count)
+                buffer.writeBytes(data)
+                try await remoteFile.write(buffer, at: UInt64(transferred))
+                transferred += Int64(data.count)
+                await progress(
+                    ImageStageProgress(
+                        transferredBytes: transferred,
+                        totalBytes: image.byteCount))
+            }
+            guard try localFile.read(upToCount: 1)?.isEmpty != false else {
+                throw ImageStagingError.byteCountMismatch
+            }
+            try await remoteFile.close()
+        } catch {
+            try? await remoteFile.close()
+            throw error
+        }
+    }
+
+    private func cancelImageStage(_ operationID: UUID) async {
+        guard let sftp = imageStageClients[operationID] else { return }
+        try? await sftp.close()
+    }
+
+    private func bestEffortRemovePart(at path: String) async {
+        guard let sftp = try? await client.openSFTP() else { return }
+        try? await sftp.remove(at: path)
+        try? await sftp.close()
+    }
+
+    private static func permissionBits(_ permissions: UInt32?) -> UInt32? {
+        permissions.map { $0 & 0o777 }
     }
 
     // MARK: Events channel (#4)
@@ -695,6 +916,11 @@ actor SSHTransport: Transport {
     /// Closes the SSH connection. Explicit close is the only way to end
     /// Citadel channels — a live exec channel ignores task cancellation.
     func close() async throws {
+        let stagingClients = Array(imageStageClients.values)
+        imageStageClients.removeAll()
+        for sftp in stagingClients {
+            try? await sftp.close()
+        }
         try await client.close()
     }
 
@@ -957,6 +1183,7 @@ actor SSHTransport: Transport {
     }
 
     private static let homeOutputPrefix = "__HERDR_MOBILE_HOME__="
+    private static let stageDirectoryOutputPrefix = "__HERDR_MOBILE_STAGE_DIR__="
 
     private static func parseRemoteHome(_ output: ByteBuffer) throws -> String {
         let text = String(buffer: output)
@@ -973,6 +1200,23 @@ actor SSHTransport: Transport {
                 detail: "home command printed: \(text.prefix(200))")
         }
         return home
+    }
+
+    private static func parseStageDirectory(_ output: ByteBuffer) throws -> String {
+        let text = String(buffer: output)
+        let directory = text.split(separator: "\n", omittingEmptySubsequences: false)
+            .reversed()
+            .first { $0.hasPrefix(stageDirectoryOutputPrefix) }
+            .map { line in
+                var value = String(line.dropFirst(stageDirectoryOutputPrefix.count))
+                if value.last == "\r" { value.removeLast() }
+                return value
+            }
+        guard let directory else {
+            throw ImageStagingError.remoteTemporaryDirectoryFailed
+        }
+        return try StagedImage(path: "\(directory)/placeholder").fileURL
+            .deletingLastPathComponent().path
     }
 
     private static func socatCommand(socatPath: String, socketPath: String) throws -> String {

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -325,6 +325,9 @@ actor SSHTransport: Transport {
         else {
             throw ImageStagingError.invalidPreparedImage
         }
+        guard client.isConnected else {
+            throw ImageStagingError.transferFailed
+        }
 
         do {
             try await acquireExecChannelSlot()
@@ -365,9 +368,12 @@ actor SSHTransport: Transport {
             output = try await client.executeCommand(
                 Self.cLocaleCommand(stageDirectoryCommand))
         } catch {
-            throw Task.isCancelled
-                ? ImageStagingError.cancelled
-                : ImageStagingError.remoteTemporaryDirectoryFailed
+            if Task.isCancelled {
+                throw ImageStagingError.cancelled
+            }
+            throw client.isConnected
+                ? ImageStagingError.remoteTemporaryDirectoryFailed
+                : ImageStagingError.transferFailed
         }
         return try Self.parseStageDirectory(output)
     }
@@ -382,8 +388,11 @@ actor SSHTransport: Transport {
         do {
             sftp = try await client.openSFTP()
         } catch {
-            throw Task.isCancelled
-                ? ImageStagingError.cancelled : ImageStagingError.sftpUnavailable
+            if Task.isCancelled {
+                throw ImageStagingError.cancelled
+            }
+            throw client.isConnected
+                ? ImageStagingError.sftpUnavailable : ImageStagingError.transferFailed
         }
         imageStageClients[operationID] = sftp
 

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -60,6 +60,14 @@ protocol Transport: Sendable {
     /// `.terminalChannelAlreadyOpen`.
     func attachTerminal(_ request: TerminalAttachRequest) async throws -> TerminalAttachSession
 
+    /// Stages one normalized app-owned image in private Host temporary
+    /// storage. Concrete transports own destination selection, restrictive
+    /// permissions, partial-file handling, and atomic completion (ADR 0006).
+    func stageImage(
+        _ image: PreparedImage,
+        progress: @escaping @Sendable (ImageStageProgress) async -> Void
+    ) async throws -> StagedImage
+
     /// Whether the underlying connection to the Host is still alive. The
     /// reconnect machinery (#18) decides "re-subscribe on this connection or
     /// re-establish it" from this flag.
@@ -74,6 +82,15 @@ extension Transport {
     /// Test doubles and alternative transports that do not expose Host-level
     /// session discovery can opt out without inventing sessions.
     func listSessions() async throws -> [HerdrSession] { [] }
+
+    /// Non-SSH test doubles and alternative transports can state that SFTP is
+    /// unavailable without importing or emulating Citadel.
+    func stageImage(
+        _ image: PreparedImage,
+        progress: @escaping @Sendable (ImageStageProgress) async -> Void
+    ) async throws -> StagedImage {
+        throw ImageStagingError.sftpUnavailable
+    }
 }
 
 /// App-domain request for launching a fresh coding agent.

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -117,6 +117,29 @@ struct AttachTerminalStoreTests {
         #expect(input.liveGeneration == nil)
     }
 
+    @Test func remoteOutputContinuesWhileLocalInputIsPaused() async throws {
+        let transport = ScriptedTransport()
+        let input = TerminalInputController()
+        let (store, captured) = makeStore(transport: transport, input: input)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("store should go live") { store.status == .live }
+
+        input.pause()
+        store.send(Data("blocked".utf8))
+        await transport.emitAttachOutput(Data("still rendering".utf8))
+        try await waitUntil("remote output should keep reaching the terminal feed") {
+            captured.text == "still rendering"
+        }
+
+        #expect(input.isPaused)
+        #expect(await transport.attachInputs.isEmpty)
+        #expect(captured.text == "still rendering")
+
+        input.resume()
+        await store.stop()
+    }
+
     @Test func reattachAdvancesTheInputSessionGeneration() async throws {
         let transport = ScriptedTransport()
         let input = TerminalInputController()

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -10,9 +10,12 @@ import Testing
 @Suite("Attach terminal store")
 struct AttachTerminalStoreTests {
     private func makeStore(
-        transport: ScriptedTransport?, target: String = "w1:p1", takeover: Bool = false
+        transport: ScriptedTransport?, target: String = "w1:p1", takeover: Bool = false,
+        input: TerminalInputController = TerminalInputController()
     ) -> (AttachTerminalStore, captured: Captured) {
-        let store = AttachTerminalStore(target: target, takeover: takeover) { transport }
+        let store = AttachTerminalStore(
+            target: target, takeover: takeover, input: input
+        ) { transport }
         let captured = Captured()
         store.feed.attach { data in captured.chunks.append(data) }
         return (store, captured)
@@ -88,6 +91,54 @@ struct AttachTerminalStoreTests {
                 .keystrokes(Data("y".utf8)),
                 .keystrokes(Data([0x1B, 0x5B, 0x41])),
             ])
+    }
+
+    @Test func inputControllerOwnsTheLiveWriterAndPauseGate() async throws {
+        let transport = ScriptedTransport()
+        let input = TerminalInputController()
+        let (store, _) = makeStore(transport: transport, input: input)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("store should go live") { store.status == .live }
+        #expect(input.liveGeneration != nil)
+
+        store.send(Data("before".utf8))
+        input.pause()
+        store.send(Data("blocked".utf8))
+        input.resume()
+        store.send(Data("after".utf8))
+        await store.stop()
+
+        #expect(
+            await transport.attachInputs == [
+                .keystrokes(Data("before".utf8)),
+                .keystrokes(Data("after".utf8)),
+            ])
+        #expect(input.liveGeneration == nil)
+    }
+
+    @Test func reattachAdvancesTheInputSessionGeneration() async throws {
+        let transport = ScriptedTransport()
+        let input = TerminalInputController()
+        let (store, _) = makeStore(transport: transport, input: input)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("store should go live") { store.status == .live }
+        let first = try #require(input.liveGeneration)
+
+        await transport.endAttachFromRemote()
+        try await waitUntil("the remote end should surface") {
+            if case .ended = store.status { return true }
+            return false
+        }
+        #expect(input.liveGeneration == nil)
+
+        store.retry()
+        try await waitUntil("store should reattach") { store.status == .live }
+        let second = try #require(input.liveGeneration)
+        #expect(first != second)
+
+        await store.stop()
     }
 
     @Test func resizeForwardsWindowChangeWithoutReattaching() async throws {

--- a/Tests/HerdrMobileTests/ImageAttachStoreTests.swift
+++ b/Tests/HerdrMobileTests/ImageAttachStoreTests.swift
@@ -1,0 +1,351 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+@MainActor
+@Suite("Image attach store")
+struct ImageAttachStoreTests {
+    @Test func successfulUploadCopiesThenInsertsIntoCapturedSession() async throws {
+        let fixture = try await makeFixture()
+        let events = ImageAttachEventRecorder()
+        fixture.clipboard.onCopy = { path in events.record(.copied(path)) }
+        fixture.input.endSession(fixture.generation)
+        let generation = fixture.input.beginSession { data in
+            events.record(.sent(String(decoding: data, as: UTF8.self)))
+        }
+
+        fixture.store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("image attach should complete") {
+            fixture.store.state.isCompleted
+        }
+
+        #expect(
+            events.events == [
+                .copied("/tmp/staged/image.jpg"),
+                .sent("/tmp/staged/image.jpg"),
+                .sent(" "),
+            ])
+        #expect(
+            fixture.store.state
+                == .completed(
+                    ImageAttachResult(
+                        stagedImage: try StagedImage(path: "/tmp/staged/image.jpg"),
+                        copied: true,
+                        inserted: true)))
+        #expect(fixture.input.liveGeneration == generation)
+        #expect(!fixture.input.isPaused)
+        #expect(!FileManager.default.fileExists(atPath: fixture.prepared.fileURL.path))
+    }
+
+    @Test func sessionGenerationChangeSuppressesAutomaticInsertion() async throws {
+        let stageGate = ScriptedTransportCallGate()
+        let fixture = try await makeFixture(stageGate: stageGate)
+        var sent = Data()
+
+        fixture.store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("upload should reach the gate") {
+            await stageGate.entryCount == 1
+        }
+        fixture.input.endSession(fixture.generation)
+        _ = fixture.input.beginSession { sent.append($0) }
+        await stageGate.open()
+        try await waitUntil("image attach should complete") {
+            fixture.store.state.isCompleted
+        }
+
+        #expect(sent.isEmpty)
+        #expect(fixture.clipboard.copiedPaths == ["/tmp/staged/image.jpg"])
+        #expect(fixture.store.state.completedResult?.inserted == false)
+        #expect(
+            fixture.store.state.completedResult?.message
+                == "Image path copied, but couldn't be inserted.")
+    }
+
+    @Test func terminalInputIsPausedOnlyWhileTheOperationIsRunning() async throws {
+        let stageGate = ScriptedTransportCallGate()
+        let fixture = try await makeFixture(stageGate: stageGate)
+
+        fixture.store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("upload should reach the gate") {
+            await stageGate.entryCount == 1
+        }
+        #expect(fixture.input.isPaused)
+        fixture.input.send(Data("blocked".utf8))
+        #expect(fixture.sent.value.isEmpty)
+
+        await stageGate.open()
+        try await waitUntil("image attach should complete") {
+            fixture.store.state.isCompleted
+        }
+        #expect(!fixture.input.isPaused)
+    }
+
+    @Test func transientFailureRetainsPreparedImageAndRetryUsesCurrentSession() async throws {
+        let fixture = try await makeFixture(stageOutcomes: [
+            .failure(ImageStagingError.transferFailed),
+            .success(try StagedImage(path: "/tmp/staged/retried.jpg")),
+        ])
+
+        fixture.store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("upload should fail") { fixture.store.state.isFailed }
+
+        #expect(fixture.store.state.failedValue?.isRetryable == true)
+        #expect(FileManager.default.fileExists(atPath: fixture.prepared.fileURL.path))
+
+        fixture.store.retry()
+        try await waitUntil("retry should complete") {
+            fixture.store.state.isCompleted
+        }
+
+        #expect(await fixture.transport.stageRequests.count == 2)
+        #expect(!FileManager.default.fileExists(atPath: fixture.prepared.fileURL.path))
+    }
+
+    @Test func backgroundCancelsWithoutAutomaticForegroundRetry() async throws {
+        let stageGate = ScriptedTransportCallGate()
+        let fixture = try await makeFixture(stageGate: stageGate)
+
+        fixture.store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("upload should reach the gate") {
+            await stageGate.entryCount == 1
+        }
+        fixture.store.didEnterBackground()
+        await stageGate.open()
+        try await waitUntil("background interruption should surface") {
+            fixture.store.state.isBackgroundInterrupted
+        }
+
+        let stageCount = await fixture.transport.stageRequests.count
+        fixture.store.didBecomeActive()
+        try await Task.sleep(for: .milliseconds(30))
+        #expect(await fixture.transport.stageRequests.count == stageCount)
+        #expect(FileManager.default.fileExists(atPath: fixture.prepared.fileURL.path))
+
+        fixture.store.retry()
+        try await waitUntil("explicit retry should complete") {
+            fixture.store.state.isCompleted
+        }
+    }
+
+    @Test func userCancellationIsSilentAndCleansLocalFile() async throws {
+        let stageGate = ScriptedTransportCallGate()
+        let fixture = try await makeFixture(stageGate: stageGate)
+
+        fixture.store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("upload should reach the gate") {
+            await stageGate.entryCount == 1
+        }
+        fixture.store.cancel()
+        await stageGate.open()
+        try await waitUntil("cancellation should return to idle") {
+            fixture.store.state == .idle
+        }
+
+        #expect(!fixture.input.isPaused)
+        #expect(!FileManager.default.fileExists(atPath: fixture.prepared.fileURL.path))
+    }
+
+    @Test func unavailableSFTPSurfacesActionableNonRetryableFailure() async throws {
+        let fixture = try await makeFixture(stageOutcomes: [
+            .failure(ImageStagingError.sftpUnavailable)
+        ])
+
+        fixture.store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("upload should fail") { fixture.store.state.isFailed }
+
+        let failure = try #require(fixture.store.state.failedValue)
+        #expect(!failure.isRetryable)
+        #expect(failure.message.contains("SFTP"))
+        #expect(!FileManager.default.fileExists(atPath: fixture.prepared.fileURL.path))
+    }
+
+    @Test func recoveryActionsRetryOnlyTheirMissingSideEffect() async throws {
+        let fixture = try await makeFixture()
+        fixture.clipboard.error = ImageClipboardTestError.failed
+
+        fixture.store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("image attach should complete") {
+            fixture.store.state.isCompleted
+        }
+        let result = try #require(fixture.store.state.completedResult)
+        #expect(result.inserted)
+        #expect(!result.copied)
+        #expect(result.message == "Image path inserted, but couldn't be copied.")
+
+        fixture.clipboard.error = nil
+        fixture.store.copyPath()
+        #expect(fixture.store.state.completedResult?.copied == true)
+        #expect(fixture.clipboard.copiedPaths == ["/tmp/staged/image.jpg"])
+        #expect(await fixture.transport.stageRequests.count == 1)
+    }
+
+    @Test func failureOfBothPostStageActionsKeepsRecoverableResult() async throws {
+        let stageGate = ScriptedTransportCallGate()
+        let fixture = try await makeFixture(stageGate: stageGate)
+        fixture.clipboard.error = ImageClipboardTestError.failed
+
+        fixture.store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("upload should reach the gate") {
+            await stageGate.entryCount == 1
+        }
+        fixture.input.endSession(fixture.generation)
+        await stageGate.open()
+        try await waitUntil("image attach should complete") {
+            fixture.store.state.isCompleted
+        }
+
+        let result = try #require(fixture.store.state.completedResult)
+        #expect(!result.copied)
+        #expect(!result.inserted)
+        #expect(
+            result.message
+                == "Image uploaded, but its path couldn't be copied or inserted.")
+
+        fixture.store.dismissResult()
+        #expect(fixture.store.state == .idle)
+    }
+
+    @Test func aSecondSelectionIsIgnoredWhileAnOperationIsActive() async throws {
+        let stageGate = ScriptedTransportCallGate()
+        let fixture = try await makeFixture(stageGate: stageGate)
+
+        fixture.store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("upload should reach the gate") {
+            await stageGate.entryCount == 1
+        }
+        fixture.store.select(DataImageSelection(data: Data([0x02])))
+        #expect(await fixture.transport.stageRequests.count == 1)
+
+        await stageGate.open()
+        try await waitUntil("image attach should complete") {
+            fixture.store.state.isCompleted
+        }
+        #expect(await fixture.transport.stageRequests.count == 1)
+    }
+
+    @Test func leavingAttachCancelsAndRemovesOnlyLocalPreparedData() async throws {
+        let stageGate = ScriptedTransportCallGate()
+        let fixture = try await makeFixture(stageGate: stageGate)
+
+        fixture.store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("upload should reach the gate") {
+            await stageGate.entryCount == 1
+        }
+        let leave = Task { await fixture.store.leaveAttach() }
+        await stageGate.open()
+        await leave.value
+
+        #expect(fixture.store.state == .idle)
+        #expect(!FileManager.default.fileExists(atPath: fixture.prepared.fileURL.path))
+        #expect(await fixture.transport.stageRequests.count == 1)
+    }
+
+    private struct Fixture {
+        let store: ImageAttachStore
+        let transport: ScriptedTransport
+        let clipboard: RecordingImageClipboard
+        let input: TerminalInputController
+        let generation: TerminalInputController.SessionGeneration
+        let prepared: PreparedImage
+        let sent: DataBox
+    }
+
+    private func makeFixture(
+        stageOutcomes: [Result<StagedImage, ImageStagingError>] = [
+            .success(try! StagedImage(path: "/tmp/staged/image.jpg"))
+        ],
+        stageGate: ScriptedTransportCallGate? = nil
+    ) async throws -> Fixture {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("image-attach-\(UUID().uuidString).jpg")
+        try Data(repeating: 0x41, count: 128).write(to: fileURL)
+        let prepared = PreparedImage(
+            fileURL: fileURL,
+            format: .jpeg,
+            pixelWidth: 16,
+            pixelHeight: 16,
+            byteCount: 128)
+        let preparer = ScriptedImagePreparer(prepared: prepared)
+        let transport = ScriptedTransport()
+        await transport.configureImageStaging(outcomes: stageOutcomes, gate: stageGate)
+        let clipboard = RecordingImageClipboard()
+        let input = TerminalInputController()
+        let sent = DataBox()
+        let generation = input.beginSession { sent.value.append($0) }
+        let store = ImageAttachStore(
+            preparer: preparer,
+            transport: { transport },
+            clipboard: clipboard,
+            input: input)
+        return Fixture(
+            store: store,
+            transport: transport,
+            clipboard: clipboard,
+            input: input,
+            generation: generation,
+            prepared: prepared,
+            sent: sent)
+    }
+
+    private func waitUntil(
+        _ comment: Comment,
+        timeout: Duration = .seconds(5),
+        condition: () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await condition(), comment)
+    }
+}
+
+private actor ScriptedImagePreparer: ImagePreparing {
+    let prepared: PreparedImage
+
+    init(prepared: PreparedImage) {
+        self.prepared = prepared
+    }
+
+    func prepare(_ selection: any ImageSelection) async throws -> PreparedImage {
+        prepared
+    }
+}
+
+@MainActor
+private final class RecordingImageClipboard: ImageClipboard {
+    var copiedPaths: [String] = []
+    var error: (any Error)?
+    var onCopy: ((String) -> Void)?
+
+    func copy(_ path: String) throws {
+        if let error { throw error }
+        copiedPaths.append(path)
+        onCopy?(path)
+    }
+}
+
+private enum ImageClipboardTestError: Error {
+    case failed
+}
+
+@MainActor
+private final class DataBox {
+    var value = Data()
+}
+
+@MainActor
+private final class ImageAttachEventRecorder {
+    enum Event: Equatable {
+        case copied(String)
+        case sent(String)
+    }
+
+    private(set) var events: [Event] = []
+
+    func record(_ event: Event) {
+        events.append(event)
+    }
+}

--- a/Tests/HerdrMobileTests/ImageAttachStoreTests.swift
+++ b/Tests/HerdrMobileTests/ImageAttachStoreTests.swift
@@ -213,6 +213,38 @@ struct ImageAttachStoreTests {
         #expect(await fixture.transport.stageRequests.count == 1)
     }
 
+    @Test func explicitInsertPathTargetsTheCurrentLiveSession() async throws {
+        let stageGate = ScriptedTransportCallGate()
+        let fixture = try await makeFixture(stageGate: stageGate)
+        let currentSessionBytes = DataBox()
+
+        fixture.store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("upload should reach the gate") {
+            await stageGate.entryCount == 1
+        }
+        fixture.input.endSession(fixture.generation)
+        let currentGeneration = fixture.input.beginSession {
+            currentSessionBytes.value.append($0)
+        }
+        await stageGate.open()
+        try await waitUntil("image attach should complete without automatic insertion") {
+            fixture.store.state.isCompleted
+        }
+        #expect(fixture.store.state.completedResult?.inserted == false)
+        #expect(currentSessionBytes.value.isEmpty)
+
+        fixture.store.insertPath()
+
+        #expect(fixture.input.liveGeneration == currentGeneration)
+        #expect(
+            currentSessionBytes.value
+                == Data("/tmp/staged/image.jpg ".utf8))
+        #expect(!currentSessionBytes.value.contains(0x0A))
+        #expect(!currentSessionBytes.value.contains(0x0D))
+        #expect(fixture.store.state.completedResult?.inserted == true)
+        #expect(await fixture.transport.stageRequests.count == 1)
+    }
+
     @Test func failureOfBothPostStageActionsKeepsRecoverableResult() async throws {
         let stageGate = ScriptedTransportCallGate()
         let fixture = try await makeFixture(stageGate: stageGate)

--- a/Tests/HerdrMobileTests/ImageAttachStoreTests.swift
+++ b/Tests/HerdrMobileTests/ImageAttachStoreTests.swift
@@ -102,6 +102,21 @@ struct ImageAttachStoreTests {
         #expect(!FileManager.default.fileExists(atPath: fixture.prepared.fileURL.path))
     }
 
+    @Test func dismissingARetryableFailureAbandonsItsPreparedImage() async throws {
+        let fixture = try await makeFixture(stageOutcomes: [
+            .failure(ImageStagingError.transferFailed)
+        ])
+
+        fixture.store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("upload should fail") { fixture.store.state.isFailed }
+        #expect(FileManager.default.fileExists(atPath: fixture.prepared.fileURL.path))
+
+        fixture.store.dismissResult()
+
+        #expect(fixture.store.state == .idle)
+        #expect(!FileManager.default.fileExists(atPath: fixture.prepared.fileURL.path))
+    }
+
     @Test func backgroundCancelsWithoutAutomaticForegroundRetry() async throws {
         let stageGate = ScriptedTransportCallGate()
         let fixture = try await makeFixture(stageGate: stageGate)

--- a/Tests/HerdrMobileTests/ImageAttachStoreTests.swift
+++ b/Tests/HerdrMobileTests/ImageAttachStoreTests.swift
@@ -146,6 +146,24 @@ struct ImageAttachStoreTests {
         #expect(!FileManager.default.fileExists(atPath: fixture.prepared.fileURL.path))
     }
 
+    @Test func cancellationAtPreparationHandoffCleansTheUnclaimedFile() async throws {
+        let preparationGate = ScriptedTransportCallGate()
+        let fixture = try await makeFixture(preparationGate: preparationGate)
+
+        fixture.store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("preparation should reach the gate") {
+            await preparationGate.entryCount == 1
+        }
+        fixture.store.cancel()
+        await preparationGate.open()
+        try await waitUntil("cancellation should return to idle") {
+            fixture.store.state == .idle
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: fixture.prepared.fileURL.path))
+        #expect(await fixture.transport.stageRequests.isEmpty)
+    }
+
     @Test func unavailableSFTPSurfacesActionableNonRetryableFailure() async throws {
         let fixture = try await makeFixture(stageOutcomes: [
             .failure(ImageStagingError.sftpUnavailable)
@@ -255,7 +273,8 @@ struct ImageAttachStoreTests {
         stageOutcomes: [Result<StagedImage, ImageStagingError>] = [
             .success(try! StagedImage(path: "/tmp/staged/image.jpg"))
         ],
-        stageGate: ScriptedTransportCallGate? = nil
+        stageGate: ScriptedTransportCallGate? = nil,
+        preparationGate: ScriptedTransportCallGate? = nil
     ) async throws -> Fixture {
         let fileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("image-attach-\(UUID().uuidString).jpg")
@@ -266,7 +285,9 @@ struct ImageAttachStoreTests {
             pixelWidth: 16,
             pixelHeight: 16,
             byteCount: 128)
-        let preparer = ScriptedImagePreparer(prepared: prepared)
+        let preparer = ScriptedImagePreparer(
+            prepared: prepared,
+            gate: preparationGate)
         let transport = ScriptedTransport()
         await transport.configureImageStaging(outcomes: stageOutcomes, gate: stageGate)
         let clipboard = RecordingImageClipboard()
@@ -304,13 +325,16 @@ struct ImageAttachStoreTests {
 
 private actor ScriptedImagePreparer: ImagePreparing {
     let prepared: PreparedImage
+    let gate: ScriptedTransportCallGate?
 
-    init(prepared: PreparedImage) {
+    init(prepared: PreparedImage, gate: ScriptedTransportCallGate?) {
         self.prepared = prepared
+        self.gate = gate
     }
 
     func prepare(_ selection: any ImageSelection) async throws -> PreparedImage {
-        prepared
+        await gate?.waitUntilOpen()
+        return prepared
     }
 }
 

--- a/Tests/HerdrMobileTests/ImagePreparerTests.swift
+++ b/Tests/HerdrMobileTests/ImagePreparerTests.swift
@@ -116,6 +116,24 @@ struct ImagePreparerTests {
         #expect(prepared.pixelHeight < 512)
     }
 
+    @Test func impossibleEncodedByteLimitFailsWithoutLeavingOutput() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = try encodedImage(
+            width: 64, height: 64, alpha: false, type: .jpeg)
+        let preparer = ImagePreparer(
+            configuration: .init(
+                maximumLongEdge: 4_096,
+                maximumEncodedByteCount: 1,
+                maximumSourcePixelCount: 200_000_000),
+            directory: directory)
+
+        await #expect(throws: ImagePreparationError.unableToProduceBoundedOutput) {
+            _ = try await preparer.prepare(DataImageSelection(data: source))
+        }
+        #expect((try FileManager.default.contentsOfDirectory(atPath: directory.path)).isEmpty)
+    }
+
     @Test func oversizedDecodedInputsAreRejectedBeforeFullResolutionRendering() async throws {
         let directory = temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Tests/HerdrMobileTests/ImagePreparerTests.swift
+++ b/Tests/HerdrMobileTests/ImagePreparerTests.swift
@@ -1,0 +1,265 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import Testing
+import UniformTypeIdentifiers
+
+@testable import HerdrMobile
+
+@Suite("Image preparer", .serialized)
+struct ImagePreparerTests {
+    @Test func opaqueInputBecomesMetadataFreeJPEG() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = try encodedImage(
+            width: 320,
+            height: 180,
+            alpha: false,
+            type: .jpeg,
+            properties: [
+                kCGImagePropertyExifDictionary: ["UserComment": "private"],
+                kCGImagePropertyGPSDictionary: [
+                    kCGImagePropertyGPSLatitude: 25.03,
+                    kCGImagePropertyGPSLongitude: 121.56,
+                ],
+            ])
+        let preparer = ImagePreparer(directory: directory)
+
+        let prepared = try await preparer.prepare(DataImageSelection(data: source))
+        defer { try? prepared.remove() }
+
+        #expect(prepared.format == .jpeg)
+        #expect(prepared.pixelWidth == 320)
+        #expect(prepared.pixelHeight == 180)
+        #expect(prepared.byteCount <= ImagePreparer.maximumEncodedByteCount)
+        #expect(prepared.fileURL.pathExtension == "jpg")
+        let output = try #require(CGImageSourceCreateWithURL(prepared.fileURL as CFURL, nil))
+        #expect(CGImageSourceGetType(output) as String? == UTType.jpeg.identifier)
+        let properties = try #require(
+            CGImageSourceCopyPropertiesAtIndex(output, 0, nil) as? [CFString: Any])
+        #expect(properties[kCGImagePropertyGPSDictionary] == nil)
+        let exif = properties[kCGImagePropertyExifDictionary] as? [CFString: Any]
+        #expect(exif?[kCGImagePropertyExifUserComment] == nil)
+    }
+
+    @Test func transparentInputPreservesAlphaAsPNG() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let preparer = ImagePreparer(directory: directory)
+
+        let prepared = try await preparer.prepare(
+            DataImageSelection(
+                data: try encodedImage(width: 64, height: 48, alpha: true, type: .png)))
+        defer { try? prepared.remove() }
+
+        #expect(prepared.format == .png)
+        let output = try #require(CGImageSourceCreateWithURL(prepared.fileURL as CFURL, nil))
+        let image = try #require(CGImageSourceCreateImageAtIndex(output, 0, nil))
+        #expect(image.alphaInfo != .none)
+        #expect(image.alphaInfo != .noneSkipFirst)
+        #expect(image.alphaInfo != .noneSkipLast)
+    }
+
+    @Test func orientationIsAppliedBeforeEncoding() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = try encodedImage(
+            width: 120,
+            height: 80,
+            alpha: false,
+            type: .jpeg,
+            properties: [kCGImagePropertyOrientation: 6])
+        let preparer = ImagePreparer(directory: directory)
+
+        let prepared = try await preparer.prepare(DataImageSelection(data: source))
+        defer { try? prepared.remove() }
+
+        #expect(prepared.pixelWidth == 80)
+        #expect(prepared.pixelHeight == 120)
+        let output = try #require(CGImageSourceCreateWithURL(prepared.fileURL as CFURL, nil))
+        let properties = try #require(
+            CGImageSourceCopyPropertiesAtIndex(output, 0, nil) as? [CFString: Any])
+        let orientation = properties[kCGImagePropertyOrientation] as? Int
+        #expect(orientation == nil || orientation == 1)
+    }
+
+    @Test func longEdgeIsDownscaledTo4096Pixels() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = try encodedImage(
+            width: 5_000, height: 1_000, alpha: false, type: .jpeg)
+        let preparer = ImagePreparer(directory: directory)
+
+        let prepared = try await preparer.prepare(DataImageSelection(data: source))
+        defer { try? prepared.remove() }
+
+        #expect(prepared.pixelWidth == 4_096)
+        #expect(prepared.pixelHeight == 819)
+    }
+
+    @Test func encodedByteLimitReducesDimensionsWhenQualityIsInsufficient() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = try noisyPNG(width: 512, height: 512, alpha: true)
+        let configuration = ImagePreparer.Configuration(
+            maximumLongEdge: 4_096,
+            maximumEncodedByteCount: 40_000,
+            maximumSourcePixelCount: 200_000_000)
+        let preparer = ImagePreparer(configuration: configuration, directory: directory)
+
+        let prepared = try await preparer.prepare(DataImageSelection(data: source))
+        defer { try? prepared.remove() }
+
+        #expect(prepared.format == .png)
+        #expect(prepared.byteCount <= 40_000)
+        #expect(prepared.pixelWidth < 512)
+        #expect(prepared.pixelHeight < 512)
+    }
+
+    @Test func oversizedDecodedInputsAreRejectedBeforeFullResolutionRendering() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let preparer = ImagePreparer(
+            configuration: .init(
+                maximumLongEdge: 4_096,
+                maximumEncodedByteCount: 16 * 1_024 * 1_024,
+                maximumSourcePixelCount: 9_999),
+            directory: directory)
+        let source = try encodedImage(width: 100, height: 100, alpha: false, type: .jpeg)
+
+        await #expect(throws: ImagePreparationError.sourceTooLarge) {
+            _ = try await preparer.prepare(DataImageSelection(data: source))
+        }
+        #expect((try FileManager.default.contentsOfDirectory(atPath: directory.path)).isEmpty)
+    }
+
+    @Test func malformedInputLeavesNoTemporaryFiles() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let preparer = ImagePreparer(directory: directory)
+
+        await #expect(throws: ImagePreparationError.invalidImage) {
+            _ = try await preparer.prepare(DataImageSelection(data: Data("not an image".utf8)))
+        }
+
+        #expect((try FileManager.default.contentsOfDirectory(atPath: directory.path)).isEmpty)
+    }
+
+    @Test func preparedFilesAreProtectedAndExcludedFromBackup() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let preparer = ImagePreparer(directory: directory)
+        let prepared = try await preparer.prepare(
+            DataImageSelection(
+                data: try encodedImage(width: 32, height: 32, alpha: false, type: .jpeg)))
+        defer { try? prepared.remove() }
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: prepared.fileURL.path)
+        let protection = attributes[.protectionKey] as? FileProtectionType
+#if targetEnvironment(simulator)
+        // The simulator accepts the protection attribute but does not expose it
+        // through stat. A physical-device acceptance run verifies enforcement.
+        #expect(protection == nil || protection == .complete)
+#else
+        #expect(protection == .complete)
+#endif
+        let values = try prepared.fileURL.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        #expect(values.isExcludedFromBackup == true)
+    }
+
+    @Test func launchCleanupRemovesOnlyPreparedImageRemnants() throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+        let remnant = directory.appendingPathComponent("old.png")
+        try Data([1, 2, 3]).write(to: remnant)
+        let neighbor = directory.deletingLastPathComponent()
+            .appendingPathComponent("keep-\(UUID().uuidString)")
+        try Data([4]).write(to: neighbor)
+        defer { try? FileManager.default.removeItem(at: neighbor) }
+
+        try ImagePreparer.cleanupRemnants(in: directory)
+
+        #expect(!FileManager.default.fileExists(atPath: remnant.path))
+        #expect(FileManager.default.fileExists(atPath: neighbor.path))
+    }
+
+    private func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("image-preparer-tests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private func encodedImage(
+        width: Int,
+        height: Int,
+        alpha: Bool,
+        type: UTType,
+        properties: [CFString: Any] = [:]
+    ) throws -> Data {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo: CGBitmapInfo =
+            alpha
+            ? CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+            : CGBitmapInfo(rawValue: CGImageAlphaInfo.noneSkipLast.rawValue)
+        let context = try #require(
+            CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: colorSpace,
+                bitmapInfo: bitmapInfo.rawValue))
+        context.setFillColor(
+            alpha
+                ? CGColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 0.5)
+                : CGColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        let image = try #require(context.makeImage())
+        let data = NSMutableData()
+        let destination = try #require(
+            CGImageDestinationCreateWithData(
+                data, type.identifier as CFString, 1, nil))
+        CGImageDestinationAddImage(destination, image, properties as CFDictionary)
+        #expect(CGImageDestinationFinalize(destination))
+        return data as Data
+    }
+
+    private func noisyPNG(width: Int, height: Int, alpha: Bool) throws -> Data {
+        var bytes = [UInt8](repeating: 0, count: width * height * 4)
+        var state: UInt64 = 0x1234_5678_9ABC_DEF0
+        for index in bytes.indices {
+            state = state &* 6_364_136_223_846_793_005 &+ 1
+            bytes[index] = UInt8(truncatingIfNeeded: state >> 24)
+        }
+        if !alpha {
+            for index in stride(from: 3, to: bytes.count, by: 4) {
+                bytes[index] = 255
+            }
+        }
+        let provider = try #require(
+            CGDataProvider(data: Data(bytes) as CFData))
+        let image = try #require(
+            CGImage(
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bitsPerPixel: 32,
+                bytesPerRow: width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGBitmapInfo(
+                    rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+                provider: provider,
+                decode: nil,
+                shouldInterpolate: false,
+                intent: .defaultIntent))
+        let data = NSMutableData()
+        let destination = try #require(
+            CGImageDestinationCreateWithData(
+                data, UTType.png.identifier as CFString, 1, nil))
+        CGImageDestinationAddImage(destination, image, nil)
+        #expect(CGImageDestinationFinalize(destination))
+        return data as Data
+    }
+}

--- a/Tests/HerdrMobileTests/ImageStagingE2ETests.swift
+++ b/Tests/HerdrMobileTests/ImageStagingE2ETests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 import Testing
 
 @testable import HerdrMobile
@@ -11,6 +12,67 @@ import Testing
     .serialized,
     .timeLimit(.minutes(1)))
 struct ImageStagingE2ETests {
+    @Test func stagingAndCompensationDoNotLogRemotePaths() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let logRecorder = SFTPLogRecorder()
+        LoggingSystem.bootstrap { _ in
+            SFTPPathCapturingLogHandler(recorder: logRecorder)
+        }
+
+        let identifier = UUID().uuidString.lowercased()
+        let localURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("image-stage-log-\(identifier).png")
+        let bytes = Data(repeating: 0x7A, count: 1_024)
+        try bytes.write(to: localURL)
+        defer { try? FileManager.default.removeItem(at: localURL) }
+        let image = PreparedImage(
+            fileURL: localURL,
+            format: .png,
+            pixelWidth: 32,
+            pixelHeight: 32,
+            byteCount: Int64(bytes.count))
+
+        let successPrefix = "herdr-mobile-log-success-\(identifier)"
+        let successDirectoryCommand =
+            "/bin/sh -c 'umask 077; "
+            + "directory=$(mktemp -d \"/tmp/\(successPrefix).XXXXXXXX\") || exit 1; "
+            + "printf \"__HERDR_MOBILE_STAGE_DIR__=%s\\n\" \"$directory\"'"
+        let successTransport = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .absolutePath("/tmp/herdr-image-stage-unused.sock"),
+                stageDirectoryCommand: successDirectoryCommand))
+        let staged = try await successTransport.stageImage(image) { _ in }
+        let successDirectory = staged.fileURL.deletingLastPathComponent()
+        defer { try? FileManager.default.removeItem(at: successDirectory) }
+        try await successTransport.close()
+
+        let failurePrefix = "herdr-mobile-log-failure-\(identifier)"
+        let failureDirectoryCommand =
+            "/bin/sh -c 'umask 077; "
+            + "directory=$(mktemp -d \"/tmp/\(failurePrefix).XXXXXXXX\") || exit 1; "
+            + "chmod 0755 \"$directory\" || exit 1; "
+            + "printf \"__HERDR_MOBILE_STAGE_DIR__=%s\\n\" \"$directory\"'"
+        let failureTransport = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .absolutePath("/tmp/herdr-image-stage-unused.sock"),
+                stageDirectoryCommand: failureDirectoryCommand))
+        await #expect(throws: ImageStagingError.permissionEnforcementFailed) {
+            _ = try await failureTransport.stageImage(image) { _ in }
+        }
+        try await failureTransport.close()
+        let failureDirectory = try #require(
+            FileManager.default.contentsOfDirectory(
+                at: URL(fileURLWithPath: "/tmp"),
+                includingPropertiesForKeys: nil
+            ).first { $0.lastPathComponent.hasPrefix(failurePrefix) })
+        defer { try? FileManager.default.removeItem(at: failureDirectory) }
+
+        let messages = logRecorder.messages
+        #expect(!messages.contains { $0.contains(successPrefix) })
+        #expect(!messages.contains { $0.contains(staged.path) })
+        #expect(!messages.contains { $0.contains(failurePrefix) })
+    }
+
     @Test func streamsPrivateFileAndAtomicallyRenamesThePart() async throws {
         let environment = try #require(LocalSSHTestEnvironment.current)
         let localURL = FileManager.default.temporaryDirectory
@@ -249,5 +311,36 @@ struct ImageStagingE2ETests {
         func record(_ progress: ImageStageProgress) {
             values.append(progress)
         }
+    }
+}
+
+private final class SFTPLogRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    var messages: [String] {
+        lock.withLock { storage }
+    }
+
+    func record(_ message: String) {
+        lock.withLock {
+            storage.append(message)
+        }
+    }
+}
+
+private struct SFTPPathCapturingLogHandler: LogHandler {
+    let recorder: SFTPLogRecorder
+    var metadataProvider: Logger.MetadataProvider?
+    var metadata: Logger.Metadata = [:]
+    var logLevel: Logger.Level = .trace
+
+    subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    func log(event: LogEvent) {
+        recorder.record(event.message.description)
     }
 }

--- a/Tests/HerdrMobileTests/ImageStagingE2ETests.swift
+++ b/Tests/HerdrMobileTests/ImageStagingE2ETests.swift
@@ -118,6 +118,95 @@ struct ImageStagingE2ETests {
         try await transport.close()
     }
 
+    @Test func stagingSharesCapacityWithRPCsWhileEventsAndAttachAreLive() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let server = try FakeHerdrServer { request in
+            if request.method == "events.subscribe" {
+                return .streamThenHold([
+                    .write(
+                        #"{"id":"\#(request.id)","result":{"type":"subscription_started"}}"#)
+                ])
+            }
+            return nil
+        }
+        defer { server.stop() }
+
+        let identifier = UUID().uuidString.lowercased()
+        let attachScript = FileManager.default.temporaryDirectory
+            .appendingPathComponent("image-stage-attach-\(identifier).sh")
+        try """
+        printf 'READY\\n'
+        exec sleep 30
+        """.write(to: attachScript, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: attachScript) }
+
+        let localURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("image-stage-capacity-\(identifier).png")
+        let bytes = Data(repeating: 0x4B, count: 200_000)
+        try bytes.write(to: localURL)
+        defer { try? FileManager.default.removeItem(at: localURL) }
+        let image = PreparedImage(
+            fileURL: localURL,
+            format: .png,
+            pixelWidth: 320,
+            pixelHeight: 200,
+            byteCount: Int64(bytes.count))
+
+        var settings = environment.makeSettings(
+            socket: .absolutePath(server.socketPath),
+            wakeCommand: "false",
+            requestTimeout: .seconds(20))
+        settings.attachCommand = "/bin/sh \(attachScript.path)"
+        let transport = try await SSHTransport.connect(settings: settings)
+        let events = try await transport.subscribeToEvents([.global(.paneCreated)])
+        let attach = try await transport.attachTerminal(
+            TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24))
+        var attachOutput = attach.output.makeAsyncIterator()
+        var attachText = ""
+        while !attachText.contains("READY") {
+            guard let bytes = try await attachOutput.next() else {
+                Issue.record("Attach ended before the capacity test was ready.")
+                break
+            }
+            attachText += String(decoding: bytes, as: UTF8.self)
+        }
+
+        let requests = (0..<SSHTransport.maxConcurrentExecChannels).map { _ in
+            Task { try await transport.listAgents() }
+        }
+        #expect(
+            await server.wait(for: {
+                $0.receivedRequests.filter { $0.method == "agent.list" }.count
+                    == SSHTransport.maxConcurrentExecChannels
+            }))
+
+        let staging = Task {
+            try await transport.stageImage(image) { _ in }
+        }
+        try await Task.sleep(for: .milliseconds(150))
+
+        requests[0].cancel()
+        await #expect(throws: TransportError.cancelled) {
+            _ = try await requests[0].value
+        }
+        let staged = try await staging.value
+        defer {
+            try? FileManager.default.removeItem(
+                at: staged.fileURL.deletingLastPathComponent())
+        }
+        #expect(try Data(contentsOf: staged.fileURL) == bytes)
+
+        for request in requests.dropFirst() {
+            request.cancel()
+            await #expect(throws: TransportError.cancelled) {
+                _ = try await request.value
+            }
+        }
+        await attach.end()
+        await events.end()
+        try await transport.close()
+    }
+
     private func waitUntil(
         _ comment: Comment,
         timeout: Duration = .seconds(5),

--- a/Tests/HerdrMobileTests/ImageStagingE2ETests.swift
+++ b/Tests/HerdrMobileTests/ImageStagingE2ETests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+@Suite(
+    "Image staging e2e",
+    .enabled(
+        if: LocalSSHTestEnvironment.isAvailable,
+        "requires localhost sshd, SFTP, and an authorized Ed25519 test key"),
+    .serialized,
+    .timeLimit(.minutes(1)))
+struct ImageStagingE2ETests {
+    @Test func streamsPrivateFileAndAtomicallyRenamesThePart() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let localURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("image-stage-\(UUID().uuidString).png")
+        let bytes = Data((0..<200_000).map { UInt8(truncatingIfNeeded: $0) })
+        try bytes.write(to: localURL)
+        defer { try? FileManager.default.removeItem(at: localURL) }
+        let image = PreparedImage(
+            fileURL: localURL,
+            format: .png,
+            pixelWidth: 320,
+            pixelHeight: 200,
+            byteCount: Int64(bytes.count))
+        let progress = ProgressRecorder()
+        let transport = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .absolutePath("/tmp/herdr-image-stage-unused.sock")))
+
+        let staged: StagedImage
+        do {
+            staged = try await transport.stageImage(image) { value in
+                await progress.record(value)
+            }
+        } catch {
+            try? await transport.close()
+            throw error
+        }
+        defer { try? FileManager.default.removeItem(at: staged.fileURL.deletingLastPathComponent()) }
+
+        #expect(staged.path.hasPrefix("/"))
+        #expect(staged.path.hasSuffix(".png"))
+        #expect(!staged.path.contains(localURL.lastPathComponent))
+        #expect(try Data(contentsOf: staged.fileURL) == bytes)
+        let fileAttributes = try FileManager.default.attributesOfItem(atPath: staged.path)
+        let directoryAttributes = try FileManager.default.attributesOfItem(
+            atPath: staged.fileURL.deletingLastPathComponent().path)
+        #expect((fileAttributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+        #expect((directoryAttributes[.posixPermissions] as? NSNumber)?.intValue == 0o700)
+        #expect(
+            try FileManager.default.contentsOfDirectory(
+                atPath: staged.fileURL.deletingLastPathComponent().path)
+                == [staged.fileURL.lastPathComponent])
+        let values = await progress.values
+        #expect(values.first == ImageStageProgress(transferredBytes: 0, totalBytes: bytes.count))
+        #expect(
+            values.last
+                == ImageStageProgress(
+                    transferredBytes: bytes.count,
+                    totalBytes: bytes.count))
+        #expect(values.map(\.transferredBytes) == values.map(\.transferredBytes).sorted())
+
+        try await transport.close()
+    }
+
+    @Test func cancellationRemovesOnlyTheCurrentIncompletePart() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let identifier = UUID().uuidString.lowercased()
+        let remotePrefix = "herdr-mobile-cancel-\(identifier)"
+        let stageDirectoryCommand =
+            "/bin/sh -c 'umask 077; "
+            + "directory=$(mktemp -d \"/tmp/\(remotePrefix).XXXXXXXX\") || exit 1; "
+            + "printf \"__HERDR_MOBILE_STAGE_DIR__=%s\\n\" \"$directory\"'"
+        let localURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("image-stage-cancel-\(identifier).jpg")
+        let bytes = Data(repeating: 0xA5, count: 8 * 1_024 * 1_024)
+        try bytes.write(to: localURL)
+        defer { try? FileManager.default.removeItem(at: localURL) }
+        let image = PreparedImage(
+            fileURL: localURL,
+            format: .jpeg,
+            pixelWidth: 4_096,
+            pixelHeight: 2_048,
+            byteCount: Int64(bytes.count))
+        let holdProgress = ScriptedTransportCallGate()
+        let transport = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .absolutePath("/tmp/herdr-image-stage-unused.sock"),
+                stageDirectoryCommand: stageDirectoryCommand))
+        let task = Task {
+            try await transport.stageImage(image) { value in
+                if value.transferredBytes > 0 {
+                    await holdProgress.waitUntilOpen()
+                }
+            }
+        }
+        try await waitUntil("upload should report a transferred chunk") {
+            await holdProgress.entryCount > 0
+        }
+
+        task.cancel()
+        await holdProgress.open()
+
+        await #expect(throws: ImageStagingError.cancelled) {
+            _ = try await task.value
+        }
+        let stagedDirectories = try FileManager.default.contentsOfDirectory(
+            at: URL(fileURLWithPath: "/tmp"),
+            includingPropertiesForKeys: nil)
+            .filter { $0.lastPathComponent.hasPrefix(remotePrefix) }
+        #expect(stagedDirectories.count == 1)
+        let directory = try #require(stagedDirectories.first)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(
+            try FileManager.default.contentsOfDirectory(atPath: directory.path).isEmpty)
+        try await transport.close()
+    }
+
+    private func waitUntil(
+        _ comment: Comment,
+        timeout: Duration = .seconds(5),
+        condition: () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if await condition() { break }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await condition(), comment)
+    }
+
+    private actor ProgressRecorder {
+        private(set) var values: [ImageStageProgress] = []
+
+        func record(_ progress: ImageStageProgress) {
+            values.append(progress)
+        }
+    }
+}

--- a/Tests/HerdrMobileTests/ImageStagingE2ETests.swift
+++ b/Tests/HerdrMobileTests/ImageStagingE2ETests.swift
@@ -118,6 +118,29 @@ struct ImageStagingE2ETests {
         try await transport.close()
     }
 
+    @Test func disconnectedTransportSurfacesRetryableTransferFailure() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let localURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("image-stage-disconnected-\(UUID().uuidString).png")
+        let bytes = Data(repeating: 0x3C, count: 1_024)
+        try bytes.write(to: localURL)
+        defer { try? FileManager.default.removeItem(at: localURL) }
+        let image = PreparedImage(
+            fileURL: localURL,
+            format: .png,
+            pixelWidth: 32,
+            pixelHeight: 32,
+            byteCount: Int64(bytes.count))
+        let transport = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .absolutePath("/tmp/herdr-image-stage-unused.sock")))
+        try await transport.close()
+
+        await #expect(throws: ImageStagingError.transferFailed) {
+            _ = try await transport.stageImage(image) { _ in }
+        }
+    }
+
     @Test func stagingSharesCapacityWithRPCsWhileEventsAndAttachAreLive() async throws {
         let environment = try #require(LocalSSHTestEnvironment.current)
         let server = try FakeHerdrServer { request in

--- a/Tests/HerdrMobileTests/ImageStagingTests.swift
+++ b/Tests/HerdrMobileTests/ImageStagingTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+@Suite("Image staging domain")
+struct ImageStagingTests {
+    @Test func stagedImagesRequireAControlFreeAbsoluteHostPath() throws {
+        #expect(throws: ImageStagingError.invalidRemotePath) {
+            _ = try StagedImage(path: "tmp/image.png")
+        }
+        #expect(throws: ImageStagingError.invalidRemotePath) {
+            _ = try StagedImage(path: "/tmp/image\u{0}.png")
+        }
+        #expect(try StagedImage(path: "/private/tmp/image.png").path == "/private/tmp/image.png")
+    }
+
+    @Test func progressReportsRealTransferredBytes() {
+        let progress = ImageStageProgress(transferredBytes: 32, totalBytes: 128)
+        #expect(progress.fractionCompleted == 0.25)
+        #expect(
+            ImageStageProgress(transferredBytes: 0, totalBytes: 0).fractionCompleted == 0)
+    }
+}

--- a/Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift
+++ b/Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift
@@ -78,6 +78,7 @@ struct LocalSSHTestEnvironment: Sendable {
         wakeCommand: String? = nil,
         requestTimeout: Duration? = nil,
         homeCommand: String? = nil,
+        stageDirectoryCommand: String? = nil,
         credentials: SSHCredentials? = nil,
         hostKeyPolicy: HostKeyPolicy? = nil
     ) -> SSHTransportSettings {
@@ -93,6 +94,7 @@ struct LocalSSHTestEnvironment: Sendable {
         if let wakeCommand { settings.wakeCommand = wakeCommand }
         if let requestTimeout { settings.requestTimeout = requestTimeout }
         if let homeCommand { settings.homeCommand = homeCommand }
+        if let stageDirectoryCommand { settings.stageDirectoryCommand = stageDirectoryCommand }
         return settings
     }
 

--- a/Tests/HerdrMobileTests/Support/ScriptedTransport.swift
+++ b/Tests/HerdrMobileTests/Support/ScriptedTransport.swift
@@ -43,6 +43,9 @@ final actor ScriptedTransport: Transport {
     private var liveAttachID: UInt64?
     private var attachContinuation: AsyncThrowingStream<Data, any Error>.Continuation?
     private var attachInputTask: Task<Void, Never>?
+    private(set) var stageRequests: [PreparedImage] = []
+    private var stageOutcomes: [Result<StagedImage, ImageStagingError>] = []
+    private var stageGate: ScriptedTransportCallGate?
 
     init(
         snapshot: SessionSnapshot = .fixture(),
@@ -99,6 +102,14 @@ final actor ScriptedTransport: Transport {
     /// Makes every subsequent `closePane` throw `failure`.
     func setCloseFailure(_ failure: TransportError?) {
         closeFailure = failure
+    }
+
+    func configureImageStaging(
+        outcomes: [Result<StagedImage, ImageStagingError>],
+        gate: ScriptedTransportCallGate? = nil
+    ) {
+        stageOutcomes = outcomes
+        stageGate = gate
     }
 
     /// Pushes one event onto the live stream; false if none is live.
@@ -234,6 +245,27 @@ final actor ScriptedTransport: Transport {
         return TerminalAttachSession(output: output, input: inputContinuation) {
             await self.endAttach(id: attachID)
         }
+    }
+
+    func stageImage(
+        _ image: PreparedImage,
+        progress: @escaping @Sendable (ImageStageProgress) async -> Void
+    ) async throws -> StagedImage {
+        stageRequests.append(image)
+        await progress(
+            ImageStageProgress(transferredBytes: 0, totalBytes: image.byteCount))
+        let gate = stageGate
+        stageGate = nil
+        await gate?.waitUntilOpen()
+        try Task.checkCancellation()
+        await progress(
+            ImageStageProgress(
+                transferredBytes: image.byteCount,
+                totalBytes: image.byteCount))
+        guard !stageOutcomes.isEmpty else {
+            throw ImageStagingError.transferFailed
+        }
+        return try stageOutcomes.removeFirst().get()
     }
 
     var isConnected: Bool {

--- a/Tests/HerdrMobileTests/TerminalAttachTests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachTests.swift
@@ -21,6 +21,66 @@ struct TerminalAttachTests {
     }
 
     @MainActor
+    @Test func keyboardAccessoryExposesSystemPasteControlInBothModes() throws {
+        let terminal = TerminalScreenView.makeConfiguredTerminal()
+        let accessory = try #require(
+            terminal.inputAccessoryView as? TerminalKeyboardAccessory)
+
+        #expect(accessory.pasteControl.target === terminal)
+        #expect(accessory.pasteControl.accessibilityLabel == "Paste")
+        #expect(accessory.pasteControl.isEnabled)
+
+        terminal.setKeyboardMode(.controls)
+        #expect(accessory.pasteControl.isDescendant(of: accessory))
+    }
+
+    @MainActor
+    @Test func pasteControlAndHardwarePasteUseTheReviewedPasteCallback() {
+        var pastes: [String] = []
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            onPaste: { pastes.append($0) })
+
+        terminal.requestPaste("one\n two")
+        #expect(pastes == ["one\n two"])
+
+        terminal.setLocalInputEnabled(false)
+        terminal.requestPaste("blocked")
+        #expect(pastes == ["one\n two"])
+        #expect(
+            (terminal.inputAccessoryView as? TerminalKeyboardAccessory)?
+                .pasteControl.isEnabled == false)
+    }
+
+    @MainActor
+    @Test func systemPasteControlLoadsTextFromItsItemProvider() async throws {
+        var pastes: [String] = []
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            onPaste: { pastes.append($0) })
+
+        terminal.paste(
+            itemProviders: [NSItemProvider(object: "provider paste" as NSString)])
+        let deadline = ContinuousClock.now + .seconds(2)
+        while pastes.isEmpty, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+
+        #expect(pastes == ["provider paste"])
+    }
+
+    @MainActor
+    @Test func pausedTerminalControlsDoNotEmitInput() async {
+        var sent = Data()
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            onSend: { sent.append($0) })
+
+        terminal.setLocalInputEnabled(false)
+        terminal.sendControlKey(.enter)
+        await Task.yield()
+
+        #expect(sent.isEmpty)
+    }
+
+    @MainActor
     @Test func terminalTouchPolicyKeepsKeyboardBehindTheCurrentInputRow() {
         let terminal = TerminalScreenView.makeConfiguredTerminal()
         let directTouch = NSNumber(value: UITouch.TouchType.direct.rawValue)

--- a/Tests/HerdrMobileTests/TerminalInputControllerTests.swift
+++ b/Tests/HerdrMobileTests/TerminalInputControllerTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+@MainActor
+@Suite("Terminal input controller")
+struct TerminalInputControllerTests {
+    @Test func imagePathInsertionIsOrderedAndNeverSubmits() throws {
+        var writes: [Data] = []
+        let controller = TerminalInputController()
+        let generation = controller.beginSession { writes.append($0) }
+
+        #expect(controller.insertPath("/private/tmp/staged/image.jpg", matching: generation))
+        #expect(
+            writes == [
+                Data("/private/tmp/staged/image.jpg".utf8),
+                Data(" ".utf8),
+            ])
+        #expect(!writes.contains(Data([0x0D])))
+        #expect(!writes.contains(Data([0x0A])))
+    }
+
+    @Test func staleGenerationCannotReceiveAutomaticInsertion() {
+        var writes: [Data] = []
+        let controller = TerminalInputController()
+        let original = controller.beginSession { writes.append($0) }
+        controller.endSession(original)
+        _ = controller.beginSession { writes.append($0) }
+
+        #expect(!controller.insertPath("/tmp/stale.png", matching: original))
+        #expect(writes.isEmpty)
+        #expect(controller.insertPathIntoCurrentSession("/tmp/current.png"))
+        #expect(
+            writes == [
+                Data("/tmp/current.png".utf8),
+                Data(" ".utf8),
+            ])
+    }
+
+    @Test func pausingDropsKeyboardPasteAndControlInputUntilResumed() {
+        var writes: [Data] = []
+        let controller = TerminalInputController()
+        _ = controller.beginSession { writes.append($0) }
+
+        controller.pause()
+        controller.send(Data("keyboard".utf8))
+        #expect(controller.requestPaste("clipboard") == .blocked)
+        #expect(controller.isPaused)
+        #expect(writes.isEmpty)
+
+        controller.resume()
+        controller.send(Data([0x03]))
+        #expect(controller.requestPaste("clipboard") == .inserted)
+        #expect(writes == [Data([0x03]), Data("clipboard".utf8)])
+    }
+
+    @Test func singleLinePasteInsertsImmediately() {
+        var writes: [Data] = []
+        let controller = TerminalInputController()
+        _ = controller.beginSession { writes.append($0) }
+
+        #expect(controller.requestPaste("git status") == .inserted)
+        #expect(writes == [Data("git status".utf8)])
+        #expect(controller.pendingPaste == nil)
+    }
+
+    @Test func multilinePasteRequiresReviewAndConfirmsAsOneWrite() throws {
+        var writes: [Data] = []
+        let controller = TerminalInputController()
+        _ = controller.beginSession { writes.append($0) }
+        let text = "printf one\nprintf two\n"
+
+        let result = controller.requestPaste(text)
+
+        guard case .requiresReview(let review) = result else {
+            Issue.record("expected multiline review")
+            return
+        }
+        #expect(review.lineCount == 3)
+        #expect(review.characterCount == text.count)
+        #expect(review.preview == text)
+        #expect(writes.isEmpty)
+
+        #expect(controller.confirmPaste())
+        #expect(writes == [Data(text.utf8)])
+        #expect(controller.pendingPaste == nil)
+    }
+
+    @Test func cancelIsTheSafeMultilineDefault() {
+        var writes: [Data] = []
+        let controller = TerminalInputController()
+        _ = controller.beginSession { writes.append($0) }
+        #expect(controller.requestPaste("one\ntwo").requiresReview)
+
+        controller.cancelPaste()
+
+        #expect(controller.pendingPaste == nil)
+        #expect(writes.isEmpty)
+    }
+
+    @Test(arguments: [
+        "nul\u{0}hidden",
+        "escape\u{1B}[31m",
+        "control\u{1F}hidden",
+        "delete\u{7F}hidden",
+        "c1\u{85}hidden",
+    ])
+    func unsafeClipboardControlsAreRejected(text: String) {
+        var writes: [Data] = []
+        let controller = TerminalInputController()
+        _ = controller.beginSession { writes.append($0) }
+
+        #expect(controller.requestPaste(text) == .rejected)
+        #expect(controller.pasteErrorMessage != nil)
+        #expect(controller.pendingPaste == nil)
+        #expect(writes.isEmpty)
+    }
+
+    @Test func pastePreviewIsBoundedWithoutChangingConfirmedContent() {
+        var writes: [Data] = []
+        let controller = TerminalInputController()
+        _ = controller.beginSession { writes.append($0) }
+        let text = String(repeating: "x", count: 3_000) + "\nsecond"
+
+        guard case .requiresReview(let review) = controller.requestPaste(text) else {
+            Issue.record("expected multiline review")
+            return
+        }
+        #expect(review.preview.count < text.count)
+        #expect(review.preview.hasSuffix("…"))
+
+        #expect(controller.confirmPaste())
+        #expect(writes == [Data(text.utf8)])
+    }
+}

--- a/docs/adr/0005-keep-staged-image-cleanup-outside-mobile.md
+++ b/docs/adr/0005-keep-staged-image-cleanup-outside-mobile.md
@@ -1,0 +1,11 @@
+# Keep Staged Image cleanup outside the mobile client
+
+herdr-mobile may create a Staged Image in the Host's OS-designated temporary storage for a user-requested image transfer, but it does not enumerate or delete completed remote image files. Cleanup belongs to the Host operating system or to a future Herdr-owned capability because remote file maintenance is outside the mobile client's ownership boundary. The current upload operation may delete only its own incomplete `.part` file as failure compensation; it never scans or maintains historical files. We accept that operating-system cleanup has no timing guarantee and that a Staged Image may remain indefinitely.
+
+## Consequences
+
+- The app makes no remote-file TTL or deletion promise.
+- Clipboard expiration does not imply deletion of the corresponding remote file.
+- A failed or cancelled upload attempts to remove only the incomplete file created by that operation; disconnects may prevent this compensation.
+- Staged Images still use private directories, restrictive permissions, and unguessable names.
+- Future deterministic cleanup requires an explicit Herdr-owned interface or a new architectural decision, not a background SFTP sweep from the mobile client.

--- a/docs/adr/0006-stage-images-over-sftp.md
+++ b/docs/adr/0006-stage-images-over-sftp.md
@@ -1,0 +1,20 @@
+# Stage images over SFTP and insert their paths through Attach
+
+`Attach Image` prepares one Photos image locally, stages it in the Host operating system's temporary storage over SFTP, copies the resulting absolute path to the iOS clipboard, and inserts that path into the existing Attach input stream without submitting it. Image preparation stays outside `Transport`; `Transport.stageImage(_:)` owns SFTP, remote temporary-directory creation, restrictive permissions, partial-file handling, and the shared SSH session-channel budget. This keeps Citadel and remote shell details out of UI code and keeps image bytes out of the terminal stream.
+
+`ImageAttachStore` owns the user operation, including preparation, progress, cancellation, retry, clipboard results, and the Attach session generation captured when selection or an explicit retry begins. `TerminalInputController` remains the single writer for local terminal input. Automatic insertion occurs only if that live Attach session still exists; it sends the path as one operation and a trailing space as a second operation, never Enter. A user may explicitly insert a successfully staged path into the current live session after an automatic insertion failure or session change.
+
+## Considered Options
+
+- **Send image bytes through the Attach PTY** — rejected because terminal input has no file framing and would interpret arbitrary binary bytes as keystrokes and control sequences.
+- **Use Herdr's private clipboard-image protocol or `pane.send_input`** — rejected because the mobile app should not depend on a private wire format or introduce a second writer beside the live Attach input stream.
+- **Stream through a remote shell command when SFTP is unavailable** — rejected for the MVP because it expands the quoting, portability, and security surface. SFTP support is an explicit Host requirement.
+- **Submit an instruction and path automatically** — rejected because the app cannot guarantee provider-specific image recognition and must not press Enter for the user.
+
+## Consequences
+
+- The MVP is available only in a live Attach surface, handles one image at a time, and uses `PhotosPicker` as its only source.
+- The app guarantees preparation, staging, clipboard copy, and path insertion. Whether an Agent turns the Staged Image into an Image Attachment is outside the capability contract.
+- Upload and terminal rendering may continue concurrently, but all local terminal input is paused while `Attach Image` is active.
+- Clipboard content is local-only, expires after 24 hours, and replaces the previously copied path.
+- Completed remote files follow ADR 0005 and are never cleaned up by the mobile client.

--- a/docs/research/image-input.md
+++ b/docs/research/image-input.md
@@ -1,0 +1,453 @@
+# Attach Image Design Review
+
+Date: 2026-07-23
+
+## Decision
+
+Image input is feasible without changing Attach into a file-transfer protocol.
+The single-image MVP will:
+
+1. Select one image with `PhotosPicker`.
+2. Decode and normalize it in app-owned temporary storage.
+3. Stage the result in the Host operating system's temporary storage over SFTP.
+4. Copy the remote absolute path to the iOS clipboard.
+5. Insert the path into the same live Attach input stream used by the terminal,
+   followed by a separately inserted space and no Enter.
+
+The image bytes never enter the PTY. herdr-mobile guarantees that a Staged Image
+exists and that its path is copied and/or inserted. It does not guarantee that a
+remote Agent or model interprets the path as an Image Attachment.
+
+The user-facing action remains `Attach Image`. This label describes user intent,
+not a stronger success claim. Result messages describe the path operations that
+actually completed.
+
+## Why the path must be remote
+
+The selected photo initially exists only within the iOS app's scoped access.
+The Agent runs on a remote Host and cannot read the phone's Photos library,
+local file URLs, or clipboard. The app must transfer the binary to that Host
+before inserting a usable path.
+
+The PTY is an ordered terminal byte stream, not a file-transfer envelope.
+Writing PNG or JPEG bytes to it would turn arbitrary binary data into terminal
+input and control sequences. SFTP provides file framing, streamed writes,
+progress, cancellation, permissions, and completion semantics without mixing
+binary transfer with terminal input.
+
+## Current system findings
+
+- `Transport` is already the boundary between UI code and Citadel. The image
+  feature should extend that boundary rather than expose SFTP primitives.
+- `TerminalAttachSession` already carries one ordered stream of terminal input,
+  output, and resize events. Image-path insertion should use that same input
+  path rather than create a second writer through Herdr's JSON API.
+- `SSHTransport` reserves capacity for short request channels, events, and
+  Attach under OpenSSH's usual session-channel limit. SFTP must acquire capacity
+  from the same bounded pool.
+- Citadel 0.12.1 is pinned and provides an SFTP client with streamed writes. No
+  new SSH dependency is required.
+- The Attach keyboard accessory already has room for a system Paste control,
+  and the embedded Ghostty view has an app-owned text-input seam.
+- iOS does not need a terminal `Ctrl+V` key. A system Paste control provides the
+  touch path, while a physical keyboard uses `Command+V`. `Ctrl+V` retains its
+  terminal meaning.
+
+## Final architecture
+
+```text
+PhotosPicker
+    |
+    v
+ImagePreparer
+    |  decode, orient, resize, re-encode, strip metadata
+    v
+PreparedImage in protected iOS temporary storage
+    |
+    v
+ImageAttachStore
+    |  state, progress, cancellation, retry, session generation
+    v
+Transport.stageImage(_:)
+    |  shared SSH channel permit, remote mktemp, SFTP, permissions, rename
+    v
+StagedImage with an absolute Host path
+    |                         |
+    |                         +--> local-only iOS clipboard, 24-hour expiry
+    v
+TerminalInputController
+    |  insert path, then insert one space, never Enter
+    v
+Current live Attach session
+```
+
+### Module boundaries
+
+`ImagePreparer` owns local image work:
+
+- load the selected Photos item into app-controlled temporary storage;
+- verify that it decodes as an image;
+- apply orientation;
+- bound decoded pixel memory;
+- resize and re-encode;
+- strip metadata;
+- produce a `PreparedImage`.
+
+`Transport` exposes one domain-level operation:
+
+```swift
+func stageImage(_ image: PreparedImage) async throws -> StagedImage
+```
+
+The concrete transport owns:
+
+- acquisition of a shared SSH session-channel permit;
+- creation of a private directory in OS-designated remote temporary storage;
+- SFTP streaming and byte progress;
+- restrictive directory and file permissions;
+- incomplete `.part` handling;
+- atomic rename to the final random filename;
+- validation of the returned absolute path.
+
+UI code never sees Citadel types, constructs remote commands, chooses remote
+paths, or manages SSH permits.
+
+`ImageAttachStore` owns the operation lifecycle:
+
+- one operation at a time;
+- the Attach session generation captured when selection or explicit Retry starts;
+- preparation and upload progress;
+- user cancellation;
+- retry with the already prepared local file;
+- clipboard and insertion results;
+- recovery actions for partial success.
+
+`TerminalInputController` is the single application-level writer for local
+terminal input. Keyboard input, system Paste, and image-path insertion all pass
+through it. `ImageAttachStore` requests text insertion; it does not write raw
+SSH bytes or call Ghostty directly.
+
+## Image preparation
+
+The MVP accepts one `PhotosPicker` selection. Camera and Files sources are
+future work.
+
+Every input is decoded and re-encoded:
+
+- preserve transparency with PNG;
+- encode opaque content as JPEG, starting near quality `0.9`;
+- apply orientation before encoding;
+- discard EXIF, GPS, original filename, and other source metadata;
+- use an unguessable random output name;
+- limit the long edge to 4096 pixels;
+- limit the final encoded file to 16 MiB;
+- lower JPEG quality and, when necessary, dimensions to fit;
+- scale PNG dimensions while preserving alpha;
+- fail only when a valid bounded output cannot be produced.
+
+Decoded pixel count and allocation must be bounded before full-resolution
+rendering so a small compressed file cannot cause unbounded memory use.
+
+The prepared file is:
+
+- stored in app-owned temporary storage;
+- excluded from backup;
+- protected with the strongest file protection compatible with immediate use;
+- deleted after success, explicit cancellation, unrecoverable failure, or
+  leaving Attach;
+- retained after a background-interrupted upload so the user can retry on
+  foreground return;
+- removed on the next launch if a crash left it behind.
+
+## Remote staging
+
+The feature supports macOS and Linux Hosts. It must not hardcode `/tmp`, a
+macOS-only directory, a home-directory cache, or a repository-relative path.
+The transport creates a private directory through a controlled remote
+`mktemp -d` operation using the Host operating system's temporary-directory
+selection.
+
+Remote requirements:
+
+- one unique directory per operation, mode `0700`;
+- one random `.part` file, mode `0600`;
+- direct restrictive creation rather than permissive creation followed by a
+  best-effort chmod;
+- streamed SFTP write;
+- final size verification;
+- atomic rename from `.part` to the final PNG or JPEG name;
+- failure if restrictive permissions cannot be enforced;
+- no caller-supplied remote filename or destination.
+
+SFTP is a deliberate Host requirement for the MVP. If the subsystem is
+disabled, the app reports that requirement and stops. It does not fall back to
+base64, `cat`, shell stdin, Herdr's private clipboard protocol, or PTY transfer.
+
+The upload operation may attempt to delete only its own incomplete `.part` file
+after failure or cancellation. It never scans old directories. Disconnects may
+prevent even that compensation.
+
+Completed Staged Images are outside the mobile client's cleanup ownership. The
+app neither deletes them nor promises a TTL. Host operating-system cleanup may
+eventually remove them, but its timing is not part of the product contract. See
+[ADR 0005](../adr/0005-keep-staged-image-cleanup-outside-mobile.md).
+
+## Attach behavior
+
+### Entry point
+
+`Attach Image` appears as a photo-icon action in the navigation toolbar only
+while Attach is live. It is disabled without a usable live session. It is not
+added to other Agent surfaces in the MVP.
+
+The action and its VoiceOver label are both `Attach Image`.
+
+### Operation state
+
+Only one image operation may be active. A second selection is disabled; there
+is no queue and no latest-wins replacement.
+
+While active:
+
+- terminal output continues rendering;
+- local terminal text, Keys controls, and Paste are disabled;
+- a compact bottom status presents progress and Cancel;
+- preparation is indeterminate: `Preparing Image…`;
+- upload uses actual streamed bytes: `Uploading Image… 42%`;
+- no fake preparation percentage or flashing finalization state is shown.
+
+After upload, clipboard copy and insertion happen immediately without an extra
+visible phase.
+
+### Session binding
+
+The store captures the Attach session generation when selection or an explicit
+Retry begins. Automatic insertion occurs only if that exact live session still
+exists when staging completes.
+
+If the session disconnects, reconnects, exits, or is replaced:
+
+- the completed remote image remains staged;
+- the app still attempts to copy its path;
+- the app does not automatically insert into the new session;
+- the result explains that the path was copied but not inserted.
+
+A remote TUI focus change within the same session does not cancel automatic
+insertion. This accepts the small risk that the path reaches a different input
+inside that same terminal.
+
+### Input sequence
+
+Automatic insertion sends two ordered operations:
+
+1. the absolute path as one standalone text insertion;
+2. one space.
+
+It sends no quotes, Markdown, explanation, newline, or Enter. The user remains
+responsible for adding an instruction and submitting it.
+
+### Clipboard
+
+After successful staging, the app copies the path before attempting automatic
+insertion. Clipboard data:
+
+- is plain text;
+- uses the local-only option;
+- expires after 24 hours;
+- replaces the previous copied image path;
+- is not stored in an app clipboard history.
+
+Clipboard expiration has no relationship to the lifetime of the remote file.
+
+### Result and recovery
+
+The ordered outcome is stage, copy, then insert.
+
+| Outcome | Message | Recovery |
+| --- | --- | --- |
+| Staged, copied, inserted | `Image path inserted and copied.` | None |
+| Staged and copied, insertion failed | `Image path copied, but couldn't be inserted.` | Paste manually or use `Insert Path` |
+| Staged and inserted, copy failed | `Image path inserted, but couldn't be copied.` | Use `Copy Path` |
+| Staged, copy and insertion failed | `Image uploaded, but its path couldn't be copied or inserted.` | Use `Copy Path` or `Insert Path` |
+| Staging failed | `Image upload failed.` | Retry when a prepared file exists |
+| User cancelled | No message | None |
+
+A successfully returned `StagedImage` remains available in the Attach-local
+result UI until dismissed or until the user leaves Attach. Recovery actions do
+not re-upload:
+
+- `Copy Path` retries the clipboard write;
+- `Insert Path` explicitly targets the current live Attach session;
+- `Dismiss` removes the result UI but does not delete the Host file.
+
+### Retry and interruption
+
+A transient upload failure retains the normalized local file for session-local
+Retry. Retry uses the current live Attach session and does not reselect or
+re-encode the image. Retry state does not survive app restart.
+
+When the app backgrounds during upload:
+
+- cancel the SFTP operation;
+- attempt compensation for the current `.part`;
+- retain the prepared local file;
+- do not copy or insert a path;
+- show Retry after returning to the foreground;
+- do not start an automatic retry or background task.
+
+Explicit Cancel or leaving Attach ends the operation and removes the local
+prepared file. A completed remote Staged Image remains untouched.
+
+## Terminal Paste
+
+Paste is a generic plain-text terminal action, not an image-only control.
+
+Add a system `UIPasteControl` to the left side of the Attach keyboard
+accessory. It remains visible in both Text and Keys modes and exposes the
+VoiceOver label `Paste`. A physical keyboard uses the standard `Command+V`.
+Do not add `Ctrl+V`.
+
+Paste safety:
+
+- ordinary single-line text inserts immediately;
+- multiline text opens a review sheet with line count, character count, and a
+  truncated monospaced preview;
+- Cancel is the default action in that review;
+- confirmed ordinary multiline text inserts as one paste;
+- NUL, ESC, and other non-whitelisted control content is rejected rather than
+  reviewed.
+
+Using the system Paste control keeps the action user initiated and uses iOS's
+standard pasteboard interaction instead of a custom clipboard button.
+
+## Diagnostics and privacy
+
+Diagnostics may record:
+
+- operation phase;
+- normalized format and dimensions;
+- byte count;
+- duration;
+- sanitized error category.
+
+Diagnostics must not record:
+
+- image bytes or rendered previews;
+- the iOS temporary path;
+- the full remote path;
+- clipboard content;
+- source Photos metadata.
+
+User-facing errors explain the actionable phase, such as preparation failure,
+SFTP unavailability, upload failure, or insertion failure. Raw SSH and SFTP
+details remain in sanitized diagnostics.
+
+## Rejected alternatives
+
+### Use `pane.send_input`
+
+Rejected for this flow. Attach already has a live terminal input stream, and a
+second API writer introduces ordering and lifecycle ambiguity. The
+application-owned `TerminalInputController` keeps one authoritative local input
+path and one session-generation check.
+
+### Use Herdr's private clipboard-image protocol
+
+Herdr's remote client validates the upload-then-paste-path concept, but its
+clipboard bridge is a private protocol for `herdr --remote`. Depending on it
+would add a second versioned wire protocol and bypass the app's current
+transport boundary.
+
+### Submit the prompt automatically
+
+Rejected. Provider and model behavior is outside the app's capability
+contract, and the app must not press Enter on the user's behalf. The standalone
+path plus trailing space leaves the terminal draft under user control.
+
+### Stream through a shell command
+
+Rejected for the MVP. A shell fallback broadens quoting, executable discovery,
+portability, and failure semantics. An explicit SFTP requirement is smaller and
+more testable.
+
+### Perform OCR on iOS
+
+OCR produces text, not image input, and loses layout, diagrams, color, and other
+visual information. It may be a separate future feature but is not a fallback
+inside `Attach Image`.
+
+## Verification plan
+
+### Unit tests
+
+- orientation is applied correctly;
+- alpha selects PNG and opaque content selects JPEG;
+- metadata is absent after encoding;
+- 4096-pixel and 16 MiB limits are enforced;
+- decoded memory is bounded;
+- state transitions cover success, partial success, cancellation, background
+  interruption, retry, session replacement, and leaving Attach;
+- clipboard options and expiration are correct;
+- image-path insertion is path then space, with no Enter;
+- Paste accepts single-line text, reviews multiline text, and rejects unsafe
+  controls.
+
+### Real SSH integration tests
+
+- macOS and Linux temporary-directory creation;
+- real Citadel SFTP streamed writes;
+- directory mode `0700` and file mode `0600`;
+- `.part` to final atomic rename;
+- current-operation compensation after failure and cancellation;
+- SFTP-disabled error behavior with no fallback;
+- shared channel permits with events and Attach active;
+- disconnect and `MaxSessions` exhaustion;
+- no image bytes written to the PTY.
+
+### iOS interaction verification
+
+- Photos selection and cancellation;
+- `Attach Image` availability in live and disconnected Attach states;
+- real preparation and upload progress;
+- disabled local input while remote output continues;
+- background cancellation and foreground Retry;
+- system Paste in Text and Keys modes;
+- multiline review and unsafe-control rejection;
+- physical-keyboard `Command+V`;
+- VoiceOver labels and focus order.
+
+Agent/model image interpretation is intentionally not an acceptance criterion.
+
+## Acceptance criteria
+
+The MVP is ready when:
+
+1. One selected image is normalized within the documented dimension and size
+   bounds.
+2. The normalized file is staged over real SFTP on both supported Host
+   operating systems.
+3. Remote directory and file permissions are enforced before sensitive bytes
+   are exposed.
+4. Image bytes never enter the Attach PTY or Herdr JSON API.
+5. Upload uses the existing bounded SSH session-channel capacity.
+6. Clipboard copy occurs only after successful staging and uses local-only,
+   expiring data.
+7. Automatic insertion targets only the original live Attach session.
+8. The inserted sequence is the path followed by a separate space, with no
+   Enter.
+9. Failure, partial success, cancellation, retry, backgrounding, and session
+   replacement have verified state transitions.
+10. The mobile client never enumerates or deletes completed remote Staged
+    Images.
+
+## Primary sources
+
+- [Apple: Selecting photos and videos in iOS](https://developer.apple.com/documentation/photokit/selecting-photos-and-videos-in-ios)
+- [Apple: What's new in the Photos picker](https://developer.apple.com/videos/play/wwdc2022/10023/)
+- [Apple: UIPasteControl](https://developer.apple.com/documentation/uikit/uipastecontrol)
+- [Apple: UIPasteConfigurationSupporting](https://developer.apple.com/documentation/uikit/uipasteconfigurationsupporting)
+- [Apple: UIPasteboard](https://developer.apple.com/documentation/uikit/uipasteboard/)
+- [RFC 4254: The Secure Shell Connection Protocol](https://datatracker.ietf.org/doc/html/rfc4254)
+- [Citadel SFTP client](https://github.com/orlandos-nl/Citadel/blob/ae8562f895de06ccb86fdb1cbb65fd99c8976e12/README.md#sftp-client)
+- [Herdr remote workflow](https://herdr.dev/docs/how-to-work/)
+- [Herdr clipboard bridge commit](https://github.com/ogulcancelik/herdr/commit/ed478be)


### PR DESCRIPTION
## Summary

- add safe PhotosPicker image normalization with metadata stripping and bounded output
- stage private temporary images over SFTP with atomic completion and path-safe logging
- add Attach image progress, cancellation, retry, session-bound insertion, clipboard recovery, and terminal paste safeguards

## Testing

- `scripts/generate-wire-types.py --check --schema scripts/herdr-schema.json`
- `xcodebuild test -quiet -project HerdrMobile.xcodeproj -scheme HerdrMobile -destination "platform=iOS Simulator,name=iPhone 17,OS=latest"`
- 309 tests passed, 0 failed, 0 skipped
- real localhost SSH/SFTP integration: 62 tests passed, including 5 image staging tests
- Computer Use acceptance on iPhone 17 Pro Simulator: Photos Picker, staged image insertion without Enter, paste review/cancel, keyboard modes, and foreground recovery

## Manual validation

- Linux SSH portability
- physical iPhone/iPad Photos Picker and file protection
- hardware Command+V and VoiceOver focus order

Refs #50