### PR TITLE
refactor: deepen runtime ownership across transport, attach and console

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Rediscovering these is expensive; they were verified against herdr 0.7.4 source 
 - The API schema is exported offline via `herdr api schema --json` (JSON Schema 2020-12, ~85 methods). Its `$ref` paths are non-standard nested (`#/schemas/request/$defs/X`) — preprocess before feeding codegen tools. 26 event kinds are subscribable but only 3 have typed payloads; verify others empirically.
 - SSH exec channels are session channels, capped by sshd's `MaxSessions` (default 10) per connection. All RPC traffic must go through a request queue that bounds concurrency.
 - `herdr agent attach` requires a TTY (ratatui). It works over an exec channel only when a PTY is requested.
+- herdr 0.7.5 tightened `agent.start` (verified against a live 0.7.5 server): the kind must be on its supported-agent list (arbitrary commands like `bash -i` are rejected with `unsupported interactive agent kind`), and a freshly created pane is rejected with `agent_pane_busy` ("not an available shell") until its shell reaches the interactive prompt — a few seconds. The transport retries on that code; see `SSHTransport.startAgentAwaitingShell`.
 - Default remote socket: `~/.config/herdr/herdr.sock`; named sessions live under `~/.config/herdr/sessions/<name>/herdr.sock`. Resolve `$HOME` over exec once per host.
 - If the herdr server is not running, connecting to the socket fails outright; there is no auto-start on the socket path. Fallback: run a herdr CLI command over exec (verify auto-spawn behavior — open question).
 

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		A2B3C4D5E6F7012345678901 /* AgentAttachStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F7012345678902 /* AgentAttachStore.swift */; };
+		A3B4C5D6E7F8012345678901 /* HostConsoleProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B4C5D6E7F8012345678902 /* HostConsoleProjection.swift */; };
 		006767F8F679B28FDC853D69 /* ConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44D9663DAB1E8942FBFCD1C /* ConsoleView.swift */; };
 		017151AEC5D404665A3FAB41 /* HostDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE12859365BC7A57B9EC256A /* HostDraft.swift */; };
 		033E8DCA2F64ABE6CA898758 /* EventsSessionSubscriptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA5E9DDE1AB0F68F6EC56EB /* EventsSessionSubscriptionsTests.swift */; };
@@ -120,6 +121,7 @@
 
 /* Begin PBXFileReference section */
 		A2B3C4D5E6F7012345678902 /* AgentAttachStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAttachStore.swift; sourceTree = "<group>"; };
+		A3B4C5D6E7F8012345678902 /* HostConsoleProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostConsoleProjection.swift; sourceTree = "<group>"; };
 		02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportFailureModesE2ETests.swift; sourceTree = "<group>"; };
 		079394F4C6AC8FE4D7B0779C /* ConsoleStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleStoreTests.swift; sourceTree = "<group>"; };
 		08E14A4298DB015E6477F789 /* StartAgentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStore.swift; sourceTree = "<group>"; };
@@ -394,6 +396,7 @@
 				498ECBCD631F9734C28861EA /* ConsoleAgent.swift */,
 				A95E62CA572C71B2C746E972 /* ConsoleStore.swift */,
 				C44D9663DAB1E8942FBFCD1C /* ConsoleView.swift */,
+				A3B4C5D6E7F8012345678902 /* HostConsoleProjection.swift */,
 				08E14A4298DB015E6477F789 /* StartAgentStore.swift */,
 				18AE2DC88A745FB457350957 /* StartAgentView.swift */,
 			);
@@ -532,6 +535,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A2B3C4D5E6F7012345678901 /* AgentAttachStore.swift in Sources */,
+				A3B4C5D6E7F8012345678901 /* HostConsoleProjection.swift in Sources */,
 				6CBE7E0961FFD970A614ED4B /* AgentCardView.swift in Sources */,
 				2CE9115816E7CE945ABCF7A8 /* AgentDetailView.swift in Sources */,
 				225ECBDC69A7785559BC4D20 /* AttachTerminalStore.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		9C1C00F36A178BF1BEE6C0A5 /* StartAgentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E14A4298DB015E6477F789 /* StartAgentStore.swift */; };
 		9F3F748E722FD8059A59ECBD /* HostStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6434D31A79422C0BAE80993F /* HostStoreTests.swift */; };
 		A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */; };
+		A1B2C3D4E5F6012345678901 /* SSHChannelBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6012345678902 /* SSHChannelBudget.swift */; };
+		A1B2C3D4E5F6012345678903 /* SSHChannelBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6012345678904 /* SSHChannelBudgetTests.swift */; };
 		A14E6D20D1216F7764E3298B /* PhotosPickerImageSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89863F261DC0C6F317D75786 /* PhotosPickerImageSelection.swift */; };
 		B0D87D1783C80597B66EDDFC /* HerdrAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD390F4EE653187BCF20037F /* HerdrAPITypes.swift */; };
 		B31E16D56EE1F19A3802625B /* TransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4476B101AA4B13190C7A7B7C /* TransportConnector.swift */; };
@@ -171,6 +173,8 @@
 		9AECAD39A269D97DAB4ED194 /* HostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStore.swift; sourceTree = "<group>"; };
 		9B106E427EE5358088B615CE /* InMemorySecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemorySecretStore.swift; sourceTree = "<group>"; };
 		9B4847B965ACCAC480398065 /* ImageAttachStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachStore.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F6012345678902 /* SSHChannelBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHChannelBudget.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F6012345678904 /* SSHChannelBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHChannelBudgetTests.swift; sourceTree = "<group>"; };
 		A32D737E753ABEB2809975EA /* ImageStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStagingTests.swift; sourceTree = "<group>"; };
 		A549DEB5B5CE8FDD29CE2A28 /* AttachTerminalStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachTerminalStoreTests.swift; sourceTree = "<group>"; };
 		A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrEventsTests.swift; sourceTree = "<group>"; };
@@ -266,6 +270,7 @@
 				567573855DCC8571BC02096D /* SecretStore.swift */,
 				3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */,
 				90875ADAF6E348E186C8125A /* SSHCredentials.swift */,
+				A1B2C3D4E5F6012345678902 /* SSHChannelBudget.swift */,
 				7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */,
 				8007AF9894BE8BAFFA7A6372 /* TerminalAttach.swift */,
 				BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */,
@@ -328,6 +333,7 @@
 				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
 				6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */,
 				5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */,
+				A1B2C3D4E5F6012345678904 /* SSHChannelBudgetTests.swift */,
 				F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */,
 				A71CE71D20ABB90D7E94264E /* StartAgentStoreTests.swift */,
 				D83F34B22988623AD8E2093C /* TerminalAttachE2ETests.swift */,
@@ -555,6 +561,7 @@
 				A14E6D20D1216F7764E3298B /* PhotosPickerImageSelection.swift in Sources */,
 				B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */,
 				8C514AFC85DAED69A4988C13 /* SSHCredentials.swift in Sources */,
+				A1B2C3D4E5F6012345678901 /* SSHChannelBudget.swift in Sources */,
 				073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */,
 				693B0173C07DAF4BFC89B094 /* SecretStore.swift in Sources */,
 				1E26593A1B05B0ACEE9AC557 /* SettingsView.swift in Sources */,
@@ -610,6 +617,7 @@
 				1BBEEF5478D91222F48C2048 /* ReconnectPolicyTests.swift in Sources */,
 				3DC1B4DCC0E2CD73A0C13B64 /* SSHAuthE2ETests.swift in Sources */,
 				5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */,
+				A1B2C3D4E5F6012345678903 /* SSHChannelBudgetTests.swift in Sources */,
 				E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */,
 				473F834A4C680F18BA303DB9 /* ScriptedTransport.swift in Sources */,
 				6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A2B3C4D5E6F7012345678901 /* AgentAttachStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F7012345678902 /* AgentAttachStore.swift */; };
 		006767F8F679B28FDC853D69 /* ConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44D9663DAB1E8942FBFCD1C /* ConsoleView.swift */; };
 		017151AEC5D404665A3FAB41 /* HostDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE12859365BC7A57B9EC256A /* HostDraft.swift */; };
 		033E8DCA2F64ABE6CA898758 /* EventsSessionSubscriptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA5E9DDE1AB0F68F6EC56EB /* EventsSessionSubscriptionsTests.swift */; };
@@ -118,6 +119,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A2B3C4D5E6F7012345678902 /* AgentAttachStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAttachStore.swift; sourceTree = "<group>"; };
 		02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportFailureModesE2ETests.swift; sourceTree = "<group>"; };
 		079394F4C6AC8FE4D7B0779C /* ConsoleStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleStoreTests.swift; sourceTree = "<group>"; };
 		08E14A4298DB015E6477F789 /* StartAgentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStore.swift; sourceTree = "<group>"; };
@@ -384,6 +386,7 @@
 		AEEB5E7751FD30413560D58D /* Console */ = {
 			isa = PBXGroup;
 			children = (
+				A2B3C4D5E6F7012345678902 /* AgentAttachStore.swift */,
 				0B3FA15CCDC83C72DDA81BEB /* AgentCardView.swift */,
 				5ADF336771A3F757F2AD441D /* AgentDetailView.swift */,
 				97970F4D535CC80592333995 /* AttachTerminalStore.swift */,
@@ -528,6 +531,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A2B3C4D5E6F7012345678901 /* AgentAttachStore.swift in Sources */,
 				6CBE7E0961FFD970A614ED4B /* AgentCardView.swift in Sources */,
 				2CE9115816E7CE945ABCF7A8 /* AgentDetailView.swift in Sources */,
 				225ECBDC69A7785559BC4D20 /* AttachTerminalStore.swift in Sources */,

--- a/Sources/HerdrMobile/Console/AgentAttachStore.swift
+++ b/Sources/HerdrMobile/Console/AgentAttachStore.swift
@@ -133,14 +133,15 @@ final class AgentAttachStore {
     }
 
     /// A new Transport requires a new terminal pipeline. The replacement is
-    /// serialized behind any earlier transition and starts only after image
-    /// work and the old terminal have both finished.
+    /// serialized behind any earlier transition and starts only after the
+    /// old terminal has finished. Image state deliberately survives: the
+    /// stager resolves the live Transport per call, so a retryable or
+    /// completed upload stays actionable across the reconnect.
     func transportGenerationDidChange(_ generation: UInt64?) {
         guard let generation, generation != transportGeneration, !hasLeft else { return }
         transportGeneration = generation
         enqueueLifecycleTransition { [weak self] in
             guard let self, !self.hasLeft, self.transportGeneration == generation else { return }
-            await self.image.leaveAttach()
             let previous = self.terminal
             await previous.stop()
             guard !self.hasLeft, self.transportGeneration == generation else { return }

--- a/Sources/HerdrMobile/Console/AgentAttachStore.swift
+++ b/Sources/HerdrMobile/Console/AgentAttachStore.swift
@@ -1,0 +1,198 @@
+import Foundation
+import Observation
+
+/// Owns the complete Agent Attach interaction: terminal lifetime, input
+/// generation and pause state, image staging, reconnect replacement, close,
+/// and deterministic leave ordering. The view only forwards UI events.
+@MainActor
+@Observable
+final class AgentAttachStore {
+    private let target: String
+    private let runTerminal: TerminalSessionRunner
+
+    private(set) var terminal: AttachTerminalStore
+    let input: TerminalInputController
+    let image: ImageAttachStore
+    let close: ClosePaneStore
+
+    private var transportGeneration: UInt64?
+    private var lifecycleTask: Task<Void, Never>?
+    private var lifecycleID: UInt64 = 0
+    private var hasLeft = false
+
+    init(
+        target: String,
+        paneTitle: String,
+        transportGeneration: UInt64?,
+        runTerminal: @escaping TerminalSessionRunner,
+        stageImage: @escaping ImageStager,
+        closePane: @escaping () async throws -> Void
+    ) {
+        let input = TerminalInputController()
+        self.target = target
+        self.runTerminal = runTerminal
+        self.transportGeneration = transportGeneration
+        self.input = input
+        terminal = AttachTerminalStore(
+            target: target, input: input, runTerminal: runTerminal)
+        image = ImageAttachStore(stageImage: stageImage, input: input)
+        close = ClosePaneStore(paneTitle: paneTitle, close: closePane)
+    }
+
+    var terminalID: ObjectIdentifier {
+        ObjectIdentifier(terminal)
+    }
+
+    var terminalStatus: AttachTerminalStore.Status {
+        terminal.status
+    }
+
+    var terminalFeed: TerminalByteFeed {
+        terminal.feed
+    }
+
+    var imageState: ImageAttachState {
+        image.state
+    }
+
+    var canSelectImage: Bool {
+        terminal.status == .live && image.canSelectImage
+    }
+
+    var isLocalInputEnabled: Bool {
+        !input.isPaused
+    }
+
+    var pendingPaste: TerminalInputController.PasteReview? {
+        input.pendingPaste
+    }
+
+    var pasteErrorMessage: String? {
+        input.pasteErrorMessage
+    }
+
+    var closeFailureMessage: String? {
+        guard case .failed(let message) = close.state else { return nil }
+        return message
+    }
+
+    func viewDidResize(cols: Int, rows: Int) {
+        terminal.viewDidResize(cols: cols, rows: rows)
+    }
+
+    func send(_ keystrokes: Data) {
+        terminal.send(keystrokes)
+    }
+
+    func requestPaste(_ text: String) {
+        _ = input.requestPaste(text)
+    }
+
+    func cancelPaste() {
+        input.cancelPaste()
+    }
+
+    func confirmPaste() {
+        _ = input.confirmPaste()
+    }
+
+    func clearPasteError() {
+        input.clearPasteError()
+    }
+
+    func selectImage(_ selection: any ImageSelection) {
+        image.select(selection)
+    }
+
+    func cancelImage() {
+        image.cancel()
+    }
+
+    func retryImage() {
+        image.retry()
+    }
+
+    func dismissImageResult() {
+        image.dismissResult()
+    }
+
+    func copyImagePath() {
+        image.copyPath()
+    }
+
+    func insertImagePath() {
+        image.insertPath()
+    }
+
+    func didBecomeActive() {
+        image.didBecomeActive()
+    }
+
+    func didEnterBackground() {
+        image.didEnterBackground()
+    }
+
+    /// A new Transport requires a new terminal pipeline. The replacement is
+    /// serialized behind any earlier transition and starts only after image
+    /// work and the old terminal have both finished.
+    func transportGenerationDidChange(_ generation: UInt64?) {
+        guard let generation, generation != transportGeneration, !hasLeft else { return }
+        transportGeneration = generation
+        enqueueLifecycleTransition { [weak self] in
+            guard let self, !self.hasLeft, self.transportGeneration == generation else { return }
+            await self.image.leaveAttach()
+            let previous = self.terminal
+            await previous.stop()
+            guard !self.hasLeft, self.transportGeneration == generation else { return }
+            self.terminal = AttachTerminalStore(
+                target: self.target,
+                input: self.input,
+                runTerminal: self.runTerminal)
+        }
+    }
+
+    func retryTerminal() {
+        terminal.retry()
+    }
+
+    func confirmClose() async -> Bool {
+        await close.confirmClose()
+        guard close.state == .closed else { return false }
+        await leave()
+        return true
+    }
+
+    func leave() async {
+        guard !hasLeft else {
+            await lifecycleTask?.value
+            return
+        }
+        hasLeft = true
+        let transition = enqueueLifecycleTransition { [weak self] in
+            guard let self else { return }
+            await self.image.leaveAttach()
+            await self.terminal.stop()
+        }
+        await transition.value
+    }
+
+    @discardableResult
+    private func enqueueLifecycleTransition(
+        _ operation: @escaping @MainActor @Sendable () async -> Void
+    ) -> Task<Void, Never> {
+        let previous = lifecycleTask
+        lifecycleID &+= 1
+        let id = lifecycleID
+        let task = Task { @MainActor in
+            await previous?.value
+            await operation()
+        }
+        lifecycleTask = task
+        Task { @MainActor [weak self] in
+            await task.value
+            guard self?.lifecycleID == id else { return }
+            self?.lifecycleTask = nil
+        }
+        return task
+    }
+}

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -8,11 +8,7 @@ struct AgentDetailView: View {
     let agent: ConsoleAgent
     private let console: ConsoleStore
     private let terminalThemes: TerminalThemeSettings
-    private let runTerminal: TerminalSessionRunner
-    @State private var input: TerminalInputController
-    @State private var store: AttachTerminalStore
-    @State private var imageAttach: ImageAttachStore
-    @State private var close: ClosePaneStore
+    @State private var attach: AgentAttachStore
     @State private var selectedPhoto: PhotosPickerItem?
     @State private var isConfirmingClose = false
     @State private var isShowingSettings = false
@@ -28,37 +24,30 @@ struct AgentDetailView: View {
         self.agent = agent
         self.console = console
         self.terminalThemes = terminalThemes
-        let runTerminal = console.terminalRunner(for: agent.hostID)
-        let input = TerminalInputController()
-        self.runTerminal = runTerminal
-        _input = State(initialValue: input)
-        _store = State(
-            initialValue: AttachTerminalStore(
+        _attach = State(
+            initialValue: AgentAttachStore(
                 target: agent.agent.paneID,
-                input: input,
-                runTerminal: runTerminal))
-        _imageAttach = State(
-            initialValue: ImageAttachStore(
-                stageImage: console.imageStager(for: agent.hostID),
-                input: input))
-        _close = State(
-            initialValue: ClosePaneStore(paneTitle: Self.displayTitle(for: agent)) {
+                paneTitle: Self.displayTitle(for: agent),
+                transportGeneration: console.hostConnectionGenerations[agent.hostID],
+                runTerminal: console.terminalRunner(for: agent.hostID),
+                stageImage: console.imageStager(for: agent.hostID)
+            ) {
                 try await console.closePane(agent.agent.paneID, on: agent.hostID)
             })
     }
 
     var body: some View {
         TerminalScreenView(
-            feed: store.feed,
+            feed: attach.terminalFeed,
             onSizeChanged: { cols, rows in
-                store.viewDidResize(cols: cols, rows: rows)
+                attach.viewDidResize(cols: cols, rows: rows)
             },
-            onSend: { keystrokes in store.send(keystrokes) },
-            onPaste: { text in _ = input.requestPaste(text) },
-            isLocalInputEnabled: !input.isPaused,
+            onSend: { keystrokes in attach.send(keystrokes) },
+            onPaste: { text in attach.requestPaste(text) },
+            isLocalInputEnabled: attach.isLocalInputEnabled,
             theme: terminalThemes.theme
         )
-        .id(ObjectIdentifier(store))
+        .id(attach.terminalID)
         .overlay { statusOverlay }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             imageAttachStatus
@@ -70,7 +59,7 @@ struct AgentDetailView: View {
                 PhotosPicker(selection: $selectedPhoto, matching: .images) {
                     Label("Attach Image", systemImage: "photo.badge.plus")
                 }
-                .disabled(store.status != .live || !imageAttach.canSelectImage)
+                .disabled(!attach.canSelectImage)
                 .accessibilityLabel("Attach Image")
             }
             ToolbarItem(placement: .primaryAction) {
@@ -94,8 +83,8 @@ struct AgentDetailView: View {
         }
         .sheet(
             isPresented: Binding(
-                get: { input.pendingPaste != nil },
-                set: { if !$0 { input.cancelPaste() } })
+                get: { attach.pendingPaste != nil },
+                set: { if !$0 { attach.cancelPaste() } })
         ) {
             pasteReviewSheet
         }
@@ -124,26 +113,26 @@ struct AgentDetailView: View {
         .alert(
             "Paste Blocked",
             isPresented: Binding(
-                get: { input.pasteErrorMessage != nil },
-                set: { if !$0 { input.clearPasteError() } })
+                get: { attach.pasteErrorMessage != nil },
+                set: { if !$0 { attach.clearPasteError() } })
         ) {
             Button("OK", role: .cancel) {
-                input.clearPasteError()
+                attach.clearPasteError()
             }
         } message: {
-            Text(input.pasteErrorMessage ?? "")
+            Text(attach.pasteErrorMessage ?? "")
         }
         .onChange(of: selectedPhoto) { _, item in
             guard let item else { return }
             selectedPhoto = nil
-            imageAttach.select(PhotosPickerImageSelection(item: item))
+            attach.selectImage(PhotosPickerImageSelection(item: item))
         }
         .onChange(of: scenePhase) { _, phase in
             switch phase {
             case .active:
-                imageAttach.didBecomeActive()
+                attach.didBecomeActive()
             case .background:
-                imageAttach.didEnterBackground()
+                attach.didEnterBackground()
             case .inactive:
                 break
             @unknown default:
@@ -151,44 +140,24 @@ struct AgentDetailView: View {
             }
         }
         .onChange(of: console.hostConnectionGenerations[agent.hostID]) { _, generation in
-            guard generation != nil else { return }
-            reconnect()
+            attach.transportGenerationDidChange(generation)
         }
         .onDisappear {
-            let terminal = store
-            let imageAttach = imageAttach
-            Task {
-                await imageAttach.leaveAttach()
-                await terminal.stop()
-            }
+            Task { await attach.leave() }
         }
-    }
-
-    private func reconnect() {
-        let previous = store
-        Task { await previous.stop() }
-        store = AttachTerminalStore(
-            target: agent.agent.paneID,
-            input: input,
-            runTerminal: runTerminal)
     }
 
     private func performClose() async {
-        await close.confirmClose()
-        switch close.state {
-        case .closed:
-            await store.stop()
+        if await attach.confirmClose() {
             dismiss()
-        case .failed(let message):
-            closeErrorMessage = message
-        case .idle, .closing:
-            break
+        } else {
+            closeErrorMessage = attach.closeFailureMessage
         }
     }
 
     @ViewBuilder
     private var statusOverlay: some View {
-        switch store.status {
+        switch attach.terminalStatus {
         case .waitingForSize, .connecting:
             ProgressView()
         case .ended(let message):
@@ -197,7 +166,7 @@ struct AgentDetailView: View {
             } description: {
                 Text(message)
             } actions: {
-                Button("Reattach") { store.retry() }
+                Button("Reattach") { attach.retryTerminal() }
                     .buttonStyle(.borderedProminent)
             }
         case .live, .stopped:
@@ -207,7 +176,7 @@ struct AgentDetailView: View {
 
     @ViewBuilder
     private var imageAttachStatus: some View {
-        switch imageAttach.state {
+        switch attach.imageState {
         case .idle:
             EmptyView()
         case .preparing:
@@ -216,7 +185,7 @@ struct AgentDetailView: View {
                 title: "Preparing Image…",
                 accessibilityLabel: "Preparing Image"
             ) {
-                Button("Cancel", role: .cancel) { imageAttach.cancel() }
+                Button("Cancel", role: .cancel) { attach.cancelImage() }
             }
         case .uploading(let progress):
             ImageAttachStatusBar(
@@ -225,7 +194,7 @@ struct AgentDetailView: View {
                 accessibilityLabel:
                     "Uploading Image, \(Int(progress.fractionCompleted * 100)) percent"
             ) {
-                Button("Cancel", role: .cancel) { imageAttach.cancel() }
+                Button("Cancel", role: .cancel) { attach.cancelImage() }
             }
         case .failed(let failure), .backgroundInterrupted(let failure):
             ImageAttachStatusBar(
@@ -234,9 +203,9 @@ struct AgentDetailView: View {
                 accessibilityLabel: failure.message
             ) {
                 if failure.isRetryable {
-                    Button("Retry") { imageAttach.retry() }
+                    Button("Retry") { attach.retryImage() }
                 }
-                Button("Dismiss", role: .cancel) { imageAttach.dismissResult() }
+                Button("Dismiss", role: .cancel) { attach.dismissImageResult() }
             }
         case .completed(let result):
             ImageAttachStatusBar(
@@ -245,19 +214,19 @@ struct AgentDetailView: View {
                 accessibilityLabel: result.message
             ) {
                 if !result.copied {
-                    Button("Copy Path") { imageAttach.copyPath() }
+                    Button("Copy Path") { attach.copyImagePath() }
                 }
                 if !result.inserted {
-                    Button("Insert Path") { imageAttach.insertPath() }
+                    Button("Insert Path") { attach.insertImagePath() }
                 }
-                Button("Done", role: .cancel) { imageAttach.dismissResult() }
+                Button("Done", role: .cancel) { attach.dismissImageResult() }
             }
         }
     }
 
     @ViewBuilder
     private var pasteReviewSheet: some View {
-        if let review = input.pendingPaste {
+        if let review = attach.pendingPaste {
             NavigationStack {
                 VStack(alignment: .leading, spacing: 12) {
                     Text(
@@ -278,10 +247,10 @@ struct AgentDetailView: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel", role: .cancel) { input.cancelPaste() }
+                        Button("Cancel", role: .cancel) { attach.cancelPaste() }
                     }
                     ToolbarItem(placement: .confirmationAction) {
-                        Button("Paste") { _ = input.confirmPaste() }
+                        Button("Paste") { attach.confirmPaste() }
                     }
                 }
             }

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -8,7 +8,7 @@ struct AgentDetailView: View {
     let agent: ConsoleAgent
     private let console: ConsoleStore
     private let terminalThemes: TerminalThemeSettings
-    private let transport: @Sendable () async -> (any Transport)?
+    private let runTerminal: TerminalSessionRunner
     @State private var input: TerminalInputController
     @State private var store: AttachTerminalStore
     @State private var imageAttach: ImageAttachStore
@@ -28,18 +28,18 @@ struct AgentDetailView: View {
         self.agent = agent
         self.console = console
         self.terminalThemes = terminalThemes
-        let transport = console.transportProvider(for: agent.hostID)
+        let runTerminal = console.terminalRunner(for: agent.hostID)
         let input = TerminalInputController()
-        self.transport = transport
+        self.runTerminal = runTerminal
         _input = State(initialValue: input)
         _store = State(
             initialValue: AttachTerminalStore(
                 target: agent.agent.paneID,
                 input: input,
-                transport: transport))
+                runTerminal: runTerminal))
         _imageAttach = State(
             initialValue: ImageAttachStore(
-                transport: transport,
+                stageImage: console.imageStager(for: agent.hostID),
                 input: input))
         _close = State(
             initialValue: ClosePaneStore(paneTitle: Self.displayTitle(for: agent)) {
@@ -157,7 +157,7 @@ struct AgentDetailView: View {
         .onDisappear {
             let terminal = store
             let imageAttach = imageAttach
-            console.scheduleTerminalTeardown(for: agent.hostID) {
+            Task {
                 await imageAttach.leaveAttach()
                 await terminal.stop()
             }
@@ -166,13 +166,11 @@ struct AgentDetailView: View {
 
     private func reconnect() {
         let previous = store
-        console.scheduleTerminalTeardown(for: agent.hostID) {
-            await previous.stop()
-        }
+        Task { await previous.stop() }
         store = AttachTerminalStore(
             target: agent.agent.paneID,
             input: input,
-            transport: transport)
+            runTerminal: runTerminal)
     }
 
     private func performClose() async {

--- a/Sources/HerdrMobile/Console/AttachTerminalStore.swift
+++ b/Sources/HerdrMobile/Console/AttachTerminalStore.swift
@@ -1,6 +1,24 @@
 import Foundation
 import Observation
 
+typealias TerminalSessionOperation =
+    @MainActor @Sendable (TerminalAttachSession) async throws -> Void
+typealias TerminalSessionRunner =
+    @Sendable (TerminalAttachRequest, TerminalSessionHandler) async throws -> Void
+
+struct TerminalSessionHandler: Sendable {
+    private let operation: TerminalSessionOperation
+
+    init(_ operation: @escaping TerminalSessionOperation) {
+        self.operation = operation
+    }
+
+    @MainActor
+    func run(_ session: TerminalAttachSession) async throws {
+        try await operation(session)
+    }
+}
+
 /// The Agent detail screen's session pipeline: a full interactive terminal
 /// over the Host's terminal channel — raw PTY bytes into the view through a
 /// `TerminalByteFeed`, keystrokes back out, geometry changes as SSH
@@ -35,9 +53,9 @@ final class AttachTerminalStore {
     private let target: String
     private let takeover: Bool
     private let input: TerminalInputController
-    /// The Host's current transport, re-queried per (re)attach: the events
-    /// session underneath may have reconnected onto a fresh one.
-    private let transport: @Sendable () async -> (any Transport)?
+    /// Opens and owns exclusive Host terminal access for one complete run,
+    /// including explicit channel teardown.
+    private let runTerminal: TerminalSessionRunner
 
     private var cols: Int?
     private var rows: Int?
@@ -49,12 +67,12 @@ final class AttachTerminalStore {
     init(
         target: String, takeover: Bool = false,
         input: TerminalInputController = TerminalInputController(),
-        transport: @escaping @Sendable () async -> (any Transport)?
+        runTerminal: @escaping TerminalSessionRunner
     ) {
         self.target = target
         self.takeover = takeover
         self.input = input
-        self.transport = transport
+        self.runTerminal = runTerminal
     }
 
     /// The terminal view's geometry, reported on first layout and on every
@@ -109,20 +127,33 @@ final class AttachTerminalStore {
     /// the stream ends, surface how it ended.
     private func run() async {
         defer { runTask = nil }
-        guard let transport = await transport() else {
-            status = .ended("The Host is not connected.")
-            return
-        }
         guard let cols, let rows else { return }
-        let session: TerminalAttachSession
         do {
-            session = try await transport.attachTerminal(
-                TerminalAttachRequest(target: target, takeover: takeover, cols: cols, rows: rows))
+            try await runTerminal(
+                TerminalAttachRequest(
+                    target: target, takeover: takeover, cols: cols, rows: rows),
+                TerminalSessionHandler { [weak self] session in
+                    guard let self else {
+                        await session.end()
+                        return
+                    }
+                    try await self.consume(
+                        session, initialCols: cols, initialRows: rows)
+                })
         } catch {
             guard !stopRequested else { return }
             status = .ended(Self.message(for: error))
             return
         }
+        guard !stopRequested else { return }
+        status = .ended("The session ended.")
+    }
+
+    private func consume(
+        _ session: TerminalAttachSession,
+        initialCols: Int,
+        initialRows: Int
+    ) async throws {
         if stopRequested {
             await session.end()
             return
@@ -133,33 +164,37 @@ final class AttachTerminalStore {
         }
         self.inputGeneration = inputGeneration
         status = .live
-        if let latestCols = self.cols, let latestRows = self.rows,
-            latestCols != cols || latestRows != rows
+        if let latestCols = cols, let latestRows = rows,
+            latestCols != initialCols || latestRows != initialRows
         {
             // The view resized while the channel was coming up; catch the
             // remote PTY up to the latest geometry.
             session.resize(cols: latestCols, rows: latestRows)
         }
 
-        var failure: (any Error)?
         do {
             for try await bytes in session.output {
                 feed.write(bytes)
             }
         } catch {
-            failure = error
+            finishSession(inputGeneration)
+            throw error
         }
+        finishSession(inputGeneration)
+    }
+
+    private func finishSession(_ inputGeneration: TerminalInputController.SessionGeneration) {
         self.session = nil
         input.endSession(inputGeneration)
         if self.inputGeneration == inputGeneration {
             self.inputGeneration = nil
         }
-        guard !stopRequested else { return }
-        status = .ended(failure.map(Self.message(for:)) ?? "The session ended.")
     }
 
     private static func message(for error: any Error) -> String {
         switch error {
+        case TransportError.sshUnreachable:
+            "The Host is not connected."
         case TransportError.terminalChannelAlreadyOpen:
             "Another terminal is already open on this Host."
         case TransportError.timedOut:

--- a/Sources/HerdrMobile/Console/ConsoleStore.swift
+++ b/Sources/HerdrMobile/Console/ConsoleStore.swift
@@ -27,19 +27,14 @@ final class ConsoleStore {
     /// Snapshot failures are separate from connection state: an events
     /// channel can remain connected while the Console data RPC is failing.
     private(set) var hostSyncErrors: [Host.ID: String] = [:]
-    /// Monotonic reconnect epochs per Host. Initial connection is generation
-    /// zero; only a return to connected after a real disconnect advances it.
+    /// Monotonic Transport generations per Host, projected directly from
+    /// `EventsSession`. Subscription-only reconnects do not advance it.
     private(set) var hostConnectionGenerations: [Host.ID: UInt64] = [:]
 
     @ObservationIgnored private var feeds: [Host.ID: HostFeed] = [:]
     @ObservationIgnored private let makeSession:
         @Sendable (Host, [EventSubscription]) -> EventsSession
     @ObservationIgnored private let snapshotRetryDelay: Duration
-    /// Explicit terminal-channel teardowns registered synchronously by a
-    /// disappearing detail screen. A new detail waits for the latest task,
-    /// preventing Attach from racing the previous screen's channel close.
-    @ObservationIgnored private var terminalTeardowns: [Host.ID: TerminalTeardown] = [:]
-    @ObservationIgnored private var nextTerminalTeardownID: UInt64 = 0
     /// Whether the Console should hold live connections (foregrounded);
     /// feeds started while suspended stay down until `resume()`.
     @ObservationIgnored private var isActive = false
@@ -120,17 +115,13 @@ final class ConsoleStore {
         guard feeds[feed.host.id] === feed else { return }
         switch update {
         case .status(let status):
-            if status == .connected {
-                if feed.hasConnected, feed.connectionWasInterrupted {
-                    hostConnectionGenerations[feed.host.id, default: 0] &+= 1
-                }
-                feed.hasConnected = true
-                feed.connectionWasInterrupted = false
-            } else if feed.hasConnected {
-                feed.connectionWasInterrupted = true
-            }
             hostStatuses[feed.host.id] = status
             if status == .connected {
+                Task { [weak self] in
+                    let generation = await feed.session.transportGeneration
+                    guard let self, self.feeds[feed.host.id] === feed else { return }
+                    self.hostConnectionGenerations[feed.host.id] = generation
+                }
                 scheduleResync(feed: feed)
             }
         case .event(let event):
@@ -162,9 +153,10 @@ final class ConsoleStore {
 
     private func runResync(feed: HostFeed) async {
         let statusRevisionBeforeSnapshot = feed.statusChangeRevision
-        guard let transport = await feed.session.currentTransport else { return }
         do {
-            let snapshot = try await transport.sessionSnapshot()
+            let snapshot = try await feed.session.withTransport { transport in
+                try await transport.sessionSnapshot()
+            }
             guard feeds[feed.host.id] === feed else { return }
             feed.resyncRetryTask?.cancel()
             feed.resyncRetryTask = nil
@@ -174,7 +166,7 @@ final class ConsoleStore {
                 preservingStatusChangesAfter: statusRevisionBeforeSnapshot)
             await feed.session.updateSubscriptions(
                 Self.subscriptions(paneIDs: feed.byPane.keys))
-            refreshSnippets(feed: feed, transport: transport)
+            refreshSnippets(feed: feed)
         } catch {
             guard feeds[feed.host.id] === feed else { return }
             hostSyncErrors[feed.host.id] = Self.snapshotErrorMessage(error)
@@ -259,8 +251,7 @@ final class ConsoleStore {
         // A status flip usually means fresh output worth showing — for
         // Blocked, it is the very question the user must answer.
         Task { [weak self] in
-            guard let transport = await feed.session.currentTransport else { return }
-            self?.refreshSnippet(feed: feed, paneID: paneID, transport: transport)
+            self?.refreshSnippet(feed: feed, paneID: paneID)
         }
     }
 
@@ -274,13 +265,13 @@ final class ConsoleStore {
     /// trailing non-blank line of that window.
     private static let snippetReadLines = 6
 
-    private func refreshSnippets(feed: HostFeed, transport: any Transport) {
+    private func refreshSnippets(feed: HostFeed) {
         for paneID in feed.byPane.keys {
-            refreshSnippet(feed: feed, paneID: paneID, transport: transport)
+            refreshSnippet(feed: feed, paneID: paneID)
         }
     }
 
-    private func refreshSnippet(feed: HostFeed, paneID: String, transport: any Transport) {
+    private func refreshSnippet(feed: HostFeed, paneID: String) {
         // One in-flight read per pane; a burst of status flips must not pile
         // requests onto the slot queue.
         guard feed.snippetFetchesInFlight.insert(paneID).inserted else {
@@ -288,10 +279,12 @@ final class ConsoleStore {
             return
         }
         Task { [weak self] in
-            let read = try? await transport.readPane(
-                PaneReadParams(
-                    paneID: paneID, source: .recent, lines: Self.snippetReadLines,
-                    stripANSI: true))
+            let read = try? await feed.session.withTransport { transport in
+                try await transport.readPane(
+                    PaneReadParams(
+                        paneID: paneID, source: .recent, lines: Self.snippetReadLines,
+                        stripANSI: true))
+            }
             guard let self else { return }
             feed.snippetFetchesInFlight.remove(paneID)
             guard self.feeds[feed.host.id] === feed else { return }
@@ -303,10 +296,9 @@ final class ConsoleStore {
             guard
                 feed.pendingSnippetRefreshes.remove(paneID) != nil,
                 feed.byPane[paneID] != nil,
-                let currentTransport = await feed.session.currentTransport,
                 self.feeds[feed.host.id] === feed
             else { return }
-            self.refreshSnippet(feed: feed, paneID: paneID, transport: currentTransport)
+            self.refreshSnippet(feed: feed, paneID: paneID)
         }
     }
 
@@ -319,44 +311,41 @@ final class ConsoleStore {
         return nil
     }
 
-    // MARK: Detail-screen transport access
+    // MARK: Detail-screen Host operations
 
-    /// The Host's live transport for the interactive terminal. A closure
-    /// rather than a value: the events
-    /// session may reconnect onto a fresh transport at any time, so it is
-    /// re-queried per use; nil while the Host is disconnected or gone.
-    func transportProvider(for hostID: Host.ID) -> @Sendable () async -> (any Transport)? {
-        return { [weak self] in
-            await self?.transportAfterTerminalTeardown(for: hostID)
+    func terminalRunner(for hostID: Host.ID) -> TerminalSessionRunner {
+        { [weak self] request, handler in
+            guard let session = await self?.session(for: hostID) else {
+                throw TransportError.sshUnreachable(detail: "The Host is not connected.")
+            }
+            try await session.withTerminalTransport { transport in
+                let terminal = try await transport.attachTerminal(request)
+                do {
+                    try await handler.run(terminal)
+                    await terminal.end()
+                } catch {
+                    await terminal.end()
+                    throw error
+                }
+            }
         }
     }
 
-    /// Registers teardown before `onDisappear` returns. Merely launching an
-    /// untracked Task here is insufficient: the next detail screen can ask
-    /// for the terminal slot before that Task begins executing.
-    func scheduleTerminalTeardown(
-        for hostID: Host.ID,
-        operation: @escaping @MainActor @Sendable () async -> Void
-    ) {
-        let previous = terminalTeardowns[hostID]?.task
-        nextTerminalTeardownID &+= 1
-        let id = nextTerminalTeardownID
-        let task = Task { @MainActor in
-            await previous?.value
-            await operation()
-        }
-        terminalTeardowns[hostID] = TerminalTeardown(id: id, task: task)
-        Task { @MainActor [weak self] in
-            await task.value
-            guard self?.terminalTeardowns[hostID]?.id == id else { return }
-            self?.terminalTeardowns[hostID] = nil
+    func imageStager(for hostID: Host.ID) -> ImageStager {
+        { [weak self] image, reporter in
+            guard let session = await self?.session(for: hostID) else {
+                throw TransportError.sshUnreachable(detail: "The Host is not connected.")
+            }
+            return try await session.withTransport { transport in
+                try await transport.stageImage(image) { progress in
+                    await reporter.report(progress)
+                }
+            }
         }
     }
 
-    private func transportAfterTerminalTeardown(for hostID: Host.ID) async -> (any Transport)? {
-        let teardown = terminalTeardowns[hostID]
-        await teardown?.task.value
-        return await feeds[hostID]?.session.currentTransport
+    private func session(for hostID: Host.ID) -> EventsSession? {
+        feeds[hostID]?.session
     }
 
     /// Retries Hosts whose session stopped on an action-required failure.
@@ -385,11 +374,12 @@ final class ConsoleStore {
     /// propagates the server's error when herdr rejects the start.
     @discardableResult
     func startAgent(_ request: AgentLaunchRequest, on hostID: Host.ID) async throws -> Agent {
-        guard let feed = feeds[hostID], let transport = await feed.session.currentTransport
-        else {
+        guard let feed = feeds[hostID] else {
             throw TransportError.sshUnreachable(detail: "The Host is not connected.")
         }
-        let agent = try await transport.startAgent(request)
+        let agent = try await feed.session.withTransport { transport in
+            try await transport.startAgent(request)
+        }
         // The membership event will re-snapshot too; this just makes the new
         // pane appear without waiting for it.
         scheduleResync(feed: feed)
@@ -406,11 +396,12 @@ final class ConsoleStore {
     /// rejects the close (leaving the Console untouched — the cancel/failure
     /// path never mutates state).
     func closePane(_ paneID: String, on hostID: Host.ID) async throws {
-        guard let feed = feeds[hostID], let transport = await feed.session.currentTransport
-        else {
+        guard let feed = feeds[hostID] else {
             throw TransportError.sshUnreachable(detail: "The Host is not connected.")
         }
-        try await transport.closePane(PaneTarget(paneID: paneID))
+        try await feed.session.withTransport { transport in
+            try await transport.closePane(PaneTarget(paneID: paneID))
+        }
         // The pane.closed membership event will re-snapshot too; this just
         // drops the closed pane without waiting for it.
         scheduleResync(feed: feed)
@@ -437,12 +428,6 @@ final class ConsoleStore {
         membershipKinds.map(EventSubscription.global)
             + paneIDs.sorted().map { EventSubscription.pane(.agentStatusChanged, paneID: $0) }
     }
-}
-
-@MainActor
-private struct TerminalTeardown {
-    let id: UInt64
-    let task: Task<Void, Never>
 }
 
 extension ConsoleStore {
@@ -484,8 +469,6 @@ private final class HostFeed {
     var resyncTask: Task<Void, Never>?
     var resyncRetryTask: Task<Void, Never>?
     var resyncPending = false
-    var hasConnected = false
-    var connectionWasInterrupted = false
     var byPane: [String: ConsoleAgent] = [:]
     /// Latest status deltas by pane, versioned so a snapshot only preserves
     /// events that arrived after that snapshot request began.

--- a/Sources/HerdrMobile/Console/ConsoleStore.swift
+++ b/Sources/HerdrMobile/Console/ConsoleStore.swift
@@ -1,42 +1,23 @@
 import Foundation
 import Observation
 
-/// The Console's state store (#8): the flat, status-sorted Agent list across
-/// all Hosts, snapshot-then-delta from day one (spec #20).
-///
-/// There is no replay-on-subscribe, so every `.connected` from a Host's
-/// `EventsSession` triggers an explicit `session.snapshot` re-fetch; between
-/// snapshots, `pane.agent_status_changed` deltas mutate rows in place.
-/// Membership and context changes (agent detected, pane closed, workspace
-/// renamed, ...) re-snapshot the Host instead of patching state
-/// speculatively — one cheap RPC beats replicating herdr's tree logic. The
-/// drop marker a bounded events buffer emits under overflow (#22) rides the
-/// same path: lost deltas cost one re-snapshot, never corrupted state.
-///
-/// Because `pane.agent_status_changed` subscribes per pane id, each snapshot
-/// also pushes the current pane set into the session via
-/// `updateSubscriptions`; a changed set costs one immediate re-subscribe and
-/// converges on the follow-up snapshot.
+/// The Console aggregate: reconciles the Host catalog and publishes one
+/// status-sorted Agent list across every Host. Each HostConsoleProjection
+/// owns its own convergence, retry, snippets and Host-scoped RPC behavior.
 @MainActor
 @Observable
 final class ConsoleStore {
-    /// The Console list, sorted Blocked > Working > Idle/Done.
     private(set) var agents: [ConsoleAgent] = []
-    /// Per-Host events-session status; the UI derives staleness from it.
     private(set) var hostStatuses: [Host.ID: EventsSessionStatus] = [:]
-    /// Snapshot failures are separate from connection state: an events
-    /// channel can remain connected while the Console data RPC is failing.
     private(set) var hostSyncErrors: [Host.ID: String] = [:]
-    /// Monotonic Transport generations per Host, projected directly from
-    /// `EventsSession`. Subscription-only reconnects do not advance it.
     private(set) var hostConnectionGenerations: [Host.ID: UInt64] = [:]
 
-    @ObservationIgnored private var feeds: [Host.ID: HostFeed] = [:]
+    @ObservationIgnored private var projections: [
+        Host.ID: HostConsoleProjection
+    ] = [:]
     @ObservationIgnored private let makeSession:
         @Sendable (Host, [EventSubscription]) -> EventsSession
     @ObservationIgnored private let snapshotRetryDelay: Duration
-    /// Whether the Console should hold live connections (foregrounded);
-    /// feeds started while suspended stay down until `resume()`.
     @ObservationIgnored private var isActive = false
 
     init(
@@ -48,394 +29,123 @@ final class ConsoleStore {
         self.makeSession = makeSession
     }
 
-    // MARK: Host reconciliation
-
-    /// Aligns the feeds with the Host catalog: new Hosts get a session,
-    /// removed Hosts lose theirs, edited Hosts get a fresh one (their
-    /// connection coordinates may have changed).
+    /// Aligns Host projections with the catalog. Editing a Host replaces its
+    /// projection because its connection coordinates may have changed.
     func setHosts(_ hosts: [Host]) {
         let incoming = Dictionary(hosts.map { ($0.id, $0) }) { _, last in last }
-        for (id, feed) in feeds where incoming[id] != feed.host {
-            endFeed(feed)
-            feeds[id] = nil
-            hostStatuses[id] = nil
-            hostSyncErrors[id] = nil
-            hostConnectionGenerations[id] = nil
+        for (id, projection) in projections where incoming[id] != projection.host {
+            projection.end()
+            projections[id] = nil
         }
-        for host in hosts where feeds[host.id] == nil {
-            startFeed(for: host)
+        for host in hosts where projections[host.id] == nil {
+            startProjection(for: host)
         }
         rebuild()
     }
 
-    /// Brings every Host's events session up (launch, foregrounding).
     func resume() async {
         isActive = true
-        for feed in feeds.values {
-            await feed.session.resume()
+        for projection in projections.values {
+            await projection.resume()
         }
     }
 
-    /// Tears every session down deliberately (backgrounding).
     func suspend() async {
         isActive = false
-        for feed in feeds.values {
-            await feed.session.suspend()
+        for projection in projections.values {
+            await projection.suspend()
         }
     }
 
-    private func startFeed(for host: Host) {
-        let session = makeSession(host, Self.subscriptions(paneIDs: []))
-        let feed = HostFeed(host: host, session: session)
-        feeds[host.id] = feed
-        hostConnectionGenerations[host.id] = 0
-        feed.consumeTask = Task { [weak self] in
-            for await update in session.updates {
-                guard let self else { return }
-                self.handle(update, feed: feed)
-            }
-        }
-        if isActive {
-            Task { await session.resume() }
+    func retryFailedHosts() async {
+        for projection in projections.values {
+            await projection.retry()
         }
     }
-
-    private func endFeed(_ feed: HostFeed) {
-        feed.resyncPending = false
-        feed.resyncRetryTask?.cancel()
-        feed.resyncRetryTask = nil
-        Task { await feed.session.end() }
-    }
-
-    // MARK: Snapshot-then-delta
-
-    private func handle(_ update: EventsSessionUpdate, feed: HostFeed) {
-        // A removed Host's session still drains its final updates; they must
-        // not resurrect its rows or status.
-        guard feeds[feed.host.id] === feed else { return }
-        switch update {
-        case .status(let status):
-            hostStatuses[feed.host.id] = status
-            if status == .connected {
-                Task { [weak self] in
-                    let generation = await feed.session.transportGeneration
-                    guard let self, self.feeds[feed.host.id] === feed else { return }
-                    self.hostConnectionGenerations[feed.host.id] = generation
-                }
-                scheduleResync(feed: feed)
-            }
-        case .event(let event):
-            if event.kind == PaneEventKind.agentStatusChanged.kind {
-                applyStatusChange(event.data, feed: feed)
-            } else if Self.resyncEventKinds.contains(event.kind) {
-                scheduleResync(feed: feed)
-            }
-        }
-    }
-
-    /// Runs one re-snapshot per Host at a time; signals arriving mid-run
-    /// coalesce into a single follow-up run.
-    private func scheduleResync(feed: HostFeed) {
-        if feed.resyncTask != nil {
-            feed.resyncPending = true
-            return
-        }
-        feed.resyncTask = Task { [weak self] in
-            await self?.runResync(feed: feed)
-            guard let self else { return }
-            feed.resyncTask = nil
-            if feed.resyncPending {
-                feed.resyncPending = false
-                self.scheduleResync(feed: feed)
-            }
-        }
-    }
-
-    private func runResync(feed: HostFeed) async {
-        let statusRevisionBeforeSnapshot = feed.statusChangeRevision
-        do {
-            let snapshot = try await feed.session.withTransport { transport in
-                try await transport.sessionSnapshot()
-            }
-            guard feeds[feed.host.id] === feed else { return }
-            feed.resyncRetryTask?.cancel()
-            feed.resyncRetryTask = nil
-            hostSyncErrors[feed.host.id] = nil
-            apply(
-                snapshot, to: feed,
-                preservingStatusChangesAfter: statusRevisionBeforeSnapshot)
-            await feed.session.updateSubscriptions(
-                Self.subscriptions(paneIDs: feed.byPane.keys))
-            refreshSnippets(feed: feed)
-        } catch {
-            guard feeds[feed.host.id] === feed else { return }
-            hostSyncErrors[feed.host.id] = Self.snapshotErrorMessage(error)
-            scheduleSnapshotRetry(feed: feed)
-        }
-    }
-
-    /// Snapshot RPC failures do not necessarily drop the events channel, so
-    /// they need their own bounded-rate retry instead of waiting for a future
-    /// membership event or reconnect that may never happen.
-    private func scheduleSnapshotRetry(feed: HostFeed) {
-        guard feed.resyncRetryTask == nil else { return }
-        feed.resyncRetryTask = Task { [weak self] in
-            guard let self else { return }
-            do {
-                try await Task.sleep(for: snapshotRetryDelay)
-            } catch {
-                return
-            }
-            guard self.feeds[feed.host.id] === feed else { return }
-            feed.resyncRetryTask = nil
-            self.scheduleResync(feed: feed)
-        }
-    }
-
-    private static func snapshotErrorMessage(_ error: any Error) -> String {
-        switch error {
-        case TransportError.timedOut:
-            "The Host did not answer while syncing Agents. Retrying…"
-        case let apiError as HerdrAPIError:
-            "herdr rejected the Console sync: \(apiError.message). Retrying…"
-        default:
-            "Could not sync this Host's Agents. Retrying…"
-        }
-    }
-
-    private func apply(
-        _ snapshot: SessionSnapshot,
-        to feed: HostFeed,
-        preservingStatusChangesAfter snapshotStartRevision: UInt64
-    ) {
-        let workspaces = Dictionary(
-            snapshot.workspaces.map { ($0.workspaceID, $0) }) { first, _ in first }
-        var byPane: [String: ConsoleAgent] = [:]
-        for info in snapshot.agents {
-            let agent = Agent(info)
-            let workspace = workspaces[agent.workspaceID]
-            byPane[agent.paneID] = ConsoleAgent(
-                hostID: feed.host.id,
-                hostName: feed.host.displayName,
-                agent: agent,
-                workspaceLabel: workspace?.label,
-                repoName: workspace?.worktree?.repoName,
-                lastOutputSnippet: feed.byPane[agent.paneID]?.lastOutputSnippet)
-        }
-        for (paneID, change) in feed.latestStatusChanges
-        where change.revision > snapshotStartRevision {
-            guard var row = byPane[paneID] else { continue }
-            row.agent.status = change.status
-            byPane[paneID] = row
-        }
-        feed.latestStatusChanges.removeAll(keepingCapacity: true)
-        feed.byPane = byPane
-        feed.workspaces = snapshot.workspaces
-            .map { ConsoleWorkspace(id: $0.workspaceID, label: $0.label) }
-            .sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
-        rebuild()
-    }
-
-    private func applyStatusChange(_ data: JSONValue, feed: HostFeed) {
-        guard
-            let paneID = data["pane_id"]?.stringValue,
-            let rawStatus = data["agent_status"]?.stringValue
-        else { return }
-        let status = AgentStatus(rawValue: rawStatus)
-        feed.statusChangeRevision &+= 1
-        feed.latestStatusChanges[paneID] = (feed.statusChangeRevision, status)
-        guard var row = feed.byPane[paneID] else { return }
-        row.agent.status = status
-        feed.byPane[paneID] = row
-        rebuild()
-        // A status flip usually means fresh output worth showing — for
-        // Blocked, it is the very question the user must answer.
-        Task { [weak self] in
-            self?.refreshSnippet(feed: feed, paneID: paneID)
-        }
-    }
-
-    private func rebuild() {
-        agents = feeds.values.flatMap { $0.byPane.values }.consoleSorted()
-    }
-
-    // MARK: Last-output snippets
-
-    /// `pane.read` line budget per snippet fetch; the card shows the
-    /// trailing non-blank line of that window.
-    private static let snippetReadLines = 6
-
-    private func refreshSnippets(feed: HostFeed) {
-        for paneID in feed.byPane.keys {
-            refreshSnippet(feed: feed, paneID: paneID)
-        }
-    }
-
-    private func refreshSnippet(feed: HostFeed, paneID: String) {
-        // One in-flight read per pane; a burst of status flips must not pile
-        // requests onto the slot queue.
-        guard feed.snippetFetchesInFlight.insert(paneID).inserted else {
-            feed.pendingSnippetRefreshes.insert(paneID)
-            return
-        }
-        Task { [weak self] in
-            let read = try? await feed.session.withTransport { transport in
-                try await transport.readPane(
-                    PaneReadParams(
-                        paneID: paneID, source: .recent, lines: Self.snippetReadLines,
-                        stripANSI: true))
-            }
-            guard let self else { return }
-            feed.snippetFetchesInFlight.remove(paneID)
-            guard self.feeds[feed.host.id] === feed else { return }
-            if let read, var row = feed.byPane[paneID] {
-                row.lastOutputSnippet = Self.snippet(fromPaneText: read.text)
-                feed.byPane[paneID] = row
-                self.rebuild()
-            }
-            guard
-                feed.pendingSnippetRefreshes.remove(paneID) != nil,
-                feed.byPane[paneID] != nil,
-                self.feeds[feed.host.id] === feed
-            else { return }
-            self.refreshSnippet(feed: feed, paneID: paneID)
-        }
-    }
-
-    /// The card snippet: the trailing non-blank line, whitespace-trimmed.
-    static func snippet(fromPaneText text: String) -> String? {
-        for line in text.split(separator: "\n").reversed() {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if !trimmed.isEmpty { return trimmed }
-        }
-        return nil
-    }
-
-    // MARK: Detail-screen Host operations
 
     func terminalRunner(for hostID: Host.ID) -> TerminalSessionRunner {
-        { [weak self] request, handler in
-            guard let session = await self?.session(for: hostID) else {
-                throw TransportError.sshUnreachable(detail: "The Host is not connected.")
-            }
-            try await session.withTerminalTransport { transport in
-                let terminal = try await transport.attachTerminal(request)
-                do {
-                    try await handler.run(terminal)
-                    await terminal.end()
-                } catch {
-                    await terminal.end()
-                    throw error
-                }
+        guard let projection = projections[hostID] else {
+            return { _, _ in
+                throw TransportError.sshUnreachable(
+                    detail: "The Host is not connected.")
             }
         }
+        return projection.terminalRunner()
     }
 
     func imageStager(for hostID: Host.ID) -> ImageStager {
-        { [weak self] image, reporter in
-            guard let session = await self?.session(for: hostID) else {
-                throw TransportError.sshUnreachable(detail: "The Host is not connected.")
-            }
-            return try await session.withTransport { transport in
-                try await transport.stageImage(image) { progress in
-                    await reporter.report(progress)
-                }
+        guard let projection = projections[hostID] else {
+            return { _, _ in
+                throw TransportError.sshUnreachable(
+                    detail: "The Host is not connected.")
             }
         }
+        return projection.imageStager()
     }
 
-    private func session(for hostID: Host.ID) -> EventsSession? {
-        feeds[hostID]?.session
-    }
-
-    /// Retries Hosts whose session stopped on an action-required failure.
-    /// Host management calls this after dismissal so corrected credentials,
-    /// trust, paths, or protocol versions take effect immediately.
-    func retryFailedHosts() async {
-        for (id, feed) in feeds {
-            guard case .failed = hostStatuses[id] else { continue }
-            await feed.session.retry()
-        }
-    }
-
-    // MARK: New-agent flow (#12)
-
-    /// The workspaces the store knows for a Host, from its latest snapshot —
-    /// the new-agent picker's target list. Empty until the Host's first
-    /// snapshot lands, or when the Host is unknown.
     func workspaces(for hostID: Host.ID) -> [ConsoleWorkspace] {
-        feeds[hostID]?.workspaces ?? []
+        projections[hostID]?.workspaces ?? []
     }
 
-    /// Starts a new Agent on a Host (#12): the transport's protocol-specific
-    /// launch flow, then one explicit resync so the new pane
-    /// surfaces promptly instead of waiting on its membership event. Throws
-    /// `.sshUnreachable` when the Host is not currently connected, and
-    /// propagates the server's error when herdr rejects the start.
     @discardableResult
-    func startAgent(_ request: AgentLaunchRequest, on hostID: Host.ID) async throws -> Agent {
-        guard let feed = feeds[hostID] else {
-            throw TransportError.sshUnreachable(detail: "The Host is not connected.")
+    func startAgent(
+        _ request: AgentLaunchRequest,
+        on hostID: Host.ID
+    ) async throws -> Agent {
+        guard let projection = projections[hostID] else {
+            throw TransportError.sshUnreachable(
+                detail: "The Host is not connected.")
         }
-        let agent = try await feed.session.withTransport { transport in
-            try await transport.startAgent(request)
-        }
-        // The membership event will re-snapshot too; this just makes the new
-        // pane appear without waiting for it.
-        scheduleResync(feed: feed)
-        return agent
+        return try await projection.startAgent(request)
     }
 
-    // MARK: Close-pane flow (#13)
-
-    /// Closes a Pane on a Host (#13, User Story 9): the thin `pane.close` RPC
-    /// on the Host's live transport, then one explicit resync so the removed
-    /// pane disappears promptly instead of waiting on its `pane.closed`
-    /// membership event. Throws `.sshUnreachable` when the Host is not
-    /// currently connected, and propagates the server's error when herdr
-    /// rejects the close (leaving the Console untouched — the cancel/failure
-    /// path never mutates state).
     func closePane(_ paneID: String, on hostID: Host.ID) async throws {
-        guard let feed = feeds[hostID] else {
-            throw TransportError.sshUnreachable(detail: "The Host is not connected.")
+        guard let projection = projections[hostID] else {
+            throw TransportError.sshUnreachable(
+                detail: "The Host is not connected.")
         }
-        try await feed.session.withTransport { transport in
-            try await transport.closePane(PaneTarget(paneID: paneID))
-        }
-        // The pane.closed membership event will re-snapshot too; this just
-        // drops the closed pane without waiting for it.
-        scheduleResync(feed: feed)
+        try await projection.closePane(paneID)
     }
 
-    // MARK: Subscriptions
+    private func startProjection(for host: Host) {
+        let session = makeSession(
+            host,
+            HostConsoleProjection.subscriptions(paneIDs: []))
+        let projection = HostConsoleProjection(
+            host: host,
+            session: session,
+            snapshotRetryDelay: snapshotRetryDelay
+        ) { [weak self] in
+            self?.rebuild()
+        }
+        projections[host.id] = projection
+        projection.start(isActive: isActive)
+    }
 
-    /// Global membership/context kinds; each triggers a Host re-snapshot.
-    private static let membershipKinds: [GlobalEventKind] = [
-        .paneAgentDetected, .paneClosed, .paneExited,
-        .workspaceCreated, .workspaceRenamed, .workspaceMetadataUpdated, .workspaceClosed,
-    ]
-    /// The membership kinds plus the local drop marker (#22): a bounded
-    /// event buffer that shed updates means the deltas are incomplete, so
-    /// the marker rides the same re-snapshot path membership changes do.
-    private static let resyncEventKinds =
-        Set(membershipKinds.map(\.kind)).union([HerdrEventKind.eventsDropped])
-
-    /// One Host's Console subscription set: the global kinds plus a per-pane
-    /// `pane.agent_status_changed` for every known Agent pane — the status
-    /// kind is pane-scoped (verified against herdr 0.7.4: a bare
-    /// subscription is rejected with `missing field pane_id`).
-    static func subscriptions(paneIDs: some Sequence<String>) -> [EventSubscription] {
-        membershipKinds.map(EventSubscription.global)
-            + paneIDs.sorted().map { EventSubscription.pane(.agentStatusChanged, paneID: $0) }
+    private func rebuild() {
+        let current = Array(projections.values)
+        agents = current
+            .flatMap { $0.agentsByPane.values }
+            .consoleSorted()
+        hostStatuses = Dictionary(
+            uniqueKeysWithValues: current.compactMap { projection in
+                projection.status.map { (projection.host.id, $0) }
+            })
+        hostSyncErrors = Dictionary(
+            uniqueKeysWithValues: current.compactMap { projection in
+                projection.syncError.map { (projection.host.id, $0) }
+            })
+        hostConnectionGenerations = Dictionary(
+            uniqueKeysWithValues: current.map {
+                ($0.host.id, $0.transportGeneration)
+            })
     }
 }
 
 extension ConsoleStore {
     /// The production session factory: SSH transports built from the Host
     /// catalog's credentials. TOFU is restricted to already-trusted
-    /// fingerprints — the Console never prompts; a Host that was never
-    /// onboarded fails into `.reconnecting` with the host-key error until
-    /// its onboarding checklist trusts it.
+    /// fingerprints; the Console never prompts.
     static func sshSessionFactory(
         connector: any TransportConnector = SSHTransportConnector(),
         knownHosts: any KnownHostsStore = UserDefaultsKnownHostsStore.shared,
@@ -452,36 +162,10 @@ extension ConsoleStore {
                 let policy = HostKeyPolicy(knownHosts: knownHosts) { _ in false }
                 return try await connector.connect(
                     settings: SSHTransportSettings(
-                        host: host, credentials: resolved, hostKeyPolicy: policy))
+                        host: host,
+                        credentials: resolved,
+                        hostKeyPolicy: policy))
             }
         }
-    }
-}
-
-/// One Host's live feed: its events session plus the rows built from its
-/// snapshots. A class so racing tasks can check identity (`===`) after the
-/// Host was removed or replaced.
-@MainActor
-private final class HostFeed {
-    let host: Host
-    let session: EventsSession
-    var consumeTask: Task<Void, Never>?
-    var resyncTask: Task<Void, Never>?
-    var resyncRetryTask: Task<Void, Never>?
-    var resyncPending = false
-    var byPane: [String: ConsoleAgent] = [:]
-    /// Latest status deltas by pane, versioned so a snapshot only preserves
-    /// events that arrived after that snapshot request began.
-    var statusChangeRevision: UInt64 = 0
-    var latestStatusChanges: [String: (revision: UInt64, status: AgentStatus)] = [:]
-    /// Workspaces from this Host's latest snapshot, for the new-agent picker.
-    var workspaces: [ConsoleWorkspace] = []
-    var snippetFetchesInFlight: Set<String> = []
-    /// Coalesced follow-up reads for panes refreshed while a read was active.
-    var pendingSnippetRefreshes: Set<String> = []
-
-    init(host: Host, session: EventsSession) {
-        self.host = host
-        self.session = session
     }
 }

--- a/Sources/HerdrMobile/Console/ConsoleStore.swift
+++ b/Sources/HerdrMobile/Console/ConsoleStore.swift
@@ -63,24 +63,38 @@ final class ConsoleStore {
         }
     }
 
+    /// The returned runner resolves the Host's live projection on every
+    /// call: editing a Host replaces its projection (and session), and a
+    /// runner captured by a long-lived Attach screen must follow it there
+    /// instead of staying bound to the ended session.
     func terminalRunner(for hostID: Host.ID) -> TerminalSessionRunner {
-        guard let projection = projections[hostID] else {
-            return { _, _ in
+        { [weak self] request, handler in
+            guard let runner = await self?.liveTerminalRunner(for: hostID) else {
                 throw TransportError.sshUnreachable(
                     detail: "The Host is not connected.")
             }
+            try await runner(request, handler)
         }
-        return projection.terminalRunner()
     }
 
+    /// Late-bound for the same reason as `terminalRunner(for:)`: a retryable
+    /// upload taken before a Host edit must stage over the new session.
     func imageStager(for hostID: Host.ID) -> ImageStager {
-        guard let projection = projections[hostID] else {
-            return { _, _ in
+        { [weak self] image, reporter in
+            guard let stager = await self?.liveImageStager(for: hostID) else {
                 throw TransportError.sshUnreachable(
                     detail: "The Host is not connected.")
             }
+            return try await stager(image, reporter)
         }
-        return projection.imageStager()
+    }
+
+    private func liveTerminalRunner(for hostID: Host.ID) -> TerminalSessionRunner? {
+        projections[hostID]?.terminalRunner()
+    }
+
+    private func liveImageStager(for hostID: Host.ID) -> ImageStager? {
+        projections[hostID]?.imageStager()
     }
 
     func workspaces(for hostID: Host.ID) -> [ConsoleWorkspace] {

--- a/Sources/HerdrMobile/Console/HostConsoleProjection.swift
+++ b/Sources/HerdrMobile/Console/HostConsoleProjection.swift
@@ -134,7 +134,12 @@ final class HostConsoleProjection {
                     guard let self else { return }
                     let generation = await session.transportGeneration
                     guard !hasEnded else { return }
-                    transportGeneration = generation
+                    // These reads race across quick `.connected` bursts and
+                    // can land out of order; generations only grow, so the
+                    // newest write must win regardless of arrival order — a
+                    // regression here would spuriously replace a healthy
+                    // terminal downstream.
+                    transportGeneration = max(transportGeneration, generation)
                     publish()
                 }
                 scheduleResync()

--- a/Sources/HerdrMobile/Console/HostConsoleProjection.swift
+++ b/Sources/HerdrMobile/Console/HostConsoleProjection.swift
@@ -1,0 +1,335 @@
+import Foundation
+
+/// One Host's Console projection. It owns snapshot-then-delta convergence,
+/// subscription changes, retry, snippet coalescing, Host RPC follow-ups and
+/// the EventsSession that supplies them. ConsoleStore only aggregates the
+/// resulting rows and observable Host state.
+@MainActor
+final class HostConsoleProjection {
+    let host: Host
+    let session: EventsSession
+
+    private(set) var agentsByPane: [String: ConsoleAgent] = [:]
+    private(set) var workspaces: [ConsoleWorkspace] = []
+    private(set) var status: EventsSessionStatus?
+    private(set) var syncError: String?
+    private(set) var transportGeneration: UInt64 = 0
+
+    private let snapshotRetryDelay: Duration
+    private let onChange: @MainActor @Sendable () -> Void
+    private var consumeTask: Task<Void, Never>?
+    private var resyncTask: Task<Void, Never>?
+    private var resyncRetryTask: Task<Void, Never>?
+    private var resyncPending = false
+    private var statusChangeRevision: UInt64 = 0
+    private var latestStatusChanges: [
+        String: (revision: UInt64, status: AgentStatus)
+    ] = [:]
+    private var snippetFetchesInFlight: Set<String> = []
+    private var pendingSnippetRefreshes: Set<String> = []
+    private var hasEnded = false
+
+    init(
+        host: Host,
+        session: EventsSession,
+        snapshotRetryDelay: Duration,
+        onChange: @escaping @MainActor @Sendable () -> Void
+    ) {
+        self.host = host
+        self.session = session
+        self.snapshotRetryDelay = snapshotRetryDelay
+        self.onChange = onChange
+    }
+
+    func start(isActive: Bool) {
+        consumeTask = Task { [weak self] in
+            guard let self else { return }
+            for await update in session.updates {
+                guard !Task.isCancelled else { return }
+                self.handle(update)
+            }
+        }
+        if isActive {
+            Task { await session.resume() }
+        }
+    }
+
+    func resume() async {
+        await session.resume()
+    }
+
+    func suspend() async {
+        await session.suspend()
+    }
+
+    func retry() async {
+        guard case .failed = status else { return }
+        await session.retry()
+    }
+
+    func end() {
+        guard !hasEnded else { return }
+        hasEnded = true
+        resyncPending = false
+        resyncTask?.cancel()
+        resyncRetryTask?.cancel()
+        consumeTask?.cancel()
+        resyncTask = nil
+        resyncRetryTask = nil
+        consumeTask = nil
+        Task { await session.end() }
+    }
+
+    func terminalRunner() -> TerminalSessionRunner {
+        let session = session
+        return { request, handler in
+            try await session.withTerminalTransport { transport in
+                let terminal = try await transport.attachTerminal(request)
+                do {
+                    try await handler.run(terminal)
+                    await terminal.end()
+                } catch {
+                    await terminal.end()
+                    throw error
+                }
+            }
+        }
+    }
+
+    func imageStager() -> ImageStager {
+        let session = session
+        return { image, reporter in
+            try await session.withTransport { transport in
+                try await transport.stageImage(image) { progress in
+                    await reporter.report(progress)
+                }
+            }
+        }
+    }
+
+    @discardableResult
+    func startAgent(_ request: AgentLaunchRequest) async throws -> Agent {
+        let agent = try await session.withTransport { transport in
+            try await transport.startAgent(request)
+        }
+        scheduleResync()
+        return agent
+    }
+
+    func closePane(_ paneID: String) async throws {
+        try await session.withTransport { transport in
+            try await transport.closePane(PaneTarget(paneID: paneID))
+        }
+        scheduleResync()
+    }
+
+    private func handle(_ update: EventsSessionUpdate) {
+        guard !hasEnded else { return }
+        switch update {
+        case .status(let status):
+            self.status = status
+            publish()
+            if status == .connected {
+                Task { [weak self] in
+                    guard let self else { return }
+                    let generation = await session.transportGeneration
+                    guard !hasEnded else { return }
+                    transportGeneration = generation
+                    publish()
+                }
+                scheduleResync()
+            }
+        case .event(let event):
+            if event.kind == PaneEventKind.agentStatusChanged.kind {
+                applyStatusChange(event.data)
+            } else if Self.resyncEventKinds.contains(event.kind) {
+                scheduleResync()
+            }
+        }
+    }
+
+    /// Runs one re-snapshot at a time; signals arriving mid-run coalesce into
+    /// one follow-up run.
+    private func scheduleResync() {
+        guard !hasEnded else { return }
+        if resyncTask != nil {
+            resyncPending = true
+            return
+        }
+        resyncTask = Task { [weak self] in
+            guard let self else { return }
+            await runResync()
+            guard !hasEnded else { return }
+            resyncTask = nil
+            if resyncPending {
+                resyncPending = false
+                scheduleResync()
+            }
+        }
+    }
+
+    private func runResync() async {
+        let statusRevisionBeforeSnapshot = statusChangeRevision
+        do {
+            let snapshot = try await session.withTransport { transport in
+                try await transport.sessionSnapshot()
+            }
+            guard !hasEnded else { return }
+            resyncRetryTask?.cancel()
+            resyncRetryTask = nil
+            syncError = nil
+            apply(
+                snapshot,
+                preservingStatusChangesAfter: statusRevisionBeforeSnapshot)
+            await session.updateSubscriptions(
+                Self.subscriptions(paneIDs: agentsByPane.keys))
+            refreshSnippets()
+        } catch {
+            guard !hasEnded else { return }
+            syncError = Self.snapshotErrorMessage(error)
+            publish()
+            scheduleSnapshotRetry()
+        }
+    }
+
+    private func scheduleSnapshotRetry() {
+        guard resyncRetryTask == nil, !hasEnded else { return }
+        resyncRetryTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await Task.sleep(for: snapshotRetryDelay)
+            } catch {
+                return
+            }
+            guard !hasEnded else { return }
+            resyncRetryTask = nil
+            scheduleResync()
+        }
+    }
+
+    private func apply(
+        _ snapshot: SessionSnapshot,
+        preservingStatusChangesAfter snapshotStartRevision: UInt64
+    ) {
+        let workspaceByID = Dictionary(
+            snapshot.workspaces.map { ($0.workspaceID, $0) }) { first, _ in first }
+        var nextAgents: [String: ConsoleAgent] = [:]
+        for info in snapshot.agents {
+            let agent = Agent(info)
+            let workspace = workspaceByID[agent.workspaceID]
+            nextAgents[agent.paneID] = ConsoleAgent(
+                hostID: host.id,
+                hostName: host.displayName,
+                agent: agent,
+                workspaceLabel: workspace?.label,
+                repoName: workspace?.worktree?.repoName,
+                lastOutputSnippet: agentsByPane[agent.paneID]?.lastOutputSnippet)
+        }
+        for (paneID, change) in latestStatusChanges
+        where change.revision > snapshotStartRevision {
+            guard var row = nextAgents[paneID] else { continue }
+            row.agent.status = change.status
+            nextAgents[paneID] = row
+        }
+        latestStatusChanges.removeAll(keepingCapacity: true)
+        agentsByPane = nextAgents
+        workspaces = snapshot.workspaces
+            .map { ConsoleWorkspace(id: $0.workspaceID, label: $0.label) }
+            .sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
+        publish()
+    }
+
+    private func applyStatusChange(_ data: JSONValue) {
+        guard
+            let paneID = data["pane_id"]?.stringValue,
+            let rawStatus = data["agent_status"]?.stringValue
+        else { return }
+        let status = AgentStatus(rawValue: rawStatus)
+        statusChangeRevision &+= 1
+        latestStatusChanges[paneID] = (statusChangeRevision, status)
+        guard var row = agentsByPane[paneID] else { return }
+        row.agent.status = status
+        agentsByPane[paneID] = row
+        publish()
+        Task { [weak self] in
+            self?.refreshSnippet(paneID: paneID)
+        }
+    }
+
+    private func refreshSnippets() {
+        for paneID in agentsByPane.keys {
+            refreshSnippet(paneID: paneID)
+        }
+    }
+
+    private func refreshSnippet(paneID: String) {
+        guard snippetFetchesInFlight.insert(paneID).inserted else {
+            pendingSnippetRefreshes.insert(paneID)
+            return
+        }
+        Task { [weak self] in
+            guard let self else { return }
+            let read = try? await session.withTransport { transport in
+                try await transport.readPane(
+                    PaneReadParams(
+                        paneID: paneID,
+                        source: .recent,
+                        lines: Self.snippetReadLines,
+                        stripANSI: true))
+            }
+            snippetFetchesInFlight.remove(paneID)
+            guard !hasEnded else { return }
+            if let read, var row = agentsByPane[paneID] {
+                row.lastOutputSnippet = Self.snippet(fromPaneText: read.text)
+                agentsByPane[paneID] = row
+                publish()
+            }
+            guard
+                pendingSnippetRefreshes.remove(paneID) != nil,
+                agentsByPane[paneID] != nil
+            else { return }
+            refreshSnippet(paneID: paneID)
+        }
+    }
+
+    private func publish() {
+        guard !hasEnded else { return }
+        onChange()
+    }
+
+    private static let snippetReadLines = 6
+
+    static func snippet(fromPaneText text: String) -> String? {
+        for line in text.split(separator: "\n").reversed() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if !trimmed.isEmpty { return trimmed }
+        }
+        return nil
+    }
+
+    private static func snapshotErrorMessage(_ error: any Error) -> String {
+        switch error {
+        case TransportError.timedOut:
+            "The Host did not answer while syncing Agents. Retrying…"
+        case let apiError as HerdrAPIError:
+            "herdr rejected the Console sync: \(apiError.message). Retrying…"
+        default:
+            "Could not sync this Host's Agents. Retrying…"
+        }
+    }
+
+    private static let membershipKinds: [GlobalEventKind] = [
+        .paneAgentDetected, .paneClosed, .paneExited,
+        .workspaceCreated, .workspaceRenamed, .workspaceMetadataUpdated, .workspaceClosed,
+    ]
+
+    private static let resyncEventKinds =
+        Set(membershipKinds.map(\.kind)).union([HerdrEventKind.eventsDropped])
+
+    static func subscriptions(
+        paneIDs: some Sequence<String>
+    ) -> [EventSubscription] {
+        membershipKinds.map(EventSubscription.global)
+            + paneIDs.sorted().map { EventSubscription.pane(.agentStatusChanged, paneID: $0) }
+    }
+}

--- a/Sources/HerdrMobile/Images/ImageAttachStore.swift
+++ b/Sources/HerdrMobile/Images/ImageAttachStore.swift
@@ -3,6 +3,22 @@ import Observation
 import UniformTypeIdentifiers
 import UIKit
 
+typealias ImageStageProgressHandler = @Sendable (ImageStageProgress) async -> Void
+typealias ImageStager =
+    @Sendable (PreparedImage, ImageStageProgressReporter) async throws -> StagedImage
+
+struct ImageStageProgressReporter: Sendable {
+    private let handler: ImageStageProgressHandler
+
+    init(_ handler: @escaping ImageStageProgressHandler) {
+        self.handler = handler
+    }
+
+    func report(_ progress: ImageStageProgress) async {
+        await handler(progress)
+    }
+}
+
 @MainActor
 protocol ImageClipboard {
     func copy(_ path: String) throws
@@ -99,7 +115,7 @@ final class ImageAttachStore {
     private(set) var state: ImageAttachState = .idle
 
     private let preparer: any ImagePreparing
-    private let transport: @Sendable () async -> (any Transport)?
+    private let stageImage: ImageStager
     private let clipboard: any ImageClipboard
     private let input: TerminalInputController
 
@@ -110,12 +126,12 @@ final class ImageAttachStore {
 
     init(
         preparer: any ImagePreparing = ImagePreparer(),
-        transport: @escaping @Sendable () async -> (any Transport)?,
+        stageImage: @escaping ImageStager,
         clipboard: any ImageClipboard = SystemImageClipboard(),
         input: TerminalInputController
     ) {
         self.preparer = preparer
-        self.transport = transport
+        self.stageImage = stageImage
         self.clipboard = clipboard
         self.input = input
     }
@@ -245,12 +261,11 @@ final class ImageAttachStore {
         operationID: UInt64
     ) async {
         do {
-            guard let transport = await transport() else {
-                throw ImageAttachStoreError.hostDisconnected
-            }
-            let staged = try await transport.stageImage(image) { [weak self] progress in
-                await self?.receive(progress: progress, operationID: operationID)
-            }
+            let staged = try await stageImage(
+                image,
+                ImageStageProgressReporter { [weak self] progress in
+                    await self?.receive(progress: progress, operationID: operationID)
+                })
             try Task.checkCancellation()
             finishSuccess(staged, generation: generation, operationID: operationID)
         } catch {
@@ -325,7 +340,7 @@ final class ImageAttachStore {
 
     private static func failure(for error: any Error) -> ImageAttachFailure {
         switch error {
-        case ImageAttachStoreError.hostDisconnected:
+        case TransportError.sshUnreachable:
             ImageAttachFailure(
                 message: "The Host is not connected. Reconnect, then retry the upload.",
                 isRetryable: true)
@@ -363,8 +378,4 @@ final class ImageAttachStore {
                 isRetryable: false)
         }
     }
-}
-
-private enum ImageAttachStoreError: Error {
-    case hostDisconnected
 }

--- a/Sources/HerdrMobile/Transport/EventsSession.swift
+++ b/Sources/HerdrMobile/Transport/EventsSession.swift
@@ -119,10 +119,14 @@ actor EventsSession {
     private let keepalive: KeepalivePolicy?
 
     private var phase: Phase = .suspended
-    /// The Host's live Transport; consumers run snapshot RPCs (`listAgents`)
-    /// through it after each `.connected`. Nil while suspended or between
-    /// SSH re-establishments.
-    private(set) var currentTransport: (any Transport)?
+    /// The Host's live Transport. It never escapes this module; consumers
+    /// use `withTransport` or `withTerminalTransport` so replacement and
+    /// terminal exclusivity remain local.
+    private var currentTransport: (any Transport)?
+    /// Monotonic identity for the installed Transport. Subscription-only
+    /// reconnects reuse the same Transport and therefore do not advance it.
+    private(set) var transportGeneration: UInt64 = 0
+    private var hasEstablishedTransport = false
     /// Set when the connection can no longer be trusted even though it may
     /// still look alive (a timed-out request or keepalive ping): the next
     /// reconnect replaces the transport instead of reusing it.
@@ -143,6 +147,12 @@ actor EventsSession {
     /// behind it, so transitions never interleave across the suspension
     /// points inside a teardown (see the actor doc).
     private var lifecycleTransition: Task<Void, Never>?
+    /// Exactly one Attach operation may hold the Host's terminal channel.
+    /// Waiters are FIFO and cancellation-safe; the permit spans the entire
+    /// operation, including explicit terminal teardown.
+    private var terminalInUse = false
+    private var terminalWaiters: [TerminalWaiter] = []
+    private var terminalIdleWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(
         subscriptions: [EventSubscription],
@@ -206,6 +216,36 @@ actor EventsSession {
         guard phase == .active, let stream = liveStream else { return }
         resubscribeRequested = true
         await stream.end()
+    }
+
+    /// Runs an ordinary RPC against the currently installed Transport.
+    /// Calls are intentionally concurrent; `SSHTransport` owns its channel
+    /// budget. The Transport value never becomes caller-owned state.
+    func withTransport<Value: Sendable>(
+        _ operation: @escaping @Sendable (any Transport) async throws -> Value
+    ) async throws -> Value {
+        guard let transport = currentTransport else {
+            throw TransportError.sshUnreachable(detail: "The Host is not connected.")
+        }
+        return try await operation(transport)
+    }
+
+    /// Runs one terminal lifetime with exclusive access to the Host's
+    /// terminal channel. The next caller cannot observe a Transport until
+    /// the previous operation, including its teardown, has returned.
+    func withTerminalTransport<Value: Sendable>(
+        _ operation: @escaping @Sendable (any Transport) async throws -> Value
+    ) async throws -> Value {
+        try await acquireTerminal()
+        do {
+            try Task.checkCancellation()
+            let value = try await withTransport(operation)
+            releaseTerminal()
+            return value
+        } catch {
+            releaseTerminal()
+            throw error
+        }
     }
 
     private func activate() {
@@ -361,6 +401,11 @@ actor EventsSession {
         }
         transportSuspect = false
         currentTransport = transport
+        if hasEstablishedTransport {
+            transportGeneration &+= 1
+        } else {
+            hasEstablishedTransport = true
+        }
         return transport
     }
 
@@ -390,6 +435,7 @@ actor EventsSession {
             currentTransport = nil
             try? await transport.close()
         }
+        await waitForTerminalIdle()
         transportSuspect = false
         pendingKeepaliveFailure = nil
         resubscribeRequested = false
@@ -440,5 +486,58 @@ actor EventsSession {
             return .deviceKeyCorrupt
         }
         return .channelFailed(detail: String(describing: error))
+    }
+
+    // MARK: Terminal exclusivity
+
+    private struct TerminalWaiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private func acquireTerminal() async throws {
+        let id = UUID()
+        try Task.checkCancellation()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else if terminalInUse {
+                    terminalWaiters.append(
+                        TerminalWaiter(id: id, continuation: continuation))
+                } else {
+                    terminalInUse = true
+                    continuation.resume()
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelTerminalWaiter(id: id) }
+        }
+    }
+
+    private func cancelTerminalWaiter(id: UUID) {
+        guard let index = terminalWaiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = terminalWaiters.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func releaseTerminal() {
+        while !terminalWaiters.isEmpty {
+            let waiter = terminalWaiters.removeFirst()
+            waiter.continuation.resume()
+            return
+        }
+        terminalInUse = false
+        let waiters = terminalIdleWaiters
+        terminalIdleWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func waitForTerminalIdle() async {
+        guard terminalInUse else { return }
+        await withCheckedContinuation { terminalIdleWaiters.append($0) }
     }
 }

--- a/Sources/HerdrMobile/Transport/SSHChannelBudget.swift
+++ b/Sources/HerdrMobile/Transport/SSHChannelBudget.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Owns the Host's bounded pool of ordinary SSH session channels.
+///
+/// Callers describe one channel lifetime with `withChannel`; capacity,
+/// cancellation-safe FIFO admission, and exactly-once release stay inside
+/// this module. Dedicated Events and Attach channels remain outside this pool,
+/// with the configured capacity reserving their MaxSessions headroom.
+actor SSHChannelBudget {
+    static let opensshDefaultSessionLimit = 10
+    static let dedicatedChannelReservation = 2
+    static let defaultOrdinaryChannelCapacity =
+        opensshDefaultSessionLimit - dedicatedChannelReservation
+
+    private struct Waiter {
+        let id: UInt64
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private let capacity: Int
+    private var channelsInUse = 0
+    private var waiters: [Waiter] = []
+    private var cancelledRequests: Set<UInt64> = []
+    private var pendingRequests: Set<UInt64> = []
+    private var nextRequestID: UInt64 = 0
+
+    init(capacity: Int) {
+        precondition(capacity > 0)
+        self.capacity = capacity
+    }
+
+    func withChannel<Value: Sendable>(
+        _ operation: @escaping @Sendable () async throws -> Value
+    ) async throws -> Value {
+        try await acquire()
+        defer { release() }
+        try Task.checkCancellation()
+        return try await operation()
+    }
+
+    private func acquire() async throws {
+        try Task.checkCancellation()
+        nextRequestID &+= 1
+        let requestID = nextRequestID
+        pendingRequests.insert(requestID)
+        defer {
+            pendingRequests.remove(requestID)
+            cancelledRequests.remove(requestID)
+        }
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                if cancelledRequests.contains(requestID) {
+                    continuation.resume(throwing: CancellationError())
+                } else if channelsInUse < capacity {
+                    channelsInUse += 1
+                    continuation.resume()
+                } else {
+                    waiters.append(Waiter(id: requestID, continuation: continuation))
+                }
+            }
+        } onCancel: {
+            Task { await self.cancel(requestID: requestID) }
+        }
+    }
+
+    private func release() {
+        if waiters.isEmpty {
+            channelsInUse -= 1
+        } else {
+            waiters.removeFirst().continuation.resume()
+        }
+    }
+
+    private func cancel(requestID: UInt64) {
+        guard pendingRequests.contains(requestID) else { return }
+        if let index = waiters.firstIndex(where: { $0.id == requestID }) {
+            waiters.remove(at: index).continuation.resume(throwing: CancellationError())
+        } else {
+            cancelledRequests.insert(requestID)
+        }
+    }
+}

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -79,7 +79,7 @@ actor SSHTransport: Transport {
     /// Exec channels are SSH session channels, capped by sshd's MaxSessions
     /// (default 10) per connection. Bound at 8 to leave headroom for the
     /// events channel and the interactive terminal.
-    static let maxConcurrentExecChannels = 8
+    static let maxConcurrentExecChannels = SSHChannelBudget.defaultOrdinaryChannelCapacity
 
     private let client: SSHClient
     private let socketLocation: HerdrSocketLocation
@@ -90,6 +90,7 @@ actor SSHTransport: Transport {
     private let homeCommand: String
     private let stageDirectoryCommand: String
     private let requestTimeout: Duration
+    private let execChannelBudget: SSHChannelBudget
     /// Remote home directory resolution, resolved over exec once per Host:
     /// concurrent first requests share one in-flight run, success is cached
     /// for the connection's lifetime, failure is not (the next request
@@ -99,78 +100,10 @@ actor SSHTransport: Transport {
     /// of racing exec channels, and a later cold start wakes again.
     private let wake = SharedAsyncOperation<Void>(cachesSuccess: false)
 
-    // MARK: Exec channel slots
-    //
-    // The actor-based request queue (#5): every exec channel — RPC, home
-    // resolution, wake — holds a slot for the channel's lifetime, bounding
-    // concurrency at `maxConcurrentExecChannels`. Slots are never held
-    // across another slot acquisition, so the queue cannot deadlock.
-
-    private struct SlotWaiter {
-        let id: UInt64
-        let continuation: CheckedContinuation<Void, any Error>
-    }
-
-    private var execSlotsInUse = 0
-    private var slotWaiters: [SlotWaiter] = []
-    /// Waiter ids whose cancellation raced ahead: the cancellation handler
-    /// hops onto the actor via a Task, so it can run before the waiter's
-    /// continuation is stored (marker consumed on arrival) or after the
-    /// waiter was already resumed (marker swept by `acquireExecChannelSlot`'s
-    /// defer, keyed on `pendingSlotRequests`).
-    private var cancelledSlotRequests: Set<UInt64> = []
-    private var pendingSlotRequests: Set<UInt64> = []
-    private var nextSlotRequestID: UInt64 = 0
     /// Active SFTP channels keyed by staging operation. Cancellation closes
     /// the exact channel so a blocked Citadel request cannot continue after
     /// the app reports an interrupted upload.
     private var imageStageClients: [UUID: SFTPClient] = [:]
-
-    /// Waits for a free exec channel slot. Throws `CancellationError` without
-    /// consuming a slot if the task is cancelled while queued.
-    private func acquireExecChannelSlot() async throws {
-        try Task.checkCancellation()
-        nextSlotRequestID += 1
-        let id = nextSlotRequestID
-        pendingSlotRequests.insert(id)
-        defer {
-            pendingSlotRequests.remove(id)
-            cancelledSlotRequests.remove(id)
-        }
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation {
-                (continuation: CheckedContinuation<Void, any Error>) in
-                if cancelledSlotRequests.contains(id) {
-                    continuation.resume(throwing: CancellationError())
-                } else if execSlotsInUse < Self.maxConcurrentExecChannels {
-                    execSlotsInUse += 1
-                    continuation.resume()
-                } else {
-                    slotWaiters.append(SlotWaiter(id: id, continuation: continuation))
-                }
-            }
-        } onCancel: {
-            Task { await self.cancelSlotWaiter(id: id) }
-        }
-    }
-
-    /// Frees a slot, handing it to the oldest waiter if any.
-    private func releaseExecChannelSlot() {
-        if slotWaiters.isEmpty {
-            execSlotsInUse -= 1
-        } else {
-            slotWaiters.removeFirst().continuation.resume()
-        }
-    }
-
-    private func cancelSlotWaiter(id: UInt64) {
-        guard pendingSlotRequests.contains(id) else { return }
-        if let index = slotWaiters.firstIndex(where: { $0.id == id }) {
-            slotWaiters.remove(at: index).continuation.resume(throwing: CancellationError())
-        } else {
-            cancelledSlotRequests.insert(id)
-        }
-    }
 
     private init(
         client: SSHClient, socketLocation: HerdrSocketLocation, socatPath: String,
@@ -187,6 +120,7 @@ actor SSHTransport: Transport {
         self.homeCommand = homeCommand
         self.stageDirectoryCommand = stageDirectoryCommand
         self.requestTimeout = requestTimeout
+        execChannelBudget = SSHChannelBudget(capacity: Self.maxConcurrentExecChannels)
     }
 
     /// Connects, verifies the host key per the TOFU policy, and
@@ -263,15 +197,16 @@ actor SSHTransport: Transport {
     }
 
     private func runSessionListCommand() async throws -> Data {
-        try await acquireExecChannelSlot()
-        defer { releaseExecChannelSlot() }
-        do {
-            let output = try await client.executeCommand(Self.cLocaleCommand(sessionListCommand))
-            return Data(output.readableBytesView)
-        } catch is CancellationError {
-            throw TransportError.cancelled
-        } catch {
-            throw TransportError.channelFailed(detail: String(describing: error))
+        try await execChannelBudget.withChannel {
+            do {
+                let output = try await self.client.executeCommand(
+                    Self.cLocaleCommand(self.sessionListCommand))
+                return Data(output.readableBytesView)
+            } catch is CancellationError {
+                throw TransportError.cancelled
+            } catch {
+                throw TransportError.channelFailed(detail: String(describing: error))
+            }
         }
     }
 
@@ -338,27 +273,22 @@ actor SSHTransport: Transport {
         }
 
         do {
-            try await acquireExecChannelSlot()
-        } catch {
-            throw ImageStagingError.cancelled
-        }
-        defer { releaseExecChannelSlot() }
+            return try await execChannelBudget.withChannel {
+                try Task.checkCancellation()
+                let remoteDirectory = try await self.createStageDirectory()
+                let operationID = UUID()
+                await progress(
+                    ImageStageProgress(transferredBytes: 0, totalBytes: image.byteCount))
 
-        try Task.checkCancellation()
-        let remoteDirectory = try await createStageDirectory()
-        let operationID = UUID()
-        await progress(
-            ImageStageProgress(transferredBytes: 0, totalBytes: image.byteCount))
-
-        do {
-            return try await withTaskCancellationHandler {
-                try await performImageStage(
-                    image,
-                    remoteDirectory: remoteDirectory,
-                    operationID: operationID,
-                    progress: progress)
-            } onCancel: {
-                Task { await self.cancelImageStage(operationID) }
+                return try await withTaskCancellationHandler {
+                    try await self.performImageStage(
+                        image,
+                        remoteDirectory: remoteDirectory,
+                        operationID: operationID,
+                        progress: progress)
+                } onCancel: {
+                    Task { await self.cancelImageStage(operationID) }
+                }
             }
         } catch let error as ImageStagingError {
             throw error
@@ -1009,9 +939,9 @@ actor SSHTransport: Transport {
     private func runWakeCommand(socketPath: String) async throws {
         let command = try Self.wakeExecCommand(
             wakeCommand: wakeCommand, socketPath: socketPath, socketLocation: socketLocation)
-        try await acquireExecChannelSlot()
-        defer { releaseExecChannelSlot() }
-        _ = try await client.executeCommand(command)
+        try await execChannelBudget.withChannel {
+            _ = try await self.client.executeCommand(command)
+        }
     }
 
     /// The full remote command for waking this Host's configured herdr
@@ -1066,46 +996,48 @@ actor SSHTransport: Transport {
     private func performExchange(line: String, socketPath: String, method: String) async throws
         -> Data
     {
-        try await acquireExecChannelSlot()
-        defer { releaseExecChannelSlot() }
-        var stdout = Data()
-        var stderr = Data()
-        do {
-            let command = try Self.socatCommand(socatPath: socatPath, socketPath: socketPath)
-            try await client.withExec(command) {
-                inbound, outbound in
-                // A fast-failing command (socat missing, socket absent) can
-                // close the channel before this write lands; the read loop
-                // below still drains stderr and surfaces the real failure.
-                try? await outbound.write(ByteBuffer(string: line))
-                for try await chunk in inbound {
-                    switch chunk {
-                    case .stdout(let buffer):
-                        stdout.append(contentsOf: buffer.readableBytesView)
-                        if stdout.contains(0x0A) { return }
-                    case .stderr(let buffer):
-                        stderr.append(contentsOf: buffer.readableBytesView)
+        try await execChannelBudget.withChannel {
+            var stdout = Data()
+            var stderr = Data()
+            do {
+                let command = try Self.socatCommand(
+                    socatPath: self.socatPath, socketPath: socketPath)
+                try await self.client.withExec(command) {
+                    inbound, outbound in
+                    // A fast-failing command (socat missing, socket absent) can
+                    // close the channel before this write lands; the read loop
+                    // below still drains stderr and surfaces the real failure.
+                    try? await outbound.write(ByteBuffer(string: line))
+                    for try await chunk in inbound {
+                        switch chunk {
+                        case .stdout(let buffer):
+                            stdout.append(contentsOf: buffer.readableBytesView)
+                            if stdout.contains(0x0A) { return }
+                        case .stderr(let buffer):
+                            stderr.append(contentsOf: buffer.readableBytesView)
+                        }
                     }
                 }
+            } catch is CancellationError {
+                throw TransportError.cancelled
+            } catch {
+                throw await self.classifyExecFailure(stderr: stderr, socketPath: socketPath)
+                    ?? TransportError.channelFailed(
+                        detail: "\(method): \(error); stderr: \(Self.preview(stderr))")
             }
-        } catch is CancellationError {
-            throw TransportError.cancelled
-        } catch {
-            throw classifyExecFailure(stderr: stderr, socketPath: socketPath)
-                ?? TransportError.channelFailed(
-                    detail: "\(method): \(error); stderr: \(Self.preview(stderr))")
+            // A cancelled exchange ends its read through the local inbound
+            // stream, after which withExec has already closed the channel;
+            // surface that instead of misreading the truncated output as a
+            // protocol error.
+            try Task.checkCancellation()
+            if !stdout.contains(0x0A),
+                let failure = await self.classifyExecFailure(
+                    stderr: stderr, socketPath: socketPath)
+            {
+                throw failure
+            }
+            return stdout
         }
-        // A cancelled exchange ends its read through the local inbound
-        // stream, after which withExec has already closed the channel;
-        // surface that instead of misreading the truncated output as a
-        // protocol error.
-        try Task.checkCancellation()
-        if !stdout.contains(0x0A),
-            let failure = classifyExecFailure(stderr: stderr, socketPath: socketPath)
-        {
-            throw failure
-        }
-        return stdout
     }
 
     /// Races `operation` against the per-request deadline, mapping expiry to
@@ -1160,15 +1092,16 @@ actor SSHTransport: Transport {
     }
 
     private func resolveHomeDirectoryOverExec() async throws -> String {
-        try await acquireExecChannelSlot()
-        defer { releaseExecChannelSlot() }
-        let output: ByteBuffer
-        do {
-            output = try await client.executeCommand(Self.cLocaleCommand(homeCommand))
-        } catch {
-            throw TransportError.homeDirectoryUnresolvable(detail: String(describing: error))
+        try await execChannelBudget.withChannel {
+            let output: ByteBuffer
+            do {
+                output = try await self.client.executeCommand(
+                    Self.cLocaleCommand(self.homeCommand))
+            } catch {
+                throw TransportError.homeDirectoryUnresolvable(detail: String(describing: error))
+            }
+            return try Self.parseRemoteHome(output)
         }
-        return try Self.parseRemoteHome(output)
     }
 
     /// Maps the observable failure shapes (verified against herdr 0.7.4 in

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -231,14 +231,8 @@ actor SSHTransport: Transport {
             params: TabCreateParams(focus: false, workspaceID: launch.workspaceID),
             decoding: TabCreatedResponse.self)
         do {
-            let response = try await request(
-                method: "agent.start",
-                params: AgentStartParams(
-                    kind: launch.kind,
-                    name: launch.name,
-                    paneID: created.rootPane.paneID,
-                    args: launch.arguments.isEmpty ? nil : launch.arguments),
-                decoding: AgentStartedResponse.self)
+            let response = try await startAgentAwaitingShell(
+                launch, paneID: created.rootPane.paneID)
             return Agent(response.agent)
         } catch let error as HerdrAPIError {
             // A definitive rejection must not leave the fresh empty tab behind.
@@ -246,8 +240,43 @@ actor SSHTransport: Transport {
             // if its reply was lost, so preserving the pane is safer there.
             try? await closePane(PaneTarget(paneID: created.rootPane.paneID))
             throw error
+        } catch is CancellationError {
+            // Only thrown between readiness retries, after a definitive
+            // rejection — no agent is running in the fresh pane for sure.
+            try? await closePane(PaneTarget(paneID: created.rootPane.paneID))
+            throw CancellationError()
         }
     }
+
+    /// herdr (0.7.5+) rejects `agent.start` with `agent_pane_busy` until the
+    /// fresh pane's shell reaches its interactive prompt; shell boot takes a
+    /// few seconds on some hosts. The pane is ours and empty, so that code
+    /// can only mean "not ready yet" — retry briefly before giving up.
+    private func startAgentAwaitingShell(
+        _ launch: AgentLaunchRequest, paneID: String
+    ) async throws -> AgentStartedResponse {
+        let params = AgentStartParams(
+            kind: launch.kind,
+            name: launch.name,
+            paneID: paneID,
+            args: launch.arguments.isEmpty ? nil : launch.arguments)
+        let deadline = ContinuousClock.now + Self.shellReadinessBudget
+        while true {
+            do {
+                return try await request(
+                    method: "agent.start", params: params,
+                    decoding: AgentStartedResponse.self)
+            } catch let error as HerdrAPIError where error.code == "agent_pane_busy" {
+                guard ContinuousClock.now + Self.shellReadinessRetryDelay < deadline else {
+                    throw error
+                }
+                try await Task.sleep(for: Self.shellReadinessRetryDelay)
+            }
+        }
+    }
+
+    private static let shellReadinessBudget: Duration = .seconds(10)
+    private static let shellReadinessRetryDelay: Duration = .milliseconds(500)
 
     func closePane(_ params: PaneTarget) async throws {
         _ = try await request(method: "pane.close", params: params, decoding: OkResponse.self)

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -334,3 +334,120 @@ struct AttachTerminalStoreTests {
         await store.stop()
     }
 }
+
+@MainActor
+@Suite("Agent Attach store")
+struct AgentAttachStoreTests {
+    @Test func transportReplacementStopsTheOldTerminalBeforeReattaching() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+        let initialID = store.terminalID
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the initial terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        store.transportGenerationDidChange(1)
+        try await waitUntil("the terminal pipeline should be replaced") {
+            store.terminalID != initialID
+        }
+        #expect(await transport.hasLiveAttachSession == false)
+
+        store.viewDidResize(cols: 100, rows: 30)
+        try await waitUntil("the replacement terminal should go live") {
+            store.terminalStatus == .live
+        }
+        #expect(await transport.attachRequests.count == 2)
+
+        await store.leave()
+    }
+
+    @Test func rapidTransportReplacementsCoalesceToTheLatestGeneration() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+        let initialID = store.terminalID
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the initial terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        store.transportGenerationDidChange(1)
+        store.transportGenerationDidChange(2)
+        try await waitUntil("the latest replacement should land") {
+            store.terminalID != initialID
+        }
+        store.viewDidResize(cols: 100, rows: 30)
+        try await waitUntil("the replacement terminal should go live") {
+            store.terminalStatus == .live
+        }
+        #expect(await transport.attachRequests.count == 2)
+
+        await store.leave()
+    }
+
+    @Test func successfulCloseLeavesTheWholeAttachInteraction() async throws {
+        let transport = ScriptedTransport()
+        let closeCalls = CloseCallRecorder()
+        let store = makeStore(transport: transport, generation: 0) {
+            await closeCalls.record()
+        }
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        #expect(await store.confirmClose())
+        #expect(await closeCalls.count == 1)
+        #expect(store.terminalStatus == .stopped)
+        #expect(await transport.hasLiveAttachSession == false)
+    }
+
+    private func makeStore(
+        transport: ScriptedTransport,
+        generation: UInt64?,
+        close: @escaping () async throws -> Void = {}
+    ) -> AgentAttachStore {
+        AgentAttachStore(
+            target: "w1:p1",
+            paneTitle: "Agent",
+            transportGeneration: generation,
+            runTerminal: { request, handler in
+                let session = try await transport.attachTerminal(request)
+                do {
+                    try await handler.run(session)
+                    await session.end()
+                } catch {
+                    await session.end()
+                    throw error
+                }
+            },
+            stageImage: { _, _ in
+                throw ImageStagingError.transferFailed
+            },
+            closePane: close)
+    }
+
+    private func waitUntil(
+        _ comment: Comment,
+        timeout: Duration = .seconds(5),
+        condition: () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await condition(), comment)
+    }
+}
+
+private actor CloseCallRecorder {
+    private(set) var count = 0
+
+    func record() {
+        count += 1
+    }
+}

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -387,6 +387,64 @@ struct AgentAttachStoreTests {
         await store.leave()
     }
 
+    @Test func transportReplacementPreservesImageAttachState() async throws {
+        // A reconnect replaces the terminal pipeline but must not touch the
+        // image interaction: its stager resolves the live Transport per
+        // call, so surfaced failures and results stay actionable.
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        // One byte of garbage: preparation fails and the failure surfaces.
+        store.selectImage(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("the failed image attach should surface") {
+            store.imageState.isFailed
+        }
+        let surfacedFailure = store.imageState
+        let initialID = store.terminalID
+
+        store.transportGenerationDidChange(1)
+        try await waitUntil("the terminal pipeline should be replaced") {
+            store.terminalID != initialID
+        }
+
+        #expect(store.imageState == surfacedFailure)
+
+        await store.leave()
+        #expect(store.imageState == .idle)
+    }
+
+    @Test func leaveDuringQueuedReplacementDoesNotResurrectTheTerminal() async throws {
+        // leave() can race in behind a queued transport replacement; the
+        // replacement must observe it and never rebuild the pipeline.
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the initial terminal should go live") {
+            store.terminalStatus == .live
+        }
+        let initialID = store.terminalID
+
+        store.transportGenerationDidChange(1)
+        await store.leave()
+
+        #expect(store.terminalID == initialID)
+        #expect(store.terminalStatus == .stopped)
+        #expect(await transport.hasLiveAttachSession == false)
+        #expect(await transport.attachRequests.count == 1)
+
+        // Generation changes arriving after leave must stay dead too.
+        store.transportGenerationDidChange(2)
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(store.terminalID == initialID)
+        #expect(await transport.attachRequests.count == 1)
+    }
+
     @Test func successfulCloseLeavesTheWholeAttachInteraction() async throws {
         let transport = ScriptedTransport()
         let closeCalls = CloseCallRecorder()

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -15,7 +15,19 @@ struct AttachTerminalStoreTests {
     ) -> (AttachTerminalStore, captured: Captured) {
         let store = AttachTerminalStore(
             target: target, takeover: takeover, input: input
-        ) { transport }
+        ) { request, handler in
+            guard let transport else {
+                throw TransportError.sshUnreachable(detail: "The Host is not connected.")
+            }
+            let session = try await transport.attachTerminal(request)
+            do {
+                try await handler.run(session)
+                await session.end()
+            } catch {
+                await session.end()
+                throw error
+            }
+        }
         let captured = Captured()
         store.feed.attach { data in captured.chunks.append(data) }
         return (store, captured)

--- a/Tests/HerdrMobileTests/ConsoleStoreTests.swift
+++ b/Tests/HerdrMobileTests/ConsoleStoreTests.swift
@@ -849,6 +849,119 @@ struct ConsoleStoreTests {
 
         store.setHosts([])
     }
+
+    /// A store whose session factory hands each Host the next transport in
+    /// its scripted sequence, so tests can drive SSH-level replacement.
+    private func makeStore(transportQueues: [Host.ID: TransportQueue]) -> ConsoleStore {
+        ConsoleStore(snapshotRetryDelay: .milliseconds(10)) { host, subscriptions in
+            EventsSession(
+                subscriptions: subscriptions,
+                connect: {
+                    guard let queue = transportQueues[host.id] else {
+                        throw TransportError.sshUnreachable(detail: "unscripted host")
+                    }
+                    return try await queue.next()
+                },
+                reconnectPolicy: Self.fastPolicy,
+                keepalive: nil)
+        }
+    }
+
+    @Test func transportReplacementAdvancesHostConnectionGeneration() async throws {
+        // The one path that must advance the projected generation: the SSH
+        // connection dies and the session installs a replacement Transport.
+        // This is the detail screen's only automatic-reattach trigger.
+        let host = Host.fixture()
+        let first = ScriptedTransport(
+            snapshot: .fixture(agents: [.fixture(paneID: "w1:p1")]))
+        let second = ScriptedTransport(
+            snapshot: .fixture(agents: [.fixture(paneID: "w1:p1")]))
+        let store = makeStore(
+            transportQueues: [host.id: TransportQueue([first, second])])
+
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the first transport should connect") {
+            store.hostStatuses[host.id] == .connected
+        }
+        #expect(store.hostConnectionGenerations[host.id] == 0)
+
+        // Kill the SSH connection outright: the stream ends and
+        // `isConnected` flips false, so the reconnect must replace the
+        // Transport instead of resubscribing on it.
+        try await first.close()
+        try await waitUntil("the replacement transport should connect") {
+            let resubscribed = await second.capturedSubscriptions.isEmpty == false
+            return resubscribed && store.hostStatuses[host.id] == .connected
+        }
+        try await waitUntil("the projected generation should advance") {
+            store.hostConnectionGenerations[host.id] == 1
+        }
+
+        store.setHosts([])
+    }
+
+    @Test func terminalRunnerAndImageStagerSurviveAHostEdit() async throws {
+        // The Attach screen holds its runner and stager for its whole
+        // lifetime. Editing the Host replaces the projection and ends its
+        // session; a call through the old handles must resolve the live
+        // projection instead of staying bound to the ended session.
+        let host = Host.fixture(name: "alpha")
+        let first = ScriptedTransport(snapshot: .fixture())
+        let second = ScriptedTransport(snapshot: .fixture())
+        let store = makeStore(
+            transportQueues: [host.id: TransportQueue([first, second])])
+
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the first transport should connect") {
+            store.hostStatuses[host.id] == .connected
+        }
+        let runner = store.terminalRunner(for: host.id)
+        let stager = store.imageStager(for: host.id)
+
+        var edited = host
+        edited.name = "alpha (renamed)"
+        store.setHosts([edited])
+        try await waitUntil("the replacement projection should connect") {
+            let resubscribed = await second.capturedSubscriptions.isEmpty == false
+            return resubscribed && store.hostStatuses[host.id] == .connected
+        }
+
+        let request = TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24)
+        try await runner(request, TerminalSessionHandler { _ in })
+        #expect(await second.attachRequests == [request])
+        #expect(await first.attachRequests.isEmpty)
+
+        let prepared = PreparedImage(
+            fileURL: URL(fileURLWithPath: "/tmp/attach-test.jpg"),
+            format: .jpeg, pixelWidth: 16, pixelHeight: 16, byteCount: 128)
+        await second.configureImageStaging(
+            outcomes: [.success(try StagedImage(path: "/tmp/staged/attach-test.jpg"))])
+        let staged = try await stager(prepared, ImageStageProgressReporter { _ in })
+        #expect(staged.path == "/tmp/staged/attach-test.jpg")
+        #expect(await second.stageRequests.count == 1)
+        #expect(await first.stageRequests.isEmpty)
+
+        store.setHosts([])
+    }
+}
+
+/// Hands out scripted transports in order, one per `connect`, so tests can
+/// drive SSH-level replacement deterministically.
+private actor TransportQueue {
+    private var remaining: [ScriptedTransport]
+
+    init(_ transports: [ScriptedTransport]) {
+        remaining = transports
+    }
+
+    func next() throws -> ScriptedTransport {
+        guard !remaining.isEmpty else {
+            throw TransportError.sshUnreachable(detail: "transport queue exhausted")
+        }
+        return remaining.removeFirst()
+    }
 }
 
 /// Captures the session a store's factory built, so overflow tests can

--- a/Tests/HerdrMobileTests/ConsoleStoreTests.swift
+++ b/Tests/HerdrMobileTests/ConsoleStoreTests.swift
@@ -515,9 +515,7 @@ struct ConsoleStoreTests {
         store.setHosts([])
     }
 
-    @Test func transportProviderHandsOutTheHostsLiveTransport() async throws {
-        // The Agent detail screen (#9) runs its backfill and live-follow
-        // through the Host's events-session transport, re-queried per use.
+    @Test func terminalRunnerOpensTheHostsLiveTransport() async throws {
         let host = Host.fixture()
         let transport = ScriptedTransport(snapshot: .fixture())
         let store = makeStore(transports: [host.id: transport])
@@ -528,20 +526,26 @@ struct ConsoleStoreTests {
             store.hostStatuses[host.id] == .connected
         }
 
-        let provider = store.transportProvider(for: host.id)
-        #expect(await provider() as? ScriptedTransport === transport)
-        let missing = await store.transportProvider(for: UUID())()
-        #expect(missing == nil)
+        let runner = store.terminalRunner(for: host.id)
+        let request = TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24)
+        try await runner(request, TerminalSessionHandler { _ in })
+        #expect(await transport.attachRequests == [request])
+
+        let missing = store.terminalRunner(for: UUID())
+        await #expect(throws: TransportError.self) {
+            try await missing(request, TerminalSessionHandler { _ in })
+        }
 
         store.setHosts([])
     }
 
-    @Test func transportProviderWaitsForPreviousTerminalTeardown() async throws {
+    @Test func terminalRunnerWaitsForPreviousTerminalTeardown() async throws {
         let host = Host.fixture()
         let transport = ScriptedTransport(snapshot: .fixture())
         let store = makeStore(transports: [host.id: transport])
         let gate = TerminalTeardownGate()
-        let result = TerminalTransportResult()
+        let result = TerminalOperationResult()
+        let request = TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24)
 
         store.setHosts([host])
         await store.resume()
@@ -549,12 +553,23 @@ struct ConsoleStoreTests {
             store.hostStatuses[host.id] == .connected
         }
 
-        store.scheduleTerminalTeardown(for: host.id) {
-            await gate.waitUntilOpen()
+        let runner = store.terminalRunner(for: host.id)
+        let first = Task {
+            try await runner(
+                request,
+                TerminalSessionHandler { _ in
+                    await gate.waitUntilOpen()
+                })
         }
-        let provider = store.transportProvider(for: host.id)
-        let request = Task {
-            await result.set(await provider())
+        try await waitUntil("the first terminal should open") {
+            await transport.attachRequests.count == 1
+        }
+        let second = Task {
+            try await runner(
+                request,
+                TerminalSessionHandler { _ in
+                    await result.set()
+                })
         }
 
         try await waitUntil("the previous teardown should start") {
@@ -562,10 +577,55 @@ struct ConsoleStoreTests {
         }
         try await Task.sleep(for: .milliseconds(30))
         #expect(await !result.wasSet)
+        #expect(await transport.attachRequests.count == 1)
 
         await gate.open()
-        await request.value
-        #expect(await result.transport as? ScriptedTransport === transport)
+        try await first.value
+        try await second.value
+        #expect(await result.wasSet)
+        #expect(await transport.attachRequests.count == 2)
+
+        store.setHosts([])
+    }
+
+    @Test func cancellingQueuedTerminalDoesNotLeakExclusiveAccess() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(snapshot: .fixture())
+        let store = makeStore(transports: [host.id: transport])
+        let gate = TerminalTeardownGate()
+        let request = TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24)
+
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the Host should connect") {
+            store.hostStatuses[host.id] == .connected
+        }
+
+        let runner = store.terminalRunner(for: host.id)
+        let first = Task {
+            try await runner(
+                request,
+                TerminalSessionHandler { _ in
+                    await gate.waitUntilOpen()
+                })
+        }
+        try await waitUntil("the first terminal should open") {
+            await transport.attachRequests.count == 1
+        }
+
+        let cancelled = Task {
+            try await runner(request, TerminalSessionHandler { _ in })
+        }
+        try await Task.sleep(for: .milliseconds(30))
+        cancelled.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await cancelled.value
+        }
+
+        await gate.open()
+        try await first.value
+        try await runner(request, TerminalSessionHandler { _ in })
+        #expect(await transport.attachRequests.count == 2)
 
         store.setHosts([])
     }
@@ -727,7 +787,7 @@ struct ConsoleStoreTests {
         store.setHosts([])
     }
 
-    @Test func realReconnectAdvancesHostConnectionGeneration() async throws {
+    @Test func eventChannelReconnectReusesHostConnectionGeneration() async throws {
         let host = Host.fixture()
         let transport = ScriptedTransport(
             snapshot: .fixture(agents: [.fixture(paneID: "w1:p1")]))
@@ -743,12 +803,12 @@ struct ConsoleStoreTests {
         #expect(store.hostConnectionGenerations[host.id] == 0)
 
         await transport.failEventStream(.channelFailed(detail: "connection dropped"))
-        try await waitUntil("the real reconnect should advance the generation") {
+        try await waitUntil("the event channel should reconnect on the same transport") {
             let subscriptions = await transport.capturedSubscriptions
             return subscriptions.count >= 3
-                && store.hostConnectionGenerations[host.id] == 1
                 && store.hostStatuses[host.id] == .connected
         }
+        #expect(store.hostConnectionGenerations[host.id] == 0)
 
         store.setHosts([])
     }
@@ -820,12 +880,10 @@ private actor TerminalTeardownGate {
     }
 }
 
-private actor TerminalTransportResult {
+private actor TerminalOperationResult {
     private(set) var wasSet = false
-    private(set) var transport: (any Transport)?
 
-    func set(_ transport: (any Transport)?) {
+    func set() {
         wasSet = true
-        self.transport = transport
     }
 }

--- a/Tests/HerdrMobileTests/EventsSessionE2ETests.swift
+++ b/Tests/HerdrMobileTests/EventsSessionE2ETests.swift
@@ -142,6 +142,7 @@ struct EventsSessionE2ETests {
             await session.resume()
             var iterator = session.updates.makeAsyncIterator()
             #expect(await iterator.next() == .status(.connected))
+            #expect(await session.transportGeneration == 0)
 
             // Kill the SSH connection out from under the session, as a
             // network death would.
@@ -152,6 +153,7 @@ struct EventsSessionE2ETests {
                 return
             }
             #expect(await iterator.next() == .status(.connected))
+            #expect(await session.transportGeneration == 1)
 
             #expect(factory.connectCount == 2)
             #expect(await !factory.transports[0].isConnected)

--- a/Tests/HerdrMobileTests/EventsSessionSubscriptionsTests.swift
+++ b/Tests/HerdrMobileTests/EventsSessionSubscriptionsTests.swift
@@ -31,12 +31,14 @@ struct EventsSessionSubscriptionsTests {
 
         await session.resume()
         #expect(await updates.next() == .status(.connected))
+        #expect(await session.transportGeneration == 0)
 
         await session.updateSubscriptions(updated)
 
         // A fresh `.connected` follows with no `.reconnecting` in between:
         // the teardown was deliberate, not a failure.
         #expect(await updates.next() == .status(.connected))
+        #expect(await session.transportGeneration == 0)
         #expect(await transport.capturedSubscriptions == [initial, updated])
         #expect(await !transport.isClosed, "resubscribe must reuse the SSH connection")
 

--- a/Tests/HerdrMobileTests/ImageAttachStoreTests.swift
+++ b/Tests/HerdrMobileTests/ImageAttachStoreTests.swift
@@ -343,7 +343,11 @@ struct ImageAttachStoreTests {
         let generation = input.beginSession { sent.value.append($0) }
         let store = ImageAttachStore(
             preparer: preparer,
-            transport: { transport },
+            stageImage: { image, reporter in
+                try await transport.stageImage(image) { progress in
+                    await reporter.report(progress)
+                }
+            },
             clipboard: clipboard,
             input: input)
         return Fixture(

--- a/Tests/HerdrMobileTests/SSHChannelBudgetTests.swift
+++ b/Tests/HerdrMobileTests/SSHChannelBudgetTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+@Suite("SSH channel budget")
+struct SSHChannelBudgetTests {
+    @Test func boundsConcurrentChannelLifetimes() async throws {
+        let budget = SSHChannelBudget(capacity: 2)
+        let gate = ChannelBudgetGate()
+        let probe = ChannelBudgetProbe()
+        let tasks = (0..<5).map { id in
+            Task {
+                try await budget.withChannel {
+                    await probe.enter(id)
+                    await gate.waitUntilOpen()
+                    await probe.leave()
+                }
+            }
+        }
+
+        try await waitUntil("two channel operations should enter") {
+            await probe.activeCount == 2
+        }
+        #expect(await probe.maximumActiveCount == 2)
+
+        await gate.open()
+        for task in tasks {
+            try await task.value
+        }
+        #expect(await probe.maximumActiveCount == 2)
+        #expect(await probe.enteredIDs.count == 5)
+    }
+
+    @Test func queuedCancellationDoesNotConsumeCapacity() async throws {
+        let budget = SSHChannelBudget(capacity: 1)
+        let holderGate = ChannelBudgetGate()
+        let holderEntered = ChannelBudgetGate()
+        let holder = Task {
+            try await budget.withChannel {
+                await holderEntered.open()
+                await holderGate.waitUntilOpen()
+            }
+        }
+        await holderEntered.waitUntilOpen()
+
+        let cancelledOperationRan = ChannelBudgetProbe()
+        let cancelled = Task {
+            try await budget.withChannel {
+                await cancelledOperationRan.enter(1)
+            }
+        }
+        await Task.yield()
+        cancelled.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await cancelled.value
+        }
+
+        let successorEntered = ChannelBudgetGate()
+        let successor = Task {
+            try await budget.withChannel {
+                await successorEntered.open()
+            }
+        }
+        await holderGate.open()
+        try await holder.value
+        await successorEntered.waitUntilOpen()
+        try await successor.value
+        #expect(await cancelledOperationRan.enteredIDs.isEmpty)
+    }
+
+    @Test func thrownOperationReleasesCapacityExactlyOnce() async throws {
+        let budget = SSHChannelBudget(capacity: 1)
+
+        await #expect(throws: ChannelBudgetTestError.expected) {
+            try await budget.withChannel {
+                throw ChannelBudgetTestError.expected
+            }
+        }
+
+        let entries = ChannelBudgetProbe()
+        try await budget.withChannel {
+            await entries.enter(1)
+            await entries.leave()
+        }
+        #expect(await entries.enteredIDs == [1])
+        #expect(await entries.maximumActiveCount == 1)
+    }
+
+    @Test func alreadyCancelledRequestNeverRunsItsOperation() async throws {
+        let budget = SSHChannelBudget(capacity: 1)
+        let entries = ChannelBudgetProbe()
+        let start = ChannelBudgetGate()
+        let task = Task {
+            await start.waitUntilOpen()
+            try await budget.withChannel {
+                await entries.enter(1)
+            }
+        }
+        task.cancel()
+        await start.open()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(await entries.enteredIDs.isEmpty)
+
+        try await budget.withChannel {}
+    }
+
+    private func waitUntil(
+        _ message: String,
+        timeout: Duration = .seconds(2),
+        condition: @escaping @Sendable () async -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        Issue.record(Comment(rawValue: message))
+    }
+}
+
+private enum ChannelBudgetTestError: Error {
+    case expected
+}
+
+private actor ChannelBudgetGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func waitUntilOpen() async {
+        if isOpen { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        let parked = waiters
+        waiters.removeAll()
+        for waiter in parked {
+            waiter.resume()
+        }
+    }
+}
+
+private actor ChannelBudgetProbe {
+    private(set) var activeCount = 0
+    private(set) var maximumActiveCount = 0
+    private(set) var enteredIDs: [Int] = []
+
+    func enter(_ id: Int) {
+        activeCount += 1
+        maximumActiveCount = max(maximumActiveCount, activeCount)
+        enteredIDs.append(id)
+    }
+
+    func leave() {
+        activeCount -= 1
+    }
+}

--- a/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Synchronization
 import Testing
 
 @testable import HerdrMobile
@@ -183,6 +184,50 @@ struct SSHTransportE2ETests {
                 server.receivedRequests.map(\.method)
                     == ["tab.create", "agent.start", "pane.close"])
             #expect(server.receivedRequests.last?.params == #"{"pane_id":"w1:p9"}"#)
+        }
+    }
+
+    @Test func agentStartRetriesWhileTheFreshPanesShellBoots() async throws {
+        // herdr 0.7.5 rejects agent.start with agent_pane_busy until the new
+        // pane's shell reaches its interactive prompt (a few seconds on some
+        // hosts). The transport retries the start briefly instead of
+        // surfacing the boot race to the user.
+        let busyReplies = Mutex(2)
+        try await withTransport { request in
+            switch request.method {
+            case "tab.create":
+                return [
+                    #"{"id":"\#(request.id)","result":{"type":"tab_created","tab":{"tab_id":"w1:t9","workspace_id":"w1","number":9,"label":"9","focused":false,"pane_count":1,"agent_status":"unknown"},"root_pane":{"pane_id":"w1:p9","terminal_id":"term_new","workspace_id":"w1","tab_id":"w1:t9","focused":false,"agent_status":"unknown","revision":0}}}"#
+                ]
+            case "agent.start":
+                let stillBooting = busyReplies.withLock { remaining in
+                    guard remaining > 0 else { return false }
+                    remaining -= 1
+                    return true
+                }
+                if stillBooting {
+                    return [
+                        #"{"id":"\#(request.id)","error":{"code":"agent_pane_busy","message":"agent target pane w1:p9 is not an available shell"}}"#
+                    ]
+                }
+                return [
+                    #"{"id":"\#(request.id)","result":{"type":"agent_started","argv":["claude"],"agent":{"terminal_id":"term_new","agent":"claude","terminal_title":"⠐ claude","terminal_title_stripped":"claude","agent_status":"working","workspace_id":"w1","tab_id":"w1:t9","pane_id":"w1:p9","focused":false,"cwd":"/work/a","foreground_cwd":"/work/a","revision":1}}}"#
+                ]
+            default:
+                Issue.record("Unexpected request: \(request.method)")
+                return []
+            }
+        } body: { transport, server in
+            let agent = try await transport.startAgent(
+                AgentLaunchRequest(kind: "claude", name: "reviewer", workspaceID: "w1"))
+
+            #expect(agent.paneID == "w1:p9")
+            #expect(agent.status == .working)
+            // Two boot rejections, then success — and the fresh pane must
+            // never have been torn down along the way.
+            #expect(
+                server.receivedRequests.map(\.method)
+                    == ["tab.create", "agent.start", "agent.start", "agent.start"])
         }
     }
 


### PR DESCRIPTION
## What

Four deep-module refactors that pull scattered runtime ownership back behind small interfaces, plus the regression fixes found while reviewing and testing them.

### Refactors

- **SSH channel budget** (`SSHChannelBudget`): FIFO queuing, cancellation safety and the acquire/release pairing move out of five hand-written call sites into one actor with a scoped `withChannel` API. The "8 + events + terminal = MaxSessions 10" budget is now named-constant arithmetic instead of three comments.
- **Host runtime ownership** (`EventsSession`): `currentTransport` no longer leaks. Ordinary RPCs go through `withTransport`, terminal lifetimes through `withTerminalTransport` (a FIFO permit held from attach until teardown returns), and the replacement generation is owned by the session — it advances only when the Transport entity is actually replaced, so an events-channel blip no longer recycles a healthy terminal.
- **Attach coordination** (`AgentAttachStore`): the cross-store ordering rules that lived in `AgentDetailView` (reconnect replacement, image-before-terminal leave, close ordering) move into one lifecycle-serialized store; the view only forwards intents. Fixes an old race where `onDisappear` could stop a stale store after a reconnect.
- **Host Console projection** (`HostConsoleProjection`): the per-Host state bag (`HostFeed`) plus all the `feed:`-parameter behavior on `ConsoleStore` becomes a projection that owns snapshot/delta convergence, retry, snippets and Host RPC. `ConsoleStore` is reduced to catalog reconciliation, cross-Host aggregation and observable publishing.

### Regression fixes (from adversarial review of the refactors)

- `terminalRunner`/`imageStager` are late-bound again: handles held by a live Attach screen resolve the current projection per call, so editing a Host no longer strands the screen on an ended session.
- Reconnect no longer wipes image-attach state: retryable failures, background-interrupted uploads and completed results survive transport replacement (the stager resolves the live Transport per call).
- The projected transport generation is monotonic — out-of-order async reads can no longer regress it and trigger a spurious terminal replacement.

### Fix found by GUI testing

- herdr 0.7.5 rejects `agent.start` with `agent_pane_busy` until the fresh pane's shell reaches its interactive prompt, which broke Start Agent outright. The transport now retries briefly during shell boot (`startAgentAwaitingShell`), and CLAUDE.md documents the tightened 0.7.5 behavior. refs #12

## Verification

- Full unit + e2e suite: 317 tests green, including the sshd-backed transport suites.
- New coverage: `SSHChannelBudgetTests` (real-concurrency FIFO/cancellation), exclusivity + queued-cancellation tests, transport-replacement generation advancement, late-binding survival after a Host edit, image-state survival across replacement, leave-vs-queued-replacement race, `agent.start` boot retry (e2e).
- Manual GUI regression pass (Simulator, driven end-to-end against a live herdr 0.7.5 over real SSH): start agent, attach, background/foreground auto-recovery on the terminal screen, image-result survival across reconnect, Host edit re-sync + reattach, close ordering — all pass.