### PR TITLE
feat: scan-to-pair new-device onboarding via herdr plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  plugin-test:
+    name: Pairing plugin (Node)
+    runs-on: [self-hosted, Linux, X64, vps]
+    defaults:
+      run:
+        working-directory: plugin
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Run plugin tests
+        run: npm test
+
   codegen-drift:
     name: Wire-type codegen drift
     runs-on: [self-hosted, Linux, X64, vps]

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ DerivedData/
 .build/
 .swiftpm/
 
+# Node (pairing plugin)
+plugin/node_modules/
+
 # macOS
 .DS_Store
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,6 +8,26 @@ A native iOS agent console for herdr. One context: the app. Terms owned by herdr
 A remote machine reachable over SSH that runs a herdr server. The unit a user adds, names, and authenticates against.
 _Avoid_: server, machine, connection
 
+**Device Key**:
+The device's SSH identity: an Ed25519 keypair generated on this device. The private key never leaves the Keychain; the public half is what a Host authorizes.
+_Avoid_: app key, client key
+
+**Pairing**:
+The full new-device ceremony: scan a Pairing Code, connect with its Bootstrap Key, complete Enrollment, then reconnect with the Device Key. Success produces a working Host, persisted only at that point.
+_Avoid_: scan to connect, binding
+
+**Pairing Code**:
+The versioned pairing payload (candidate addresses, host key fingerprint, Bootstrap Key, expiry) produced by the pairing plugin. The QR image is just its rendering.
+_Avoid_: QR code, invite
+
+**Bootstrap Key**:
+A single-use, TTL-bound Ed25519 keypair carried inside a Pairing Code. Its authorized_keys line is restricted to a forced command that can only perform Enrollment; it is destroyed on success or expiry.
+_Avoid_: temp key, one-time password
+
+**Enrollment**:
+The server-side step of Pairing: the forced command appends the Device Key's public key to authorized_keys. Distinct from Pairing as a whole — failure copy must say which step failed.
+_Avoid_: install key, authorization
+
 **Agent**:
 A coding agent process (claude, codex, ...) running inside a herdr pane, as reported by herdr's detection. The primary object of the app.
 _Avoid_: bot, task, session

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		4C80E23F09C8CFB3A93101B8 /* JSONValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3E2308A50D4744A24A874B /* JSONValue.swift */; };
 		4D5BBEA6FE5430530AB0AAE7 /* AgentAttachStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C07948FE6D5E399672A9395 /* AgentAttachStore.swift */; };
 		4DECB9E21914EFB5C89D4AB3 /* PairingCeremonyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1ED5537111C58EDB54FD37 /* PairingCeremonyTests.swift */; };
+		527D9FD128FA6F9C7BC8B572 /* AuthorizedKeysTestLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98770FDE6BA9A8EEC4FECA3 /* AuthorizedKeysTestLock.swift */; };
 		535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */; };
 		54C4A61E21C2C7D8A618E462 /* PairingCeremony.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D4C26D457FF045C3E7D3EF9 /* PairingCeremony.swift */; };
 		5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */; };
@@ -76,6 +77,7 @@
 		A50735C51FEFF58E6B83025B /* PairingScanStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC250A036B0CEE727A99C5B4 /* PairingScanStore.swift */; };
 		B0D87D1783C80597B66EDDFC /* HerdrAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD390F4EE653187BCF20037F /* HerdrAPITypes.swift */; };
 		B31E16D56EE1F19A3802625B /* TransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4476B101AA4B13190C7A7B7C /* TransportConnector.swift */; };
+		B32EA361C16DD5F87AEEEDEC /* PairingCeremonyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FDA76A0BFC199882EAF72B /* PairingCeremonyE2ETests.swift */; };
 		B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCA39340517CEF3DAA35A09B /* Preflight.swift */; };
 		B67206DA3D497FF8E75F79AC /* HostConsoleProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DA2856C9762E5E0BC147BA /* HostConsoleProjection.swift */; };
 		B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C232163905675760F37FD7A0 /* KnownHostsStore.swift */; };
@@ -90,6 +92,7 @@
 		C863E192DD66E3689C012342 /* ImageAttachStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCDC5144D5AA6403150431A /* ImageAttachStoreTests.swift */; };
 		CAFF027EF047D3AACE5F5243 /* ImagePreparerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29ABD9B1F458A3948086A16 /* ImagePreparerTests.swift */; };
 		CC20BAD2AC1A725889F82A20 /* ClosePaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13921A61B4E4F17CDE47C96 /* ClosePaneStore.swift */; };
+		CD358CC16A58086C056E975D /* SSHPairingConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22BD6D0C396E9EC0E979793 /* SSHPairingConnector.swift */; };
 		CDF8E14EC629CBD8F946FE05 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D95D580BCF4FE792AEFE974 /* ContentView.swift */; };
 		D11D524FCF49C49763C9F9D7 /* Host.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806A90DBCA99FD02E76D68C6 /* Host.swift */; };
 		D51F828E0AC4A2F6C23A0CBE /* TerminalThemeSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */; };
@@ -101,6 +104,7 @@
 		DE84101EE6E1BF5878C76C49 /* ConsoleStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95E62CA572C71B2C746E972 /* ConsoleStore.swift */; };
 		E163DDD01C21515191F6DF55 /* HostListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9B76E2DA818DAB4259286C /* HostListView.swift */; };
 		E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */; };
+		E26AA78B1E305437525A32D4 /* PairingConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C9A0A8D0063285A276A28DA /* PairingConnector.swift */; };
 		E30244FD0231DD02EC9978D0 /* EventsSubscribeE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4076B0E816625CD09EB29F2E /* EventsSubscribeE2ETests.swift */; };
 		E37B688F0A59B1E4085C2C18 /* HostDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E3451A4ECA518B0AE43F93 /* HostDraftTests.swift */; };
 		E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */; };
@@ -136,6 +140,7 @@
 		0B3FA15CCDC83C72DDA81BEB /* AgentCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentCardView.swift; sourceTree = "<group>"; };
 		127EB78F8CCC219F6C435626 /* ImageStaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStaging.swift; sourceTree = "<group>"; };
 		13D82A3B3C17DBFB114AAF0A /* SSHChannelBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHChannelBudget.swift; sourceTree = "<group>"; };
+		16FDA76A0BFC199882EAF72B /* PairingCeremonyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCeremonyE2ETests.swift; sourceTree = "<group>"; };
 		17424B6972D7D7E6271350A5 /* PairingCodeVectorFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCodeVectorFile.swift; sourceTree = "<group>"; };
 		17F86744BFAC66D732CE7833 /* JSONValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueTests.swift; sourceTree = "<group>"; };
 		18AE2DC88A745FB457350957 /* StartAgentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentView.swift; sourceTree = "<group>"; };
@@ -185,6 +190,7 @@
 		8323C68B13826B7388800B1F /* DeviceKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyStoreTests.swift; sourceTree = "<group>"; };
 		87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStoreTests.swift; sourceTree = "<group>"; };
 		89863F261DC0C6F317D75786 /* PhotosPickerImageSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosPickerImageSelection.swift; sourceTree = "<group>"; };
+		8C9A0A8D0063285A276A28DA /* PairingConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingConnector.swift; sourceTree = "<group>"; };
 		904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSSHTestEnvironment.swift; sourceTree = "<group>"; };
 		90875ADAF6E348E186C8125A /* SSHCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHCredentials.swift; sourceTree = "<group>"; };
 		9291334E33C85C7588F86281 /* EventsSessionE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionE2ETests.swift; sourceTree = "<group>"; };
@@ -201,6 +207,7 @@
 		A95E62CA572C71B2C746E972 /* ConsoleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleStore.swift; sourceTree = "<group>"; };
 		A961D26EDEAA03AFB0F9C408 /* TerminalThemeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemeSettings.swift; sourceTree = "<group>"; };
 		A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConcurrencyE2ETests.swift; sourceTree = "<group>"; };
+		B22BD6D0C396E9EC0E979793 /* SSHPairingConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPairingConnector.swift; sourceTree = "<group>"; };
 		B383994C2C8492694D5F3690 /* HerdrMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HerdrMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B66B41C393D38FA09388E3E2 /* ReconnectPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectPolicyTests.swift; sourceTree = "<group>"; };
 		B75316F4E6B80E442C365765 /* TerminalInputControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalInputControllerTests.swift; sourceTree = "<group>"; };
@@ -233,6 +240,7 @@
 		F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWire.swift; sourceTree = "<group>"; };
 		F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransportE2ETests.swift; sourceTree = "<group>"; };
 		F6851566A8DBF603AA768404 /* PairingCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCode.swift; sourceTree = "<group>"; };
+		F98770FDE6BA9A8EEC4FECA3 /* AuthorizedKeysTestLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizedKeysTestLock.swift; sourceTree = "<group>"; };
 		FC250A036B0CEE727A99C5B4 /* PairingScanStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScanStore.swift; sourceTree = "<group>"; };
 		FCB521B35951ABDA186FAFCF /* TerminalTouchScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTouchScroll.swift; sourceTree = "<group>"; };
 		FCB59377D34D0C652DF70F01 /* UnixSockets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnixSockets.swift; sourceTree = "<group>"; };
@@ -350,6 +358,7 @@
 				A32D737E753ABEB2809975EA /* ImageStagingTests.swift */,
 				17F86744BFAC66D732CE7833 /* JSONValueTests.swift */,
 				87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */,
+				16FDA76A0BFC199882EAF72B /* PairingCeremonyE2ETests.swift */,
 				EB1ED5537111C58EDB54FD37 /* PairingCeremonyTests.swift */,
 				9C1FDF65F7282EF79C3D376C /* PairingCodeTests.swift */,
 				6FF497632F5FD2BBB8D5BF0F /* PairingScanStoreTests.swift */,
@@ -377,8 +386,10 @@
 			children = (
 				5D4C26D457FF045C3E7D3EF9 /* PairingCeremony.swift */,
 				F6851566A8DBF603AA768404 /* PairingCode.swift */,
+				8C9A0A8D0063285A276A28DA /* PairingConnector.swift */,
 				FC250A036B0CEE727A99C5B4 /* PairingScanStore.swift */,
 				26D91CE49181E7932CBD1AAC /* PairingScanView.swift */,
+				B22BD6D0C396E9EC0E979793 /* SSHPairingConnector.swift */,
 			);
 			path = Pairing;
 			sourceTree = "<group>";
@@ -474,6 +485,7 @@
 		CB45F25667AE3C5C2EFD76CB /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				F98770FDE6BA9A8EEC4FECA3 /* AuthorizedKeysTestLock.swift */,
 				20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */,
 				C14983BD8988E4AAE79DC46A /* FakeTransportConnector.swift */,
 				9B106E427EE5358088B615CE /* InMemorySecretStore.swift */,
@@ -631,12 +643,14 @@
 				B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */,
 				54C4A61E21C2C7D8A618E462 /* PairingCeremony.swift in Sources */,
 				EE22FB818F023585C4A07D9C /* PairingCode.swift in Sources */,
+				E26AA78B1E305437525A32D4 /* PairingConnector.swift in Sources */,
 				A50735C51FEFF58E6B83025B /* PairingScanStore.swift in Sources */,
 				BC46FD1688F34030A1121C58 /* PairingScanView.swift in Sources */,
 				A14E6D20D1216F7764E3298B /* PhotosPickerImageSelection.swift in Sources */,
 				B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */,
 				8196491DBF3B6024B4DB214C /* SSHChannelBudget.swift in Sources */,
 				8C514AFC85DAED69A4988C13 /* SSHCredentials.swift in Sources */,
+				CD358CC16A58086C056E975D /* SSHPairingConnector.swift in Sources */,
 				073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */,
 				693B0173C07DAF4BFC89B094 /* SecretStore.swift in Sources */,
 				1E26593A1B05B0ACEE9AC557 /* SettingsView.swift in Sources */,
@@ -662,6 +676,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D818864671292BE9F965CAA6 /* AttachTerminalStoreTests.swift in Sources */,
+				527D9FD128FA6F9C7BC8B572 /* AuthorizedKeysTestLock.swift in Sources */,
 				6092F63FF2DE77AD7D087A7C /* ClosePaneStoreTests.swift in Sources */,
 				0700F97FBF6A714C5D9EA5CD /* ColdStartE2ETests.swift in Sources */,
 				93851E040C292A16F5ECB10D /* ConsoleStoreTests.swift in Sources */,
@@ -688,6 +703,7 @@
 				969057C35F7E5F162B0CF41D /* JSONValueTests.swift in Sources */,
 				2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */,
 				F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */,
+				B32EA361C16DD5F87AEEEDEC /* PairingCeremonyE2ETests.swift in Sources */,
 				4DECB9E21914EFB5C89D4AB3 /* PairingCeremonyTests.swift in Sources */,
 				8558806B5DFE751EB1FA3814 /* PairingCodeTests.swift in Sources */,
 				678CB0B828602B38AC23BD26 /* PairingCodeVectorFile.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		A2B3C4D5E6F7012345678901 /* AgentAttachStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F7012345678902 /* AgentAttachStore.swift */; };
-		A3B4C5D6E7F8012345678901 /* HostConsoleProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B4C5D6E7F8012345678902 /* HostConsoleProjection.swift */; };
 		006767F8F679B28FDC853D69 /* ConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44D9663DAB1E8942FBFCD1C /* ConsoleView.swift */; };
 		017151AEC5D404665A3FAB41 /* HostDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE12859365BC7A57B9EC256A /* HostDraft.swift */; };
 		033E8DCA2F64ABE6CA898758 /* EventsSessionSubscriptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA5E9DDE1AB0F68F6EC56EB /* EventsSessionSubscriptionsTests.swift */; };
@@ -29,6 +27,7 @@
 		27C44B69FBE155A397F54B77 /* HostStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AECAD39A269D97DAB4ED194 /* HostStore.swift */; };
 		29832666B5E02B0D33453DB1 /* EventsSessionBufferingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641088A470B51F40C898830F /* EventsSessionBufferingTests.swift */; };
 		298FA49167E3CB1402B7B86B /* DeviceKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04EAA030D8329A1716714A8 /* DeviceKeyStore.swift */; };
+		2BA659E85F8A8A7A4CAC614E /* pairing-code-v1.json in Resources */ = {isa = PBXBuildFile; fileRef = 7474FD0BACB07ADB3570E5BE /* pairing-code-v1.json */; };
 		2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */; };
 		2CE9115816E7CE945ABCF7A8 /* AgentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADF336771A3F757F2AD441D /* AgentDetailView.swift */; };
 		2E4C392847F96047AF0510DD /* PreflightReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB88AD0F4E9EE776B17FAFAA /* PreflightReportTests.swift */; };
@@ -42,11 +41,13 @@
 		48C7F12EA8EF701E1F6D8649 /* ImagePreparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7730887B9AF1CE45D9FB9AAB /* ImagePreparer.swift */; };
 		49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E51D58B1094AC5B389EDA /* Transport.swift */; };
 		4C80E23F09C8CFB3A93101B8 /* JSONValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3E2308A50D4744A24A874B /* JSONValue.swift */; };
+		4D5BBEA6FE5430530AB0AAE7 /* AgentAttachStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C07948FE6D5E399672A9395 /* AgentAttachStore.swift */; };
 		535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */; };
 		5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */; };
 		5D1B735C72D551ADE0D82D44 /* TerminalThemeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A961D26EDEAA03AFB0F9C408 /* TerminalThemeSettings.swift */; };
 		6092F63FF2DE77AD7D087A7C /* ClosePaneStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC2552636663F92A55D1DFF1 /* ClosePaneStoreTests.swift */; };
 		6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */; };
+		678CB0B828602B38AC23BD26 /* PairingCodeVectorFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17424B6972D7D7E6271350A5 /* PairingCodeVectorFile.swift */; };
 		68E0CF3B2078B4450366AF36 /* ImageStagingE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA18CA4EC57526EA84A6DEE8 /* ImageStagingE2ETests.swift */; };
 		693B0173C07DAF4BFC89B094 /* SecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567573855DCC8571BC02096D /* SecretStore.swift */; };
 		6CBE7E0961FFD970A614ED4B /* AgentCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3FA15CCDC83C72DDA81BEB /* AgentCardView.swift */; };
@@ -54,7 +55,10 @@
 		718719DA8913E787FA68BD45 /* GhosttyTerminal in Frameworks */ = {isa = PBXBuildFile; productRef = 168EBAF199220582EB0C49F7 /* GhosttyTerminal */; };
 		724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */; };
 		782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */; };
+		7C453E2308A9E12532A24705 /* SSHChannelBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CA60F860890A7CAA368B268 /* SSHChannelBudgetTests.swift */; };
 		7EEB41E5CD728587D7DCEC96 /* StartAgentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18AE2DC88A745FB457350957 /* StartAgentView.swift */; };
+		8196491DBF3B6024B4DB214C /* SSHChannelBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13D82A3B3C17DBFB114AAF0A /* SSHChannelBudget.swift */; };
+		8558806B5DFE751EB1FA3814 /* PairingCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1FDF65F7282EF79C3D376C /* PairingCodeTests.swift */; };
 		86C5F3E2D17523948343DF09 /* GeneratedWireTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87B816CE7206B37622287C4 /* GeneratedWireTypesTests.swift */; };
 		8C514AFC85DAED69A4988C13 /* SSHCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90875ADAF6E348E186C8125A /* SSHCredentials.swift */; };
 		8DF99F3257BCC6AE08595A45 /* TerminalKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DB204D5F25D5375D5B2974 /* TerminalKeyboard.swift */; };
@@ -66,12 +70,11 @@
 		9C1C00F36A178BF1BEE6C0A5 /* StartAgentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E14A4298DB015E6477F789 /* StartAgentStore.swift */; };
 		9F3F748E722FD8059A59ECBD /* HostStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6434D31A79422C0BAE80993F /* HostStoreTests.swift */; };
 		A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */; };
-		A1B2C3D4E5F6012345678901 /* SSHChannelBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6012345678902 /* SSHChannelBudget.swift */; };
-		A1B2C3D4E5F6012345678903 /* SSHChannelBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6012345678904 /* SSHChannelBudgetTests.swift */; };
 		A14E6D20D1216F7764E3298B /* PhotosPickerImageSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89863F261DC0C6F317D75786 /* PhotosPickerImageSelection.swift */; };
 		B0D87D1783C80597B66EDDFC /* HerdrAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD390F4EE653187BCF20037F /* HerdrAPITypes.swift */; };
 		B31E16D56EE1F19A3802625B /* TransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4476B101AA4B13190C7A7B7C /* TransportConnector.swift */; };
 		B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCA39340517CEF3DAA35A09B /* Preflight.swift */; };
+		B67206DA3D497FF8E75F79AC /* HostConsoleProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DA2856C9762E5E0BC147BA /* HostConsoleProjection.swift */; };
 		B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C232163905675760F37FD7A0 /* KnownHostsStore.swift */; };
 		B8ACB86B152D44FC0C80DADA /* TerminalTouchScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB521B35951ABDA186FAFCF /* TerminalTouchScroll.swift */; };
 		BAC9F51A72EA9774DEDBC193 /* TerminalByteFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7C6974BD9BE77000016FCA /* TerminalByteFeed.swift */; };
@@ -101,6 +104,7 @@
 		E908289DF03C6732F7D91328 /* HerdrEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */; };
 		EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */; };
 		EDFEE058F85AF41DBFE351A7 /* TerminalTextSelectionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786B2BA8A0683BB9DC71D797 /* TerminalTextSelectionPresenter.swift */; };
+		EE22FB818F023585C4A07D9C /* PairingCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6851566A8DBF603AA768404 /* PairingCode.swift */; };
 		EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */; };
 		F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */; };
 		F62A9CD06CFB784550AF4977 /* DeviceKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558159B2AF61C28F6B1391A2 /* DeviceKeyTests.swift */; };
@@ -120,13 +124,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		A2B3C4D5E6F7012345678902 /* AgentAttachStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAttachStore.swift; sourceTree = "<group>"; };
-		A3B4C5D6E7F8012345678902 /* HostConsoleProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostConsoleProjection.swift; sourceTree = "<group>"; };
 		02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportFailureModesE2ETests.swift; sourceTree = "<group>"; };
+		05DA2856C9762E5E0BC147BA /* HostConsoleProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostConsoleProjection.swift; sourceTree = "<group>"; };
 		079394F4C6AC8FE4D7B0779C /* ConsoleStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleStoreTests.swift; sourceTree = "<group>"; };
 		08E14A4298DB015E6477F789 /* StartAgentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStore.swift; sourceTree = "<group>"; };
 		0B3FA15CCDC83C72DDA81BEB /* AgentCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentCardView.swift; sourceTree = "<group>"; };
 		127EB78F8CCC219F6C435626 /* ImageStaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStaging.swift; sourceTree = "<group>"; };
+		13D82A3B3C17DBFB114AAF0A /* SSHChannelBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHChannelBudget.swift; sourceTree = "<group>"; };
+		17424B6972D7D7E6271350A5 /* PairingCodeVectorFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCodeVectorFile.swift; sourceTree = "<group>"; };
 		17F86744BFAC66D732CE7833 /* JSONValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueTests.swift; sourceTree = "<group>"; };
 		18AE2DC88A745FB457350957 /* StartAgentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentView.swift; sourceTree = "<group>"; };
 		1C3ACB2A319C5C1298A29F3F /* EventsSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSession.swift; sourceTree = "<group>"; };
@@ -138,6 +143,7 @@
 		25E3451A4ECA518B0AE43F93 /* HostDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostDraftTests.swift; sourceTree = "<group>"; };
 		278668F4D5B3EB85E6CDA16A /* HostFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostFormView.swift; sourceTree = "<group>"; };
 		29DD3828DAEF46DBA7038B0A /* HostOnboardingStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostOnboardingStoreTests.swift; sourceTree = "<group>"; };
+		3C07948FE6D5E399672A9395 /* AgentAttachStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAttachStore.swift; sourceTree = "<group>"; };
 		3CCDC5144D5AA6403150431A /* ImageAttachStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachStoreTests.swift; sourceTree = "<group>"; };
 		3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedAsyncOperation.swift; sourceTree = "<group>"; };
 		4076B0E816625CD09EB29F2E /* EventsSubscribeE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSubscribeE2ETests.swift; sourceTree = "<group>"; };
@@ -155,11 +161,13 @@
 		6CA5E9DDE1AB0F68F6EC56EB /* EventsSessionSubscriptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionSubscriptionsTests.swift; sourceTree = "<group>"; };
 		6F7C6974BD9BE77000016FCA /* TerminalByteFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalByteFeed.swift; sourceTree = "<group>"; };
 		73DB204D5F25D5375D5B2974 /* TerminalKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeyboard.swift; sourceTree = "<group>"; };
+		7474FD0BACB07ADB3570E5BE /* pairing-code-v1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "pairing-code-v1.json"; sourceTree = "<group>"; };
 		7730887B9AF1CE45D9FB9AAB /* ImagePreparer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreparer.swift; sourceTree = "<group>"; };
 		78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrMobileApp.swift; sourceTree = "<group>"; };
 		786B2BA8A0683BB9DC71D797 /* TerminalTextSelectionPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTextSelectionPresenter.swift; sourceTree = "<group>"; };
 		7AFE5C640586747D567E1CF1 /* ScriptedTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptedTransport.swift; sourceTree = "<group>"; };
 		7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransport.swift; sourceTree = "<group>"; };
+		7CA60F860890A7CAA368B268 /* SSHChannelBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHChannelBudgetTests.swift; sourceTree = "<group>"; };
 		7D95D580BCF4FE792AEFE974 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7DCAF31058B6430B514B2188 /* HostOnboardingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostOnboardingStore.swift; sourceTree = "<group>"; };
 		7E538BF75AE58E16C58782F7 /* HostOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostOnboardingView.swift; sourceTree = "<group>"; };
@@ -177,8 +185,7 @@
 		9AECAD39A269D97DAB4ED194 /* HostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStore.swift; sourceTree = "<group>"; };
 		9B106E427EE5358088B615CE /* InMemorySecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemorySecretStore.swift; sourceTree = "<group>"; };
 		9B4847B965ACCAC480398065 /* ImageAttachStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachStore.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F6012345678902 /* SSHChannelBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHChannelBudget.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F6012345678904 /* SSHChannelBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHChannelBudgetTests.swift; sourceTree = "<group>"; };
+		9C1FDF65F7282EF79C3D376C /* PairingCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCodeTests.swift; sourceTree = "<group>"; };
 		A32D737E753ABEB2809975EA /* ImageStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStagingTests.swift; sourceTree = "<group>"; };
 		A549DEB5B5CE8FDD29CE2A28 /* AttachTerminalStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachTerminalStoreTests.swift; sourceTree = "<group>"; };
 		A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrEventsTests.swift; sourceTree = "<group>"; };
@@ -216,6 +223,7 @@
 		F3D159C84E98A59AA47EBE6C /* HerdrMobileTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HerdrMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWire.swift; sourceTree = "<group>"; };
 		F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransportE2ETests.swift; sourceTree = "<group>"; };
+		F6851566A8DBF603AA768404 /* PairingCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCode.swift; sourceTree = "<group>"; };
 		FCB521B35951ABDA186FAFCF /* TerminalTouchScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTouchScroll.swift; sourceTree = "<group>"; };
 		FCB59377D34D0C652DF70F01 /* UnixSockets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnixSockets.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -273,8 +281,8 @@
 				C232163905675760F37FD7A0 /* KnownHostsStore.swift */,
 				567573855DCC8571BC02096D /* SecretStore.swift */,
 				3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */,
+				13D82A3B3C17DBFB114AAF0A /* SSHChannelBudget.swift */,
 				90875ADAF6E348E186C8125A /* SSHCredentials.swift */,
-				A1B2C3D4E5F6012345678902 /* SSHChannelBudget.swift */,
 				7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */,
 				8007AF9894BE8BAFFA7A6372 /* TerminalAttach.swift */,
 				BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */,
@@ -332,12 +340,13 @@
 				A32D737E753ABEB2809975EA /* ImageStagingTests.swift */,
 				17F86744BFAC66D732CE7833 /* JSONValueTests.swift */,
 				87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */,
+				9C1FDF65F7282EF79C3D376C /* PairingCodeTests.swift */,
 				DB88AD0F4E9EE776B17FAFAA /* PreflightReportTests.swift */,
 				B66B41C393D38FA09388E3E2 /* ReconnectPolicyTests.swift */,
 				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
 				6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */,
+				7CA60F860890A7CAA368B268 /* SSHChannelBudgetTests.swift */,
 				5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */,
-				A1B2C3D4E5F6012345678904 /* SSHChannelBudgetTests.swift */,
 				F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */,
 				A71CE71D20ABB90D7E94264E /* StartAgentStoreTests.swift */,
 				D83F34B22988623AD8E2093C /* TerminalAttachE2ETests.swift */,
@@ -349,6 +358,14 @@
 				CB45F25667AE3C5C2EFD76CB /* Support */,
 			);
 			path = HerdrMobileTests;
+			sourceTree = "<group>";
+		};
+		853F15C2EAF72E4C01430318 /* Pairing */ = {
+			isa = PBXGroup;
+			children = (
+				F6851566A8DBF603AA768404 /* PairingCode.swift */,
+			);
+			path = Pairing;
 			sourceTree = "<group>";
 		};
 		859D599DFA07BF9B6E1632DC /* Tests */ = {
@@ -379,6 +396,7 @@
 		92BF3289E67D5AE641333441 = {
 			isa = PBXGroup;
 			children = (
+				BF37D2443711E9C737D114B2 /* plugin */,
 				DCFD134B630B84B0F5FA6115 /* Sources */,
 				859D599DFA07BF9B6E1632DC /* Tests */,
 				55902E0ABDF1F168FA193448 /* Products */,
@@ -388,7 +406,7 @@
 		AEEB5E7751FD30413560D58D /* Console */ = {
 			isa = PBXGroup;
 			children = (
-				A2B3C4D5E6F7012345678902 /* AgentAttachStore.swift */,
+				3C07948FE6D5E399672A9395 /* AgentAttachStore.swift */,
 				0B3FA15CCDC83C72DDA81BEB /* AgentCardView.swift */,
 				5ADF336771A3F757F2AD441D /* AgentDetailView.swift */,
 				97970F4D535CC80592333995 /* AttachTerminalStore.swift */,
@@ -396,7 +414,7 @@
 				498ECBCD631F9734C28861EA /* ConsoleAgent.swift */,
 				A95E62CA572C71B2C746E972 /* ConsoleStore.swift */,
 				C44D9663DAB1E8942FBFCD1C /* ConsoleView.swift */,
-				A3B4C5D6E7F8012345678902 /* HostConsoleProjection.swift */,
+				05DA2856C9762E5E0BC147BA /* HostConsoleProjection.swift */,
 				08E14A4298DB015E6477F789 /* StartAgentStore.swift */,
 				18AE2DC88A745FB457350957 /* StartAgentView.swift */,
 			);
@@ -411,6 +429,7 @@
 				AEEB5E7751FD30413560D58D /* Console */,
 				85F7BECB72876852AAA885F2 /* Hosts */,
 				B9BA381B5B296A3BE02F125E /* Images */,
+				853F15C2EAF72E4C01430318 /* Pairing */,
 				076C8448389275EA5E67DA9F /* Settings */,
 				758C1B00FCD3935541ADA64F /* Terminal */,
 				41C75ABDF8DC22F0282957C5 /* Transport */,
@@ -429,6 +448,14 @@
 			path = Images;
 			sourceTree = "<group>";
 		};
+		BF37D2443711E9C737D114B2 /* plugin */ = {
+			isa = PBXGroup;
+			children = (
+				FBD6A7CD89990AD177ADB1D0 /* test-vectors */,
+			);
+			path = plugin;
+			sourceTree = "<group>";
+		};
 		CB45F25667AE3C5C2EFD76CB /* Support */ = {
 			isa = PBXGroup;
 			children = (
@@ -436,6 +463,7 @@
 				C14983BD8988E4AAE79DC46A /* FakeTransportConnector.swift */,
 				9B106E427EE5358088B615CE /* InMemorySecretStore.swift */,
 				904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */,
+				17424B6972D7D7E6271350A5 /* PairingCodeVectorFile.swift */,
 				7AFE5C640586747D567E1CF1 /* ScriptedTransport.swift */,
 				FCB59377D34D0C652DF70F01 /* UnixSockets.swift */,
 			);
@@ -448,6 +476,14 @@
 				B5CBF3555504362CC1FFDFE5 /* HerdrMobile */,
 			);
 			path = Sources;
+			sourceTree = "<group>";
+		};
+		FBD6A7CD89990AD177ADB1D0 /* test-vectors */ = {
+			isa = PBXGroup;
+			children = (
+				7474FD0BACB07ADB3570E5BE /* pairing-code-v1.json */,
+			);
+			path = "test-vectors";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -479,6 +515,7 @@
 			buildConfigurationList = 0D85695648C7ED60972632BD /* Build configuration list for PBXNativeTarget "HerdrMobileTests" */;
 			buildPhases = (
 				B4B9C6FCBEEBB72725BFF787 /* Sources */,
+				ADD4254368B6DA14497BD8B7 /* Resources */,
 				D05488154B05215AC8565AB4 /* Frameworks */,
 			);
 			buildRules = (
@@ -529,13 +566,23 @@
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		ADD4254368B6DA14497BD8B7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2BA659E85F8A8A7A4CAC614E /* pairing-code-v1.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		8A7F6144162C733E402E680E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A2B3C4D5E6F7012345678901 /* AgentAttachStore.swift in Sources */,
-				A3B4C5D6E7F8012345678901 /* HostConsoleProjection.swift in Sources */,
+				4D5BBEA6FE5430530AB0AAE7 /* AgentAttachStore.swift in Sources */,
 				6CBE7E0961FFD970A614ED4B /* AgentCardView.swift in Sources */,
 				2CE9115816E7CE945ABCF7A8 /* AgentDetailView.swift in Sources */,
 				225ECBDC69A7785559BC4D20 /* AttachTerminalStore.swift in Sources */,
@@ -552,6 +599,7 @@
 				EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */,
 				A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */,
 				D11D524FCF49C49763C9F9D7 /* Host.swift in Sources */,
+				B67206DA3D497FF8E75F79AC /* HostConsoleProjection.swift in Sources */,
 				1BF53C7A5E6402747F26096A /* HostCredentialsProvider.swift in Sources */,
 				017151AEC5D404665A3FAB41 /* HostDraft.swift in Sources */,
 				DBB9FF4BC72D3AA244E2ECE0 /* HostFormView.swift in Sources */,
@@ -566,10 +614,11 @@
 				0B82C5F60B548ED11F8C3045 /* ImageStaging.swift in Sources */,
 				4C80E23F09C8CFB3A93101B8 /* JSONValue.swift in Sources */,
 				B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */,
+				EE22FB818F023585C4A07D9C /* PairingCode.swift in Sources */,
 				A14E6D20D1216F7764E3298B /* PhotosPickerImageSelection.swift in Sources */,
 				B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */,
+				8196491DBF3B6024B4DB214C /* SSHChannelBudget.swift in Sources */,
 				8C514AFC85DAED69A4988C13 /* SSHCredentials.swift in Sources */,
-				A1B2C3D4E5F6012345678901 /* SSHChannelBudget.swift in Sources */,
 				073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */,
 				693B0173C07DAF4BFC89B094 /* SecretStore.swift in Sources */,
 				1E26593A1B05B0ACEE9AC557 /* SettingsView.swift in Sources */,
@@ -621,11 +670,13 @@
 				969057C35F7E5F162B0CF41D /* JSONValueTests.swift in Sources */,
 				2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */,
 				F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */,
+				8558806B5DFE751EB1FA3814 /* PairingCodeTests.swift in Sources */,
+				678CB0B828602B38AC23BD26 /* PairingCodeVectorFile.swift in Sources */,
 				2E4C392847F96047AF0510DD /* PreflightReportTests.swift in Sources */,
 				1BBEEF5478D91222F48C2048 /* ReconnectPolicyTests.swift in Sources */,
 				3DC1B4DCC0E2CD73A0C13B64 /* SSHAuthE2ETests.swift in Sources */,
+				7C453E2308A9E12532A24705 /* SSHChannelBudgetTests.swift in Sources */,
 				5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */,
-				A1B2C3D4E5F6012345678903 /* SSHChannelBudgetTests.swift in Sources */,
 				E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */,
 				473F834A4C680F18BA303DB9 /* ScriptedTransport.swift in Sources */,
 				6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -991,7 +991,7 @@
 			repositoryURL = "https://github.com/lakr233/libghostty-spm.git";
 			requirement = {
 				kind = exactVersion;
-				version = 1.3.2;
+				version = 1.3.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		9F3F748E722FD8059A59ECBD /* HostStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6434D31A79422C0BAE80993F /* HostStoreTests.swift */; };
 		A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */; };
 		A14E6D20D1216F7764E3298B /* PhotosPickerImageSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89863F261DC0C6F317D75786 /* PhotosPickerImageSelection.swift */; };
+		A50735C51FEFF58E6B83025B /* PairingScanStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC250A036B0CEE727A99C5B4 /* PairingScanStore.swift */; };
 		B0D87D1783C80597B66EDDFC /* HerdrAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD390F4EE653187BCF20037F /* HerdrAPITypes.swift */; };
 		B31E16D56EE1F19A3802625B /* TransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4476B101AA4B13190C7A7B7C /* TransportConnector.swift */; };
 		B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCA39340517CEF3DAA35A09B /* Preflight.swift */; };
@@ -91,6 +92,7 @@
 		D51F828E0AC4A2F6C23A0CBE /* TerminalThemeSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */; };
 		D6E9D6545089932306C4704F /* HostKeyFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CBE401E4A5FA5871809E540 /* HostKeyFingerprint.swift */; };
 		D818864671292BE9F965CAA6 /* AttachTerminalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A549DEB5B5CE8FDD29CE2A28 /* AttachTerminalStoreTests.swift */; };
+		DB2F714BFA12259D2D6D9715 /* PairingScanStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF497632F5FD2BBB8D5BF0F /* PairingScanStoreTests.swift */; };
 		DBB9FF4BC72D3AA244E2ECE0 /* HostFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278668F4D5B3EB85E6CDA16A /* HostFormView.swift */; };
 		DC564E76486D243AD1741F7E /* SharedAsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */; };
 		DE84101EE6E1BF5878C76C49 /* ConsoleStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95E62CA572C71B2C746E972 /* ConsoleStore.swift */; };
@@ -160,6 +162,7 @@
 		6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHAuthE2ETests.swift; sourceTree = "<group>"; };
 		6CA5E9DDE1AB0F68F6EC56EB /* EventsSessionSubscriptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionSubscriptionsTests.swift; sourceTree = "<group>"; };
 		6F7C6974BD9BE77000016FCA /* TerminalByteFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalByteFeed.swift; sourceTree = "<group>"; };
+		6FF497632F5FD2BBB8D5BF0F /* PairingScanStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScanStoreTests.swift; sourceTree = "<group>"; };
 		73DB204D5F25D5375D5B2974 /* TerminalKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeyboard.swift; sourceTree = "<group>"; };
 		7474FD0BACB07ADB3570E5BE /* pairing-code-v1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "pairing-code-v1.json"; sourceTree = "<group>"; };
 		7730887B9AF1CE45D9FB9AAB /* ImagePreparer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreparer.swift; sourceTree = "<group>"; };
@@ -224,6 +227,7 @@
 		F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWire.swift; sourceTree = "<group>"; };
 		F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransportE2ETests.swift; sourceTree = "<group>"; };
 		F6851566A8DBF603AA768404 /* PairingCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCode.swift; sourceTree = "<group>"; };
+		FC250A036B0CEE727A99C5B4 /* PairingScanStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScanStore.swift; sourceTree = "<group>"; };
 		FCB521B35951ABDA186FAFCF /* TerminalTouchScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTouchScroll.swift; sourceTree = "<group>"; };
 		FCB59377D34D0C652DF70F01 /* UnixSockets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnixSockets.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -341,6 +345,7 @@
 				17F86744BFAC66D732CE7833 /* JSONValueTests.swift */,
 				87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */,
 				9C1FDF65F7282EF79C3D376C /* PairingCodeTests.swift */,
+				6FF497632F5FD2BBB8D5BF0F /* PairingScanStoreTests.swift */,
 				DB88AD0F4E9EE776B17FAFAA /* PreflightReportTests.swift */,
 				B66B41C393D38FA09388E3E2 /* ReconnectPolicyTests.swift */,
 				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
@@ -364,6 +369,7 @@
 			isa = PBXGroup;
 			children = (
 				F6851566A8DBF603AA768404 /* PairingCode.swift */,
+				FC250A036B0CEE727A99C5B4 /* PairingScanStore.swift */,
 			);
 			path = Pairing;
 			sourceTree = "<group>";
@@ -615,6 +621,7 @@
 				4C80E23F09C8CFB3A93101B8 /* JSONValue.swift in Sources */,
 				B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */,
 				EE22FB818F023585C4A07D9C /* PairingCode.swift in Sources */,
+				A50735C51FEFF58E6B83025B /* PairingScanStore.swift in Sources */,
 				A14E6D20D1216F7764E3298B /* PhotosPickerImageSelection.swift in Sources */,
 				B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */,
 				8196491DBF3B6024B4DB214C /* SSHChannelBudget.swift in Sources */,
@@ -672,6 +679,7 @@
 				F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */,
 				8558806B5DFE751EB1FA3814 /* PairingCodeTests.swift in Sources */,
 				678CB0B828602B38AC23BD26 /* PairingCodeVectorFile.swift in Sources */,
+				DB2F714BFA12259D2D6D9715 /* PairingScanStoreTests.swift in Sources */,
 				2E4C392847F96047AF0510DD /* PreflightReportTests.swift in Sources */,
 				1BBEEF5478D91222F48C2048 /* ReconnectPolicyTests.swift in Sources */,
 				3DC1B4DCC0E2CD73A0C13B64 /* SSHAuthE2ETests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		B8ACB86B152D44FC0C80DADA /* TerminalTouchScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB521B35951ABDA186FAFCF /* TerminalTouchScroll.swift */; };
 		BAC9F51A72EA9774DEDBC193 /* TerminalByteFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7C6974BD9BE77000016FCA /* TerminalByteFeed.swift */; };
 		BC107519427157CF5191E34F /* FakeTransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14983BD8988E4AAE79DC46A /* FakeTransportConnector.swift */; };
+		BC46FD1688F34030A1121C58 /* PairingScanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D91CE49181E7932CBD1AAC /* PairingScanView.swift */; };
 		C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB59377D34D0C652DF70F01 /* UnixSockets.swift */; };
 		C60E8E0398665C36520DDA8E /* HerdrEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABFC5E35C19F809355619E7 /* HerdrEvents.swift */; };
 		C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 03BEAFDD98C535CDCE9AE335 /* Citadel */; };
@@ -143,6 +144,7 @@
 		20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeHerdrServer.swift; sourceTree = "<group>"; };
 		259E51D58B1094AC5B389EDA /* Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
 		25E3451A4ECA518B0AE43F93 /* HostDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostDraftTests.swift; sourceTree = "<group>"; };
+		26D91CE49181E7932CBD1AAC /* PairingScanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScanView.swift; sourceTree = "<group>"; };
 		278668F4D5B3EB85E6CDA16A /* HostFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostFormView.swift; sourceTree = "<group>"; };
 		29DD3828DAEF46DBA7038B0A /* HostOnboardingStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostOnboardingStoreTests.swift; sourceTree = "<group>"; };
 		3C07948FE6D5E399672A9395 /* AgentAttachStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAttachStore.swift; sourceTree = "<group>"; };
@@ -370,6 +372,7 @@
 			children = (
 				F6851566A8DBF603AA768404 /* PairingCode.swift */,
 				FC250A036B0CEE727A99C5B4 /* PairingScanStore.swift */,
+				26D91CE49181E7932CBD1AAC /* PairingScanView.swift */,
 			);
 			path = Pairing;
 			sourceTree = "<group>";
@@ -622,6 +625,7 @@
 				B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */,
 				EE22FB818F023585C4A07D9C /* PairingCode.swift in Sources */,
 				A50735C51FEFF58E6B83025B /* PairingScanStore.swift in Sources */,
+				BC46FD1688F34030A1121C58 /* PairingScanView.swift in Sources */,
 				A14E6D20D1216F7764E3298B /* PhotosPickerImageSelection.swift in Sources */,
 				B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */,
 				8196491DBF3B6024B4DB214C /* SSHChannelBudget.swift in Sources */,
@@ -717,6 +721,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "herdr uses the camera to scan the Pairing Code shown on your computer, so you can add that machine without typing anything.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "herdr uses the microphone to transcribe your spoken reply into the message box. Audio is processed on device and never leaves your phone.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -757,6 +762,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "herdr uses the camera to scan the Pairing Code shown on your computer, so you can add that machine without typing anything.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "herdr uses the microphone to transcribe your spoken reply into the message box. Audio is processed on device and never leaves your phone.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		2E4C392847F96047AF0510DD /* PreflightReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB88AD0F4E9EE776B17FAFAA /* PreflightReportTests.swift */; };
 		30A69209EA01A8DF784ABC52 /* TerminalInputControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75316F4E6B80E442C365765 /* TerminalInputControllerTests.swift */; };
 		36B674DF605ECAE382E51196 /* HostOnboardingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCAF31058B6430B514B2188 /* HostOnboardingStore.swift */; };
+		3B0FFA83C8F1751A86BD3EA5 /* FakePairingConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7448C8647569740BB956262 /* FakePairingConnector.swift */; };
 		3DC1B4DCC0E2CD73A0C13B64 /* SSHAuthE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */; };
 		3ECB4DD848A1C73AF0ED4B5F /* ConsoleAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498ECBCD631F9734C28861EA /* ConsoleAgent.swift */; };
 		41BBA40C97BAE65E56D0E3B5 /* TerminalAttach.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8007AF9894BE8BAFFA7A6372 /* TerminalAttach.swift */; };
@@ -240,6 +241,7 @@
 		F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWire.swift; sourceTree = "<group>"; };
 		F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransportE2ETests.swift; sourceTree = "<group>"; };
 		F6851566A8DBF603AA768404 /* PairingCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCode.swift; sourceTree = "<group>"; };
+		F7448C8647569740BB956262 /* FakePairingConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakePairingConnector.swift; sourceTree = "<group>"; };
 		F98770FDE6BA9A8EEC4FECA3 /* AuthorizedKeysTestLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizedKeysTestLock.swift; sourceTree = "<group>"; };
 		FC250A036B0CEE727A99C5B4 /* PairingScanStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScanStore.swift; sourceTree = "<group>"; };
 		FCB521B35951ABDA186FAFCF /* TerminalTouchScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTouchScroll.swift; sourceTree = "<group>"; };
@@ -487,6 +489,7 @@
 			children = (
 				F98770FDE6BA9A8EEC4FECA3 /* AuthorizedKeysTestLock.swift */,
 				20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */,
+				F7448C8647569740BB956262 /* FakePairingConnector.swift */,
 				C14983BD8988E4AAE79DC46A /* FakeTransportConnector.swift */,
 				9B106E427EE5358088B615CE /* InMemorySecretStore.swift */,
 				904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */,
@@ -687,6 +690,7 @@
 				033E8DCA2F64ABE6CA898758 /* EventsSessionSubscriptionsTests.swift in Sources */,
 				E30244FD0231DD02EC9978D0 /* EventsSubscribeE2ETests.swift in Sources */,
 				EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */,
+				3B0FFA83C8F1751A86BD3EA5 /* FakePairingConnector.swift in Sources */,
 				BC107519427157CF5191E34F /* FakeTransportConnector.swift in Sources */,
 				86C5F3E2D17523948343DF09 /* GeneratedWireTypesTests.swift in Sources */,
 				E908289DF03C6732F7D91328 /* HerdrEventsTests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -42,7 +42,9 @@
 		49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E51D58B1094AC5B389EDA /* Transport.swift */; };
 		4C80E23F09C8CFB3A93101B8 /* JSONValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3E2308A50D4744A24A874B /* JSONValue.swift */; };
 		4D5BBEA6FE5430530AB0AAE7 /* AgentAttachStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C07948FE6D5E399672A9395 /* AgentAttachStore.swift */; };
+		4DECB9E21914EFB5C89D4AB3 /* PairingCeremonyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1ED5537111C58EDB54FD37 /* PairingCeremonyTests.swift */; };
 		535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */; };
+		54C4A61E21C2C7D8A618E462 /* PairingCeremony.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D4C26D457FF045C3E7D3EF9 /* PairingCeremony.swift */; };
 		5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */; };
 		5D1B735C72D551ADE0D82D44 /* TerminalThemeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A961D26EDEAA03AFB0F9C408 /* TerminalThemeSettings.swift */; };
 		6092F63FF2DE77AD7D087A7C /* ClosePaneStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC2552636663F92A55D1DFF1 /* ClosePaneStoreTests.swift */; };
@@ -158,6 +160,7 @@
 		567573855DCC8571BC02096D /* SecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretStore.swift; sourceTree = "<group>"; };
 		597ACEE9D688E433B20108D7 /* TerminalScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalScreenView.swift; sourceTree = "<group>"; };
 		5ADF336771A3F757F2AD441D /* AgentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetailView.swift; sourceTree = "<group>"; };
+		5D4C26D457FF045C3E7D3EF9 /* PairingCeremony.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCeremony.swift; sourceTree = "<group>"; };
 		641088A470B51F40C898830F /* EventsSessionBufferingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionBufferingTests.swift; sourceTree = "<group>"; };
 		6434D31A79422C0BAE80993F /* HostStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStoreTests.swift; sourceTree = "<group>"; };
 		646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColdStartE2ETests.swift; sourceTree = "<group>"; };
@@ -221,6 +224,7 @@
 		DE12859365BC7A57B9EC256A /* HostDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostDraft.swift; sourceTree = "<group>"; };
 		E87B816CE7206B37622287C4 /* GeneratedWireTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedWireTypesTests.swift; sourceTree = "<group>"; };
 		EA18CA4EC57526EA84A6DEE8 /* ImageStagingE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStagingE2ETests.swift; sourceTree = "<group>"; };
+		EB1ED5537111C58EDB54FD37 /* PairingCeremonyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCeremonyTests.swift; sourceTree = "<group>"; };
 		EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemeSettingsTests.swift; sourceTree = "<group>"; };
 		EF9B76E2DA818DAB4259286C /* HostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostListView.swift; sourceTree = "<group>"; };
 		F13921A61B4E4F17CDE47C96 /* ClosePaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosePaneStore.swift; sourceTree = "<group>"; };
@@ -346,6 +350,7 @@
 				A32D737E753ABEB2809975EA /* ImageStagingTests.swift */,
 				17F86744BFAC66D732CE7833 /* JSONValueTests.swift */,
 				87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */,
+				EB1ED5537111C58EDB54FD37 /* PairingCeremonyTests.swift */,
 				9C1FDF65F7282EF79C3D376C /* PairingCodeTests.swift */,
 				6FF497632F5FD2BBB8D5BF0F /* PairingScanStoreTests.swift */,
 				DB88AD0F4E9EE776B17FAFAA /* PreflightReportTests.swift */,
@@ -370,6 +375,7 @@
 		853F15C2EAF72E4C01430318 /* Pairing */ = {
 			isa = PBXGroup;
 			children = (
+				5D4C26D457FF045C3E7D3EF9 /* PairingCeremony.swift */,
 				F6851566A8DBF603AA768404 /* PairingCode.swift */,
 				FC250A036B0CEE727A99C5B4 /* PairingScanStore.swift */,
 				26D91CE49181E7932CBD1AAC /* PairingScanView.swift */,
@@ -623,6 +629,7 @@
 				0B82C5F60B548ED11F8C3045 /* ImageStaging.swift in Sources */,
 				4C80E23F09C8CFB3A93101B8 /* JSONValue.swift in Sources */,
 				B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */,
+				54C4A61E21C2C7D8A618E462 /* PairingCeremony.swift in Sources */,
 				EE22FB818F023585C4A07D9C /* PairingCode.swift in Sources */,
 				A50735C51FEFF58E6B83025B /* PairingScanStore.swift in Sources */,
 				BC46FD1688F34030A1121C58 /* PairingScanView.swift in Sources */,
@@ -681,6 +688,7 @@
 				969057C35F7E5F162B0CF41D /* JSONValueTests.swift in Sources */,
 				2C5A21065C48B7C40AE9A760 /* KnownHostsStoreTests.swift in Sources */,
 				F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */,
+				4DECB9E21914EFB5C89D4AB3 /* PairingCeremonyTests.swift in Sources */,
 				8558806B5DFE751EB1FA3814 /* PairingCodeTests.swift in Sources */,
 				678CB0B828602B38AC23BD26 /* PairingCodeVectorFile.swift in Sources */,
 				DB2F714BFA12259D2D6D9715 /* PairingScanStoreTests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HerdrMobile.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lakr233/libghostty-spm.git",
       "state" : {
-        "revision" : "5530721e8e975178ac8293708f23815281f16f72",
-        "version" : "1.3.2"
+        "revision" : "b0930320739324886590e865d571eb5dd7073912",
+        "version" : "1.3.1"
       }
     },
     {

--- a/Sources/HerdrMobile/Hosts/HostListView.swift
+++ b/Sources/HerdrMobile/Hosts/HostListView.swift
@@ -67,6 +67,7 @@ struct HostListView: View {
     let store: HostStore
     @State private var removal: HostRemovalStore
     @State private var isAddingHost = false
+    @State private var isScanningToPair = false
     @State private var path: [Host.ID] = []
 
     init(store: HostStore) {
@@ -91,8 +92,13 @@ struct HostListView: View {
                     } description: {
                         Text("Add a machine that runs herdr to get started.")
                     } actions: {
-                        Button("Add Host") { isAddingHost = true }
-                            .buttonStyle(.borderedProminent)
+                        // Scan to Pair is the primary add-Host action; the
+                        // manual form is the fallback (ADR 0007).
+                        Button("Scan to Pair", systemImage: "qrcode.viewfinder") {
+                            isScanningToPair = true
+                        }
+                        .buttonStyle(.borderedProminent)
+                        Button("Add Manually") { isAddingHost = true }
                     }
                 } else {
                     List {
@@ -107,6 +113,12 @@ struct HostListView: View {
             }
             .navigationTitle("Hosts")
             .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Scan to Pair", systemImage: "qrcode.viewfinder") {
+                        isScanningToPair = true
+                    }
+                    .disabled(store.catalogLoadError != nil)
+                }
                 ToolbarItem(placement: .primaryAction) {
                     Button("Add Host", systemImage: "plus") { isAddingHost = true }
                         .disabled(store.catalogLoadError != nil)
@@ -126,6 +138,9 @@ struct HostListView: View {
                 HostFormView(store: store) { saved in
                     path.append(saved.id)
                 }
+            }
+            .sheet(isPresented: $isScanningToPair) {
+                PairingScanView()
             }
             .alert(
                 removal.pendingRequest?.title ?? "Remove Host?",

--- a/Sources/HerdrMobile/Hosts/HostListView.swift
+++ b/Sources/HerdrMobile/Hosts/HostListView.swift
@@ -68,6 +68,7 @@ struct HostListView: View {
     @State private var removal: HostRemovalStore
     @State private var isAddingHost = false
     @State private var isScanningToPair = false
+    @State private var manualFallbackRequested = false
     @State private var path: [Host.ID] = []
 
     init(store: HostStore) {
@@ -139,11 +140,24 @@ struct HostListView: View {
                     path.append(saved.id)
                 }
             }
-            .sheet(isPresented: $isScanningToPair) {
+            .sheet(
+                isPresented: $isScanningToPair,
+                onDismiss: {
+                    // The scan sheet's "Add Manually" fallback (camera denied
+                    // or unsupported): present the form only once this sheet
+                    // is fully gone, so the two sheets never overlap.
+                    if manualFallbackRequested {
+                        manualFallbackRequested = false
+                        isAddingHost = true
+                    }
+                }
+            ) {
                 // A successful Pairing lands in the same onboarding preflight
                 // a manually added Host enters (session discovery included).
                 PairingScanView(catalog: store) { paired in
                     path.append(paired.id)
+                } onAddManually: {
+                    manualFallbackRequested = true
                 }
             }
             .alert(

--- a/Sources/HerdrMobile/Hosts/HostListView.swift
+++ b/Sources/HerdrMobile/Hosts/HostListView.swift
@@ -140,7 +140,11 @@ struct HostListView: View {
                 }
             }
             .sheet(isPresented: $isScanningToPair) {
-                PairingScanView()
+                // A successful Pairing lands in the same onboarding preflight
+                // a manually added Host enters (session discovery included).
+                PairingScanView(catalog: store) { paired in
+                    path.append(paired.id)
+                }
             }
             .alert(
                 removal.pendingRequest?.title ?? "Remove Host?",

--- a/Sources/HerdrMobile/Pairing/PairingCeremony.swift
+++ b/Sources/HerdrMobile/Pairing/PairingCeremony.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// The steps of the pairing ceremony, in order (ADR 0007). Failure copy is
+/// keyed per step so the user knows whether to rescan, fix the network, or
+/// regenerate the Pairing Code. `parse` failures never reach the ceremony
+/// client — `PairingCode.decode` reports them as `PairingCodeError` — but the
+/// step exists so every failure surface shares one taxonomy.
+enum PairingStep: Sendable, Equatable, CaseIterable {
+    /// Decoding the scanned string into a Pairing Code.
+    case parse
+    /// Finding a candidate address that presents the pinned host key.
+    case reach
+    /// Authenticating with the Bootstrap Key.
+    case authenticate
+    /// Submitting the Device Key public line to the Enrollment entrypoint.
+    case enroll
+    /// Reconnecting with the Device Key to prove Enrollment took effect.
+    case verify
+}
+
+/// Why the pairing ceremony failed, classified per step.
+enum PairingCeremonyError: Error, Sendable, Equatable {
+    /// No candidate address yielded an SSH server presenting the pinned host
+    /// key within the per-address timeout. Carries one line per attempted
+    /// address for diagnostics.
+    case hostUnreachable(detail: String)
+    /// The Host is there — its key matched the pinned fingerprint — but it
+    /// rejected the Bootstrap Key: the code was already used, its line
+    /// expired and was swept, or the popup was closed.
+    case bootstrapRejected
+    /// The Enrollment entrypoint answered, and said no.
+    case enrollmentRefused(EnrollmentRefusal)
+    /// The Enrollment exchange broke down: the forced command's stdout did
+    /// not speak the accept protocol, the channel died, or the exchange
+    /// timed out.
+    case enrollmentFailed(detail: String)
+    /// The reconnect with the enrolled Device Key failed, so the Host was
+    /// not persisted.
+    case verificationFailed(detail: String)
+
+    /// The Pairing step this failure is attributed to.
+    var step: PairingStep {
+        switch self {
+        case .hostUnreachable: .reach
+        case .bootstrapRejected: .authenticate
+        case .enrollmentRefused, .enrollmentFailed: .enroll
+        case .verificationFailed: .verify
+        }
+    }
+}
+
+/// A refusal code from the Enrollment accept protocol (`plugin/README.md`).
+/// Unrecognized codes are kept verbatim: a newer plugin may refuse for
+/// reasons this build does not know, and that is still a refusal.
+enum EnrollmentRefusal: Sendable, Equatable {
+    /// No pending ceremony: already used, cleaned up, or never existed.
+    case unknownPairing
+    /// The TTL passed; the Bootstrap Key line was removed. Regenerate.
+    case expired
+    /// The submission was not a bare Ed25519 public line. Retry is allowed.
+    case invalidKey
+    /// Nothing arrived on stdin. Retry is allowed.
+    case noInput
+    case unrecognized(code: String)
+
+    init(wireCode: String) {
+        switch wireCode {
+        case "unknown_pairing": self = .unknownPairing
+        case "expired": self = .expired
+        case "invalid_key": self = .invalidKey
+        case "no_input": self = .noInput
+        default: self = .unrecognized(code: wireCode)
+        }
+    }
+}
+
+/// What a completed ceremony proves: the facts the app persists as a Host
+/// (only after the verified reconnect — a failed pairing leaves nothing).
+struct PairingResult: Sendable, Equatable {
+    /// The candidate address the ceremony succeeded against.
+    let address: String
+    let port: Int
+    let username: String
+    /// The fingerprint the Host actually presented, digest-equal to the
+    /// pinned one from the Pairing Code but algorithm-aware, ready for the
+    /// known-hosts store.
+    let hostKeyFingerprint: HostKeyFingerprint
+}
+
+/// One line of the Enrollment accept stdout protocol:
+///
+///     HERDR-ENROLL:OK:<SHA256:fingerprint>
+///     HERDR-ENROLL:ERR:<code>
+///
+/// Anything else is not a response at all (login-shell noise, a wrong forced
+/// command) and parses to nil.
+enum EnrollmentResponse: Sendable, Equatable {
+    case enrolled(fingerprint: String)
+    case refused(EnrollmentRefusal)
+
+    static func parse(line: String) -> EnrollmentResponse? {
+        if let fingerprint = line.wholeMatch(of: /HERDR-ENROLL:OK:(SHA256:[A-Za-z0-9+\/]{43})/) {
+            return .enrolled(fingerprint: String(fingerprint.1))
+        }
+        if let refusal = line.wholeMatch(of: /HERDR-ENROLL:ERR:([a-z_]+)/) {
+            return .refused(EnrollmentRefusal(wireCode: String(refusal.1)))
+        }
+        return nil
+    }
+}

--- a/Sources/HerdrMobile/Pairing/PairingCode.swift
+++ b/Sources/HerdrMobile/Pairing/PairingCode.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+/// A parsed Pairing Code: the versioned payload the pairing plugin renders as
+/// a QR image (ADR 0007). Wire format:
+///
+///     HERDR-PAIR:<version>:<base64url(JSON, no padding)>
+///
+/// The schema and error taxonomy live in `plugin/README.md`; the shared test
+/// vectors in `plugin/test-vectors/pairing-code-v1.json` are the single
+/// source of truth for both this decoder and the plugin's encoder. Unknown
+/// payload fields are ignored (additive v1 metadata); breaking changes bump
+/// the version, which both implementations must honor together.
+struct PairingCode: Sendable, Equatable {
+    static let prefix = "HERDR-PAIR"
+    static let version = 1
+
+    /// Candidate addresses in the order the app should try them.
+    /// IPv6 literals carry no brackets and no zone id.
+    let addresses: [String]
+    /// SSH port, 1...65535.
+    let port: Int
+    /// SSH username.
+    let username: String
+    /// The Host's SSH host key fingerprint, pinned instead of a TOFU prompt.
+    let hostKeyFingerprint: HostKeyFingerprint
+    /// The Bootstrap Key material, absent on a config-only Pairing Code.
+    let bootstrap: Bootstrap?
+
+    /// The single-use Enrollment credential carried inside a Pairing Code.
+    /// Lives in memory only; never enters the Keychain (ADR 0007).
+    struct Bootstrap: Sendable, Equatable {
+        /// Raw 32-byte Ed25519 seed of the Bootstrap Key.
+        let seed: Data
+        /// When the Host deletes the Bootstrap Key's authorized_keys line.
+        let expiresAt: Date
+    }
+
+    /// Decodes and validates a scanned Pairing Code string.
+    static func decode(_ scanned: String) throws(PairingCodeError) -> PairingCode {
+        guard scanned.hasPrefix("\(prefix):") else {
+            throw .badPrefix
+        }
+        let rest = scanned.dropFirst(prefix.count + 1)
+        guard let separator = rest.firstIndex(of: ":") else {
+            throw .badPrefix
+        }
+        let foundVersion = String(rest[..<separator])
+        guard foundVersion == String(version) else {
+            throw .unsupportedVersion(found: foundVersion)
+        }
+
+        guard let body = decodeBase64URL(String(rest[rest.index(after: separator)...])) else {
+            throw .badEncoding
+        }
+        let wire: WirePayload
+        do {
+            wire = try JSONDecoder().decode(WirePayload.self, from: body)
+        } catch DecodingError.dataCorrupted {
+            // Only unparseable JSON reaches here: every wire field is decoded
+            // as an optional lenient type, so shape problems surface as
+            // typeMismatch/valueNotFound and are classified below.
+            throw .badEncoding
+        } catch {
+            throw .badPayload(reason: "payload shape mismatch")
+        }
+        return try validated(wire)
+    }
+
+    private static func validated(_ wire: WirePayload) throws(PairingCodeError) -> PairingCode {
+        guard let addresses = wire.addrs, !addresses.isEmpty else {
+            throw .badPayload(reason: "addresses must be a non-empty array")
+        }
+        for address in addresses where address.isEmpty || containsWhitespace(address) {
+            throw .badPayload(reason: "invalid address: \(address)")
+        }
+        guard
+            let portValue = wire.port, let port = Int(exactly: portValue),
+            (1...65535).contains(port)
+        else {
+            throw .badPayload(reason: "port must be an integer in 1..65535")
+        }
+        guard let username = wire.user, !username.isEmpty, !containsWhitespace(username) else {
+            throw .badPayload(reason: "username must be a non-empty string without whitespace")
+        }
+        guard let fingerprint = parseFingerprint(wire.fp) else {
+            throw .badPayload(reason: "fp must be an OpenSSH SHA256 fingerprint")
+        }
+
+        let bootstrap: Bootstrap?
+        switch (wire.seed, wire.exp) {
+        case (nil, nil):
+            bootstrap = nil
+        case (let seed?, let exp?):
+            guard let seedData = decodeBase64URL(seed), seedData.count == bootstrapSeedBytes else {
+                throw .badPayload(reason: "seed must be \(bootstrapSeedBytes) bytes of base64url")
+            }
+            guard let expiry = Int(exactly: exp), expiry > 0 else {
+                throw .badPayload(reason: "exp must be a positive unix-seconds integer")
+            }
+            bootstrap = Bootstrap(
+                seed: seedData, expiresAt: Date(timeIntervalSince1970: TimeInterval(expiry)))
+        default:
+            throw .badPayload(reason: "seed and exp must be present together")
+        }
+
+        return PairingCode(
+            addresses: addresses, port: port, username: username,
+            hostKeyFingerprint: fingerprint, bootstrap: bootstrap)
+    }
+
+    private static let bootstrapSeedBytes = 32
+
+    /// JSON wire shape. Every field is optional and numbers are decoded as
+    /// Double so that missing keys and wrong values fail validation with
+    /// `badPayload` instead of dying inside JSONDecoder with an error we
+    /// cannot tell apart from malformed JSON.
+    private struct WirePayload: Decodable {
+        var addrs: [String]?
+        var port: Double?
+        var user: String?
+        var fp: String?
+        var seed: String?
+        var exp: Double?
+    }
+
+    /// OpenSSH presentation: "SHA256:" + 43 chars of unpadded standard base64
+    /// (a 32-byte digest). Returns the digest-backed fingerprint, or nil.
+    private static func parseFingerprint(_ text: String?) -> HostKeyFingerprint? {
+        guard let text, text.wholeMatch(of: /SHA256:[A-Za-z0-9+\/]{43}/) != nil else {
+            return nil
+        }
+        guard let digest = Data(base64Encoded: String(text.dropFirst("SHA256:".count)) + "=")
+        else { return nil }
+        return HostKeyFingerprint(digest: digest)
+    }
+
+    /// Strict unpadded base64url (RFC 4648 `-`/`_` alphabet): rejects other
+    /// characters, padding, and impossible lengths, matching the plugin.
+    private static func decodeBase64URL(_ text: String) -> Data? {
+        guard
+            !text.isEmpty, text.count % 4 != 1,
+            text.utf8.allSatisfy(isBase64URLByte)
+        else { return nil }
+        let base64 =
+            text
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+            + String(repeating: "=", count: (4 - text.count % 4) % 4)
+        return Data(base64Encoded: base64)
+    }
+
+    private static func isBase64URLByte(_ byte: UInt8) -> Bool {
+        switch byte {
+        case UInt8(ascii: "A")...UInt8(ascii: "Z"),
+            UInt8(ascii: "a")...UInt8(ascii: "z"),
+            UInt8(ascii: "0")...UInt8(ascii: "9"),
+            UInt8(ascii: "-"), UInt8(ascii: "_"):
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func containsWhitespace(_ text: String) -> Bool {
+        text.unicodeScalars.contains { CharacterSet.whitespacesAndNewlines.contains($0) }
+    }
+}
+
+/// Why a scanned string is not a Pairing Code. These map 1:1 to the error
+/// identifiers in the shared test vectors and belong to the "parse" step of
+/// the pairing failure taxonomy (ADR 0007).
+enum PairingCodeError: Error, Sendable, Equatable {
+    /// Not a Pairing Code at all — likely someone else's QR.
+    case badPrefix
+    /// A Pairing Code from a plugin speaking another envelope version.
+    case unsupportedVersion(found: String)
+    /// The framing is right but the body is not base64url-encoded JSON.
+    case badEncoding
+    /// Well-formed JSON that violates the payload schema.
+    case badPayload(reason: String)
+
+    /// The cross-implementation identifier used by the shared test vectors.
+    var wireCode: String {
+        switch self {
+        case .badPrefix: "bad_prefix"
+        case .unsupportedVersion: "unsupported_version"
+        case .badEncoding: "bad_encoding"
+        case .badPayload: "bad_payload"
+        }
+    }
+}

--- a/Sources/HerdrMobile/Pairing/PairingConnector.swift
+++ b/Sources/HerdrMobile/Pairing/PairingConnector.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Runs the pairing ceremony for a scanned Pairing Code: the seam between UI
+/// stores and real SSH, mirroring `TransportConnector`. Production is
+/// `SSHPairingConnector`; tests inject a scripted fake, so screen logic never
+/// touches Citadel. The ceremony client lives beside Transport, not inside
+/// it — Transport keeps its herdr socket semantics (ADR 0007).
+protocol PairingConnector: Sendable {
+    /// Performs the ceremony: reach a candidate address presenting the
+    /// pinned host key, authenticate with the Bootstrap Key, submit the
+    /// Device Key public line for Enrollment, then reconnect with the Device
+    /// Key to prove it took effect. Returns the facts the app persists as a
+    /// Host; throws `PairingCeremonyError` classified per step.
+    ///
+    /// `onStep` fires as each ceremony step begins, for progress UI. `parse`
+    /// never appears — decoding happens before a code reaches the connector.
+    func pair(
+        code: PairingCode,
+        deviceKey: DeviceKey,
+        onStep: @escaping @Sendable (PairingStep) -> Void
+    ) async throws -> PairingResult
+}

--- a/Sources/HerdrMobile/Pairing/PairingScanStore.swift
+++ b/Sources/HerdrMobile/Pairing/PairingScanStore.swift
@@ -51,6 +51,12 @@ final class PairingScanStore {
     /// verify-step failure, where the Bootstrap Key is dropped — Enrollment
     /// already took effect, so only the Device Key reconnect remains.
     @ObservationIgnored private var attemptCode: PairingCode?
+    /// True once a bootstrap ceremony reached Enrollment and we stripped the
+    /// Bootstrap Key from `attemptCode`. A later verify failure then carries a
+    /// bootstrap-less `attemptCode`, but the device really was enrolled, so
+    /// this keeps the enrolled-then-unverified copy instead of regressing to
+    /// the config-only "add your authorized_keys line" guidance.
+    @ObservationIgnored private var enrolledViaBootstrap = false
     /// Invalidates step callbacks still in flight from earlier attempts.
     @ObservationIgnored private var attemptGeneration = 0
 
@@ -74,6 +80,7 @@ final class PairingScanStore {
             let code = try PairingCode.decode(scannedCode)
             pairingCode = code
             attemptCode = code
+            enrolledViaBootstrap = false
             scanFailureMessage = nil
         } catch {
             scanFailureMessage = Self.message(for: error)
@@ -126,8 +133,10 @@ final class PairingScanStore {
         } catch let error as PairingCeremonyError {
             if case .verificationFailed = error, code.bootstrap != nil {
                 attemptCode = code.withoutBootstrap
+                enrolledViaBootstrap = true
             }
-            failure = Self.failure(for: error, isConfigOnly: code.bootstrap == nil)
+            failure = Self.failure(
+                for: error, isConfigOnly: code.bootstrap == nil && !enrolledViaBootstrap)
             return
         } catch is CancellationError {
             // The scan sheet went away mid-ceremony; nobody is left to tell.
@@ -167,6 +176,7 @@ final class PairingScanStore {
         guard !isPairing else { return }
         pairingCode = nil
         attemptCode = nil
+        enrolledViaBootstrap = false
         scanFailureMessage = nil
         failure = nil
         pairedHost = nil

--- a/Sources/HerdrMobile/Pairing/PairingScanStore.swift
+++ b/Sources/HerdrMobile/Pairing/PairingScanStore.swift
@@ -1,10 +1,29 @@
 import Foundation
 import Observation
 
-/// Turns strings recognized by the QR scanner into a parsed Pairing Code or
-/// scan-step failure copy (#62). Camera capture stays in the view layer;
-/// everything downstream of the scanned string is testable here against the
-/// shared envelope vectors.
+/// User-facing outcome of a failed pairing attempt, classified per ceremony
+/// step (ADR 0007) so the copy says whether to rescan, fix the network, or
+/// regenerate the Pairing Code on the computer.
+struct PairingFailure: Equatable, Sendable {
+    /// The Pairing step the failure is attributed to. `.parse` marks
+    /// failures caught before any connection was attempted (an expired code,
+    /// an unloadable Device Key): no ceremony step ran, so none is to blame.
+    let step: PairingStep
+    /// Step-specific copy, including its recovery guidance.
+    let message: String
+    /// Whether trying again with the same scanned code (inside its TTL) can
+    /// succeed; false means the user needs a fresh Pairing Code or the
+    /// manual form.
+    let canRetry: Bool
+}
+
+/// Drives Scan to Pair (#62, #66): turns strings recognized by the QR
+/// scanner into a parsed Pairing Code, runs the ceremony through the
+/// injected `PairingConnector`, and persists the Host only after the
+/// verified reconnect, with its fingerprint pinned so preflight never
+/// TOFU-prompts. Camera capture stays in the view layer; everything
+/// downstream of the scanned string is testable here with scripted
+/// connector fakes.
 @MainActor
 @Observable
 final class PairingScanStore {
@@ -13,21 +32,214 @@ final class PairingScanStore {
     /// User-facing copy for the last failed scan, per the pairing failure
     /// taxonomy's parse step. Cleared by a successful scan or `rescan()`.
     private(set) var scanFailureMessage: String?
+    /// True while a ceremony attempt is in flight.
+    private(set) var isPairing = false
+    /// The ceremony step currently underway, for progress UI.
+    private(set) var step: PairingStep?
+    /// The last attempt's failure, with its recovery options.
+    private(set) var failure: PairingFailure?
+    /// The persisted Host, set only after the verified reconnect succeeded.
+    /// The view hands it to the same preflight a manually added Host enters.
+    private(set) var pairedHost: Host?
+
+    @ObservationIgnored private let catalog: HostStore
+    @ObservationIgnored private let connector: any PairingConnector
+    @ObservationIgnored private let knownHosts: any KnownHostsStore
+    @ObservationIgnored private let credentials: HostCredentialsProvider
+    @ObservationIgnored private let now: @Sendable () -> Date
+    /// The code the next attempt will use: the scanned code, except after a
+    /// verify-step failure, where the Bootstrap Key is dropped — Enrollment
+    /// already took effect, so only the Device Key reconnect remains.
+    @ObservationIgnored private var attemptCode: PairingCode?
+    /// Invalidates step callbacks still in flight from earlier attempts.
+    @ObservationIgnored private var attemptGeneration = 0
+
+    init(
+        catalog: HostStore,
+        connector: any PairingConnector = SSHPairingConnector(),
+        knownHosts: any KnownHostsStore = UserDefaultsKnownHostsStore.shared,
+        credentials: HostCredentialsProvider = HostCredentialsProvider(),
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.catalog = catalog
+        self.connector = connector
+        self.knownHosts = knownHosts
+        self.credentials = credentials
+        self.now = now
+    }
 
     func submit(scannedCode: String) {
         guard pairingCode == nil else { return }
         do {
-            pairingCode = try PairingCode.decode(scannedCode)
+            let code = try PairingCode.decode(scannedCode)
+            pairingCode = code
+            attemptCode = code
             scanFailureMessage = nil
         } catch {
             scanFailureMessage = Self.message(for: error)
         }
     }
 
+    /// Runs one ceremony attempt against the scanned code. Reentrancy-safe:
+    /// a call while an attempt runs, or after one succeeded, does nothing.
+    /// Calling it again after a retryable failure is the Try Again action.
+    func pair() async {
+        guard let code = attemptCode, !isPairing, pairedHost == nil else { return }
+        isPairing = true
+        failure = nil
+        attemptGeneration += 1
+        let generation = attemptGeneration
+        defer {
+            isPairing = false
+            step = nil
+        }
+
+        if let bootstrap = code.bootstrap, bootstrap.expiresAt <= now() {
+            // Locally detectable expiry: skip the doomed connection and go
+            // straight to the regenerate guidance.
+            failure = PairingFailure(step: .parse, message: Self.expiredCopy, canRetry: false)
+            return
+        }
+
+        let deviceKey: DeviceKey
+        do {
+            deviceKey = try credentials.deviceKey()
+        } catch {
+            failure = PairingFailure(
+                step: .parse,
+                message: "This device's Device Key could not be loaded. "
+                    + "Open the manual Add Host form to inspect or replace it.",
+                canRetry: false)
+            return
+        }
+
+        let result: PairingResult
+        do {
+            result = try await connector.pair(code: code, deviceKey: deviceKey) { [weak self] step in
+                Task { @MainActor [weak self] in
+                    guard let self, self.attemptGeneration == generation, self.isPairing else {
+                        return
+                    }
+                    self.step = step
+                }
+            }
+        } catch let error as PairingCeremonyError {
+            if case .verificationFailed = error, code.bootstrap != nil {
+                attemptCode = code.withoutBootstrap
+            }
+            failure = Self.failure(for: error, isConfigOnly: code.bootstrap == nil)
+            return
+        } catch is CancellationError {
+            // The scan sheet went away mid-ceremony; nobody is left to tell.
+            return
+        } catch {
+            failure = PairingFailure(
+                step: .reach,
+                message: "Pairing failed unexpectedly. Try again with the same code. (\(error))",
+                canRetry: true)
+            return
+        }
+
+        // Only a fully verified ceremony creates a Host (ADR 0007). The
+        // fingerprint pin lands with it, against the address that actually
+        // answered, so preflight connects without a TOFU prompt.
+        let host = Host(
+            address: result.address, port: result.port, username: result.username,
+            authMethod: .deviceKey)
+        do {
+            try catalog.add(host)
+        } catch {
+            failure = PairingFailure(
+                step: .verify,
+                message: "Pairing succeeded, but the Host could not be saved because the Host "
+                    + "catalog on this device is unreadable. Resolve that first, then pair again "
+                    + "with a fresh code.",
+                canRetry: false)
+            return
+        }
+        await knownHosts.setFingerprint(
+            result.hostKeyFingerprint, host: result.address, port: result.port)
+        pairedHost = host
+    }
+
     /// Back to a fresh scanning state (the "Scan Again" action).
     func rescan() {
+        guard !isPairing else { return }
         pairingCode = nil
+        attemptCode = nil
         scanFailureMessage = nil
+        failure = nil
+        pairedHost = nil
+    }
+
+    // MARK: Failure copy
+
+    private static let expiredCopy =
+        "This Pairing Code has expired. Generate a new one on the computer and scan it."
+
+    private static func failure(
+        for error: PairingCeremonyError, isConfigOnly: Bool
+    ) -> PairingFailure {
+        switch error {
+        case .hostUnreachable:
+            PairingFailure(
+                step: .reach,
+                message: "The Host did not answer at any of its addresses. Check that this "
+                    + "device is on the same network or VPN as the computer, then try again "
+                    + "with the same code.",
+                canRetry: true)
+        case .bootstrapRejected:
+            PairingFailure(
+                step: .authenticate,
+                message: "The Host rejected this Pairing Code. It may have been used already, "
+                    + "expired, or its popup was closed. Generate a new Pairing Code on the "
+                    + "computer and scan it.",
+                canRetry: false)
+        case .enrollmentRefused(.expired):
+            PairingFailure(step: .enroll, message: expiredCopy, canRetry: false)
+        case .enrollmentRefused(.unknownPairing):
+            PairingFailure(
+                step: .enroll,
+                message: "The Host has no pairing in progress for this code. Generate a new "
+                    + "Pairing Code on the computer and scan it.",
+                canRetry: false)
+        case .enrollmentRefused(.invalidKey):
+            PairingFailure(
+                step: .enroll,
+                message: "The Host did not accept this device's key. Try again; if it keeps "
+                    + "failing, update the app and the pairing plugin so they match.",
+                canRetry: true)
+        case .enrollmentRefused(.noInput):
+            PairingFailure(
+                step: .enroll,
+                message: "This device's key never reached the Host. Try again with the same code.",
+                canRetry: true)
+        case .enrollmentRefused(.unrecognized(let code)):
+            PairingFailure(
+                step: .enroll,
+                message: "The Host refused Enrollment (\(code)). Update the app and the pairing "
+                    + "plugin so they match, then generate a new Pairing Code.",
+                canRetry: false)
+        case .enrollmentFailed:
+            PairingFailure(
+                step: .enroll,
+                message: "Enrollment did not complete, likely a network hiccup. "
+                    + "Try again with the same code.",
+                canRetry: true)
+        case .verificationFailed where isConfigOnly:
+            PairingFailure(
+                step: .verify,
+                message: "The Host did not accept the Device Key, so it is not authorized there "
+                    + "yet. Add this device's authorized_keys line on the Host, or generate a "
+                    + "Pairing Code in herdr instead.",
+                canRetry: false)
+        case .verificationFailed:
+            PairingFailure(
+                step: .verify,
+                message: "This device was enrolled, but the verifying reconnect did not get "
+                    + "through. Try again to finish with the enrolled key.",
+                canRetry: true)
+        }
     }
 
     private static func message(for error: PairingCodeError) -> String {
@@ -40,5 +252,15 @@ final class PairingScanStore {
         case .badEncoding, .badPayload:
             "The Pairing Code could not be read. Regenerate it in herdr and scan again."
         }
+    }
+}
+
+extension PairingCode {
+    /// The same Host coordinates without the Bootstrap Key: what a retry
+    /// needs once Enrollment has already landed on the Host.
+    fileprivate var withoutBootstrap: PairingCode {
+        PairingCode(
+            addresses: addresses, port: port, username: username,
+            hostKeyFingerprint: hostKeyFingerprint, bootstrap: nil)
     }
 }

--- a/Sources/HerdrMobile/Pairing/PairingScanStore.swift
+++ b/Sources/HerdrMobile/Pairing/PairingScanStore.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Observation
+
+/// Turns strings recognized by the QR scanner into a parsed Pairing Code or
+/// scan-step failure copy (#62). Camera capture stays in the view layer;
+/// everything downstream of the scanned string is testable here against the
+/// shared envelope vectors.
+@MainActor
+@Observable
+final class PairingScanStore {
+    /// Set once a scan parses; further scans are ignored until `rescan()`.
+    private(set) var pairingCode: PairingCode?
+    /// User-facing copy for the last failed scan, per the pairing failure
+    /// taxonomy's parse step. Cleared by a successful scan or `rescan()`.
+    private(set) var scanFailureMessage: String?
+
+    func submit(scannedCode: String) {
+        guard pairingCode == nil else { return }
+        do {
+            pairingCode = try PairingCode.decode(scannedCode)
+            scanFailureMessage = nil
+        } catch {
+            scanFailureMessage = Self.message(for: error)
+        }
+    }
+
+    /// Back to a fresh scanning state (the "Scan Again" action).
+    func rescan() {
+        pairingCode = nil
+        scanFailureMessage = nil
+    }
+
+    private static func message(for error: PairingCodeError) -> String {
+        switch error {
+        case .badPrefix:
+            "That QR code is not a herdr Pairing Code."
+        case .unsupportedVersion(let found):
+            "This Pairing Code uses version \(found), which this app does not "
+                + "understand. Update the app and the pairing plugin so they match."
+        case .badEncoding, .badPayload:
+            "The Pairing Code could not be read. Regenerate it in herdr and scan again."
+        }
+    }
+}

--- a/Sources/HerdrMobile/Pairing/PairingScanView.swift
+++ b/Sources/HerdrMobile/Pairing/PairingScanView.swift
@@ -9,12 +9,18 @@ import VisionKit
 /// preflight a manually added Host does.
 struct PairingScanView: View {
     let onPaired: (Host) -> Void
+    let onAddManually: () -> Void
     @State private var store: PairingScanStore
     @State private var cameraAccess: CameraAccess = .undetermined
     @Environment(\.dismiss) private var dismiss
 
-    init(catalog: HostStore, onPaired: @escaping (Host) -> Void = { _ in }) {
+    init(
+        catalog: HostStore,
+        onPaired: @escaping (Host) -> Void = { _ in },
+        onAddManually: @escaping () -> Void = {}
+    ) {
         self.onPaired = onPaired
+        self.onAddManually = onAddManually
         _store = State(initialValue: PairingScanStore(catalog: catalog))
     }
 
@@ -65,6 +71,7 @@ struct PairingScanView: View {
             } actions: {
                 Button("Open Settings") { openSettings() }
                     .buttonStyle(.borderedProminent)
+                Button("Add Manually") { addManually() }
             }
         case .authorized:
             if DataScannerViewController.isSupported {
@@ -76,9 +83,19 @@ struct PairingScanView: View {
                     Text(
                         "This device cannot scan QR codes. "
                             + "Add the Host manually instead.")
+                } actions: {
+                    Button("Add Manually") { addManually() }
+                        .buttonStyle(.borderedProminent)
                 }
             }
         }
+    }
+
+    /// The manual fallback: hand off to the presenter (which owns the manual
+    /// Host form) and close this sheet, mirroring the `onPaired` hand-off.
+    private func addManually() {
+        onAddManually()
+        dismiss()
     }
 
     private var scannerViewport: some View {

--- a/Sources/HerdrMobile/Pairing/PairingScanView.swift
+++ b/Sources/HerdrMobile/Pairing/PairingScanView.swift
@@ -2,14 +2,21 @@ import AVFoundation
 import SwiftUI
 import VisionKit
 
-/// Scan to Pair (#62): the camera entry for Pairing Codes, with the
-/// permission prompt, a usable denied path, and the parsed Host summary once
-/// a code parses. The connect/enroll/verify ceremony lands with the follow-up
-/// tickets of the pairing spec; until then the summary is the end of the road.
+/// Scan to Pair (#62, #66): the camera entry for Pairing Codes, with the
+/// permission prompt and a usable denied path. Once a code parses, the
+/// pairing ceremony runs immediately — one scan, no confirmation step — and
+/// on success the persisted Host is handed to `onPaired`, entering the same
+/// preflight a manually added Host does.
 struct PairingScanView: View {
-    @State private var store = PairingScanStore()
+    let onPaired: (Host) -> Void
+    @State private var store: PairingScanStore
     @State private var cameraAccess: CameraAccess = .undetermined
     @Environment(\.dismiss) private var dismiss
+
+    init(catalog: HostStore, onPaired: @escaping (Host) -> Void = { _ in }) {
+        self.onPaired = onPaired
+        _store = State(initialValue: PairingScanStore(catalog: catalog))
+    }
 
     private enum CameraAccess {
         case undetermined
@@ -21,9 +28,7 @@ struct PairingScanView: View {
         NavigationStack {
             Group {
                 if let code = store.pairingCode {
-                    PairingCodeSummaryView(code: code) {
-                        store.rescan()
-                    }
+                    PairingCeremonyView(code: code, store: store)
                 } else {
                     scanner
                 }
@@ -36,6 +41,11 @@ struct PairingScanView: View {
                 }
             }
             .task { await resolveCameraAccess() }
+            .onChange(of: store.pairedHost) { _, paired in
+                guard let paired else { return }
+                dismiss()
+                onPaired(paired)
+            }
         }
     }
 
@@ -102,54 +112,121 @@ struct PairingScanView: View {
     }
 }
 
-/// The parsed Pairing Code, presented as the Host it describes. Read-only for
-/// now: creating the Host awaits the verified reconnect of the full ceremony.
-struct PairingCodeSummaryView: View {
+/// The ceremony in flight (#66): the scanned Host, per-step progress, and on
+/// failure that step's copy with its recovery actions. The ceremony starts on
+/// arrival; Try Again reruns it with the same code while its TTL holds, so a
+/// network blip never forces a rescan.
+private struct PairingCeremonyView: View {
     let code: PairingCode
-    var onRescan: () -> Void
+    let store: PairingScanStore
+    @State private var attempt = 0
+
+    private enum StepStatus {
+        case pending
+        case active
+        case done
+        case failed
+    }
 
     var body: some View {
         List {
             Section("Host") {
                 LabeledContent("User", value: code.username)
-                LabeledContent("Port", value: String(code.port))
-            }
-
-            Section {
-                ForEach(code.addresses, id: \.self) { address in
-                    Text(address)
-                        .font(.callout.monospaced())
-                }
-            } header: {
-                Text("Addresses")
-            } footer: {
-                Text("Tried in this order when connecting.")
-            }
-
-            Section {
-                Text(code.hostKeyFingerprint.displayString)
-                    .font(.caption.monospaced())
-                    .textSelection(.enabled)
-            } header: {
-                Text("Host Key")
-            } footer: {
-                Text("Pinned from the Pairing Code — no fingerprint prompt on first connect.")
-            }
-
-            if let bootstrap = code.bootstrap {
-                Section("Bootstrap Key") {
-                    LabeledContent(
-                        "Expires",
-                        value: bootstrap.expiresAt.formatted(date: .omitted, time: .standard))
+                LabeledContent(
+                    "Address",
+                    value: code.addresses.count == 1
+                        ? code.addresses[0] : "\(code.addresses.count) candidates")
+                if code.port != 22 {
+                    LabeledContent("Port", value: String(code.port))
                 }
             }
 
             Section {
-                Button("Scan Again", systemImage: "qrcode.viewfinder") {
-                    onRescan()
+                ForEach(ceremonySteps, id: \.self) { step in
+                    stepRow(step)
+                }
+            } header: {
+                Text("Pairing")
+            } footer: {
+                if store.failure == nil {
+                    Text("Host key pinned from the Pairing Code — no fingerprint prompt.")
+                }
+            }
+
+            if let failure = store.failure {
+                Section {
+                    Text(failure.message)
+                    if failure.canRetry {
+                        Button("Try Again", systemImage: "arrow.clockwise") {
+                            attempt += 1
+                        }
+                    }
+                    Button("Scan Again", systemImage: "qrcode.viewfinder") {
+                        store.rescan()
+                    }
                 }
             }
         }
+        .task(id: attempt) { await store.pair() }
+    }
+
+    /// The steps this code's ceremony performs. A config-only code carries no
+    /// Bootstrap Key: the Device Key reconnect is the whole ceremony.
+    private var ceremonySteps: [PairingStep] {
+        code.bootstrap == nil
+            ? [.reach, .verify]
+            : [.reach, .authenticate, .enroll, .verify]
+    }
+
+    private func stepRow(_ step: PairingStep) -> some View {
+        HStack {
+            Text(title(for: step))
+            Spacer()
+            switch status(for: step) {
+            case .pending:
+                Image(systemName: "circle")
+                    .foregroundStyle(.tertiary)
+            case .active:
+                ProgressView()
+            case .done:
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            case .failed:
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private func title(for step: PairingStep) -> String {
+        switch step {
+        case .parse: "Read the code"
+        case .reach: "Reach the Host"
+        case .authenticate: "Authenticate with the Pairing Code"
+        case .enroll: "Enroll this device"
+        case .verify: "Verify the new key"
+        }
+    }
+
+    private func status(for step: PairingStep) -> StepStatus {
+        if store.pairedHost != nil {
+            return .done
+        }
+        if let failure = store.failure {
+            // `.parse` failures precede the ceremony: every row stays pending.
+            if step == failure.step { return .failed }
+            return rank(step) < rank(failure.step) ? .done : .pending
+        }
+        guard let current = store.step else {
+            return store.isPairing && step == ceremonySteps.first ? .active : .pending
+        }
+        // The connector reports a step as it begins; earlier ones finished.
+        if step == current { return .active }
+        return rank(step) < rank(current) ? .done : .pending
+    }
+
+    private func rank(_ step: PairingStep) -> Int {
+        PairingStep.allCases.firstIndex(of: step) ?? 0
     }
 }
 

--- a/Sources/HerdrMobile/Pairing/PairingScanView.swift
+++ b/Sources/HerdrMobile/Pairing/PairingScanView.swift
@@ -1,0 +1,201 @@
+import AVFoundation
+import SwiftUI
+import VisionKit
+
+/// Scan to Pair (#62): the camera entry for Pairing Codes, with the
+/// permission prompt, a usable denied path, and the parsed Host summary once
+/// a code parses. The connect/enroll/verify ceremony lands with the follow-up
+/// tickets of the pairing spec; until then the summary is the end of the road.
+struct PairingScanView: View {
+    @State private var store = PairingScanStore()
+    @State private var cameraAccess: CameraAccess = .undetermined
+    @Environment(\.dismiss) private var dismiss
+
+    private enum CameraAccess {
+        case undetermined
+        case authorized
+        case denied
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if let code = store.pairingCode {
+                    PairingCodeSummaryView(code: code) {
+                        store.rescan()
+                    }
+                } else {
+                    scanner
+                }
+            }
+            .navigationTitle("Scan to Pair")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+            .task { await resolveCameraAccess() }
+        }
+    }
+
+    @ViewBuilder
+    private var scanner: some View {
+        switch cameraAccess {
+        case .undetermined:
+            // The system permission prompt is up (or about to be).
+            ProgressView()
+        case .denied:
+            ContentUnavailableView {
+                Label("Camera Access Needed", systemImage: "camera")
+            } description: {
+                Text(
+                    "Scanning a Pairing Code uses the camera. Allow camera access "
+                        + "in Settings, or add the Host manually instead.")
+            } actions: {
+                Button("Open Settings") { openSettings() }
+                    .buttonStyle(.borderedProminent)
+            }
+        case .authorized:
+            if DataScannerViewController.isSupported {
+                scannerViewport
+            } else {
+                ContentUnavailableView {
+                    Label("Scanning Unavailable", systemImage: "camera")
+                } description: {
+                    Text(
+                        "This device cannot scan QR codes. "
+                            + "Add the Host manually instead.")
+                }
+            }
+        }
+    }
+
+    private var scannerViewport: some View {
+        PairingCodeScanner { store.submit(scannedCode: $0) }
+            .ignoresSafeArea(edges: .bottom)
+            .overlay(alignment: .bottom) {
+                Text(store.scanFailureMessage ?? "Point the camera at the Pairing Code shown by herdr.")
+                    .font(.callout)
+                    .multilineTextAlignment(.center)
+                    .padding(12)
+                    .background(.regularMaterial, in: .rect(cornerRadius: 12))
+                    .padding()
+            }
+    }
+
+    private func resolveCameraAccess() async {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            cameraAccess = .authorized
+        case .notDetermined:
+            let granted = await AVCaptureDevice.requestAccess(for: .video)
+            cameraAccess = granted ? .authorized : .denied
+        default:
+            cameraAccess = .denied
+        }
+    }
+
+    private func openSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+}
+
+/// The parsed Pairing Code, presented as the Host it describes. Read-only for
+/// now: creating the Host awaits the verified reconnect of the full ceremony.
+struct PairingCodeSummaryView: View {
+    let code: PairingCode
+    var onRescan: () -> Void
+
+    var body: some View {
+        List {
+            Section("Host") {
+                LabeledContent("User", value: code.username)
+                LabeledContent("Port", value: String(code.port))
+            }
+
+            Section {
+                ForEach(code.addresses, id: \.self) { address in
+                    Text(address)
+                        .font(.callout.monospaced())
+                }
+            } header: {
+                Text("Addresses")
+            } footer: {
+                Text("Tried in this order when connecting.")
+            }
+
+            Section {
+                Text(code.hostKeyFingerprint.displayString)
+                    .font(.caption.monospaced())
+                    .textSelection(.enabled)
+            } header: {
+                Text("Host Key")
+            } footer: {
+                Text("Pinned from the Pairing Code — no fingerprint prompt on first connect.")
+            }
+
+            if let bootstrap = code.bootstrap {
+                Section("Bootstrap Key") {
+                    LabeledContent(
+                        "Expires",
+                        value: bootstrap.expiresAt.formatted(date: .omitted, time: .standard))
+                }
+            }
+
+            Section {
+                Button("Scan Again", systemImage: "qrcode.viewfinder") {
+                    onRescan()
+                }
+            }
+        }
+    }
+}
+
+/// The system scanner (VisionKit), narrowed to QR codes. Reports every newly
+/// recognized payload string; filtering and parsing belong to the store.
+private struct PairingCodeScanner: UIViewControllerRepresentable {
+    let onScan: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onScan: onScan)
+    }
+
+    func makeUIViewController(context: Context) -> DataScannerViewController {
+        let scanner = DataScannerViewController(
+            recognizedDataTypes: [.barcode(symbologies: [.qr])],
+            qualityLevel: .fast,
+            isHighlightingEnabled: true)
+        scanner.delegate = context.coordinator
+        return scanner
+    }
+
+    func updateUIViewController(_ scanner: DataScannerViewController, context: Context) {
+        guard !scanner.isScanning else { return }
+        // Fails only when capture is unavailable (already gated on
+        // authorization and isSupported); the denied path covers the rest.
+        try? scanner.startScanning()
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, DataScannerViewControllerDelegate {
+        private let onScan: (String) -> Void
+
+        init(onScan: @escaping (String) -> Void) {
+            self.onScan = onScan
+        }
+
+        func dataScanner(
+            _ dataScanner: DataScannerViewController,
+            didAdd addedItems: [RecognizedItem],
+            allItems: [RecognizedItem]
+        ) {
+            for case .barcode(let barcode) in addedItems {
+                if let payload = barcode.payloadStringValue {
+                    onScan(payload)
+                }
+            }
+        }
+    }
+}

--- a/Sources/HerdrMobile/Pairing/SSHPairingConnector.swift
+++ b/Sources/HerdrMobile/Pairing/SSHPairingConnector.swift
@@ -1,0 +1,313 @@
+// @preconcurrency: Citadel predates strict concurrency; see SSHTransport.
+@preconcurrency import Citadel
+import CryptoKit
+import Foundation
+import NIOCore
+@preconcurrency import NIOSSH
+import Synchronization
+
+/// The production pairing ceremony client (ADR 0007): a dedicated one-shot
+/// SSH client beside `SSHTransport`, not inside it. Two short-lived
+/// connections per ceremony — bootstrap (authenticate + enroll) and the
+/// verified Device Key reconnect — with the host key pinned from the Pairing
+/// Code on both; no TOFU prompt, no known-hosts store.
+struct SSHPairingConnector: PairingConnector {
+    /// TCP-establishment budget per candidate address, so one unreachable
+    /// interface fails over quickly. Citadel caps the subsequent handshake
+    /// and authentication at 10 seconds on its own.
+    var perAddressTimeout: Duration = .seconds(4)
+    /// Deadline for the whole Enrollment exec exchange. Generous: the accept
+    /// entrypoint edits authorized_keys under a lock with its own 5s bound.
+    var enrollTimeout: Duration = .seconds(20)
+    /// Comment on the submitted Device Key line; the plugin popup shows it
+    /// as the enrolled device's label. Must be printable ASCII — the accept
+    /// entrypoint rejects anything else as `invalid_key`.
+    var deviceKeyComment: String = "herdr-mobile"
+
+    func pair(
+        code: PairingCode,
+        deviceKey: DeviceKey,
+        onStep: @escaping @Sendable (PairingStep) -> Void
+    ) async throws -> PairingResult {
+        guard let bootstrap = code.bootstrap else {
+            // A config-only Pairing Code is this ceremony minus the
+            // bootstrap connection: the Device Key must already be
+            // authorized on the Host (pasted manually), so the first
+            // connect doubles as the verification.
+            onStep(.reach)
+            let reached = try await reach(
+                code: code, key: deviceKey.privateKey,
+                whenAuthenticationFails: .verificationFailed(
+                    detail: "The Host did not accept the Device Key; it is not enrolled there yet."
+                ))
+            onStep(.verify)
+            try? await reached.client.close()
+            return PairingResult(
+                address: reached.address, port: code.port, username: code.username,
+                hostKeyFingerprint: reached.presented)
+        }
+
+        // Decode-time validation guarantees a 32-byte seed, and CryptoKit
+        // accepts any 32 bytes as an Ed25519 seed; an unusable Bootstrap Key
+        // is still an authenticate-step failure, not a crash.
+        guard
+            let bootstrapKey = try? Curve25519.Signing.PrivateKey(
+                rawRepresentation: bootstrap.seed)
+        else {
+            throw PairingCeremonyError.bootstrapRejected
+        }
+
+        onStep(.reach)
+        let reached = try await reach(
+            code: code, key: bootstrapKey, whenAuthenticationFails: .bootstrapRejected)
+
+        onStep(.enroll)
+        do {
+            try await enroll(deviceKey: deviceKey, over: reached.client)
+            try? await reached.client.close()
+        } catch {
+            try? await reached.client.close()
+            throw error
+        }
+
+        try Task.checkCancellation()
+        onStep(.verify)
+        return try await verify(code: code, address: reached.address, deviceKey: deviceKey)
+    }
+
+    // MARK: Reach
+
+    private struct ReachedHost {
+        let client: SSHClient
+        let address: String
+        /// Algorithm-aware fingerprint of the key the Host presented;
+        /// digest-equal to the pinned one.
+        let presented: HostKeyFingerprint
+    }
+
+    /// Tries each candidate address in order until one yields an SSH server
+    /// presenting the pinned host key and accepting `key`. An address whose
+    /// host key does not match the pin is some other machine — skip it and
+    /// keep looking. A matching host that rejects the key IS our Host saying
+    /// no; that ends the loop with `whenAuthenticationFails`.
+    private func reach(
+        code: PairingCode,
+        key: Curve25519.Signing.PrivateKey,
+        whenAuthenticationFails: PairingCeremonyError
+    ) async throws -> ReachedHost {
+        var attempts: [String] = []
+        for address in code.addresses {
+            try Task.checkCancellation()
+            let validator = PinnedHostKeyValidator(pinned: code.hostKeyFingerprint)
+            do {
+                let client = try await SSHClient.connect(
+                    host: address,
+                    port: code.port,
+                    authenticationMethod: .ed25519(username: code.username, privateKey: key),
+                    hostKeyValidator: .custom(validator),
+                    reconnect: .never,
+                    connectTimeout: Self.timeAmount(perAddressTimeout))
+                guard let presented = validator.presented else {
+                    // Unreachable: a completed handshake ran the validator.
+                    try? await client.close()
+                    attempts.append("\(address): host key was never validated")
+                    continue
+                }
+                return ReachedHost(client: client, address: address, presented: presented)
+            } catch {
+                // The validator's verdict is the source of truth: NIOSSH may
+                // wrap its error on the way out of the handshake.
+                if let mismatch = validator.mismatch {
+                    attempts.append(
+                        "\(address): presented \(mismatch.displayString), not the pinned host key")
+                    continue
+                }
+                switch error {
+                case SSHClientError.allAuthenticationOptionsFailed,
+                    SSHClientError.unsupportedPasswordAuthentication,
+                    SSHClientError.unsupportedPrivateKeyAuthentication,
+                    SSHClientError.unsupportedHostBasedAuthentication:
+                    throw whenAuthenticationFails
+                default:
+                    attempts.append("\(address): \(error)")
+                }
+            }
+        }
+        throw PairingCeremonyError.hostUnreachable(detail: attempts.joined(separator: "; "))
+    }
+
+    // MARK: Enroll
+
+    /// One exec exchange with the Enrollment accept entrypoint: sshd ignores
+    /// the requested command (`restrict,command=` forces the accept script)
+    /// and the Device Key public line goes in on stdin. The first stdout
+    /// line is the whole answer.
+    private func enroll(deviceKey: DeviceKey, over client: SSHClient) async throws {
+        let submission = deviceKey.authorizedKeysLine(comment: deviceKeyComment) + "\n"
+        let responseLine = try await Self.withDeadline(
+            enrollTimeout,
+            onTimeout: .enrollmentFailed(detail: "the Enrollment exchange timed out")
+        ) {
+            var stdout = Data()
+            var stderr = Data()
+            do {
+                try await client.withExec("herdr-mobile-enroll") { inbound, outbound in
+                    // A fast-failing forced command can close the channel
+                    // before this write lands; the read loop still drains
+                    // the response or surfaces the failure.
+                    try? await outbound.write(ByteBuffer(string: submission))
+                    for try await chunk in inbound {
+                        switch chunk {
+                        case .stdout(let buffer):
+                            stdout.append(contentsOf: buffer.readableBytesView)
+                            if stdout.contains(0x0A) { return }
+                        case .stderr(let buffer):
+                            stderr.append(contentsOf: buffer.readableBytesView)
+                        }
+                    }
+                }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                throw PairingCeremonyError.enrollmentFailed(
+                    detail: "\(error); stderr: \(Self.preview(stderr))")
+            }
+            guard let newline = stdout.firstIndex(of: 0x0A) else {
+                throw PairingCeremonyError.enrollmentFailed(
+                    detail:
+                        "the accept entrypoint closed without answering; stderr: \(Self.preview(stderr))"
+                )
+            }
+            return String(decoding: stdout[stdout.startIndex..<newline], as: UTF8.self)
+        }
+
+        switch EnrollmentResponse.parse(line: responseLine) {
+        case .enrolled(let fingerprint):
+            let expected = HostKeyFingerprint(publicKeyBlob: deviceKey.publicKeyBlob)
+            guard fingerprint == expected.displayString else {
+                throw PairingCeremonyError.enrollmentFailed(
+                    detail: "the Host enrolled a different key: \(fingerprint)")
+            }
+        case .refused(let refusal):
+            throw PairingCeremonyError.enrollmentRefused(refusal)
+        case nil:
+            throw PairingCeremonyError.enrollmentFailed(
+                detail: "unexpected accept response: \(Self.preview(Data(responseLine.utf8)))")
+        }
+    }
+
+    // MARK: Verify
+
+    /// The reconnect that proves Enrollment took effect: same address, same
+    /// pinned host key, Device Key credentials. Only after this succeeds may
+    /// the caller persist the Host.
+    private func verify(
+        code: PairingCode, address: String, deviceKey: DeviceKey
+    ) async throws -> PairingResult {
+        let validator = PinnedHostKeyValidator(pinned: code.hostKeyFingerprint)
+        do {
+            let client = try await SSHClient.connect(
+                host: address,
+                port: code.port,
+                authenticationMethod: .ed25519(
+                    username: code.username, privateKey: deviceKey.privateKey),
+                hostKeyValidator: .custom(validator),
+                reconnect: .never,
+                connectTimeout: Self.timeAmount(perAddressTimeout))
+            guard let presented = validator.presented else {
+                try? await client.close()
+                throw PairingCeremonyError.verificationFailed(
+                    detail: "host key was never validated")
+            }
+            try? await client.close()
+            return PairingResult(
+                address: address, port: code.port, username: code.username,
+                hostKeyFingerprint: presented)
+        } catch let error as PairingCeremonyError {
+            throw error
+        } catch {
+            if let mismatch = validator.mismatch {
+                throw PairingCeremonyError.verificationFailed(
+                    detail: "the host key changed mid-ceremony to \(mismatch.displayString)")
+            }
+            switch error {
+            case SSHClientError.allAuthenticationOptionsFailed:
+                throw PairingCeremonyError.verificationFailed(
+                    detail: "the Host did not accept the enrolled Device Key")
+            default:
+                throw PairingCeremonyError.verificationFailed(detail: "\(error)")
+            }
+        }
+    }
+
+    // MARK: Plumbing
+
+    /// Races `operation` against a deadline. A live exec channel ignores
+    /// Swift task cancellation, but cancelling ends the *local* inbound
+    /// stream; the exec body then returns and Citadel closes the channel on
+    /// the way out (same shape as SSHTransport's request deadline).
+    private static func withDeadline<T: Sendable>(
+        _ timeout: Duration,
+        onTimeout timeoutError: PairingCeremonyError,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T?.self) { group in
+            group.addTask { try await operation() }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                return nil
+            }
+            defer { group.cancelAll() }
+            guard let finished = try await group.next(), let value = finished else {
+                throw timeoutError
+            }
+            return value
+        }
+    }
+
+    private static func timeAmount(_ duration: Duration) -> TimeAmount {
+        let (seconds, attoseconds) = duration.components
+        return .nanoseconds(seconds * 1_000_000_000 + attoseconds / 1_000_000_000)
+    }
+
+    private static func preview(_ data: Data) -> String {
+        String(decoding: data.prefix(200), as: UTF8.self)
+    }
+}
+
+/// Validates the Host's key against the fingerprint pinned from the Pairing
+/// Code: match proceeds, anything else fails — no TOFU prompt, no store
+/// (ADR 0007). The verdict is recorded here because NIOSSH may wrap the
+/// promise's failure on its way out of the handshake; callers consult
+/// `presented`/`mismatch`, not the thrown error.
+final class PinnedHostKeyValidator: NIOSSHClientServerAuthenticationDelegate, Sendable {
+    private struct PinMismatch: Error {}
+
+    private let pinned: HostKeyFingerprint
+    private let presentedState = Mutex<HostKeyFingerprint?>(nil)
+    private let mismatchState = Mutex<HostKeyFingerprint?>(nil)
+
+    init(pinned: HostKeyFingerprint) {
+        self.pinned = pinned
+    }
+
+    /// The algorithm-aware fingerprint of the accepted host key.
+    var presented: HostKeyFingerprint? { presentedState.withLock { $0 } }
+    /// The fingerprint of a rejected host key, if validation failed one.
+    var mismatch: HostKeyFingerprint? { mismatchState.withLock { $0 } }
+
+    func validateHostKey(
+        hostKey: NIOSSHPublicKey, validationCompletePromise: EventLoopPromise<Void>
+    ) {
+        var buffer = ByteBuffer()
+        hostKey.write(to: &buffer)
+        let fingerprint = HostKeyFingerprint(publicKeyBlob: Data(buffer.readableBytesView))
+        if fingerprint == pinned {
+            presentedState.withLock { $0 = fingerprint }
+            validationCompletePromise.succeed(())
+        } else {
+            mismatchState.withLock { $0 = fingerprint }
+            validationCompletePromise.fail(PinMismatch())
+        }
+    }
+}

--- a/Tests/HerdrMobileTests/PairingCeremonyE2ETests.swift
+++ b/Tests/HerdrMobileTests/PairingCeremonyE2ETests.swift
@@ -1,0 +1,395 @@
+import CryptoKit
+import Foundation
+import Synchronization
+import Testing
+
+@testable import HerdrMobile
+
+// The pairing ceremony (#65) against the real localhost sshd, with the real
+// plugin accept script (`plugin/src/pair-accept.js`) wired as the Bootstrap
+// Key's forced command — exactly what `pairing-session.js` mints, except the
+// line is composed here because the simulator cannot shell out to Node. The
+// suite temporarily rewrites the host user's real `~/.ssh/authorized_keys`
+// and restores it byte-exactly, hash-verified (acceptance criterion).
+@Suite(
+    "Pairing ceremony e2e",
+    .enabled(
+        if: PairingE2EEnvironment.isAvailable,
+        "requires localhost sshd, an authorized Ed25519 test key, node, and the plugin checkout"),
+    .serialized)
+struct PairingCeremonyE2ETests {
+    @Test func fullCeremonyEnrollsTheDeviceKeyAndVerifies() async throws {
+        let environment = try #require(PairingE2EEnvironment.current)
+        try await AuthorizedKeysTestLock.shared.withLock {
+            let pinned = try await Self.discoverHostKeyFingerprint(environment.base)
+            let staged = try StagedPairing(environment: environment, ttlSeconds: 120)
+            defer { staged.cleanUp() }
+            let snapshot = AuthorizedKeysSnapshot(username: environment.base.username)
+            defer {
+                snapshot.restore()
+                #expect(snapshot.isRestoredByteExact)
+            }
+            try snapshot.append(line: staged.authorizedKeysLine)
+
+            let deviceKey = DeviceKey(privateKey: .init())
+            // A TEST-NET-1 address first: unroutable, so success proves the
+            // client fails over to the next candidate within its timeout.
+            let code = PairingCode(
+                addresses: ["192.0.2.1", environment.base.host],
+                port: environment.base.port,
+                username: environment.base.username,
+                hostKeyFingerprint: pinned,
+                bootstrap: .init(seed: staged.seed, expiresAt: staged.expiresAt))
+            let steps = Mutex<[PairingStep]>([])
+
+            let result = try await Self.connector.pair(code: code, deviceKey: deviceKey) {
+                step in steps.withLock { $0.append(step) }
+            }
+
+            #expect(
+                result
+                    == PairingResult(
+                        address: environment.base.host,
+                        port: environment.base.port,
+                        username: environment.base.username,
+                        hostKeyFingerprint: pinned))
+            #expect(result.hostKeyFingerprint.algorithm != HostKeyFingerprint.unknownAlgorithm)
+            #expect(steps.withLock { $0 } == [.reach, .enroll, .verify])
+
+            // The server side really happened: the Device Key is enrolled,
+            // the bootstrap line self-revoked, the pending state consumed,
+            // and the popup's Enrollment record written.
+            let contents = snapshot.currentContents
+            #expect(contents.contains(deviceKey.openSSHPublicKey))
+            #expect(!contents.contains(staged.publicLine))
+            #expect(!FileManager.default.fileExists(atPath: staged.pendingPath))
+            let record = try #require(staged.enrollmentRecord)
+            #expect(
+                record.fingerprint
+                    == HostKeyFingerprint(publicKeyBlob: deviceKey.publicKeyBlob).displayString)
+        }
+    }
+
+    @Test func expiredPairingIsRefusedAtEnrollAndSelfHeals() async throws {
+        let environment = try #require(PairingE2EEnvironment.current)
+        try await AuthorizedKeysTestLock.shared.withLock {
+            let pinned = try await Self.discoverHostKeyFingerprint(environment.base)
+            let staged = try StagedPairing(environment: environment, ttlSeconds: -30)
+            defer { staged.cleanUp() }
+            let snapshot = AuthorizedKeysSnapshot(username: environment.base.username)
+            defer {
+                snapshot.restore()
+                #expect(snapshot.isRestoredByteExact)
+            }
+            try snapshot.append(line: staged.authorizedKeysLine)
+
+            let code = PairingCode(
+                addresses: [environment.base.host],
+                port: environment.base.port,
+                username: environment.base.username,
+                hostKeyFingerprint: pinned,
+                bootstrap: .init(seed: staged.seed, expiresAt: staged.expiresAt))
+            let steps = Mutex<[PairingStep]>([])
+
+            await #expect(throws: PairingCeremonyError.enrollmentRefused(.expired)) {
+                _ = try await Self.connector.pair(
+                    code: code, deviceKey: DeviceKey(privateKey: .init())
+                ) { step in steps.withLock { $0.append(step) } }
+            }
+            #expect(steps.withLock { $0 } == [.reach, .enroll])
+            // The accept entrypoint's self-heal removed the expired line.
+            #expect(!snapshot.currentContents.contains(staged.publicLine))
+        }
+    }
+
+    @Test func missingPendingStateIsRefusedAsUnknownPairing() async throws {
+        let environment = try #require(PairingE2EEnvironment.current)
+        try await AuthorizedKeysTestLock.shared.withLock {
+            let pinned = try await Self.discoverHostKeyFingerprint(environment.base)
+            let staged = try StagedPairing(
+                environment: environment, ttlSeconds: 120, writePendingState: false)
+            defer { staged.cleanUp() }
+            let snapshot = AuthorizedKeysSnapshot(username: environment.base.username)
+            defer {
+                snapshot.restore()
+                #expect(snapshot.isRestoredByteExact)
+            }
+            try snapshot.append(line: staged.authorizedKeysLine)
+
+            let code = PairingCode(
+                addresses: [environment.base.host],
+                port: environment.base.port,
+                username: environment.base.username,
+                hostKeyFingerprint: pinned,
+                bootstrap: .init(seed: staged.seed, expiresAt: staged.expiresAt))
+
+            await #expect(throws: PairingCeremonyError.enrollmentRefused(.unknownPairing)) {
+                _ = try await Self.connector.pair(
+                    code: code, deviceKey: DeviceKey(privateKey: .init())
+                ) { _ in }
+            }
+        }
+    }
+
+    /// A Bootstrap Key sshd has never seen (the line was never installed):
+    /// the pinned host key matches, so this is our Host saying no — the
+    /// authenticate step, telling the user to regenerate, not to fix the
+    /// network. Mutates nothing, so no snapshot is needed.
+    @Test func unauthorizedBootstrapKeyFailsTheAuthenticateStep() async throws {
+        let environment = try #require(PairingE2EEnvironment.current)
+        let pinned = try await Self.discoverHostKeyFingerprint(environment.base)
+
+        let strayKey = Curve25519.Signing.PrivateKey()
+        let code = PairingCode(
+            addresses: [environment.base.host],
+            port: environment.base.port,
+            username: environment.base.username,
+            hostKeyFingerprint: pinned,
+            bootstrap: .init(
+                seed: strayKey.rawRepresentation,
+                expiresAt: Date(timeIntervalSinceNow: 120)))
+        let steps = Mutex<[PairingStep]>([])
+
+        await #expect(throws: PairingCeremonyError.bootstrapRejected) {
+            _ = try await Self.connector.pair(code: code, deviceKey: DeviceKey(privateKey: .init())) {
+                step in steps.withLock { $0.append(step) }
+            }
+        }
+        #expect(steps.withLock { $0 } == [.reach])
+    }
+
+    /// A pin that matches nothing: the ceremony must never authenticate
+    /// against a host whose key differs from the Pairing Code's fingerprint
+    /// (that host is not ours), and the failure reads as unreachable.
+    @Test func mismatchedPinnedFingerprintNeverAuthenticates() async throws {
+        let environment = try #require(PairingE2EEnvironment.current)
+
+        let code = PairingCode(
+            addresses: [environment.base.host],
+            port: environment.base.port,
+            username: environment.base.username,
+            hostKeyFingerprint: HostKeyFingerprint(digest: Data(repeating: 7, count: 32)),
+            bootstrap: .init(
+                seed: Curve25519.Signing.PrivateKey().rawRepresentation,
+                expiresAt: Date(timeIntervalSinceNow: 120)))
+
+        do {
+            _ = try await Self.connector.pair(
+                code: code, deviceKey: DeviceKey(privateKey: .init())
+            ) { _ in }
+            Issue.record("ceremony succeeded against a host with the wrong key")
+        } catch let error as PairingCeremonyError {
+            guard case .hostUnreachable(let detail) = error else {
+                Issue.record("expected hostUnreachable, got \(error)")
+                return
+            }
+            #expect(detail.contains("not the pinned host key"))
+        }
+    }
+
+    private static let connector = SSHPairingConnector(
+        perAddressTimeout: .seconds(2), deviceKeyComment: "herdr-mobile-e2e")
+
+    /// The fingerprint the localhost sshd actually presents, discovered the
+    /// same way the plugin discovers it at code-generation time. Pinning it
+    /// keeps these tests independent of which host key sshd negotiates.
+    private static func discoverHostKeyFingerprint(
+        _ base: LocalSSHTestEnvironment
+    ) async throws -> HostKeyFingerprint {
+        let seen = Mutex<HostKeyFingerprint?>(nil)
+        let policy = HostKeyPolicy(knownHosts: InMemoryKnownHostsStore()) { candidate in
+            seen.withLock { $0 = candidate.fingerprint }
+            return true
+        }
+        let transport = try await SSHTransport.connect(
+            settings: base.makeSettings(
+                socket: .absolutePath("/tmp/herdr-irrelevant.sock"), hostKeyPolicy: policy))
+        try await transport.close()
+        return try #require(seen.withLock { $0 })
+    }
+}
+
+// Reach failures that need no live sshd, mirroring SSHConnectFailureTests.
+@Suite("Pairing reach failure taxonomy")
+struct PairingReachFailureTests {
+    @Test func deadCandidateAddressesMapToHostUnreachable() async throws {
+        // Nothing listens on port 1 (privileged, unused): connection refused.
+        let code = PairingCode(
+            addresses: ["127.0.0.1"],
+            port: 1,
+            username: "nobody",
+            hostKeyFingerprint: HostKeyFingerprint(digest: Data(repeating: 1, count: 32)),
+            bootstrap: .init(
+                seed: Curve25519.Signing.PrivateKey().rawRepresentation,
+                expiresAt: Date(timeIntervalSinceNow: 120)))
+        let steps = Mutex<[PairingStep]>([])
+
+        do {
+            _ = try await SSHPairingConnector(perAddressTimeout: .seconds(2)).pair(
+                code: code, deviceKey: DeviceKey(privateKey: .init())
+            ) { step in steps.withLock { $0.append(step) } }
+            Issue.record("ceremony succeeded against a dead port")
+        } catch let error as PairingCeremonyError {
+            guard case .hostUnreachable = error else {
+                Issue.record("expected hostUnreachable, got \(error)")
+                return
+            }
+        }
+        #expect(steps.withLock { $0 } == [.reach])
+    }
+}
+
+/// Probes for the pairing e2e prerequisites on top of the shared local-SSH
+/// environment: a Node binary for the forced command and the plugin checkout
+/// (the accept script runs from the working tree, exactly as
+/// `herdr plugin link` would run it). Overridable via HERDR_TEST_NODE.
+private struct PairingE2EEnvironment: Sendable {
+    let base: LocalSSHTestEnvironment
+    let nodePath: String
+    let acceptScriptPath: String
+
+    static var isAvailable: Bool { current != nil }
+
+    static let current: PairingE2EEnvironment? = probe()
+
+    private static func probe() -> PairingE2EEnvironment? {
+        guard let base = LocalSSHTestEnvironment.current else { return nil }
+
+        let environment = ProcessInfo.processInfo.environment
+        let nodePath = environment["HERDR_TEST_NODE"] ?? "/opt/homebrew/bin/node"
+        guard FileManager.default.isExecutableFile(atPath: nodePath) else { return nil }
+
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // HerdrMobileTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+        let acceptScript = repoRoot.appendingPathComponent("plugin/src/pair-accept.js").path
+        guard FileManager.default.fileExists(atPath: acceptScript) else { return nil }
+
+        return PairingE2EEnvironment(
+            base: base, nodePath: nodePath, acceptScriptPath: acceptScript)
+    }
+}
+
+/// One staged server-side pairing: the restricted Bootstrap Key line whose
+/// forced command runs the real accept script, plus the pending state the
+/// plugin's `beginPairing` would have written. Field-for-field the format of
+/// `pairing-session.js`/`authorized-keys.js`; composed in Swift because the
+/// simulator cannot spawn Node itself.
+private struct StagedPairing {
+    let seed: Data
+    let publicLine: String
+    let pairingId: String
+    let expiresAt: Date
+    let stateDir: URL
+    let authorizedKeysLine: String
+
+    var pendingPath: String {
+        stateDir.appendingPathComponent("pending/\(pairingId).json").path
+    }
+
+    private var enrolledPath: String {
+        stateDir.appendingPathComponent("enrolled/\(pairingId).json").path
+    }
+
+    struct EnrollmentRecord: Decodable {
+        let pairingId: String
+        let fingerprint: String
+        let line: String
+    }
+
+    /// The record `pair-accept.js` leaves for the popup, or nil.
+    var enrollmentRecord: EnrollmentRecord? {
+        guard let data = FileManager.default.contents(atPath: enrolledPath) else { return nil }
+        return try? JSONDecoder().decode(EnrollmentRecord.self, from: data)
+    }
+
+    init(
+        environment: PairingE2EEnvironment, ttlSeconds: Int, writePendingState: Bool = true
+    ) throws {
+        let bootstrapKey = Curve25519.Signing.PrivateKey()
+        seed = bootstrapKey.rawRepresentation
+        publicLine = DeviceKey(privateKey: bootstrapKey).openSSHPublicKey
+        pairingId = Data((0..<6).map { _ in UInt8.random(in: 0...255) })
+            .map { String(format: "%02x", $0) }.joined()
+        let expiresAtSeconds = Int(Date().timeIntervalSince1970) + ttlSeconds
+        expiresAt = Date(timeIntervalSince1970: TimeInterval(expiresAtSeconds))
+        stateDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herdr-pairing-e2e-\(pairingId)", isDirectory: true)
+
+        // The forced command embeds absolute paths, single-quoted exactly
+        // like the plugin's acceptCommand; the paths involved carry no
+        // quotes on any supported setup.
+        for path in [environment.nodePath, environment.acceptScriptPath, stateDir.path] {
+            precondition(!path.contains("'"), "unquotable path in test setup: \(path)")
+        }
+        let command = "'\(environment.nodePath)' '\(environment.acceptScriptPath)'"
+            + " --state-dir '\(stateDir.path)' --pairing-id \(pairingId)"
+        authorizedKeysLine =
+            "restrict,command=\"\(command)\" \(publicLine)"
+            + " herdr-pairing:\(pairingId):exp:\(expiresAtSeconds)"
+
+        if writePendingState {
+            let pendingDir = stateDir.appendingPathComponent("pending", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: pendingDir, withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700])
+            let pending = try JSONSerialization.data(withJSONObject: [
+                "pairingId": pairingId,
+                "expiresAt": expiresAtSeconds,
+                "publicLine": publicLine,
+            ])
+            try pending.write(to: URL(fileURLWithPath: pendingPath))
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600], ofItemAtPath: pendingPath)
+        }
+    }
+
+    func cleanUp() {
+        try? FileManager.default.removeItem(at: stateDir)
+    }
+}
+
+/// Snapshot of the host user's real authorized_keys, restored byte-exactly
+/// after each test. The ceremony rewrites the file server-side (enroll
+/// appends, self-revoke removes), so restoration writes the original bytes
+/// back and `isRestoredByteExact` proves it with a SHA-256 comparison — the
+/// suite's acceptance criterion for touching the real file at all.
+private struct AuthorizedKeysSnapshot {
+    private let path: String
+    private let original: Data?
+
+    init(username: String) {
+        path = "/Users/\(username)/.ssh/authorized_keys"
+        original = FileManager.default.contents(atPath: path)
+    }
+
+    /// Appends one line, preserving prior content. Non-atomic on purpose:
+    /// rewriting in place keeps the permissions sshd's StrictModes checks.
+    func append(line: String) throws {
+        var content = original.map { String(decoding: $0, as: UTF8.self) } ?? ""
+        if !content.isEmpty, !content.hasSuffix("\n") { content += "\n" }
+        content += line + "\n"
+        try content.write(toFile: path, atomically: false, encoding: .utf8)
+    }
+
+    var currentContents: String {
+        FileManager.default.contents(atPath: path)
+            .map { String(decoding: $0, as: UTF8.self) } ?? ""
+    }
+
+    func restore() {
+        if let original {
+            try? original.write(to: URL(fileURLWithPath: path))
+        } else {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+    }
+
+    var isRestoredByteExact: Bool {
+        let current = FileManager.default.contents(atPath: path)
+        guard let original else { return current == nil }
+        guard let current else { return false }
+        return SHA256.hash(data: current) == SHA256.hash(data: original) && current == original
+    }
+}

--- a/Tests/HerdrMobileTests/PairingCeremonyTests.swift
+++ b/Tests/HerdrMobileTests/PairingCeremonyTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+/// The pure parts of the pairing ceremony client (#65): the Enrollment accept
+/// stdout protocol (documented in `plugin/README.md`) and the per-step
+/// classification of ceremony failures (ADR 0007 failure taxonomy).
+@Suite("Enrollment accept protocol")
+struct EnrollmentResponseTests {
+    @Test func parsesSuccessLineWithFingerprint() {
+        let line = "HERDR-ENROLL:OK:SHA256:0Y1eCbGuGWCGKirP9nWzOTLIcuBLvewToJfOPQqrjHY"
+        #expect(
+            EnrollmentResponse.parse(line: line)
+                == .enrolled(fingerprint: "SHA256:0Y1eCbGuGWCGKirP9nWzOTLIcuBLvewToJfOPQqrjHY"))
+    }
+
+    @Test(arguments: [
+        ("HERDR-ENROLL:ERR:unknown_pairing", EnrollmentRefusal.unknownPairing),
+        ("HERDR-ENROLL:ERR:expired", .expired),
+        ("HERDR-ENROLL:ERR:invalid_key", .invalidKey),
+        ("HERDR-ENROLL:ERR:no_input", .noInput),
+    ])
+    func parsesEveryDocumentedRefusalCode(line: String, refusal: EnrollmentRefusal) {
+        #expect(EnrollmentResponse.parse(line: line) == .refused(refusal))
+    }
+
+    /// A future plugin may add refusal codes within the protocol's framing;
+    /// they must surface as refusals, not as protocol violations.
+    @Test func keepsUnrecognizedRefusalCodesAsRefusals() {
+        #expect(
+            EnrollmentResponse.parse(line: "HERDR-ENROLL:ERR:quota_exceeded")
+                == .refused(.unrecognized(code: "quota_exceeded")))
+    }
+
+    @Test(arguments: [
+        "",
+        "HERDR-ENROLL:OK:",
+        "HERDR-ENROLL:ERR:",
+        "HERDR-ENROLL:WAT:hm",
+        "welcome to fish, the friendly interactive shell",
+        "HERDR-PAIR:1:e30",
+    ])
+    func rejectsLinesOutsideTheProtocol(line: String) {
+        #expect(EnrollmentResponse.parse(line: line) == nil)
+    }
+
+    /// The accept script's OK fingerprint must be OpenSSH's SHA256 shape;
+    /// anything else on the OK line is a protocol violation, not a success.
+    @Test func rejectsSuccessLineWithMalformedFingerprint() {
+        #expect(EnrollmentResponse.parse(line: "HERDR-ENROLL:OK:MD5:aa:bb") == nil)
+    }
+}
+
+@Suite("Pairing failure taxonomy")
+struct PairingCeremonyErrorTests {
+    @Test func classifiesEveryFailureToItsStep() {
+        #expect(PairingCeremonyError.hostUnreachable(detail: "x").step == .reach)
+        #expect(PairingCeremonyError.bootstrapRejected.step == .authenticate)
+        #expect(PairingCeremonyError.enrollmentRefused(.expired).step == .enroll)
+        #expect(PairingCeremonyError.enrollmentFailed(detail: "x").step == .enroll)
+        #expect(PairingCeremonyError.verificationFailed(detail: "x").step == .verify)
+    }
+
+    @Test func refusalCodesRoundTripTheWireCodes() {
+        #expect(EnrollmentRefusal(wireCode: "unknown_pairing") == .unknownPairing)
+        #expect(EnrollmentRefusal(wireCode: "expired") == .expired)
+        #expect(EnrollmentRefusal(wireCode: "invalid_key") == .invalidKey)
+        #expect(EnrollmentRefusal(wireCode: "no_input") == .noInput)
+        #expect(EnrollmentRefusal(wireCode: "later_code") == .unrecognized(code: "later_code"))
+    }
+}

--- a/Tests/HerdrMobileTests/PairingCodeTests.swift
+++ b/Tests/HerdrMobileTests/PairingCodeTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+/// Decoder tests for the Pairing Code v1 envelope (#62), driven by the shared
+/// vectors in `plugin/test-vectors/pairing-code-v1.json` — the same file the
+/// Node plugin tests consume, so the two implementations cannot drift.
+@Suite("Pairing Code envelope")
+struct PairingCodeTests {
+    private static let vectors = PairingCodeVectorFile.shared
+
+    /// Guards against silently loading an empty or truncated vector file;
+    /// mirrors the same assertion in the Node suite.
+    @Test func sharedVectorFileHasCases() {
+        #expect(Self.vectors.valid.count >= 3)
+        #expect(Self.vectors.invalid.count >= 10)
+    }
+
+    @Test(arguments: vectors.valid)
+    func decodesValidVector(vector: PairingCodeVectorFile.Valid) throws {
+        let code = try PairingCode.decode(vector.code)
+
+        #expect(code.addresses == vector.payload.addresses)
+        #expect(code.port == vector.payload.port)
+        #expect(code.username == vector.payload.username)
+        #expect(code.hostKeyFingerprint.displayString == vector.payload.hostKeyFingerprint)
+
+        if let expectedSeed = vector.payload.bootstrapSeed {
+            let bootstrap = try #require(code.bootstrap)
+            #expect(base64URL(bootstrap.seed) == expectedSeed)
+            let expectedExpiry = try #require(vector.payload.expiresAt)
+            #expect(bootstrap.expiresAt == Date(timeIntervalSince1970: TimeInterval(expectedExpiry)))
+        } else {
+            #expect(code.bootstrap == nil)
+        }
+    }
+
+    @Test(arguments: vectors.invalid)
+    func rejectsInvalidVector(vector: PairingCodeVectorFile.Invalid) {
+        do {
+            _ = try PairingCode.decode(vector.code)
+            Issue.record("unexpectedly decoded \(vector.name)")
+        } catch {
+            #expect(error.wireCode == vector.error, "\(vector.name)")
+        }
+    }
+
+    private func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/Tests/HerdrMobileTests/PairingScanStoreTests.swift
+++ b/Tests/HerdrMobileTests/PairingScanStoreTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+@MainActor
+@Suite("Pairing scan store")
+struct PairingScanStoreTests {
+    /// A canonical config-only code from the shared vectors, so the store
+    /// tests ride on the same source of truth as the decoder tests.
+    private static let validCode = PairingCodeVectorFile.shared.valid[0].code
+
+    @Test func parsesAScannedPairingCode() throws {
+        let store = PairingScanStore()
+
+        store.submit(scannedCode: Self.validCode)
+
+        let code = try #require(store.pairingCode)
+        #expect(code == (try PairingCode.decode(Self.validCode)))
+        #expect(store.scanFailureMessage == nil)
+    }
+
+    @Test func foreignQRCodesAskForTheHerdrPairingCode() {
+        let store = PairingScanStore()
+
+        store.submit(scannedCode: "https://example.com/some-other-qr")
+
+        #expect(store.pairingCode == nil)
+        let message = store.scanFailureMessage
+        #expect(message?.contains("not a herdr Pairing Code") == true)
+    }
+
+    @Test func unsupportedVersionsNameTheVersionAndAskForAnUpdate() {
+        let store = PairingScanStore()
+
+        store.submit(scannedCode: "HERDR-PAIR:2:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXX0")
+
+        #expect(store.pairingCode == nil)
+        let message = store.scanFailureMessage
+        #expect(message?.contains("version 2") == true)
+        #expect(message?.contains("Update") == true)
+    }
+
+    @Test func corruptCodesAskForRegeneration() {
+        let store = PairingScanStore()
+
+        store.submit(scannedCode: "HERDR-PAIR:1:!!!corrupt!!!")
+
+        #expect(store.pairingCode == nil)
+        #expect(store.scanFailureMessage?.contains("Regenerate") == true)
+    }
+
+    @Test func aGoodScanClearsAnEarlierFailure() throws {
+        let store = PairingScanStore()
+        store.submit(scannedCode: "HERDR-PAIR:1:!!!corrupt!!!")
+
+        store.submit(scannedCode: Self.validCode)
+
+        #expect(store.pairingCode != nil)
+        #expect(store.scanFailureMessage == nil)
+    }
+
+    @Test func furtherScansAreIgnoredOnceACodeParsed() throws {
+        let store = PairingScanStore()
+        store.submit(scannedCode: Self.validCode)
+        let first = try #require(store.pairingCode)
+
+        store.submit(scannedCode: "HERDR-PAIR:1:!!!corrupt!!!")
+
+        #expect(store.pairingCode == first)
+        #expect(store.scanFailureMessage == nil)
+    }
+
+    @Test func rescanReturnsToAFreshScanningState() {
+        let store = PairingScanStore()
+        store.submit(scannedCode: Self.validCode)
+
+        store.rescan()
+
+        #expect(store.pairingCode == nil)
+        #expect(store.scanFailureMessage == nil)
+    }
+}

--- a/Tests/HerdrMobileTests/PairingScanStoreTests.swift
+++ b/Tests/HerdrMobileTests/PairingScanStoreTests.swift
@@ -8,76 +8,372 @@ import Testing
 struct PairingScanStoreTests {
     /// A canonical config-only code from the shared vectors, so the store
     /// tests ride on the same source of truth as the decoder tests.
-    private static let validCode = PairingCodeVectorFile.shared.valid[0].code
+    private static let configOnlyCode = PairingCodeVectorFile.shared.valid[0].code
+    /// The shared vector carrying a Bootstrap Key (expires 1753305600).
+    private static let bootstrapVector = PairingCodeVectorFile.shared.valid.first {
+        $0.payload.bootstrapSeed != nil
+    }!
+    /// A moment safely inside the bootstrap vector's TTL.
+    private static let insideTTL = Date(timeIntervalSince1970: 1_753_305_500)
+
+    /// What the fake ceremony proves; the vector's Host answered on its
+    /// only address.
+    private static let pairedResult = PairingResult(
+        address: "10.0.0.7", port: 22, username: "lin",
+        hostKeyFingerprint: HostKeyFingerprint(publicKeyBlob: Data("host-public-key".utf8)))
+
+    private struct Env {
+        let store: PairingScanStore
+        let connector: FakePairingConnector
+        let catalog: HostStore
+        let knownHosts: InMemoryKnownHostsStore
+        let cleanup: () -> Void
+    }
+
+    private func makeEnv(
+        outcomes: [FakePairingConnector.Outcome] = [.succeeds(pairedResult)],
+        now: Date = insideTTL,
+        credentials: HostCredentialsProvider? = nil,
+        corruptCatalog: Bool = false
+    ) throws -> Env {
+        let suiteName = "hm-pairing-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        if corruptCatalog {
+            defaults.set(Data("not a catalog".utf8), forKey: "hosts")
+        }
+        let catalog = HostStore(defaults: defaults, secrets: InMemorySecretStore())
+        let connector = FakePairingConnector(outcomes: outcomes)
+        let knownHosts = InMemoryKnownHostsStore()
+        let store = PairingScanStore(
+            catalog: catalog,
+            connector: connector,
+            knownHosts: knownHosts,
+            credentials: credentials
+                ?? HostCredentialsProvider(
+                    deviceKeys: DeviceKeyStore(secrets: InMemorySecretStore()),
+                    secrets: InMemorySecretStore()),
+            now: { now })
+        return Env(
+            store: store, connector: connector, catalog: catalog, knownHosts: knownHosts,
+            cleanup: { defaults.removePersistentDomain(forName: suiteName) })
+    }
+
+    /// Polls until `condition` holds, yielding the main actor so the store's
+    /// ceremony task can progress in between.
+    private func waitUntil(_ comment: Comment, condition: () -> Bool) async throws {
+        for _ in 0..<500 where !condition() {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(condition(), comment)
+    }
+
+    // MARK: Scanning (the parse step)
 
     @Test func parsesAScannedPairingCode() throws {
-        let store = PairingScanStore()
+        let env = try makeEnv()
+        defer { env.cleanup() }
 
-        store.submit(scannedCode: Self.validCode)
+        env.store.submit(scannedCode: Self.configOnlyCode)
 
-        let code = try #require(store.pairingCode)
-        #expect(code == (try PairingCode.decode(Self.validCode)))
-        #expect(store.scanFailureMessage == nil)
+        let code = try #require(env.store.pairingCode)
+        #expect(code == (try PairingCode.decode(Self.configOnlyCode)))
+        #expect(env.store.scanFailureMessage == nil)
     }
 
-    @Test func foreignQRCodesAskForTheHerdrPairingCode() {
-        let store = PairingScanStore()
+    @Test func foreignQRCodesAskForTheHerdrPairingCode() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
 
-        store.submit(scannedCode: "https://example.com/some-other-qr")
+        env.store.submit(scannedCode: "https://example.com/some-other-qr")
 
-        #expect(store.pairingCode == nil)
-        let message = store.scanFailureMessage
-        #expect(message?.contains("not a herdr Pairing Code") == true)
+        #expect(env.store.pairingCode == nil)
+        #expect(env.store.scanFailureMessage?.contains("not a herdr Pairing Code") == true)
     }
 
-    @Test func unsupportedVersionsNameTheVersionAndAskForAnUpdate() {
-        let store = PairingScanStore()
+    @Test func unsupportedVersionsNameTheVersionAndAskForAnUpdate() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
 
-        store.submit(scannedCode: "HERDR-PAIR:2:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXX0")
+        env.store.submit(scannedCode: "HERDR-PAIR:2:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXX0")
 
-        #expect(store.pairingCode == nil)
-        let message = store.scanFailureMessage
+        #expect(env.store.pairingCode == nil)
+        let message = env.store.scanFailureMessage
         #expect(message?.contains("version 2") == true)
         #expect(message?.contains("Update") == true)
     }
 
-    @Test func corruptCodesAskForRegeneration() {
-        let store = PairingScanStore()
+    @Test func corruptCodesAskForRegeneration() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
 
-        store.submit(scannedCode: "HERDR-PAIR:1:!!!corrupt!!!")
+        env.store.submit(scannedCode: "HERDR-PAIR:1:!!!corrupt!!!")
 
-        #expect(store.pairingCode == nil)
-        #expect(store.scanFailureMessage?.contains("Regenerate") == true)
+        #expect(env.store.pairingCode == nil)
+        #expect(env.store.scanFailureMessage?.contains("Regenerate") == true)
     }
 
     @Test func aGoodScanClearsAnEarlierFailure() throws {
-        let store = PairingScanStore()
-        store.submit(scannedCode: "HERDR-PAIR:1:!!!corrupt!!!")
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: "HERDR-PAIR:1:!!!corrupt!!!")
 
-        store.submit(scannedCode: Self.validCode)
+        env.store.submit(scannedCode: Self.configOnlyCode)
 
-        #expect(store.pairingCode != nil)
-        #expect(store.scanFailureMessage == nil)
+        #expect(env.store.pairingCode != nil)
+        #expect(env.store.scanFailureMessage == nil)
     }
 
     @Test func furtherScansAreIgnoredOnceACodeParsed() throws {
-        let store = PairingScanStore()
-        store.submit(scannedCode: Self.validCode)
-        let first = try #require(store.pairingCode)
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: Self.configOnlyCode)
+        let first = try #require(env.store.pairingCode)
 
-        store.submit(scannedCode: "HERDR-PAIR:1:!!!corrupt!!!")
+        env.store.submit(scannedCode: "HERDR-PAIR:1:!!!corrupt!!!")
 
-        #expect(store.pairingCode == first)
-        #expect(store.scanFailureMessage == nil)
+        #expect(env.store.pairingCode == first)
+        #expect(env.store.scanFailureMessage == nil)
     }
 
-    @Test func rescanReturnsToAFreshScanningState() {
-        let store = PairingScanStore()
-        store.submit(scannedCode: Self.validCode)
+    @Test func rescanReturnsToAFreshScanningState() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: Self.configOnlyCode)
 
-        store.rescan()
+        env.store.rescan()
 
-        #expect(store.pairingCode == nil)
-        #expect(store.scanFailureMessage == nil)
+        #expect(env.store.pairingCode == nil)
+        #expect(env.store.scanFailureMessage == nil)
+    }
+
+    @Test func rescanAfterACeremonyFailureClearsTheFailure() async throws {
+        let env = try makeEnv(outcomes: [.fails(.bootstrapRejected)])
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: Self.bootstrapVector.code)
+        await env.store.pair()
+        #expect(env.store.failure != nil)
+
+        env.store.rescan()
+
+        #expect(env.store.pairingCode == nil)
+        #expect(env.store.failure == nil)
+    }
+
+    // MARK: Ceremony success
+
+    @Test func successfulCeremonyPersistsTheHostAndPinsTheFingerprint() async throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: Self.bootstrapVector.code)
+
+        await env.store.pair()
+
+        let paired = try #require(env.store.pairedHost)
+        #expect(env.catalog.hosts == [paired])
+        #expect(paired.address == "10.0.0.7")
+        #expect(paired.port == 22)
+        #expect(paired.username == "lin")
+        #expect(paired.authMethod == .deviceKey)
+        // Session selection stays with preflight discovery (ADR 0007).
+        #expect(paired.sessionName.isEmpty)
+        #expect(paired.displayName == "lin@10.0.0.7")
+        // The pinned fingerprint means preflight never TOFU-prompts.
+        #expect(
+            await env.knownHosts.fingerprint(host: "10.0.0.7", port: 22)
+                == Self.pairedResult.hostKeyFingerprint)
+        #expect(env.store.failure == nil)
+        #expect(env.store.isPairing == false)
+        #expect(env.store.step == nil)
+    }
+
+    @Test func pairingAgainAfterSuccessIsIgnored() async throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: Self.bootstrapVector.code)
+        await env.store.pair()
+
+        await env.store.pair()
+
+        #expect(await env.connector.capturedCodes.count == 1)
+        #expect(env.catalog.hosts.count == 1)
+    }
+
+    @Test func hostIsPersistedOnlyAfterTheVerifiedReconnect() async throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        await env.connector.hold()
+        env.store.submit(scannedCode: Self.bootstrapVector.code)
+
+        let run = Task { await env.store.pair() }
+        try await waitUntil("the ceremony should reach the verify step") {
+            env.store.step == .verify
+        }
+        #expect(env.store.isPairing)
+        #expect(env.store.pairedHost == nil)
+        #expect(env.catalog.hosts.isEmpty)
+
+        await env.connector.release()
+        await run.value
+
+        #expect(env.store.pairedHost != nil)
+        #expect(env.catalog.hosts.count == 1)
+    }
+
+    // MARK: Ceremony failures
+
+    @Test(arguments: [
+        PairingCeremonyError.hostUnreachable(detail: "x"),
+        .bootstrapRejected,
+        .enrollmentRefused(.unknownPairing),
+        .enrollmentRefused(.expired),
+        .enrollmentRefused(.invalidKey),
+        .enrollmentRefused(.noInput),
+        .enrollmentRefused(.unrecognized(code: "quota_exceeded")),
+        .enrollmentFailed(detail: "x"),
+        .verificationFailed(detail: "x"),
+    ])
+    func everyStepFailureLeavesNoHostResidue(error: PairingCeremonyError) async throws {
+        let env = try makeEnv(outcomes: [.fails(error)])
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: Self.bootstrapVector.code)
+
+        await env.store.pair()
+
+        #expect(env.store.pairedHost == nil)
+        #expect(env.catalog.hosts.isEmpty)
+        #expect(await env.knownHosts.fingerprint(host: "10.0.0.7", port: 22) == nil)
+        let failure = try #require(env.store.failure)
+        #expect(failure.step == error.step)
+        #expect(env.store.isPairing == false)
+        #expect(env.store.step == nil)
+    }
+
+    @Test(arguments: [
+        (PairingCeremonyError.hostUnreachable(detail: "x"), true, "same network"),
+        (.bootstrapRejected, false, "Generate a new Pairing Code"),
+        (.enrollmentRefused(.unknownPairing), false, "Generate a new Pairing Code"),
+        (.enrollmentRefused(.expired), false, "expired"),
+        (.enrollmentRefused(.invalidKey), true, "Try again"),
+        (.enrollmentRefused(.noInput), true, "Try again"),
+        (.enrollmentRefused(.unrecognized(code: "quota_exceeded")), false, "quota_exceeded"),
+        (.enrollmentFailed(detail: "x"), true, "Try again"),
+        (.verificationFailed(detail: "x"), true, "Try again"),
+    ])
+    func failureCopyGuidesRecoveryPerStep(
+        error: PairingCeremonyError, canRetry: Bool, phrase: String
+    ) async throws {
+        let env = try makeEnv(outcomes: [.fails(error)])
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: Self.bootstrapVector.code)
+
+        await env.store.pair()
+
+        let failure = try #require(env.store.failure)
+        #expect(failure.canRetry == canRetry)
+        #expect(failure.message.contains(phrase), "copy was: \(failure.message)")
+    }
+
+    @Test func expiredCodeIsReportedWithoutConnecting() async throws {
+        let env = try makeEnv(now: Date(timeIntervalSince1970: 1_753_305_601))
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: Self.bootstrapVector.code)
+
+        await env.store.pair()
+
+        let failure = try #require(env.store.failure)
+        #expect(failure.canRetry == false)
+        #expect(failure.message.contains("expired"))
+        #expect(failure.message.contains("computer"))
+        #expect(await env.connector.capturedCodes.isEmpty)
+        #expect(env.catalog.hosts.isEmpty)
+    }
+
+    @Test func transientFailureRetriesWithTheSameCodeWithoutRescanning() async throws {
+        let env = try makeEnv(outcomes: [
+            .fails(.hostUnreachable(detail: "no route")),
+            .succeeds(Self.pairedResult),
+        ])
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: Self.bootstrapVector.code)
+
+        await env.store.pair()
+        let failure = try #require(env.store.failure)
+        #expect(failure.canRetry)
+        #expect(env.store.pairingCode != nil, "a retry must not require a rescan")
+
+        await env.store.pair()
+
+        #expect(env.store.pairedHost != nil)
+        let scanned = try PairingCode.decode(Self.bootstrapVector.code)
+        #expect(await env.connector.capturedCodes == [scanned, scanned])
+    }
+
+    @Test func verifyFailureRetriesWithoutTheBootstrapKey() async throws {
+        let env = try makeEnv(outcomes: [
+            .fails(.verificationFailed(detail: "timeout")),
+            .succeeds(Self.pairedResult),
+        ])
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: Self.bootstrapVector.code)
+
+        await env.store.pair()
+        #expect(try #require(env.store.failure).canRetry)
+
+        await env.store.pair()
+
+        #expect(env.store.pairedHost != nil)
+        let codes = await env.connector.capturedCodes
+        #expect(codes.count == 2)
+        // Enrollment already landed on the Host; the retry repeats only the
+        // Device Key reconnect instead of burning the spent Bootstrap Key.
+        #expect(codes.first?.bootstrap != nil)
+        #expect(codes.last?.bootstrap == nil)
+        #expect(codes.last?.addresses == codes.first?.addresses)
+        #expect(codes.last?.username == codes.first?.username)
+    }
+
+    @Test func configOnlyVerifyFailurePointsAtManualAuthorization() async throws {
+        let env = try makeEnv(outcomes: [.fails(.verificationFailed(detail: "auth failed"))])
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: Self.configOnlyCode)
+
+        await env.store.pair()
+
+        let failure = try #require(env.store.failure)
+        #expect(failure.canRetry == false)
+        #expect(failure.message.contains("authorized_keys"))
+    }
+
+    @Test func corruptDeviceKeyFailsBeforeTheCeremony() async throws {
+        let account = "device-ed25519-private-key"
+        let secrets = InMemorySecretStore()
+        try secrets.write(Data("not-an-ed25519-key".utf8), account: account)
+        let env = try makeEnv(
+            credentials: HostCredentialsProvider(
+                deviceKeys: DeviceKeyStore(secrets: secrets, account: account), secrets: secrets))
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: Self.bootstrapVector.code)
+
+        await env.store.pair()
+
+        let failure = try #require(env.store.failure)
+        #expect(failure.canRetry == false)
+        #expect(failure.message.contains("Device Key"))
+        #expect(await env.connector.capturedCodes.isEmpty)
+        #expect(env.catalog.hosts.isEmpty)
+    }
+
+    @Test func unwritableCatalogSurfacesTheSaveFailureAndPinsNothing() async throws {
+        let env = try makeEnv(corruptCatalog: true)
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: Self.bootstrapVector.code)
+
+        await env.store.pair()
+
+        #expect(env.store.pairedHost == nil)
+        let failure = try #require(env.store.failure)
+        #expect(failure.canRetry == false)
+        #expect(failure.message.contains("could not be saved"))
+        #expect(await env.knownHosts.fingerprint(host: "10.0.0.7", port: 22) == nil)
     }
 }

--- a/Tests/HerdrMobileTests/PairingScanStoreTests.swift
+++ b/Tests/HerdrMobileTests/PairingScanStoreTests.swift
@@ -162,12 +162,19 @@ struct PairingScanStoreTests {
     // MARK: Ceremony success
 
     @Test func successfulCeremonyPersistsTheHostAndPinsTheFingerprint() async throws {
-        let env = try makeEnv()
+        let secrets = InMemorySecretStore()
+        let credentials = HostCredentialsProvider(
+            deviceKeys: DeviceKeyStore(secrets: secrets), secrets: secrets)
+        let env = try makeEnv(credentials: credentials)
         defer { env.cleanup() }
         env.store.submit(scannedCode: Self.bootstrapVector.code)
 
         await env.store.pair()
 
+        // The ceremony must submit this device's own Device Key, not some
+        // other blob; the connector captured what actually went over the wire.
+        let expectedBlob = try credentials.deviceKey().publicKeyBlob
+        #expect(await env.connector.capturedDeviceKeyBlobs == [expectedBlob])
         let paired = try #require(env.store.pairedHost)
         #expect(env.catalog.hosts == [paired])
         #expect(paired.address == "10.0.0.7")
@@ -330,6 +337,35 @@ struct PairingScanStoreTests {
         #expect(codes.last?.bootstrap == nil)
         #expect(codes.last?.addresses == codes.first?.addresses)
         #expect(codes.last?.username == codes.first?.username)
+    }
+
+    @Test func secondVerifyFailureAfterEnrollmentKeepsTheEnrolledCopy() async throws {
+        let env = try makeEnv(outcomes: [
+            .fails(.verificationFailed(detail: "timeout")),
+            .fails(.verificationFailed(detail: "still no route")),
+        ])
+        defer { env.cleanup() }
+        env.store.submit(scannedCode: Self.bootstrapVector.code)
+
+        await env.store.pair()
+        // First verify failure strips the spent Bootstrap Key for the retry.
+        #expect(try #require(env.store.failure).message.contains("enrolled"))
+
+        await env.store.pair()
+
+        // Enrollment already landed, so the retry ran bootstrap-less. The copy
+        // must stay truthful about that (this device WAS enrolled) instead of
+        // regressing to the config-only "authorized_keys" guidance just because
+        // the retry code no longer carries a Bootstrap Key. It also stays
+        // retryable: only the Device Key reconnect remains to finish.
+        let failure = try #require(env.store.failure)
+        #expect(failure.message.contains("enrolled"))
+        #expect(!failure.message.contains("authorized_keys"))
+        #expect(failure.canRetry)
+        let codes = await env.connector.capturedCodes
+        #expect(codes.count == 2)
+        #expect(codes.first?.bootstrap != nil)
+        #expect(codes.last?.bootstrap == nil)
     }
 
     @Test func configOnlyVerifyFailurePointsAtManualAuthorization() async throws {

--- a/Tests/HerdrMobileTests/SSHAuthE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHAuthE2ETests.swift
@@ -17,16 +17,19 @@ struct SSHAuthE2ETests {
     @Test func generatedDeviceKeyAuthenticatesOnceItsLineIsAuthorized() async throws {
         let environment = try #require(LocalSSHTestEnvironment.current)
         let deviceKey = try DeviceKeyStore(secrets: InMemorySecretStore()).loadOrCreate()
-        let installed = try AuthorizedKeysEntry(
-            username: environment.username,
-            line: deviceKey.authorizedKeysLine(comment: "herdr-mobile-e2e"))
-        defer { installed.restore() }
+        // Cross-suite exclusion: the pairing e2e rewrites the same file.
+        try await AuthorizedKeysTestLock.shared.withLock {
+            let installed = try AuthorizedKeysEntry(
+                username: environment.username,
+                line: deviceKey.authorizedKeysLine(comment: "herdr-mobile-e2e"))
+            defer { installed.restore() }
 
-        let transport = try await SSHTransport.connect(
-            settings: environment.makeSettings(
-                socket: .absolutePath("/tmp/herdr-irrelevant.sock"),
-                credentials: .ed25519(deviceKey.privateKey)))
-        try await transport.close()
+            let transport = try await SSHTransport.connect(
+                settings: environment.makeSettings(
+                    socket: .absolutePath("/tmp/herdr-irrelevant.sock"),
+                    credentials: .ed25519(deviceKey.privateKey)))
+            try await transport.close()
+        }
     }
 
     @Test func unauthorizedDeviceKeyMapsToAuthenticationFailed() async throws {

--- a/Tests/HerdrMobileTests/Support/AuthorizedKeysTestLock.swift
+++ b/Tests/HerdrMobileTests/Support/AuthorizedKeysTestLock.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Serializes every test that rewrites the host user's real
+/// `~/.ssh/authorized_keys`. Swift Testing's `.serialized` only orders tests
+/// within one suite, and both the auth e2e and the pairing e2e edit the same
+/// file, so cross-suite mutual exclusion has to be explicit — interleaved
+/// snapshot/restore would clobber each other's byte-exact restoration.
+actor AuthorizedKeysTestLock {
+    static let shared = AuthorizedKeysTestLock()
+
+    private var isHeld = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func withLock<T: Sendable>(
+        _ body: @Sendable () async throws -> T
+    ) async rethrows -> T {
+        await acquire()
+        defer { release() }
+        return try await body()
+    }
+
+    private func acquire() async {
+        if !isHeld {
+            isHeld = true
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    private func release() {
+        if let next = waiters.first {
+            waiters.removeFirst()
+            next.resume()
+        } else {
+            isHeld = false
+        }
+    }
+}

--- a/Tests/HerdrMobileTests/Support/FakePairingConnector.swift
+++ b/Tests/HerdrMobileTests/Support/FakePairingConnector.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+@testable import HerdrMobile
+
+/// Scripted `PairingConnector` for store tests: replays the real client's
+/// step callbacks up to a scripted outcome, no SSH. Outcomes are consumed
+/// one per `pair` call and the last one repeats, so retry scripts read
+/// naturally: `[.fails(...), .succeeds(...)]`.
+final actor FakePairingConnector: PairingConnector {
+    enum Outcome: Sendable {
+        case succeeds(PairingResult)
+        case fails(PairingCeremonyError)
+    }
+
+    private var outcomes: [Outcome]
+    private var isHolding = false
+    private var holdWaiters: [CheckedContinuation<Void, Never>] = []
+    private(set) var capturedCodes: [PairingCode] = []
+    private(set) var capturedDeviceKeyBlobs: [Data] = []
+
+    init(outcomes: [Outcome]) {
+        precondition(!outcomes.isEmpty, "script at least one outcome")
+        self.outcomes = outcomes
+    }
+
+    /// Makes every subsequent `pair` call wait, after reporting its steps,
+    /// until `release()`, so tests can observe in-flight progress state.
+    func hold() {
+        isHolding = true
+    }
+
+    func release() {
+        isHolding = false
+        for waiter in holdWaiters {
+            waiter.resume()
+        }
+        holdWaiters.removeAll()
+    }
+
+    func pair(
+        code: PairingCode,
+        deviceKey: DeviceKey,
+        onStep: @escaping @Sendable (PairingStep) -> Void
+    ) async throws -> PairingResult {
+        capturedCodes.append(code)
+        capturedDeviceKeyBlobs.append(deviceKey.publicKeyBlob)
+        let outcome = outcomes.count > 1 ? outcomes.removeFirst() : outcomes[0]
+        for step in Self.emittedSteps(for: outcome, code: code) {
+            onStep(step)
+        }
+        if isHolding {
+            await withCheckedContinuation { holdWaiters.append($0) }
+        }
+        switch outcome {
+        case .succeeds(let result):
+            return result
+        case .fails(let error):
+            throw error
+        }
+    }
+
+    /// The steps the real client reports before this outcome resolves: every
+    /// ceremony step that begins at or before the failing one. `authenticate`
+    /// is never emitted, matching `SSHPairingConnector`, where authentication
+    /// happens inside the reach connect.
+    private static func emittedSteps(for outcome: Outcome, code: PairingCode) -> [PairingStep] {
+        let ceremony: [PairingStep] =
+            code.bootstrap == nil ? [.reach, .verify] : [.reach, .enroll, .verify]
+        switch outcome {
+        case .succeeds:
+            return ceremony
+        case .fails(let error):
+            return ceremony.filter { rank($0) <= rank(error.step) }
+        }
+    }
+
+    private static func rank(_ step: PairingStep) -> Int {
+        PairingStep.allCases.firstIndex(of: step)!
+    }
+}

--- a/Tests/HerdrMobileTests/Support/PairingCodeVectorFile.swift
+++ b/Tests/HerdrMobileTests/Support/PairingCodeVectorFile.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The shared Pairing Code v1 vectors from `plugin/test-vectors/`, the single
+/// source of truth for the envelope across the Node plugin and this app
+/// (ADR 0007). The JSON file is bundled into the test target as a resource so
+/// the Swift tests exercise exactly the same cases as the Node tests.
+struct PairingCodeVectorFile: Decodable, Sendable {
+    let valid: [Valid]
+    let invalid: [Invalid]
+
+    struct Valid: Decodable, Sendable, CustomStringConvertible {
+        let name: String
+        let code: String
+        let payload: Payload
+        var description: String { name }
+    }
+
+    struct Payload: Decodable, Sendable {
+        let addresses: [String]
+        let port: Int
+        let username: String
+        let hostKeyFingerprint: String
+        /// Raw 32-byte Bootstrap Key seed as unpadded base64url (wire encoding).
+        let bootstrapSeed: String?
+        let expiresAt: Int?
+    }
+
+    struct Invalid: Decodable, Sendable, CustomStringConvertible {
+        let name: String
+        let code: String
+        /// The expected error identifier, e.g. "bad_prefix".
+        let error: String
+        var description: String { name }
+    }
+
+    static let shared: PairingCodeVectorFile = {
+        guard
+            let url = Bundle(for: BundleLocator.self)
+                .url(forResource: "pairing-code-v1", withExtension: "json")
+        else {
+            fatalError("pairing-code-v1.json is missing from the test bundle")
+        }
+        do {
+            return try JSONDecoder().decode(PairingCodeVectorFile.self, from: Data(contentsOf: url))
+        } catch {
+            fatalError("shared pairing vectors failed to load: \(error)")
+        }
+    }()
+
+    private final class BundleLocator {}
+}

--- a/docs/adr/0007-pairing-via-herdr-plugin.md
+++ b/docs/adr/0007-pairing-via-herdr-plugin.md
@@ -1,0 +1,26 @@
+# Pair new devices through a herdr plugin with a one-time Bootstrap Key
+
+New-device onboarding previously required carrying the Device Key's public half to the server out of band, plus manual Host entry and a TOFU fingerprint prompt. herdr is a third-party project, so the server side cannot live in herdr core; its plugin system (`herdr plugin install owner/repo/subdir`, unsandboxed, full CLI access) is the extension surface we control. We decided Pairing is the primary onboarding path: a herdr plugin renders a Pairing Code in a herdr popup pane, the app scans it, connects with the embedded Bootstrap Key, performs Enrollment through a forced command, then reconnects with the Device Key. The Host is persisted only after the full ceremony succeeds.
+
+Decisions fixed during design:
+
+- **Plugin**: Node ≥ 20 (`node:crypto` exports the raw Ed25519 seed; `qrcode` renders without system dependencies; `npm ci` build), living in this repo under `plugin/`. Developed via `herdr plugin link`; publishing requires this repo to become public first.
+- **Pairing Code payload**: minimal and versioned — user-selected candidate addresses (enumerated, likely ones pre-checked), port, username, host key fingerprint, Bootstrap Key seed, expiry. No herdr session data; session discovery stays in preflight.
+- **Bootstrap Key**: single-use, 2-minute TTL, `restrict,command=` line pointing at the plugin's accept script; deleted on success, expiry, or stale-line sweep. Enrollment is fully automatic — no human confirmation on the computer — with the enrolled fingerprint displayed afterward and a one-key revoke as the compensating control.
+- **App**: scanning is the primary action when adding a Host; the manual form and copy-paste `authorized_keys` line remain the fallback. Pairing uses a dedicated one-shot client beside `SSHTransport`, which keeps its socat/herdr semantics.
+- **Testing**: real-sshd e2e on both ends (the app exercises the actual accept script as a forced command) plus shared protocol test vectors consumed by both the Node and Swift implementations.
+
+## Considered Options
+
+- **Add pairing to herdr core** — not ours to change; the plugin API is the supported surface and needs no herdr modifications.
+- **Standalone server script** — rejected because distributing the script is itself an out-of-band step, which defeats the feature's purpose; `herdr plugin install` is one command.
+- **In-app ssh-copy-id over password auth** — dropped: it depends on `PasswordAuthentication yes`, which hardened developer servers commonly disable. May return if password users show up.
+- **Config-only QR without a Bootstrap Key** — subsumed: it is this payload minus the seed, not a separate feature.
+- **Staged confirmation or numeric-comparison pairing** — rejected for ceremony cost; the accepted residual risk is a same-room attacker photographing the QR and racing the user inside the TTL.
+
+## Consequences
+
+- A private key rides inside a QR code on purpose. Its blast radius is bounded by `restrict`, the forced command, single use, and the 2-minute TTL — not by secrecy of the screen.
+- The pairing envelope is a cross-implementation protocol; changes require a version bump honored by both the plugin and the app.
+- Reachability is scoped to same-LAN or same-VPN (Tailscale interfaces enumerate like any other); cellular-only phones are explicitly unsupported, and failure copy must say which Pairing step failed.
+- The plugin pins `min_herdr_version`; herdr plugin API changes become an upgrade dependency for onboarding.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -5,9 +5,10 @@ QR so the herdr-mobile app can add this machine as a Host by scanning it
 (ADR 0007). The `pair` action opens a popup pane: confirm which of the
 machine's addresses go into the code, then scan the QR with the app.
 
-This stage ships the config-only Pairing Code (addresses, port, username, host
-key fingerprint). The Bootstrap Key and automatic Enrollment land with the
-follow-up tickets of the pairing spec.
+The Pairing Code carries a single-use **Bootstrap Key**: the app connects with
+it once, submits its Device Key public line, and the plugin's Enrollment
+entrypoint appends that key to `authorized_keys` automatically. See
+[Bootstrap Key lifecycle](#bootstrap-key-lifecycle).
 
 ## Requirements
 
@@ -31,7 +32,8 @@ herdr plugin action invoke herdr-mobile.pairing.pair
 ```
 
 The popup checklist: arrows or `j`/`k` move, space toggles, `a` toggles all,
-enter renders the QR, `q`/escape closes.
+enter mints a Bootstrap Key and renders the QR, `q`/escape closes (revoking
+the key). When the code expires, enter generates a fresh one.
 
 Known limitation: the advertised SSH port is currently fixed at 22.
 
@@ -78,6 +80,55 @@ depend on key order.
 - Any breaking change (removing, renaming, or re-typing a field, or changing
   the envelope framing) bumps `<version>`, and both implementations must be
   updated together.
+
+## Bootstrap Key lifecycle
+
+Confirming the address checklist mints an ephemeral Ed25519 **Bootstrap Key**.
+Its raw 32-byte seed rides in the Pairing Code (`seed`/`exp`); its public half
+is written to `~/.ssh/authorized_keys` as a restricted line:
+
+```
+restrict,command="'<node>' '<plugin>/src/pair-accept.js' --state-dir '<state>' --pairing-id <id>" ssh-ed25519 <blob> herdr-pairing:<id>:exp:<unix-seconds>
+```
+
+- `restrict` plus the forced command mean the key can do exactly one thing:
+  run the Enrollment accept entrypoint. The command embeds absolute paths
+  because sshd provides no plugin environment.
+- The trailing `herdr-pairing:<id>:exp:<unix-seconds>` comment marks the line
+  so cleanup and the sweep can find it with no state beyond the file.
+- All edits to `authorized_keys` are atomic (exclusive lock, temp file +
+  rename) and preserve the file mode, so sshd `StrictModes` keeps accepting
+  the file.
+
+The line is removed on successful Enrollment (self-revoke), when the 2-minute
+TTL expires, when the popup exits (including SIGTERM/SIGHUP), and by a sweep
+of expired lines every time the popup starts — so a killed popup leaves at
+worst a line that dies with its TTL and is swept at the next start. Pending
+ceremony state lives under `$HERDR_PLUGIN_STATE_DIR/pending/<id>.json`, never
+in the plugin checkout. An invalid submission does not consume the line;
+the app may retry until the TTL runs out.
+
+### Enrollment accept protocol
+
+The app connects with the Bootstrap Key and writes its Device Key public line
+(`ssh-ed25519 <blob> [comment]`, printable-ASCII comment) followed by a
+newline to stdin. The forced command answers with one line on stdout:
+
+| Response | Meaning |
+| -------- | ------- |
+| `HERDR-ENROLL:OK:<SHA256:fingerprint>` | Device Key appended (or already authorized); bootstrap line revoked. Exit 0. |
+| `HERDR-ENROLL:ERR:invalid_key` | Submission is not a bare Ed25519 public line. Line not consumed; retry allowed. Exit 1. |
+| `HERDR-ENROLL:ERR:no_input` | Nothing arrived on stdin. Line not consumed. Exit 1. |
+| `HERDR-ENROLL:ERR:expired` | TTL passed; the bootstrap line was removed. Regenerate the code. Exit 1. |
+| `HERDR-ENROLL:ERR:unknown_pairing` | No pending ceremony (already used, cleaned up, or never existed). Exit 1. |
+
+Human-readable detail goes to stderr. Manual demo from another machine:
+
+```bash
+# On the phone side stand-in: seed.key holds the Bootstrap Key in any format
+# ssh accepts; the app itself uses the raw seed from the Pairing Code.
+ssh -i seed.key <user>@<host> < device_key.pub
+```
 
 ### Shared test vectors
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,97 @@
+# Herdr Mobile Pairing plugin
+
+A [herdr plugin](https://herdr.dev/docs/plugins/) that renders a **Pairing Code**
+QR so the herdr-mobile app can add this machine as a Host by scanning it
+(ADR 0007). The `pair` action opens a popup pane: confirm which of the
+machine's addresses go into the code, then scan the QR with the app.
+
+This stage ships the config-only Pairing Code (addresses, port, username, host
+key fingerprint). The Bootstrap Key and automatic Enrollment land with the
+follow-up tickets of the pairing spec.
+
+## Requirements
+
+- Node.js >= 20 on `PATH`
+- herdr >= 0.7.5
+- An OpenSSH server on this machine (the code pins its host key fingerprint)
+
+## Install
+
+```bash
+herdr plugin install zinger-labs/herdr-mobile/plugin   # once this repo is public
+```
+
+For local development, link the working tree instead (build it yourself,
+`plugin link` does not run build commands):
+
+```bash
+cd plugin && npm ci
+herdr plugin link "$(pwd)"
+herdr plugin action invoke herdr-mobile.pairing.pair
+```
+
+The popup checklist: arrows or `j`/`k` move, space toggles, `a` toggles all,
+enter renders the QR, `q`/escape closes.
+
+Known limitation: the advertised SSH port is currently fixed at 22.
+
+## Pairing Code envelope (v1)
+
+The Pairing Code is a single-line string; the QR image is just its rendering.
+
+```
+HERDR-PAIR:<version>:<base64url(JSON, no padding)>
+```
+
+- `HERDR-PAIR` is a literal prefix; anything else is rejected (`bad_prefix`).
+- `<version>` is a decimal integer. This document specifies version `1`;
+  any other value is rejected (`unsupported_version`).
+- The body is the payload JSON, UTF-8, encoded as unpadded base64url
+  (RFC 4648 `-`/`_` alphabet). Invalid base64url or JSON is rejected
+  (`bad_encoding`).
+
+### Payload fields
+
+| Wire key | Type    | Required | Meaning |
+| -------- | ------- | -------- | ------- |
+| `addrs`  | string[]| yes      | Candidate addresses in the order the app should try them. Non-empty; each entry a non-empty string without whitespace. IPv6 literals carry no brackets and no zone id. |
+| `port`   | integer | yes      | SSH port, `1..65535`. |
+| `user`   | string  | yes      | SSH username. Non-empty, no whitespace. |
+| `fp`     | string  | yes      | Host key fingerprint exactly as OpenSSH prints it: `SHA256:` + 43 chars of unpadded standard base64. The app pins this instead of showing a TOFU prompt. |
+| `seed`   | string  | no       | Raw 32-byte Ed25519 seed of the Bootstrap Key, unpadded base64url. Present together with `exp` or not at all. |
+| `exp`    | integer | no       | Unix-seconds expiry of the Bootstrap Key. Present together with `seed` or not at all. |
+
+A payload violating these rules is rejected (`bad_payload`). A code without
+`seed`/`exp` is a config-only Pairing Code: same ceremony minus the bootstrap
+connection.
+
+### Canonical encoding
+
+Encoders emit the keys in the order of the table above with no JSON
+whitespace, so a given payload has exactly one canonical code. Decoders do not
+depend on key order.
+
+### Compatibility rules
+
+- Decoders ignore unknown payload fields; additive metadata may appear within
+  v1.
+- Any breaking change (removing, renaming, or re-typing a field, or changing
+  the envelope framing) bumps `<version>`, and both implementations must be
+  updated together.
+
+### Shared test vectors
+
+`test-vectors/pairing-code-v1.json` is the single source of truth for the
+envelope, consumed by the Node tests here and the Swift tests in the app.
+Valid vectors must decode to the given payload and (unless `decodeOnly`)
+re-encode to the exact code; invalid vectors must fail with the given error
+code (`bad_prefix`, `unsupported_version`, `bad_encoding`, `bad_payload` —
+these map to the "parse" step of the pairing failure taxonomy).
+
+## Tests
+
+```bash
+npm test
+```
+
+Uses Node's built-in test runner; no test dependencies.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -33,7 +33,10 @@ herdr plugin action invoke herdr-mobile.pairing.pair
 
 The popup checklist: arrows or `j`/`k` move, space toggles, `a` toggles all,
 enter mints a Bootstrap Key and renders the QR, `q`/escape closes (revoking
-the key). When the code expires, enter generates a fresh one.
+the key). When the code expires, enter generates a fresh one. Once a device
+enrolls, the QR is replaced by a success screen showing the enrolled Device
+Key's fingerprint and label; press `r` there to revoke that key (removing its
+`authorized_keys` line), or any other key to close.
 
 Known limitation: the advertised SSH port is currently fixed at 22.
 
@@ -105,8 +108,11 @@ TTL expires, when the popup exits (including SIGTERM/SIGHUP), and by a sweep
 of expired lines every time the popup starts — so a killed popup leaves at
 worst a line that dies with its TTL and is swept at the next start. Pending
 ceremony state lives under `$HERDR_PLUGIN_STATE_DIR/pending/<id>.json`, never
-in the plugin checkout. An invalid submission does not consume the line;
-the app may retry until the TTL runs out.
+in the plugin checkout. On successful Enrollment the accept entrypoint writes
+`$HERDR_PLUGIN_STATE_DIR/enrolled/<id>.json` (the enrolled fingerprint and
+line); the popup polls for it to show the success screen and drive the revoke,
+and clears it on exit. An invalid submission does not consume the line; the
+app may retry until the TTL runs out.
 
 ### Enrollment accept protocol
 

--- a/plugin/herdr-plugin.toml
+++ b/plugin/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr-mobile.pairing"
 name = "Herdr Mobile Pairing"
-version = "0.1.0"
+version = "0.2.0"
 min_herdr_version = "0.7.5"
 description = "Pair a herdr-mobile device by scanning a QR Pairing Code"
 platforms = ["linux", "macos"]

--- a/plugin/herdr-plugin.toml
+++ b/plugin/herdr-plugin.toml
@@ -1,0 +1,22 @@
+id = "herdr-mobile.pairing"
+name = "Herdr Mobile Pairing"
+version = "0.1.0"
+min_herdr_version = "0.7.5"
+description = "Pair a herdr-mobile device by scanning a QR Pairing Code"
+platforms = ["linux", "macos"]
+
+[[build]]
+command = ["npm", "ci"]
+
+[[actions]]
+id = "pair"
+title = "Pair a mobile device"
+description = "Show a Pairing Code QR for the herdr-mobile app"
+contexts = ["global"]
+command = ["node", "src/pair-action.js"]
+
+[[panes]]
+id = "pair"
+title = "Pair device"
+placement = "popup"
+command = ["node", "src/pair-popup.js"]

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,0 +1,323 @@
+{
+  "name": "herdr-mobile-pairing",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "herdr-mobile-pairing",
+      "version": "0.1.0",
+      "dependencies": {
+        "qrcode": "^1.5.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "herdr-mobile-pairing",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "herdr plugin that renders a Pairing Code QR for herdr-mobile device onboarding",
   "type": "module",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "herdr-mobile-pairing",
+  "version": "0.1.0",
+  "private": true,
+  "description": "herdr plugin that renders a Pairing Code QR for herdr-mobile device onboarding",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "test": "node --test"
+  },
+  "dependencies": {
+    "qrcode": "^1.5.4"
+  }
+}

--- a/plugin/src/addresses.js
+++ b/plugin/src/addresses.js
@@ -1,0 +1,78 @@
+// Candidate address enumeration for the Pairing Code (ADR 0007).
+//
+// The Pairing Code carries user-selected candidate addresses; this module
+// enumerates the routable ones and marks the likely candidates (private LAN,
+// Tailscale CGNAT, ULA) as pre-checked so the common case is one confirmation.
+
+import os from "node:os";
+
+function ipv4Octets(address) {
+  return address.split(".").map(Number);
+}
+
+function isIpv4LinkLocal(address) {
+  const [a, b] = ipv4Octets(address);
+  return a === 169 && b === 254;
+}
+
+function isIpv4Likely(address) {
+  const [a, b] = ipv4Octets(address);
+  if (a === 10) return true; // 10/8 private
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16/12 private
+  if (a === 192 && b === 168) return true; // 192.168/16 private
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64/10 CGNAT (Tailscale)
+  return false;
+}
+
+function isIpv6LinkLocal(address) {
+  return /^fe[89ab]/i.test(address); // fe80::/10
+}
+
+function isIpv6Likely(address) {
+  return /^f[cd]/i.test(address); // fc00::/7 ULA (includes Tailscale fd7a:...)
+}
+
+/**
+ * Enumerate routable candidate addresses for the Pairing Code.
+ *
+ * Skips loopback and link-local addresses; marks likely candidates
+ * (private IPv4, CGNAT IPv4, ULA IPv6) as pre-checked. Ordered pre-checked
+ * first, IPv4 before IPv6 within each group, otherwise input order.
+ *
+ * @param {ReturnType<typeof os.networkInterfaces>} [interfaces]
+ * @returns {{address: string, family: "IPv4"|"IPv6", interfaceName: string, preChecked: boolean}[]}
+ */
+export function candidateAddresses(interfaces = os.networkInterfaces()) {
+  const seen = new Set();
+  const candidates = [];
+
+  for (const [interfaceName, entries] of Object.entries(interfaces)) {
+    for (const entry of entries ?? []) {
+      if (entry.internal) continue;
+      const { family } = entry;
+      // Zone ids (fe80::1%en0) are meaningless off-machine.
+      const address = entry.address.split("%")[0];
+      if (seen.has(address)) continue;
+
+      let preChecked;
+      if (family === "IPv4") {
+        if (isIpv4LinkLocal(address)) continue;
+        preChecked = isIpv4Likely(address);
+      } else if (family === "IPv6") {
+        if (isIpv6LinkLocal(address)) continue;
+        preChecked = isIpv6Likely(address);
+      } else {
+        continue;
+      }
+
+      seen.add(address);
+      candidates.push({ address, family, interfaceName, preChecked });
+    }
+  }
+
+  const rank = (c) => (c.preChecked ? 0 : 2) + (c.family === "IPv4" ? 0 : 1);
+  return candidates
+    .map((candidate, index) => ({ candidate, index }))
+    .sort((a, b) => rank(a.candidate) - rank(b.candidate) || a.index - b.index)
+    .map(({ candidate }) => candidate);
+}

--- a/plugin/src/authorized-keys.js
+++ b/plugin/src/authorized-keys.js
@@ -1,0 +1,197 @@
+// Atomic authorized_keys editing for the Bootstrap Key lifecycle (ADR 0007).
+//
+// Every mutation goes through editAuthorizedKeys: take an exclusive lock,
+// read, rewrite through a temp file in the same directory, rename. The file
+// mode is preserved (0600 for a fresh file) so sshd's StrictModes keeps
+// accepting it. Bootstrap lines are tagged with a marker comment
+// "herdr-pairing:<id>:exp:<unix-seconds>" so cleanup and the startup sweep
+// can find them without any state beyond the file itself.
+
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { setTimeout as sleep } from "node:timers/promises";
+import { join } from "node:path";
+
+const BOOTSTRAP_COMMENT_PATTERN = /(?:^|\s)herdr-pairing:([A-Za-z0-9-]+):exp:(\d+)$/;
+const LOCK_RETRY_MS = 25;
+const LOCK_TIMEOUT_MS = 5_000;
+// A crashed editor leaves its lock behind; edits are millisecond-scale, so a
+// lock this old is garbage, not contention.
+const LOCK_STALE_MS = 10_000;
+
+export function authorizedKeysPath(home) {
+  return join(home, ".ssh", "authorized_keys");
+}
+
+/**
+ * Compose a restricted Bootstrap Key authorized_keys line.
+ *
+ * @param {object} options
+ * @param {string} options.publicLine bare "ssh-ed25519 <blob>" public line
+ * @param {string} options.pairingId marker id, alphanumeric/hyphen
+ * @param {number} options.expiresAt unix-seconds expiry, embedded in the marker
+ * @param {string} options.command forced command (Enrollment accept entrypoint)
+ */
+export function bootstrapLine({ publicLine, pairingId, expiresAt, command }) {
+  if (/["\n\r]/.test(command)) {
+    throw new Error("forced command must not contain double quotes or newlines");
+  }
+  if (!/^[A-Za-z0-9-]+$/.test(pairingId)) {
+    throw new Error("pairing id must be alphanumeric/hyphen");
+  }
+  if (!Number.isInteger(expiresAt) || expiresAt <= 0) {
+    throw new Error("expiresAt must be a positive unix-seconds integer");
+  }
+  return `restrict,command="${command}" ${publicLine} herdr-pairing:${pairingId}:exp:${expiresAt}`;
+}
+
+/** Parse the marker comment of a Bootstrap Key line, or null for other lines. */
+export function parseBootstrapLine(line) {
+  const match = BOOTSTRAP_COMMENT_PATTERN.exec(line);
+  if (match === null) {
+    return null;
+  }
+  return { pairingId: match[1], expiresAt: Number(match[2]) };
+}
+
+async function acquireLock(lockPath) {
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  for (;;) {
+    try {
+      const fd = openSync(lockPath, "wx", 0o600);
+      writeSync(fd, `${process.pid}\n`);
+      closeSync(fd);
+      return;
+    } catch (error) {
+      if (error.code !== "EEXIST") {
+        throw error;
+      }
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > LOCK_STALE_MS) {
+          rmSync(lockPath, { force: true });
+          continue;
+        }
+      } catch {
+        continue; // lock vanished between open and stat; retry immediately
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`timed out waiting for authorized_keys lock ${lockPath}`);
+      }
+      await sleep(LOCK_RETRY_MS);
+    }
+  }
+}
+
+/**
+ * Atomically edit authorized_keys under an exclusive lock.
+ *
+ * @param {string} home the account's home directory (sshd reads
+ *   `~/.ssh/authorized_keys` under StrictModes)
+ * @param {(lines: string[]) => string[] | null} edit receives the current
+ *   lines (no trailing empty line) and returns the new lines, or null to
+ *   leave the file untouched
+ * @returns {Promise<boolean>} whether the file was rewritten
+ */
+export async function editAuthorizedKeys(home, edit) {
+  const sshDir = join(home, ".ssh");
+  const path = authorizedKeysPath(home);
+  mkdirSync(sshDir, { recursive: true, mode: 0o700 });
+
+  const lockPath = `${path}.herdr-pairing.lock`;
+  await acquireLock(lockPath);
+  try {
+    let content = null;
+    try {
+      content = readFileSync(path, "utf8");
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+    const lines = content === null ? [] : content.split("\n");
+    if (lines.at(-1) === "") {
+      lines.pop();
+    }
+
+    const edited = edit([...lines]);
+    if (edited === null) {
+      return false;
+    }
+
+    const mode = content === null ? 0o600 : statSync(path).mode & 0o777;
+    const tempPath = `${path}.herdr-pairing.${process.pid}.tmp`;
+    const body = edited.length === 0 ? "" : `${edited.join("\n")}\n`;
+    try {
+      writeFileSync(tempPath, body, { mode });
+      renameSync(tempPath, path);
+    } catch (error) {
+      rmSync(tempPath, { force: true });
+      throw error;
+    }
+    return true;
+  } finally {
+    unlinkSync(lockPath);
+  }
+}
+
+/** Remove the Bootstrap Key line with the given pairing id, if present. */
+export async function removeBootstrapLine(home, pairingId) {
+  return editAuthorizedKeys(home, (lines) => {
+    const kept = lines.filter((line) => parseBootstrapLine(line)?.pairingId !== pairingId);
+    return kept.length === lines.length ? null : kept;
+  });
+}
+
+/**
+ * Startup sweep: remove every Bootstrap Key line whose embedded expiry has
+ * passed. Lines still inside their TTL are left alone (another pairing may
+ * legitimately be in flight).
+ *
+ * @returns {Promise<number>} how many stale lines were removed
+ */
+export async function sweepExpiredBootstrapLines(home, now = Math.floor(Date.now() / 1000)) {
+  let removed = 0;
+  await editAuthorizedKeys(home, (lines) => {
+    const kept = lines.filter((line) => {
+      const marker = parseBootstrapLine(line);
+      return marker === null || marker.expiresAt > now;
+    });
+    removed = lines.length - kept.length;
+    return removed === 0 ? null : kept;
+  });
+  return removed;
+}
+
+/** The "<type> <blob>" identity of a public key line, ignoring the comment. */
+export function keyBlobOf(line) {
+  const words = line.trim().split(/\s+/);
+  // Skip an options word if present; bare public lines start with the type.
+  const start = words[0]?.startsWith("ssh-") || words[0]?.startsWith("ecdsa-") ? 0 : 1;
+  return words.slice(start, start + 2).join(" ");
+}
+
+/**
+ * Append a validated Device Key public line (Enrollment). Appending a key
+ * that is already authorized is a success, not a duplicate.
+ *
+ * @returns {Promise<boolean>} whether the line was newly appended
+ */
+export async function appendDeviceKeyLine(home, line) {
+  return editAuthorizedKeys(home, (lines) => {
+    const blob = keyBlobOf(line);
+    if (lines.some((existing) => keyBlobOf(existing) === blob)) {
+      return null;
+    }
+    return [...lines, line];
+  });
+}

--- a/plugin/src/authorized-keys.js
+++ b/plugin/src/authorized-keys.js
@@ -179,19 +179,3 @@ export function keyBlobOf(line) {
   const start = words[0]?.startsWith("ssh-") || words[0]?.startsWith("ecdsa-") ? 0 : 1;
   return words.slice(start, start + 2).join(" ");
 }
-
-/**
- * Append a validated Device Key public line (Enrollment). Appending a key
- * that is already authorized is a success, not a duplicate.
- *
- * @returns {Promise<boolean>} whether the line was newly appended
- */
-export async function appendDeviceKeyLine(home, line) {
-  return editAuthorizedKeys(home, (lines) => {
-    const blob = keyBlobOf(line);
-    if (lines.some((existing) => keyBlobOf(existing) === blob)) {
-      return null;
-    }
-    return [...lines, line];
-  });
-}

--- a/plugin/src/authorized-keys.js
+++ b/plugin/src/authorized-keys.js
@@ -179,3 +179,25 @@ export function keyBlobOf(line) {
   const start = words[0]?.startsWith("ssh-") || words[0]?.startsWith("ecdsa-") ? 0 : 1;
   return words.slice(start, start + 2).join(" ");
 }
+
+/** The comment (everything after "<type> <blob>") of a public key line. */
+export function commentOf(line) {
+  const words = line.trim().split(/\s+/);
+  const start = words[0]?.startsWith("ssh-") || words[0]?.startsWith("ecdsa-") ? 0 : 1;
+  return words.slice(start + 2).join(" ");
+}
+
+/**
+ * Remove any authorized_keys line whose key blob matches the given line. Used
+ * to revoke an enrolled Device Key; matching on the blob (not the whole line)
+ * makes the revoke robust to comment differences.
+ *
+ * @returns {Promise<boolean>} whether a line was removed
+ */
+export async function removeKeyLine(home, line) {
+  const target = keyBlobOf(line);
+  return editAuthorizedKeys(home, (lines) => {
+    const kept = lines.filter((existing) => keyBlobOf(existing) !== target);
+    return kept.length === lines.length ? null : kept;
+  });
+}

--- a/plugin/src/bootstrap-key.js
+++ b/plugin/src/bootstrap-key.js
@@ -1,0 +1,59 @@
+// Bootstrap Key material (ADR 0007).
+//
+// A Bootstrap Key is an ephemeral Ed25519 keypair: its raw 32-byte seed rides
+// inside the Pairing Code, its public half becomes a restricted
+// authorized_keys line. Only the seed and the public line ever exist outside
+// this process; the private key object is discarded after derivation.
+
+import { createPrivateKey, createPublicKey, generateKeyPairSync } from "node:crypto";
+
+const SEED_BYTES = 32;
+const KEY_TYPE = "ssh-ed25519";
+
+// PKCS8 DER prefix for an Ed25519 private key; the raw seed follows directly.
+const PKCS8_ED25519_PREFIX = Buffer.from("302e020100300506032b657004220420", "hex");
+
+function sshString(buffer) {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(buffer.length);
+  return Buffer.concat([length, buffer]);
+}
+
+/** OpenSSH public key line ("ssh-ed25519 <base64 blob>") for a raw public key. */
+function publicLineFromRawPublicKey(rawPublicKey) {
+  const blob = Buffer.concat([sshString(Buffer.from(KEY_TYPE, "utf8")), sshString(rawPublicKey)]);
+  return `${KEY_TYPE} ${blob.toString("base64")}`;
+}
+
+function rawPublicKeyOf(publicKey) {
+  // JWK "x" is the raw Ed25519 public key, base64url.
+  return Buffer.from(publicKey.export({ format: "jwk" }).x, "base64url");
+}
+
+/**
+ * Derive the OpenSSH public key line from a raw 32-byte Ed25519 seed.
+ * Matches what `ssh-keygen -y` prints for the same key.
+ */
+export function publicLineFromSeed(seed) {
+  if (!Buffer.isBuffer(seed) || seed.length !== SEED_BYTES) {
+    throw new Error(`Bootstrap Key seed must be ${SEED_BYTES} bytes`);
+  }
+  const privateKey = createPrivateKey({
+    key: Buffer.concat([PKCS8_ED25519_PREFIX, seed]),
+    format: "der",
+    type: "pkcs8",
+  });
+  return publicLineFromRawPublicKey(rawPublicKeyOf(createPublicKey(privateKey)));
+}
+
+/**
+ * Generate a fresh Bootstrap Key.
+ *
+ * @returns {{seed: Buffer, publicLine: string}}
+ */
+export function generateBootstrapKey() {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  // JWK "d" is the raw Ed25519 seed, base64url.
+  const seed = Buffer.from(privateKey.export({ format: "jwk" }).d, "base64url");
+  return { seed, publicLine: publicLineFromRawPublicKey(rawPublicKeyOf(publicKey)) };
+}

--- a/plugin/src/device-key.js
+++ b/plugin/src/device-key.js
@@ -1,0 +1,96 @@
+// Strict validation of a submitted Device Key public line (ADR 0007).
+//
+// The Enrollment accept entrypoint runs as an sshd forced command and appends
+// whatever passes this parser to authorized_keys, so the rules are strict:
+// exactly one bare "ssh-ed25519 <blob> [comment]" line, the wire blob must be
+// a well-formed Ed25519 public key, and the comment must be printable ASCII.
+// Anything else is rejected without consuming the Bootstrap Key.
+
+import { fingerprintPublicKeyLine } from "./host-key.js";
+
+const KEY_TYPE = "ssh-ed25519";
+const ED25519_KEY_BYTES = 32;
+const MAX_LINE_LENGTH = 1024;
+const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+// Space through tilde: printable ASCII only, no tabs or control characters.
+const COMMENT_PATTERN = /^[\x20-\x7e]+$/;
+
+export class DeviceKeyError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "DeviceKeyError";
+  }
+}
+
+function fail(message) {
+  throw new DeviceKeyError(message);
+}
+
+function readSshString(buffer, offset) {
+  if (offset + 4 > buffer.length) {
+    fail("truncated key blob");
+  }
+  const length = buffer.readUInt32BE(offset);
+  const end = offset + 4 + length;
+  if (end > buffer.length) {
+    fail("truncated key blob");
+  }
+  return { value: buffer.subarray(offset + 4, end), end };
+}
+
+/**
+ * Parse and strictly validate a submitted Device Key public line.
+ *
+ * @param {string} input the raw submission (one line, whitespace tolerated)
+ * @returns {{line: string, fingerprint: string}} the canonical authorized_keys
+ *   line and its OpenSSH SHA256 fingerprint
+ * @throws {DeviceKeyError} on anything that is not a bare Ed25519 public line
+ */
+export function parseDeviceKeyLine(input) {
+  if (typeof input !== "string") {
+    fail("submission must be text");
+  }
+  if (input.length > MAX_LINE_LENGTH) {
+    fail(`submission exceeds ${MAX_LINE_LENGTH} characters`);
+  }
+  const line = input.trim();
+  if (line.length === 0) {
+    fail("submission is empty");
+  }
+  if (/[\n\r]/.test(line)) {
+    fail("submission must be a single line");
+  }
+
+  const [keyType, blobText, ...commentWords] = line.split(" ");
+  if (keyType !== KEY_TYPE) {
+    fail(`key type must be ${KEY_TYPE}`);
+  }
+  if (blobText === undefined || !BASE64_PATTERN.test(blobText)) {
+    fail("key blob is not base64");
+  }
+
+  const blob = Buffer.from(blobText, "base64");
+  const type = readSshString(blob, 0);
+  if (type.value.toString("utf8") !== KEY_TYPE) {
+    fail("key blob type disagrees with the line type");
+  }
+  const key = readSshString(blob, type.end);
+  if (key.value.length !== ED25519_KEY_BYTES) {
+    fail(`Ed25519 public key must be ${ED25519_KEY_BYTES} bytes`);
+  }
+  if (key.end !== blob.length) {
+    fail("key blob has trailing bytes");
+  }
+
+  const comment = commentWords.join(" ");
+  if (comment.length > 0 && !COMMENT_PATTERN.test(comment)) {
+    fail("comment must be printable ASCII");
+  }
+
+  // Re-emit the blob from the decoded bytes so authorized_keys only ever
+  // receives canonical base64, whatever padding the submission used.
+  const canonicalBlob = blob.toString("base64");
+  const canonical =
+    comment.length > 0 ? `${KEY_TYPE} ${canonicalBlob} ${comment}` : `${KEY_TYPE} ${canonicalBlob}`;
+  return { line: canonical, fingerprint: fingerprintPublicKeyLine(canonical).fingerprint };
+}

--- a/plugin/src/envelope.js
+++ b/plugin/src/envelope.js
@@ -1,0 +1,154 @@
+// Pairing Code v1 envelope (ADR 0007).
+//
+// Wire format: "HERDR-PAIR:<version>:<base64url(JSON, no padding)>".
+// The JSON payload uses short wire keys; see README.md for the schema and
+// test-vectors/pairing-code-v1.json for the cross-implementation vectors.
+// Unknown payload fields are ignored (additive metadata); breaking changes
+// bump the version, which both implementations must honor.
+
+export const PAIRING_CODE_PREFIX = "HERDR-PAIR";
+export const PAIRING_CODE_VERSION = 1;
+
+const BOOTSTRAP_SEED_BYTES = 32;
+// OpenSSH fingerprint: "SHA256:" + unpadded standard base64 of a 32-byte digest.
+const FINGERPRINT_PATTERN = /^SHA256:[A-Za-z0-9+/]{43}$/;
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export class PairingCodeError extends Error {
+  /**
+   * @param {"bad_prefix"|"unsupported_version"|"bad_encoding"|"bad_payload"} code
+   * @param {string} message
+   */
+  constructor(code, message) {
+    super(message);
+    this.name = "PairingCodeError";
+    this.code = code;
+  }
+}
+
+function fail(code, message) {
+  throw new PairingCodeError(code, message);
+}
+
+/**
+ * Validate the in-memory payload shape shared by encode and decode.
+ *
+ * @param {object} payload
+ * @param {string[]} payload.addresses candidate addresses in try-order
+ * @param {number} payload.port SSH port
+ * @param {string} payload.username SSH username
+ * @param {string} payload.hostKeyFingerprint OpenSSH SHA256 host key fingerprint
+ * @param {Buffer} [payload.bootstrapSeed] raw Ed25519 seed of the Bootstrap Key
+ * @param {number} [payload.expiresAt] unix-seconds expiry of the Bootstrap Key
+ */
+function validatePayload(payload) {
+  const { addresses, port, username, hostKeyFingerprint, bootstrapSeed, expiresAt } = payload;
+
+  if (!Array.isArray(addresses) || addresses.length === 0) {
+    fail("bad_payload", "addresses must be a non-empty array");
+  }
+  for (const address of addresses) {
+    if (typeof address !== "string" || address.length === 0 || /\s/.test(address)) {
+      fail("bad_payload", `invalid address: ${JSON.stringify(address)}`);
+    }
+  }
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    fail("bad_payload", `port must be an integer in 1..65535, got ${port}`);
+  }
+  if (typeof username !== "string" || username.length === 0 || /\s/.test(username)) {
+    fail("bad_payload", "username must be a non-empty string without whitespace");
+  }
+  if (typeof hostKeyFingerprint !== "string" || !FINGERPRINT_PATTERN.test(hostKeyFingerprint)) {
+    fail("bad_payload", "hostKeyFingerprint must be an OpenSSH SHA256 fingerprint");
+  }
+  if ((bootstrapSeed === undefined) !== (expiresAt === undefined)) {
+    fail("bad_payload", "bootstrapSeed and expiresAt must be present together");
+  }
+  if (bootstrapSeed !== undefined && bootstrapSeed.length !== BOOTSTRAP_SEED_BYTES) {
+    fail("bad_payload", `bootstrapSeed must be ${BOOTSTRAP_SEED_BYTES} bytes`);
+  }
+  if (expiresAt !== undefined && (!Number.isInteger(expiresAt) || expiresAt <= 0)) {
+    fail("bad_payload", "expiresAt must be a positive unix-seconds integer");
+  }
+}
+
+/**
+ * Encode a Pairing Code payload into its canonical v1 string.
+ *
+ * Key order is fixed so the same payload always yields the same code; the
+ * shared vectors assert on the exact string.
+ */
+export function encodePairingCode(payload) {
+  validatePayload(payload);
+  const wire = {
+    addrs: payload.addresses,
+    port: payload.port,
+    user: payload.username,
+    fp: payload.hostKeyFingerprint,
+  };
+  if (payload.bootstrapSeed !== undefined) {
+    wire.seed = payload.bootstrapSeed.toString("base64url");
+    wire.exp = payload.expiresAt;
+  }
+  const body = Buffer.from(JSON.stringify(wire), "utf8").toString("base64url");
+  return `${PAIRING_CODE_PREFIX}:${PAIRING_CODE_VERSION}:${body}`;
+}
+
+function decodeBase64UrlStrict(text, what, errorCode) {
+  if (!BASE64URL_PATTERN.test(text) || text.length % 4 === 1) {
+    fail(errorCode, `${what} is not unpadded base64url`);
+  }
+  return Buffer.from(text, "base64url");
+}
+
+/**
+ * Decode and validate a scanned Pairing Code string.
+ *
+ * @returns {{addresses: string[], port: number, username: string,
+ *            hostKeyFingerprint: string, bootstrapSeed?: Buffer, expiresAt?: number}}
+ * @throws {PairingCodeError} with a step-taxonomy code:
+ *   bad_prefix | unsupported_version | bad_encoding | bad_payload
+ */
+export function decodePairingCode(code) {
+  if (typeof code !== "string" || !code.startsWith(`${PAIRING_CODE_PREFIX}:`)) {
+    fail("bad_prefix", `expected "${PAIRING_CODE_PREFIX}:<version>:<payload>"`);
+  }
+  const rest = code.slice(PAIRING_CODE_PREFIX.length + 1);
+  const separator = rest.indexOf(":");
+  if (separator === -1) {
+    fail("bad_prefix", "missing version separator");
+  }
+  const version = rest.slice(0, separator);
+  if (version !== String(PAIRING_CODE_VERSION)) {
+    fail("unsupported_version", `unsupported Pairing Code version "${version}"`);
+  }
+
+  const body = decodeBase64UrlStrict(rest.slice(separator + 1), "payload", "bad_encoding");
+  let wire;
+  try {
+    wire = JSON.parse(body.toString("utf8"));
+  } catch {
+    fail("bad_encoding", "payload is not valid JSON");
+  }
+  if (typeof wire !== "object" || wire === null || Array.isArray(wire)) {
+    fail("bad_payload", "payload must be a JSON object");
+  }
+
+  const payload = {
+    addresses: wire.addrs,
+    port: wire.port,
+    username: wire.user,
+    hostKeyFingerprint: wire.fp,
+  };
+  if (wire.seed !== undefined) {
+    if (typeof wire.seed !== "string") {
+      fail("bad_payload", "seed must be a base64url string");
+    }
+    payload.bootstrapSeed = decodeBase64UrlStrict(wire.seed, "seed", "bad_payload");
+  }
+  if (wire.exp !== undefined) {
+    payload.expiresAt = wire.exp;
+  }
+  validatePayload(payload);
+  return payload;
+}

--- a/plugin/src/host-key.js
+++ b/plugin/src/host-key.js
@@ -1,0 +1,56 @@
+// Host key fingerprint for the Pairing Code (ADR 0007).
+//
+// The app pins the Host's SSH fingerprint from the Pairing Code instead of
+// showing a TOFU prompt, so the plugin must compute exactly what OpenSSH
+// prints: SHA256 of the public key blob, base64 without padding.
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Preference order mirrors what modern clients negotiate first.
+const HOST_KEY_FILES = [
+  "ssh_host_ed25519_key.pub",
+  "ssh_host_ecdsa_key.pub",
+  "ssh_host_rsa_key.pub",
+];
+
+const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+
+/**
+ * Compute the OpenSSH SHA256 fingerprint of a public key line
+ * ("<type> <base64 blob> [comment]"), as printed by `ssh-keygen -lf`.
+ *
+ * @returns {{keyType: string, fingerprint: string}}
+ */
+export function fingerprintPublicKeyLine(line) {
+  const [keyType, blob] = line.trim().split(/\s+/);
+  if (!keyType?.startsWith("ssh-") && !keyType?.startsWith("ecdsa-")) {
+    throw new Error(`not an SSH public key line: ${JSON.stringify(line)}`);
+  }
+  if (!blob || !BASE64_PATTERN.test(blob)) {
+    throw new Error("SSH public key line has no base64 key blob");
+  }
+  const digest = createHash("sha256").update(Buffer.from(blob, "base64")).digest("base64");
+  return { keyType, fingerprint: `SHA256:${digest.replace(/=+$/, "")}` };
+}
+
+/**
+ * Read the machine's preferred SSH host key fingerprint from `sshDir`.
+ * Public halves are world-readable, so no privileges are needed.
+ *
+ * @returns {{keyType: string, fingerprint: string, path: string} | null}
+ */
+export function readHostKeyFingerprint(sshDir = "/etc/ssh") {
+  for (const file of HOST_KEY_FILES) {
+    const path = join(sshDir, file);
+    let line;
+    try {
+      line = readFileSync(path, "utf8");
+    } catch {
+      continue;
+    }
+    return { ...fingerprintPublicKeyLine(line), path };
+  }
+  return null;
+}

--- a/plugin/src/pair-accept.js
+++ b/plugin/src/pair-accept.js
@@ -1,0 +1,123 @@
+// Enrollment accept entrypoint (ADR 0007).
+//
+// Runs as the sshd forced command behind a Bootstrap Key's restricted
+// authorized_keys line: the app connects with the Bootstrap Key and writes
+// its Device Key public line to stdin. On success the Device Key is appended
+// atomically and the bootstrap line self-revokes (single use). Invalid
+// submissions consume nothing, so the app may retry within the TTL.
+//
+// stdout speaks a one-line protocol the app parses:
+//   HERDR-ENROLL:OK:<SHA256:fingerprint>
+//   HERDR-ENROLL:ERR:<unknown_pairing|expired|invalid_key|no_input>
+// Human-readable detail goes to stderr.
+
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { parseArgs } from "node:util";
+
+import { editAuthorizedKeys, keyBlobOf, parseBootstrapLine } from "./authorized-keys.js";
+import { parseDeviceKeyLine, DeviceKeyError } from "./device-key.js";
+import { endPairing, pendingPath } from "./pairing-session.js";
+
+const MAX_INPUT_BYTES = 4096;
+const INPUT_TIMEOUT_MS = 30_000;
+
+function ok(fingerprint) {
+  process.stdout.write(`HERDR-ENROLL:OK:${fingerprint}\n`);
+  process.exit(0);
+}
+
+function err(code, detail) {
+  process.stdout.write(`HERDR-ENROLL:ERR:${code}\n`);
+  process.stderr.write(`${detail}\n`);
+  process.exit(1);
+}
+
+/** Read stdin until the first newline, EOF, a size cap, or a timeout. */
+function readSubmission(stream) {
+  return new Promise((resolve) => {
+    let data = "";
+    let done = false;
+    const finish = () => {
+      if (!done) {
+        done = true;
+        clearTimeout(timer);
+        resolve(data.split("\n")[0]);
+      }
+    };
+    const timer = setTimeout(finish, INPUT_TIMEOUT_MS);
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk) => {
+      data += chunk;
+      if (data.includes("\n") || data.length >= MAX_INPUT_BYTES) {
+        finish();
+      }
+    });
+    stream.on("end", finish);
+    stream.on("error", finish);
+  });
+}
+
+const { values } = parseArgs({
+  options: {
+    "state-dir": { type: "string" },
+    "pairing-id": { type: "string" },
+  },
+});
+const stateDir = values["state-dir"];
+const pairingId = values["pairing-id"];
+const home = process.env.HOME;
+if (!stateDir || !pairingId || !home) {
+  err("unknown_pairing", "pair-accept requires --state-dir, --pairing-id, and HOME");
+}
+
+let pending = null;
+try {
+  pending = JSON.parse(readFileSync(pendingPath(stateDir, pairingId), "utf8"));
+} catch {
+  // Unknown, already completed, or already cleaned up. Self-heal any
+  // leftover line for this id before rejecting.
+  await endPairing({ home, stateDir, pairingId });
+  err("unknown_pairing", `no pending pairing ${pairingId}`);
+}
+
+if (Math.floor(Date.now() / 1000) > pending.expiresAt) {
+  await endPairing({ home, stateDir, pairingId });
+  err("expired", `pairing ${pairingId} expired; regenerate the Pairing Code`);
+}
+
+const submission = await readSubmission(process.stdin);
+if (submission.trim().length === 0) {
+  err("no_input", "expected a Device Key public line on stdin");
+}
+
+let deviceKey;
+try {
+  deviceKey = parseDeviceKeyLine(submission);
+} catch (error) {
+  if (error instanceof DeviceKeyError) {
+    err("invalid_key", `rejected Device Key line: ${error.message}`);
+  }
+  throw error;
+}
+
+// One locked edit enrolls the Device Key and self-revokes the bootstrap
+// line. Pending state is deleted inside the critical section so a racing
+// second connection cannot enroll twice with the same Bootstrap Key.
+let alreadyUsed = false;
+await editAuthorizedKeys(home, (lines) => {
+  if (!existsSync(pendingPath(stateDir, pairingId))) {
+    alreadyUsed = true;
+    return null;
+  }
+  const kept = lines.filter((line) => parseBootstrapLine(line)?.pairingId !== pairingId);
+  if (!kept.some((line) => keyBlobOf(line) === keyBlobOf(deviceKey.line))) {
+    kept.push(deviceKey.line);
+  }
+  rmSync(pendingPath(stateDir, pairingId), { force: true });
+  return kept;
+});
+if (alreadyUsed) {
+  err("unknown_pairing", `pairing ${pairingId} was already used`);
+}
+
+ok(deviceKey.fingerprint);

--- a/plugin/src/pair-accept.js
+++ b/plugin/src/pair-accept.js
@@ -102,7 +102,10 @@ try {
 
 // One locked edit enrolls the Device Key and self-revokes the bootstrap
 // line. Pending state is deleted inside the critical section so a racing
-// second connection cannot enroll twice with the same Bootstrap Key.
+// second connection cannot enroll twice with the same Bootstrap Key, and
+// the Enrollment record is written inside it too, so the popup's locked
+// expiry check (expirePairing) can never miss an enroll that already
+// happened — it would render "expired" over a silently enrolled device.
 let alreadyUsed = false;
 let expired = false;
 await editAuthorizedKeys(home, (lines) => {
@@ -122,6 +125,14 @@ await editAuthorizedKeys(home, (lines) => {
   if (!kept.some((line) => keyBlobOf(line) === keyBlobOf(deviceKey.line))) {
     kept.push(deviceKey.line);
   }
+  // The record the popup polls for: enrolled fingerprint plus the appended
+  // line, its one-key revoke target.
+  recordEnrollment({
+    stateDir,
+    pairingId,
+    fingerprint: deviceKey.fingerprint,
+    line: deviceKey.line,
+  });
   return kept;
 });
 if (alreadyUsed) {
@@ -130,9 +141,5 @@ if (alreadyUsed) {
 if (expired) {
   err("expired", `pairing ${pairingId} expired; regenerate the Pairing Code`);
 }
-
-// Leave a record for the popup: it polls this to show the enrolled
-// fingerprint and to offer a one-key revoke of the line we just appended.
-recordEnrollment({ stateDir, pairingId, fingerprint: deviceKey.fingerprint, line: deviceKey.line });
 
 ok(deviceKey.fingerprint);

--- a/plugin/src/pair-accept.js
+++ b/plugin/src/pair-accept.js
@@ -130,6 +130,7 @@ await editAuthorizedKeys(home, (lines) => {
   recordEnrollment({
     stateDir,
     pairingId,
+    expiresAt: pending.expiresAt,
     fingerprint: deviceKey.fingerprint,
     line: deviceKey.line,
   });

--- a/plugin/src/pair-accept.js
+++ b/plugin/src/pair-accept.js
@@ -104,20 +104,31 @@ try {
 // line. Pending state is deleted inside the critical section so a racing
 // second connection cannot enroll twice with the same Bootstrap Key.
 let alreadyUsed = false;
+let expired = false;
 await editAuthorizedKeys(home, (lines) => {
   if (!existsSync(pendingPath(stateDir, pairingId))) {
     alreadyUsed = true;
     return null;
   }
   const kept = lines.filter((line) => parseBootstrapLine(line)?.pairingId !== pairingId);
+  rmSync(pendingPath(stateDir, pairingId), { force: true });
+  // Re-validate expiry inside the lock: the stdin read can block for up to
+  // INPUT_TIMEOUT_MS, so the TTL may have lapsed since the pre-read check.
+  // Still revoke the bootstrap line, but do not enroll the Device Key.
+  if (Math.floor(Date.now() / 1000) > pending.expiresAt) {
+    expired = true;
+    return kept;
+  }
   if (!kept.some((line) => keyBlobOf(line) === keyBlobOf(deviceKey.line))) {
     kept.push(deviceKey.line);
   }
-  rmSync(pendingPath(stateDir, pairingId), { force: true });
   return kept;
 });
 if (alreadyUsed) {
   err("unknown_pairing", `pairing ${pairingId} was already used`);
+}
+if (expired) {
+  err("expired", `pairing ${pairingId} expired; regenerate the Pairing Code`);
 }
 
 ok(deviceKey.fingerprint);

--- a/plugin/src/pair-accept.js
+++ b/plugin/src/pair-accept.js
@@ -16,7 +16,7 @@ import { parseArgs } from "node:util";
 
 import { editAuthorizedKeys, keyBlobOf, parseBootstrapLine } from "./authorized-keys.js";
 import { parseDeviceKeyLine, DeviceKeyError } from "./device-key.js";
-import { endPairing, pendingPath } from "./pairing-session.js";
+import { endPairing, pendingPath, recordEnrollment } from "./pairing-session.js";
 
 const MAX_INPUT_BYTES = 4096;
 const INPUT_TIMEOUT_MS = 30_000;
@@ -130,5 +130,9 @@ if (alreadyUsed) {
 if (expired) {
   err("expired", `pairing ${pairingId} expired; regenerate the Pairing Code`);
 }
+
+// Leave a record for the popup: it polls this to show the enrolled
+// fingerprint and to offer a one-key revoke of the line we just appended.
+recordEnrollment({ stateDir, pairingId, fingerprint: deviceKey.fingerprint, line: deviceKey.line });
 
 ok(deviceKey.fingerprint);

--- a/plugin/src/pair-action.js
+++ b/plugin/src/pair-action.js
@@ -1,0 +1,21 @@
+// "Pair a mobile device" action: opens the pairing popup pane.
+//
+// Actions run headless; the interactive checklist and QR live in the popup
+// pane entrypoint (placement = "popup" in herdr-plugin.toml). Calling back
+// through HERDR_BIN_PATH keeps this portable across socket transports.
+
+import { spawnSync } from "node:child_process";
+
+const herdr = process.env.HERDR_BIN_PATH ?? "herdr";
+const plugin = process.env.HERDR_PLUGIN_ID ?? "herdr-mobile.pairing";
+
+const result = spawnSync(
+  herdr,
+  ["plugin", "pane", "open", "--plugin", plugin, "--entrypoint", "pair"],
+  { stdio: "inherit" },
+);
+
+if (result.error) {
+  process.stderr.write(`failed to run herdr: ${result.error.message}\n`);
+}
+process.exit(result.status ?? 1);

--- a/plugin/src/pair-popup.js
+++ b/plugin/src/pair-popup.js
@@ -1,9 +1,10 @@
 // Pairing popup pane (ADR 0007, herdr `[[panes]]` entrypoint "pair").
 //
-// Flow: enumerate candidate addresses -> user confirms the checklist ->
-// render the Pairing Code QR. This ticket ships the config-only Pairing Code
-// (no Bootstrap Key yet); the Enrollment ceremony arrives with the Bootstrap
-// Key lifecycle.
+// Flow: sweep stale bootstrap lines -> enumerate candidate addresses -> user
+// confirms the checklist -> mint a Bootstrap Key and render the Pairing Code
+// QR. The Bootstrap Key's restricted authorized_keys line lives exactly as
+// long as this popup and its 2-minute TTL, whichever ends first; Enrollment
+// itself happens in pair-accept.js, invoked by sshd as the forced command.
 
 import os from "node:os";
 import { emitKeypressEvents } from "node:readline";
@@ -12,6 +13,8 @@ import QRCode from "qrcode";
 import { candidateAddresses } from "./addresses.js";
 import { readHostKeyFingerprint } from "./host-key.js";
 import { encodePairingCode } from "./envelope.js";
+import { sweepExpiredBootstrapLines } from "./authorized-keys.js";
+import { beginPairing, endPairing, PAIRING_TTL_SECONDS } from "./pairing-session.js";
 import {
   createSelection,
   moveCursor,
@@ -60,6 +63,7 @@ function renderChecklist(state, warning) {
 async function renderPairingCode(payload) {
   const code = encodePairingCode(payload);
   const qr = await QRCode.toString(code, { type: "terminal", small: true });
+  const expires = new Date(payload.expiresAt * 1000).toLocaleTimeString();
   const lines = [
     `${BOLD}Scan with herdr-mobile${RESET}`,
     "",
@@ -68,8 +72,20 @@ async function renderPairingCode(payload) {
     `${BOLD}${payload.username}${RESET} on port ${BOLD}${payload.port}${RESET}`,
     `Host key ${payload.hostKeyFingerprint}`,
     `Addresses: ${payload.addresses.join(", ")}`,
+    `Code valid until ${BOLD}${expires}${RESET}, single use`,
     "",
     `${DIM}Press any key to close.${RESET}`,
+  ];
+  process.stdout.write(CLEAR + lines.join("\n") + "\n");
+}
+
+function renderExpired() {
+  const lines = [
+    `${BOLD}Pairing Code expired${RESET}`,
+    "",
+    "The Bootstrap Key was removed; the old QR is now useless.",
+    "",
+    `${DIM}enter generate a new code, any other key close${RESET}`,
   ];
   process.stdout.write(CLEAR + lines.join("\n") + "\n");
 }
@@ -88,6 +104,13 @@ async function main() {
     return;
   }
 
+  const stateDir = process.env.HERDR_PLUGIN_STATE_DIR;
+  if (!stateDir) {
+    fatal("HERDR_PLUGIN_STATE_DIR is not set. Run this popup through herdr.");
+    return;
+  }
+  const home = os.homedir();
+
   const hostKey = readHostKeyFingerprint();
   if (hostKey === null) {
     fatal("No SSH host key found under /etc/ssh. Is an OpenSSH server set up here?");
@@ -99,18 +122,94 @@ async function main() {
     return;
   }
 
+  // Startup sweep: crashed or killed ceremonies must leave no residue.
+  await sweepExpiredBootstrapLines(home);
+
   let state = createSelection(candidates);
   let phase = "select";
+  let confirmedAddresses = null;
+  let session = null;
+  let expiryTimer = null;
+  let closing = false;
+
+  async function cleanup() {
+    if (expiryTimer !== null) {
+      clearTimeout(expiryTimer);
+      expiryTimer = null;
+    }
+    if (session !== null) {
+      const { pairingId } = session;
+      session = null;
+      await endPairing({ home, stateDir, pairingId });
+    }
+  }
+
+  async function close(code) {
+    if (closing) {
+      return;
+    }
+    closing = true;
+    try {
+      await cleanup();
+    } finally {
+      process.exit(code);
+    }
+  }
+
+  // herdr closes a popup by ending the pane; make sure the bootstrap line
+  // dies with us. SIGKILL is covered by the startup sweep instead.
+  for (const signal of ["SIGTERM", "SIGHUP", "SIGINT"]) {
+    process.on(signal, () => void close(0));
+  }
+
+  async function startCeremony() {
+    session = await beginPairing({ home, stateDir });
+    expiryTimer = setTimeout(() => {
+      expiryTimer = null;
+      phase = "expired";
+      void cleanup().then(renderExpired);
+    }, PAIRING_TTL_SECONDS * 1000);
+    await renderPairingCode({
+      addresses: confirmedAddresses,
+      port: DEFAULT_SSH_PORT,
+      username: os.userInfo().username,
+      hostKeyFingerprint: hostKey.fingerprint,
+      bootstrapSeed: session.seed,
+      expiresAt: session.expiresAt,
+    });
+  }
+
+  function startCeremonyOrDie() {
+    startCeremony().catch((error) => {
+      fatal(`Could not start pairing: ${error.message}`);
+      void close(1);
+    });
+  }
+
   process.stdout.write(HIDE_CURSOR);
   process.on("exit", () => process.stdout.write(SHOW_CURSOR));
   renderChecklist(state);
 
   readKeys((key) => {
+    if (closing) {
+      return;
+    }
     if (key.name === "q" || key.name === "escape" || (key.ctrl && key.name === "c")) {
-      process.exit(0);
+      void close(0);
+      return;
     }
     if (phase === "qr") {
-      process.exit(0);
+      void close(0);
+      return;
+    }
+    if (phase === "expired") {
+      if (key.name === "return") {
+        phase = "qr";
+        startCeremonyOrDie();
+      } else {
+        void close(0);
+      }
+      return;
     }
     switch (key.name) {
       case "up":
@@ -134,15 +233,8 @@ async function main() {
           return;
         }
         phase = "qr";
-        renderPairingCode({
-          addresses,
-          port: DEFAULT_SSH_PORT,
-          username: os.userInfo().username,
-          hostKeyFingerprint: hostKey.fingerprint,
-        }).catch((error) => {
-          fatal(`Could not render the Pairing Code: ${error.message}`);
-          process.exit(1);
-        });
+        confirmedAddresses = addresses;
+        startCeremonyOrDie();
         return;
       }
       default:

--- a/plugin/src/pair-popup.js
+++ b/plugin/src/pair-popup.js
@@ -19,6 +19,7 @@ import {
   endPairing,
   expirePairing,
   readEnrollment,
+  sweepExpiredStateFiles,
   PAIRING_TTL_SECONDS,
 } from "./pairing-session.js";
 import {
@@ -176,8 +177,10 @@ async function main() {
     return;
   }
 
-  // Startup sweep: crashed or killed ceremonies must leave no residue.
+  // Startup sweep: crashed or killed ceremonies must leave no residue —
+  // neither authorized_keys lines nor pending/enrolled state files.
   await sweepExpiredBootstrapLines(home);
+  sweepExpiredStateFiles(stateDir);
 
   let state = createSelection(candidates);
   let phase = "select";

--- a/plugin/src/pair-popup.js
+++ b/plugin/src/pair-popup.js
@@ -13,8 +13,13 @@ import QRCode from "qrcode";
 import { candidateAddresses } from "./addresses.js";
 import { readHostKeyFingerprint } from "./host-key.js";
 import { encodePairingCode } from "./envelope.js";
-import { sweepExpiredBootstrapLines } from "./authorized-keys.js";
-import { beginPairing, endPairing, PAIRING_TTL_SECONDS } from "./pairing-session.js";
+import { commentOf, removeKeyLine, sweepExpiredBootstrapLines } from "./authorized-keys.js";
+import {
+  beginPairing,
+  endPairing,
+  readEnrollment,
+  PAIRING_TTL_SECONDS,
+} from "./pairing-session.js";
 import {
   createSelection,
   moveCursor,
@@ -24,6 +29,11 @@ import {
 } from "./select-list.js";
 
 const DEFAULT_SSH_PORT = 22;
+// How often the QR screen checks whether Enrollment has completed. The pending
+// -> enrolled transition happens on the server side in pair-accept.js; polling
+// the record it leaves is simpler than an fs.watch and just as timely at human
+// scale.
+const ENROLL_POLL_MS = 400;
 
 const CLEAR = "\u001b[2J\u001b[H";
 const HIDE_CURSOR = "\u001b[?25l";
@@ -90,6 +100,49 @@ function renderExpired() {
   process.stdout.write(CLEAR + lines.join("\n") + "\n");
 }
 
+function renderEnrolled(record) {
+  const comment = commentOf(record.line);
+  const label = comment.length > 0 ? `${BOLD}${comment}${RESET}` : `${DIM}(no label)${RESET}`;
+  const lines = [
+    `${BOLD}Device paired${RESET}`,
+    "",
+    "A device just enrolled its Device Key on this machine:",
+    "",
+    `  Fingerprint  ${BOLD}${record.fingerprint}${RESET}`,
+    `  Label        ${label}`,
+    "",
+    "If this was not you, revoke it now to lock that device out.",
+    "",
+    `${DIM}r revoke this device, any other key close${RESET}`,
+  ];
+  process.stdout.write(CLEAR + lines.join("\n") + "\n");
+}
+
+function renderRevoked(record) {
+  const lines = [
+    `${BOLD}Device Key revoked${RESET}`,
+    "",
+    `${DIM}${record.fingerprint}${RESET}`,
+    "was removed from authorized_keys; that device can no longer connect.",
+    "",
+    `${DIM}Press any key to close.${RESET}`,
+  ];
+  process.stdout.write(CLEAR + lines.join("\n") + "\n");
+}
+
+function renderRevokeFailed(message) {
+  const lines = [
+    `${BOLD}Could not revoke the Device Key${RESET}`,
+    "",
+    message,
+    "",
+    "Remove the enrolled line from ~/.ssh/authorized_keys by hand.",
+    "",
+    `${DIM}Press any key to close.${RESET}`,
+  ];
+  process.stdout.write(CLEAR + lines.join("\n") + "\n");
+}
+
 function readKeys(onKey) {
   emitKeypressEvents(process.stdin);
   process.stdin.setRawMode(true);
@@ -130,12 +183,18 @@ async function main() {
   let confirmedAddresses = null;
   let session = null;
   let expiryTimer = null;
+  let enrollWatch = null;
+  let enrolled = null;
   let closing = false;
 
   async function cleanup() {
     if (expiryTimer !== null) {
       clearTimeout(expiryTimer);
       expiryTimer = null;
+    }
+    if (enrollWatch !== null) {
+      clearInterval(enrollWatch);
+      enrollWatch = null;
     }
     if (session !== null) {
       const { pairingId } = session;
@@ -162,8 +221,49 @@ async function main() {
     process.on(signal, () => void close(0));
   }
 
+  // Enrollment happens server-side (pair-accept.js as the sshd forced command)
+  // and leaves a record in the state dir. Poll for it while the QR is up; once
+  // it lands the Bootstrap Key has already self-revoked, so stop the TTL clock
+  // and show the enrolled device with a one-key revoke.
+  function onEnrollmentPoll(pairingId) {
+    if (closing || phase !== "qr") {
+      return;
+    }
+    const record = readEnrollment(stateDir, pairingId);
+    if (record === null) {
+      return;
+    }
+    enrolled = record;
+    if (enrollWatch !== null) {
+      clearInterval(enrollWatch);
+      enrollWatch = null;
+    }
+    if (expiryTimer !== null) {
+      clearTimeout(expiryTimer);
+      expiryTimer = null;
+    }
+    phase = "enrolled";
+    renderEnrolled(record);
+  }
+
+  async function revokeEnrolledDevice() {
+    if (enrolled === null) {
+      void close(0);
+      return;
+    }
+    phase = "revoked";
+    try {
+      await removeKeyLine(home, enrolled.line);
+    } catch (error) {
+      renderRevokeFailed(error.message);
+      return;
+    }
+    renderRevoked(enrolled);
+  }
+
   async function startCeremony() {
     session = await beginPairing({ home, stateDir });
+    const { pairingId } = session;
     expiryTimer = setTimeout(() => {
       expiryTimer = null;
       phase = "expired";
@@ -177,6 +277,7 @@ async function main() {
       bootstrapSeed: session.seed,
       expiresAt: session.expiresAt,
     });
+    enrollWatch = setInterval(() => onEnrollmentPoll(pairingId), ENROLL_POLL_MS);
   }
 
   function startCeremonyOrDie() {
@@ -195,6 +296,18 @@ async function main() {
       return;
     }
     if (key.name === "q" || key.name === "escape" || (key.ctrl && key.name === "c")) {
+      void close(0);
+      return;
+    }
+    if (phase === "enrolled") {
+      if (key.name === "r") {
+        void revokeEnrolledDevice();
+      } else {
+        void close(0);
+      }
+      return;
+    }
+    if (phase === "revoked") {
       void close(0);
       return;
     }

--- a/plugin/src/pair-popup.js
+++ b/plugin/src/pair-popup.js
@@ -17,6 +17,7 @@ import { commentOf, removeKeyLine, sweepExpiredBootstrapLines } from "./authoriz
 import {
   beginPairing,
   endPairing,
+  expirePairing,
   readEnrollment,
   PAIRING_TTL_SECONDS,
 } from "./pairing-session.js";
@@ -250,6 +251,32 @@ async function main() {
     enterEnrolled(record);
   }
 
+  // The TTL lapsed. A device can enroll inside the accept script's lock right
+  // up to the deadline, after our last poll, so the check for its record runs
+  // inside that same lock (expirePairing): either the Enrollment is honored,
+  // or the cleanup wins and the accept script rejects. Anything else could
+  // delete an enrolled device's record and never offer the revoke (ADR 0007's
+  // compensating control).
+  async function expireCeremony(pairingId) {
+    phase = "expiring";
+    if (enrollWatch !== null) {
+      clearInterval(enrollWatch);
+      enrollWatch = null;
+    }
+    const record = await expirePairing({ home, stateDir, pairingId });
+    if (closing) {
+      return;
+    }
+    if (record !== null) {
+      enterEnrolled(record);
+      return;
+    }
+    // expirePairing already dropped the bootstrap line and pending state.
+    session = null;
+    phase = "expired";
+    renderExpired();
+  }
+
   async function revokeEnrolledDevice() {
     if (enrolled === null) {
       void close(0);
@@ -277,17 +304,7 @@ async function main() {
       if (closing || phase !== "qr") {
         return;
       }
-      // A device can enroll inside the accept script's lock right up to the
-      // deadline, after our last poll. Honor a record that landed in that gap
-      // instead of expiring, or we would delete an enrolled device and never
-      // offer the revoke (ADR 0007's compensating control).
-      const record = readEnrollment(stateDir, pairingId);
-      if (record !== null) {
-        enterEnrolled(record);
-        return;
-      }
-      phase = "expired";
-      void cleanup().then(renderExpired);
+      void expireCeremony(pairingId);
     }, PAIRING_TTL_SECONDS * 1000);
     await renderPairingCode({
       addresses: confirmedAddresses,
@@ -315,9 +332,9 @@ async function main() {
     if (closing) {
       return;
     }
-    // Ignore every key while a revoke is in flight; the removal is fast and a
-    // stray press must not close the popup before it settles.
-    if (phase === "revoking") {
+    // Ignore every key while a revoke or the expiry check is in flight; both
+    // are fast and a stray press must not close the popup before they settle.
+    if (phase === "revoking" || phase === "expiring") {
       return;
     }
     if (key.name === "q" || key.name === "escape" || (key.ctrl && key.name === "c")) {

--- a/plugin/src/pair-popup.js
+++ b/plugin/src/pair-popup.js
@@ -1,0 +1,155 @@
+// Pairing popup pane (ADR 0007, herdr `[[panes]]` entrypoint "pair").
+//
+// Flow: enumerate candidate addresses -> user confirms the checklist ->
+// render the Pairing Code QR. This ticket ships the config-only Pairing Code
+// (no Bootstrap Key yet); the Enrollment ceremony arrives with the Bootstrap
+// Key lifecycle.
+
+import os from "node:os";
+import { emitKeypressEvents } from "node:readline";
+import QRCode from "qrcode";
+
+import { candidateAddresses } from "./addresses.js";
+import { readHostKeyFingerprint } from "./host-key.js";
+import { encodePairingCode } from "./envelope.js";
+import {
+  createSelection,
+  moveCursor,
+  toggleCurrent,
+  toggleAll,
+  selectedAddresses,
+} from "./select-list.js";
+
+const DEFAULT_SSH_PORT = 22;
+
+const CLEAR = "\u001b[2J\u001b[H";
+const HIDE_CURSOR = "\u001b[?25l";
+const SHOW_CURSOR = "\u001b[?25h";
+const BOLD = "\u001b[1m";
+const DIM = "\u001b[2m";
+const REVERSE = "\u001b[7m";
+const RESET = "\u001b[0m";
+
+function fatal(message) {
+  process.stdout.write(`${CLEAR}${BOLD}Pairing cannot start${RESET}\n\n${message}\n`);
+  process.exitCode = 1;
+}
+
+function renderChecklist(state, warning) {
+  const lines = [
+    `${BOLD}Pair a herdr-mobile device${RESET}`,
+    "",
+    "Select the addresses the phone can reach this machine on:",
+    "",
+  ];
+  state.items.forEach((item, index) => {
+    const cursor = index === state.cursor ? `${REVERSE}>` : " ";
+    const box = item.checked ? "[x]" : "[ ]";
+    const label = `${item.address} ${DIM}(${item.interfaceName}, ${item.family})${RESET}`;
+    lines.push(` ${cursor} ${box} ${label}${RESET}`);
+  });
+  lines.push("");
+  lines.push(`${DIM}up/down move, space toggle, a all, enter confirm, q quit${RESET}`);
+  if (warning) {
+    lines.push("");
+    lines.push(`${BOLD}${warning}${RESET}`);
+  }
+  process.stdout.write(CLEAR + lines.join("\n") + "\n");
+}
+
+async function renderPairingCode(payload) {
+  const code = encodePairingCode(payload);
+  const qr = await QRCode.toString(code, { type: "terminal", small: true });
+  const lines = [
+    `${BOLD}Scan with herdr-mobile${RESET}`,
+    "",
+    qr.trimEnd(),
+    "",
+    `${BOLD}${payload.username}${RESET} on port ${BOLD}${payload.port}${RESET}`,
+    `Host key ${payload.hostKeyFingerprint}`,
+    `Addresses: ${payload.addresses.join(", ")}`,
+    "",
+    `${DIM}Press any key to close.${RESET}`,
+  ];
+  process.stdout.write(CLEAR + lines.join("\n") + "\n");
+}
+
+function readKeys(onKey) {
+  emitKeypressEvents(process.stdin);
+  process.stdin.setRawMode(true);
+  process.stdin.resume();
+  process.stdin.on("keypress", (_chunk, key) => onKey(key ?? {}));
+}
+
+async function main() {
+  if (!process.stdout.isTTY || !process.stdin.isTTY) {
+    process.stderr.write("pair-popup must run inside a terminal pane\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  const hostKey = readHostKeyFingerprint();
+  if (hostKey === null) {
+    fatal("No SSH host key found under /etc/ssh. Is an OpenSSH server set up here?");
+    return;
+  }
+  const candidates = candidateAddresses();
+  if (candidates.length === 0) {
+    fatal("No routable network address found. Connect to a LAN or VPN and retry.");
+    return;
+  }
+
+  let state = createSelection(candidates);
+  let phase = "select";
+  process.stdout.write(HIDE_CURSOR);
+  process.on("exit", () => process.stdout.write(SHOW_CURSOR));
+  renderChecklist(state);
+
+  readKeys((key) => {
+    if (key.name === "q" || key.name === "escape" || (key.ctrl && key.name === "c")) {
+      process.exit(0);
+    }
+    if (phase === "qr") {
+      process.exit(0);
+    }
+    switch (key.name) {
+      case "up":
+      case "k":
+        state = moveCursor(state, -1);
+        break;
+      case "down":
+      case "j":
+        state = moveCursor(state, 1);
+        break;
+      case "space":
+        state = toggleCurrent(state);
+        break;
+      case "a":
+        state = toggleAll(state);
+        break;
+      case "return": {
+        const addresses = selectedAddresses(state);
+        if (addresses.length === 0) {
+          renderChecklist(state, "Select at least one address.");
+          return;
+        }
+        phase = "qr";
+        renderPairingCode({
+          addresses,
+          port: DEFAULT_SSH_PORT,
+          username: os.userInfo().username,
+          hostKeyFingerprint: hostKey.fingerprint,
+        }).catch((error) => {
+          fatal(`Could not render the Pairing Code: ${error.message}`);
+          process.exit(1);
+        });
+        return;
+      }
+      default:
+        return;
+    }
+    renderChecklist(state);
+  });
+}
+
+await main();

--- a/plugin/src/pair-popup.js
+++ b/plugin/src/pair-popup.js
@@ -221,18 +221,9 @@ async function main() {
     process.on(signal, () => void close(0));
   }
 
-  // Enrollment happens server-side (pair-accept.js as the sshd forced command)
-  // and leaves a record in the state dir. Poll for it while the QR is up; once
-  // it lands the Bootstrap Key has already self-revoked, so stop the TTL clock
-  // and show the enrolled device with a one-key revoke.
-  function onEnrollmentPoll(pairingId) {
-    if (closing || phase !== "qr") {
-      return;
-    }
-    const record = readEnrollment(stateDir, pairingId);
-    if (record === null) {
-      return;
-    }
+  // A device enrolled: the Bootstrap Key has already self-revoked, so stop the
+  // TTL clock and the poll and show the enrolled device with a one-key revoke.
+  function enterEnrolled(record) {
     enrolled = record;
     if (enrollWatch !== null) {
       clearInterval(enrollWatch);
@@ -246,18 +237,35 @@ async function main() {
     renderEnrolled(record);
   }
 
+  // Enrollment happens server-side (pair-accept.js as the sshd forced command)
+  // and leaves a record in the state dir. Poll for it while the QR is up.
+  function onEnrollmentPoll(pairingId) {
+    if (closing || phase !== "qr") {
+      return;
+    }
+    const record = readEnrollment(stateDir, pairingId);
+    if (record === null) {
+      return;
+    }
+    enterEnrolled(record);
+  }
+
   async function revokeEnrolledDevice() {
     if (enrolled === null) {
       void close(0);
       return;
     }
-    phase = "revoked";
+    // Hold an in-flight phase across the await so a second keypress can't fall
+    // through to a terminal branch and close(0) before removeKeyLine settles.
+    phase = "revoking";
     try {
       await removeKeyLine(home, enrolled.line);
     } catch (error) {
+      phase = "revoked";
       renderRevokeFailed(error.message);
       return;
     }
+    phase = "revoked";
     renderRevoked(enrolled);
   }
 
@@ -266,6 +274,18 @@ async function main() {
     const { pairingId } = session;
     expiryTimer = setTimeout(() => {
       expiryTimer = null;
+      if (closing || phase !== "qr") {
+        return;
+      }
+      // A device can enroll inside the accept script's lock right up to the
+      // deadline, after our last poll. Honor a record that landed in that gap
+      // instead of expiring, or we would delete an enrolled device and never
+      // offer the revoke (ADR 0007's compensating control).
+      const record = readEnrollment(stateDir, pairingId);
+      if (record !== null) {
+        enterEnrolled(record);
+        return;
+      }
       phase = "expired";
       void cleanup().then(renderExpired);
     }, PAIRING_TTL_SECONDS * 1000);
@@ -293,6 +313,11 @@ async function main() {
 
   readKeys((key) => {
     if (closing) {
+      return;
+    }
+    // Ignore every key while a revoke is in flight; the removal is fast and a
+    // stray press must not close the popup before it settles.
+    if (phase === "revoking") {
       return;
     }
     if (key.name === "q" || key.name === "escape" || (key.ctrl && key.name === "c")) {

--- a/plugin/src/pairing-session.js
+++ b/plugin/src/pairing-session.js
@@ -1,0 +1,95 @@
+// One pairing ceremony on the server side (ADR 0007).
+//
+// beginPairing mints a Bootstrap Key, writes its restricted authorized_keys
+// line (restrict + forced command at the Enrollment accept entrypoint), and
+// records pending state under the plugin state directory. endPairing undoes
+// both; it runs on popup exit, on TTL expiry, and is idempotent so crashed
+// ceremonies can be cleaned up twice without harm.
+//
+// The forced command embeds absolute paths because sshd runs it with a bare
+// login-shell environment: no herdr plugin env, possibly no node on PATH.
+
+import { randomBytes } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { generateBootstrapKey } from "./bootstrap-key.js";
+import { bootstrapLine, editAuthorizedKeys, removeBootstrapLine } from "./authorized-keys.js";
+
+export const PAIRING_TTL_SECONDS = 120;
+
+const ACCEPT_SCRIPT = fileURLToPath(new URL("./pair-accept.js", import.meta.url));
+
+export function pendingPath(stateDir, pairingId) {
+  return join(stateDir, "pending", `${pairingId}.json`);
+}
+
+function singleQuoted(path, what) {
+  // The whole forced command lives inside authorized_keys double quotes and
+  // is then parsed by the login shell; single-quoting the paths keeps both
+  // layers happy as long as the path has no quote characters of its own.
+  if (/['"\n\r]/.test(path)) {
+    throw new Error(`${what} must not contain quotes or newlines: ${path}`);
+  }
+  return `'${path}'`;
+}
+
+function acceptCommand(stateDir, pairingId) {
+  return [
+    singleQuoted(process.execPath, "node binary path"),
+    singleQuoted(ACCEPT_SCRIPT, "accept script path"),
+    "--state-dir",
+    singleQuoted(stateDir, "plugin state dir"),
+    "--pairing-id",
+    pairingId,
+  ].join(" ");
+}
+
+/**
+ * Start a pairing ceremony: Bootstrap Key + restricted line + pending state.
+ *
+ * @param {object} options
+ * @param {string} options.home account home (owns ~/.ssh/authorized_keys)
+ * @param {string} options.stateDir plugin state directory (HERDR_PLUGIN_STATE_DIR)
+ * @param {number} [options.now] unix seconds, defaults to the clock
+ * @param {number} [options.ttlSeconds] Bootstrap Key TTL
+ * @returns {Promise<{pairingId: string, seed: Buffer, expiresAt: number, publicLine: string}>}
+ */
+export async function beginPairing({
+  home,
+  stateDir,
+  now = Math.floor(Date.now() / 1000),
+  ttlSeconds = PAIRING_TTL_SECONDS,
+}) {
+  const pairingId = randomBytes(6).toString("hex");
+  const expiresAt = now + ttlSeconds;
+  const { seed, publicLine } = generateBootstrapKey();
+  const line = bootstrapLine({
+    publicLine,
+    pairingId,
+    expiresAt,
+    command: acceptCommand(stateDir, pairingId),
+  });
+
+  mkdirSync(join(stateDir, "pending"), { recursive: true, mode: 0o700 });
+  writeFileSync(
+    pendingPath(stateDir, pairingId),
+    `${JSON.stringify({ pairingId, expiresAt, publicLine })}\n`,
+    { mode: 0o600 },
+  );
+  try {
+    await editAuthorizedKeys(home, (lines) => [...lines, line]);
+  } catch (error) {
+    rmSync(pendingPath(stateDir, pairingId), { force: true });
+    throw error;
+  }
+
+  return { pairingId, seed, expiresAt, publicLine };
+}
+
+/** End a ceremony: drop the bootstrap line and pending state. Idempotent. */
+export async function endPairing({ home, stateDir, pairingId }) {
+  await removeBootstrapLine(home, pairingId);
+  rmSync(pendingPath(stateDir, pairingId), { force: true });
+}

--- a/plugin/src/pairing-session.js
+++ b/plugin/src/pairing-session.js
@@ -10,7 +10,7 @@
 // login-shell environment: no herdr plugin env, possibly no node on PATH.
 
 import { randomBytes } from "node:crypto";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -43,14 +43,16 @@ export function enrolledPath(stateDir, pairingId) {
  * @param {object} options
  * @param {string} options.stateDir plugin state directory
  * @param {string} options.pairingId the completed pairing's id
+ * @param {number} options.expiresAt the ceremony's expiry (unix seconds); lets
+ *   the startup sweep age out records a killed popup never cleaned up
  * @param {string} options.fingerprint enrolled Device Key SHA256 fingerprint
  * @param {string} options.line canonical enrolled authorized_keys line (revoke target)
  */
-export function recordEnrollment({ stateDir, pairingId, fingerprint, line }) {
+export function recordEnrollment({ stateDir, pairingId, expiresAt, fingerprint, line }) {
   mkdirSync(join(stateDir, "enrolled"), { recursive: true, mode: 0o700 });
   writeFileSync(
     enrolledPath(stateDir, pairingId),
-    `${JSON.stringify({ pairingId, fingerprint, line })}\n`,
+    `${JSON.stringify({ pairingId, expiresAt, fingerprint, line })}\n`,
     { mode: 0o600 },
   );
 }
@@ -160,4 +162,68 @@ export async function endPairing({ home, stateDir, pairingId }) {
   await removeBootstrapLine(home, pairingId);
   rmSync(pendingPath(stateDir, pairingId), { force: true });
   rmSync(enrolledPath(stateDir, pairingId), { force: true });
+}
+
+// How far past its ceremony's expiry an enrolled record must be before the
+// sweep may call it orphaned. A live popup reads the record within a poll
+// interval of the accept writing it, so anything a full TTL late is garbage.
+const STATE_SWEEP_GRACE_SECONDS = PAIRING_TTL_SECONDS;
+
+/**
+ * Startup sweep for the plugin state dir, the file-side twin of
+ * sweepExpiredBootstrapLines: a SIGKILLed popup never runs endPairing, so its
+ * pending/enrolled records would otherwise live forever. Only provably stale
+ * files go — pending records past their embedded expiry, enrolled records a
+ * grace period past theirs — so a concurrent popup's live ceremony is never
+ * clobbered.
+ *
+ * @returns {number} how many stale files were removed
+ */
+export function sweepExpiredStateFiles(stateDir, now = Math.floor(Date.now() / 1000)) {
+  return (
+    sweepDir(join(stateDir, "pending"), now, (record) => record.expiresAt) +
+    sweepDir(join(stateDir, "enrolled"), now, (record) => record.expiresAt + STATE_SWEEP_GRACE_SECONDS)
+  );
+}
+
+function sweepDir(dir, now, keepUntilOf) {
+  let names;
+  try {
+    names = readdirSync(dir);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return 0;
+    }
+    throw error;
+  }
+  let removed = 0;
+  for (const name of names) {
+    const path = join(dir, name);
+    if (keepUntil(path, keepUntilOf) <= now) {
+      rmSync(path, { force: true });
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+/** Unix-seconds instant until which a state file must be kept. */
+function keepUntil(path, keepUntilOf) {
+  try {
+    const value = keepUntilOf(JSON.parse(readFileSync(path, "utf8")));
+    if (Number.isFinite(value)) {
+      return value;
+    }
+  } catch {
+    // Unreadable or malformed: fall through to the mtime rule below.
+  }
+  // Garbage still ages out, but by mtime and with full TTL + grace slack so
+  // a concurrent writer's file mid-write is never misjudged as stale.
+  try {
+    return (
+      Math.floor(statSync(path).mtimeMs / 1000) + PAIRING_TTL_SECONDS + STATE_SWEEP_GRACE_SECONDS
+    );
+  } catch {
+    return Infinity; // vanished mid-sweep: someone else already cleaned it up
+  }
 }

--- a/plugin/src/pairing-session.js
+++ b/plugin/src/pairing-session.js
@@ -15,7 +15,12 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { generateBootstrapKey } from "./bootstrap-key.js";
-import { bootstrapLine, editAuthorizedKeys, removeBootstrapLine } from "./authorized-keys.js";
+import {
+  bootstrapLine,
+  editAuthorizedKeys,
+  parseBootstrapLine,
+  removeBootstrapLine,
+} from "./authorized-keys.js";
 
 export const PAIRING_TTL_SECONDS = 120;
 
@@ -31,8 +36,9 @@ export function enrolledPath(stateDir, pairingId) {
 
 /**
  * Record a completed Enrollment so the popup can show the enrolled fingerprint
- * and offer a one-key revoke. Written by pair-accept.js after a successful
- * enroll; the popup polls for it as its Enrollment signal.
+ * and offer a one-key revoke. Written by pair-accept.js inside the
+ * authorized_keys lock, atomically with the Device Key append; the popup polls
+ * for it as its Enrollment signal and expirePairing checks it under that lock.
  *
  * @param {object} options
  * @param {string} options.stateDir plugin state directory
@@ -119,6 +125,31 @@ export async function beginPairing({
   }
 
   return { pairingId, seed, expiresAt, publicLine };
+}
+
+/**
+ * Expire a ceremony from the popup's TTL timer. Like endPairing, but the
+ * enrolled-record check runs inside the authorized_keys lock — the same lock
+ * under which pair-accept.js commits an Enrollment — so exactly one outcome
+ * is possible: either the record is visible here (return it, touch nothing,
+ * the popup shows the revoke screen), or this cleanup consumes the pending
+ * state first and the accept script rejects. No interleaving can enroll a
+ * device silently (ADR 0007's compensating control depends on that).
+ *
+ * @returns {Promise<object | null>} the Enrollment record, if a device enrolled
+ */
+export async function expirePairing({ home, stateDir, pairingId }) {
+  let record = null;
+  await editAuthorizedKeys(home, (lines) => {
+    record = readEnrollment(stateDir, pairingId);
+    if (record !== null) {
+      return null;
+    }
+    rmSync(pendingPath(stateDir, pairingId), { force: true });
+    const kept = lines.filter((line) => parseBootstrapLine(line)?.pairingId !== pairingId);
+    return kept.length === lines.length ? null : kept;
+  });
+  return record;
 }
 
 /**

--- a/plugin/src/pairing-session.js
+++ b/plugin/src/pairing-session.js
@@ -10,7 +10,7 @@
 // login-shell environment: no herdr plugin env, possibly no node on PATH.
 
 import { randomBytes } from "node:crypto";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -23,6 +23,39 @@ const ACCEPT_SCRIPT = fileURLToPath(new URL("./pair-accept.js", import.meta.url)
 
 export function pendingPath(stateDir, pairingId) {
   return join(stateDir, "pending", `${pairingId}.json`);
+}
+
+export function enrolledPath(stateDir, pairingId) {
+  return join(stateDir, "enrolled", `${pairingId}.json`);
+}
+
+/**
+ * Record a completed Enrollment so the popup can show the enrolled fingerprint
+ * and offer a one-key revoke. Written by pair-accept.js after a successful
+ * enroll; the popup polls for it as its Enrollment signal.
+ *
+ * @param {object} options
+ * @param {string} options.stateDir plugin state directory
+ * @param {string} options.pairingId the completed pairing's id
+ * @param {string} options.fingerprint enrolled Device Key SHA256 fingerprint
+ * @param {string} options.line canonical enrolled authorized_keys line (revoke target)
+ */
+export function recordEnrollment({ stateDir, pairingId, fingerprint, line }) {
+  mkdirSync(join(stateDir, "enrolled"), { recursive: true, mode: 0o700 });
+  writeFileSync(
+    enrolledPath(stateDir, pairingId),
+    `${JSON.stringify({ pairingId, fingerprint, line })}\n`,
+    { mode: 0o600 },
+  );
+}
+
+/** Read a completed Enrollment record, or null if none exists yet. */
+export function readEnrollment(stateDir, pairingId) {
+  try {
+    return JSON.parse(readFileSync(enrolledPath(stateDir, pairingId), "utf8"));
+  } catch {
+    return null;
+  }
 }
 
 function singleQuoted(path, what) {
@@ -88,8 +121,12 @@ export async function beginPairing({
   return { pairingId, seed, expiresAt, publicLine };
 }
 
-/** End a ceremony: drop the bootstrap line and pending state. Idempotent. */
+/**
+ * End a ceremony: drop the bootstrap line, pending state, and any Enrollment
+ * record. Idempotent, so crashed ceremonies can be cleaned up twice.
+ */
 export async function endPairing({ home, stateDir, pairingId }) {
   await removeBootstrapLine(home, pairingId);
   rmSync(pendingPath(stateDir, pairingId), { force: true });
+  rmSync(enrolledPath(stateDir, pairingId), { force: true });
 }

--- a/plugin/src/select-list.js
+++ b/plugin/src/select-list.js
@@ -1,0 +1,32 @@
+// Pure state for the popup's address checklist. The TUI in pair-popup.js is
+// a thin render loop over these transitions, so selection behavior stays
+// testable without a terminal.
+
+/** @param {{address: string, preChecked: boolean}[]} candidates */
+export function createSelection(candidates) {
+  return {
+    items: candidates.map((candidate) => ({ ...candidate, checked: candidate.preChecked })),
+    cursor: 0,
+  };
+}
+
+export function moveCursor(state, delta) {
+  const cursor = Math.min(Math.max(state.cursor + delta, 0), state.items.length - 1);
+  return { ...state, cursor };
+}
+
+export function toggleCurrent(state) {
+  const items = state.items.map((item, index) =>
+    index === state.cursor ? { ...item, checked: !item.checked } : item,
+  );
+  return { ...state, items };
+}
+
+export function toggleAll(state) {
+  const checked = !state.items.every((item) => item.checked);
+  return { ...state, items: state.items.map((item) => ({ ...item, checked })) };
+}
+
+export function selectedAddresses(state) {
+  return state.items.filter((item) => item.checked).map((item) => item.address);
+}

--- a/plugin/test-vectors/pairing-code-v1.json
+++ b/plugin/test-vectors/pairing-code-v1.json
@@ -1,0 +1,135 @@
+{
+  "description": "Shared Pairing Code v1 test vectors. Single source of truth for the envelope, consumed by both the Node plugin tests and the Swift app tests (ADR 0007). Codes were generated independently of both implementations. `decodeOnly: true` marks codes that must decode to `payload` but are not the canonical encoding of it; all other valid vectors must round-trip exactly through encode.",
+  "valid": [
+    {
+      "name": "config-only single LAN IPv4, default port",
+      "code": "HERDR-PAIR:1:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXSwicG9ydCI6MjIsInVzZXIiOiJhZGEiLCJmcCI6IlNIQTI1Njo2K2puY05kaWJzRzJjcXZmb0xBcEdyTzhDdkl3QUVNenNCK0lpbE9zOHRnIn0",
+      "payload": {
+        "addresses": ["192.168.1.42"],
+        "port": 22,
+        "username": "ada",
+        "hostKeyFingerprint": "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg"
+      }
+    },
+    {
+      "name": "multiple addresses (LAN, Tailscale CGNAT, ULA IPv6), non-default port",
+      "code": "HERDR-PAIR:1:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiLCIxMDAuMTAxLjEwMi4xMDMiLCJmZDdhOjExNWM6YTFlMDo6MSJdLCJwb3J0IjoyMjIyLCJ1c2VyIjoiZ3JhY2UiLCJmcCI6IlNIQTI1Njo2K2puY05kaWJzRzJjcXZmb0xBcEdyTzhDdkl3QUVNenNCK0lpbE9zOHRnIn0",
+      "payload": {
+        "addresses": ["192.168.1.42", "100.101.102.103", "fd7a:115c:a1e0::1"],
+        "port": 2222,
+        "username": "grace",
+        "hostKeyFingerprint": "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg"
+      }
+    },
+    {
+      "name": "with bootstrap seed and expiry",
+      "code": "HERDR-PAIR:1:eyJhZGRycyI6WyIxMC4wLjAuNyJdLCJwb3J0IjoyMiwidXNlciI6ImxpbiIsImZwIjoiU0hBMjU2OjYram5jTmRpYnNHMmNxdmZvTEFwR3JPOEN2SXdBRU16c0IrSWlsT3M4dGciLCJzZWVkIjoiQUFFQ0F3UUZCZ2NJQ1FvTERBME9EeEFSRWhNVUZSWVhHQmthR3h3ZEhoOCIsImV4cCI6MTc1MzMwNTYwMH0",
+      "payload": {
+        "addresses": ["10.0.0.7"],
+        "port": 22,
+        "username": "lin",
+        "hostKeyFingerprint": "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg",
+        "bootstrapSeed": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+        "expiresAt": 1753305600
+      }
+    },
+    {
+      "name": "unknown field is ignored (additive v1 metadata)",
+      "decodeOnly": true,
+      "code": "HERDR-PAIR:1:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXSwicG9ydCI6MjIsInVzZXIiOiJhZGEiLCJmcCI6IlNIQTI1Njo2K2puY05kaWJzRzJjcXZmb0xBcEdyTzhDdkl3QUVNenNCK0lpbE9zOHRnIiwiZnV0dXJlX2ZpZWxkIjoiaWdub3JlZCJ9",
+      "payload": {
+        "addresses": ["192.168.1.42"],
+        "port": 22,
+        "username": "ada",
+        "hostKeyFingerprint": "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg"
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "name": "missing prefix",
+      "code": "eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXX0",
+      "error": "bad_prefix"
+    },
+    {
+      "name": "wrong prefix word",
+      "code": "HERDRPAIR:1:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXX0",
+      "error": "bad_prefix"
+    },
+    {
+      "name": "unsupported version 2",
+      "code": "HERDR-PAIR:2:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXX0",
+      "error": "unsupported_version"
+    },
+    {
+      "name": "non-numeric version",
+      "code": "HERDR-PAIR:one:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXX0",
+      "error": "unsupported_version"
+    },
+    {
+      "name": "body is not base64url",
+      "code": "HERDR-PAIR:1:!!!not-base64url!!!",
+      "error": "bad_encoding"
+    },
+    {
+      "name": "body decodes but is not JSON",
+      "code": "HERDR-PAIR:1:bm90IGpzb24gYXQgYWxs",
+      "error": "bad_encoding"
+    },
+    {
+      "name": "missing addrs",
+      "code": "HERDR-PAIR:1:eyJwb3J0IjoyMiwidXNlciI6ImFkYSIsImZwIjoiU0hBMjU2OjYram5jTmRpYnNHMmNxdmZvTEFwR3JPOEN2SXdBRU16c0IrSWlsT3M4dGcifQ",
+      "error": "bad_payload"
+    },
+    {
+      "name": "empty addrs array",
+      "code": "HERDR-PAIR:1:eyJhZGRycyI6W10sInBvcnQiOjIyLCJ1c2VyIjoiYWRhIiwiZnAiOiJTSEEyNTY6NitqbmNOZGlic0cyY3F2Zm9MQXBHck84Q3ZJd0FFTXpzQitJaWxPczh0ZyJ9",
+      "error": "bad_payload"
+    },
+    {
+      "name": "address contains whitespace",
+      "code": "HERDR-PAIR:1:eyJhZGRycyI6WyIxOTIuMTY4LiAxLjQyIl0sInBvcnQiOjIyLCJ1c2VyIjoiYWRhIiwiZnAiOiJTSEEyNTY6NitqbmNOZGlic0cyY3F2Zm9MQXBHck84Q3ZJd0FFTXpzQitJaWxPczh0ZyJ9",
+      "error": "bad_payload"
+    },
+    {
+      "name": "port zero",
+      "code": "HERDR-PAIR:1:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXSwicG9ydCI6MCwidXNlciI6ImFkYSIsImZwIjoiU0hBMjU2OjYram5jTmRpYnNHMmNxdmZvTEFwR3JPOEN2SXdBRU16c0IrSWlsT3M4dGcifQ",
+      "error": "bad_payload"
+    },
+    {
+      "name": "port above 65535",
+      "code": "HERDR-PAIR:1:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXSwicG9ydCI6NzAwMDAsInVzZXIiOiJhZGEiLCJmcCI6IlNIQTI1Njo2K2puY05kaWJzRzJjcXZmb0xBcEdyTzhDdkl3QUVNenNCK0lpbE9zOHRnIn0",
+      "error": "bad_payload"
+    },
+    {
+      "name": "port not an integer",
+      "code": "HERDR-PAIR:1:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXSwicG9ydCI6MjIuNSwidXNlciI6ImFkYSIsImZwIjoiU0hBMjU2OjYram5jTmRpYnNHMmNxdmZvTEFwR3JPOEN2SXdBRU16c0IrSWlsT3M4dGcifQ",
+      "error": "bad_payload"
+    },
+    {
+      "name": "empty username",
+      "code": "HERDR-PAIR:1:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXSwicG9ydCI6MjIsInVzZXIiOiIiLCJmcCI6IlNIQTI1Njo2K2puY05kaWJzRzJjcXZmb0xBcEdyTzhDdkl3QUVNenNCK0lpbE9zOHRnIn0",
+      "error": "bad_payload"
+    },
+    {
+      "name": "fingerprint not OpenSSH SHA256 format",
+      "code": "HERDR-PAIR:1:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXSwicG9ydCI6MjIsInVzZXIiOiJhZGEiLCJmcCI6Ik1ENTphYmMifQ",
+      "error": "bad_payload"
+    },
+    {
+      "name": "seed is not 32 bytes",
+      "code": "HERDR-PAIR:1:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXSwicG9ydCI6MjIsInVzZXIiOiJhZGEiLCJmcCI6IlNIQTI1Njo2K2puY05kaWJzRzJjcXZmb0xBcEdyTzhDdkl3QUVNenNCK0lpbE9zOHRnIiwic2VlZCI6IkFBRUNBd1FGQmdjSUNRb0xEQTBPRHhBUkVoTVVGUllYR0JrYUd4d2RIZyIsImV4cCI6MTc1MzMwNTYwMH0",
+      "error": "bad_payload"
+    },
+    {
+      "name": "seed without expiry",
+      "code": "HERDR-PAIR:1:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXSwicG9ydCI6MjIsInVzZXIiOiJhZGEiLCJmcCI6IlNIQTI1Njo2K2puY05kaWJzRzJjcXZmb0xBcEdyTzhDdkl3QUVNenNCK0lpbE9zOHRnIiwic2VlZCI6IkFBRUNBd1FGQmdjSUNRb0xEQTBPRHhBUkVoTVVGUllYR0JrYUd4d2RIaDgifQ",
+      "error": "bad_payload"
+    },
+    {
+      "name": "expiry without seed",
+      "code": "HERDR-PAIR:1:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXSwicG9ydCI6MjIsInVzZXIiOiJhZGEiLCJmcCI6IlNIQTI1Njo2K2puY05kaWJzRzJjcXZmb0xBcEdyTzhDdkl3QUVNenNCK0lpbE9zOHRnIiwiZXhwIjoxNzUzMzA1NjAwfQ",
+      "error": "bad_payload"
+    }
+  ]
+}

--- a/plugin/test/addresses.test.js
+++ b/plugin/test/addresses.test.js
@@ -1,0 +1,99 @@
+import { test, suite } from "node:test";
+import assert from "node:assert/strict";
+
+import { candidateAddresses } from "../src/addresses.js";
+
+function iface(address, family, internal = false) {
+  return { address, family, internal };
+}
+
+suite("candidateAddresses", () => {
+  test("skips loopback and link-local, keeps routable addresses", () => {
+    const candidates = candidateAddresses({
+      lo0: [iface("127.0.0.1", "IPv4", true), iface("::1", "IPv6", true)],
+      en0: [
+        iface("192.168.1.42", "IPv4"),
+        iface("169.254.10.20", "IPv4"),
+        iface("fe80::1c2d:3e4f:5a6b:7c8d", "IPv6"),
+        iface("2001:db8:85a3::8a2e:370:7334", "IPv6"),
+      ],
+    });
+    assert.deepEqual(
+      candidates.map((c) => c.address),
+      ["192.168.1.42", "2001:db8:85a3::8a2e:370:7334"],
+    );
+  });
+
+  test("pre-checks private LAN, Tailscale CGNAT, and ULA addresses", () => {
+    const candidates = candidateAddresses({
+      en0: [iface("192.168.1.42", "IPv4"), iface("2001:db8::7", "IPv6")],
+      en1: [iface("10.0.0.7", "IPv4"), iface("172.20.0.3", "IPv4")],
+      utun3: [iface("100.101.102.103", "IPv4"), iface("fd7a:115c:a1e0::1", "IPv6")],
+      en2: [iface("203.0.113.9", "IPv4")],
+    });
+    const byAddress = Object.fromEntries(candidates.map((c) => [c.address, c.preChecked]));
+    assert.deepEqual(byAddress, {
+      "192.168.1.42": true,
+      "10.0.0.7": true,
+      "172.20.0.3": true,
+      "100.101.102.103": true,
+      "fd7a:115c:a1e0::1": true,
+      "2001:db8::7": false,
+      "203.0.113.9": false,
+    });
+  });
+
+  test("does not pre-check IPv4 outside private/CGNAT ranges", () => {
+    const candidates = candidateAddresses({
+      en0: [
+        iface("172.15.0.1", "IPv4"),
+        iface("172.32.0.1", "IPv4"),
+        iface("100.63.255.255", "IPv4"),
+        iface("100.128.0.1", "IPv4"),
+      ],
+    });
+    assert.deepEqual(
+      candidates.map((c) => c.preChecked),
+      [false, false, false, false],
+    );
+  });
+
+  test("orders pre-checked first, IPv4 before IPv6 within each group", () => {
+    const candidates = candidateAddresses({
+      en0: [iface("2001:db8::7", "IPv6"), iface("203.0.113.9", "IPv4")],
+      utun3: [iface("fd7a:115c:a1e0::1", "IPv6"), iface("100.101.102.103", "IPv4")],
+      en1: [iface("192.168.1.42", "IPv4")],
+    });
+    assert.deepEqual(
+      candidates.map((c) => c.address),
+      [
+        "100.101.102.103",
+        "192.168.1.42",
+        "fd7a:115c:a1e0::1",
+        "203.0.113.9",
+        "2001:db8::7",
+      ],
+    );
+  });
+
+  test("strips IPv6 zone ids and deduplicates repeated addresses", () => {
+    const candidates = candidateAddresses({
+      utun0: [iface("fd7a:115c:a1e0::1%utun0", "IPv6")],
+      utun1: [iface("fd7a:115c:a1e0::1", "IPv6")],
+    });
+    assert.deepEqual(candidates.map((c) => c.address), ["fd7a:115c:a1e0::1"]);
+  });
+
+  test("reports the owning interface name", () => {
+    const candidates = candidateAddresses({
+      en0: [iface("192.168.1.42", "IPv4")],
+    });
+    assert.deepEqual(candidates, [
+      { address: "192.168.1.42", family: "IPv4", interfaceName: "en0", preChecked: true },
+    ]);
+  });
+
+  test("returns an empty list when nothing is routable", () => {
+    assert.deepEqual(candidateAddresses({ lo0: [iface("127.0.0.1", "IPv4", true)] }), []);
+  });
+});

--- a/plugin/test/authorized-keys.test.js
+++ b/plugin/test/authorized-keys.test.js
@@ -7,8 +7,10 @@ import { join } from "node:path";
 import {
   authorizedKeysPath,
   bootstrapLine,
+  commentOf,
   editAuthorizedKeys,
   removeBootstrapLine,
+  removeKeyLine,
   sweepExpiredBootstrapLines,
 } from "../src/authorized-keys.js";
 
@@ -110,6 +112,39 @@ suite("removeBootstrapLine", () => {
   test("is a no-op when the file does not exist", async () => {
     await removeBootstrapLine(home, "mine");
     assert.equal(existsSync(authorizedKeysPath(home)), false);
+  });
+});
+
+suite("commentOf", () => {
+  test("returns the comment of a bare public line", () => {
+    assert.equal(commentOf(USER_LINE), "laptop");
+    assert.equal(commentOf(`${PUBLIC_LINE} herdr mobile phone`), "herdr mobile phone");
+  });
+
+  test("returns an empty string when there is no comment", () => {
+    assert.equal(commentOf(PUBLIC_LINE), "");
+  });
+});
+
+suite("removeKeyLine", () => {
+  test("removes the line matching the key blob, keeping the others", async () => {
+    await editAuthorizedKeys(home, () => [USER_LINE, PUBLIC_LINE]);
+    const removed = await removeKeyLine(home, PUBLIC_LINE);
+    assert.equal(removed, true);
+    assert.equal(readKeys(), `${USER_LINE}\n`);
+  });
+
+  test("matches on the key blob even when the comment differs", async () => {
+    await editAuthorizedKeys(home, () => [USER_LINE, `${PUBLIC_LINE} phone`]);
+    await removeKeyLine(home, `${PUBLIC_LINE} a-different-label`);
+    assert.equal(readKeys(), `${USER_LINE}\n`);
+  });
+
+  test("is a no-op when the key is not present", async () => {
+    await editAuthorizedKeys(home, () => [USER_LINE]);
+    const removed = await removeKeyLine(home, PUBLIC_LINE);
+    assert.equal(removed, false);
+    assert.equal(readKeys(), `${USER_LINE}\n`);
   });
 });
 

--- a/plugin/test/authorized-keys.test.js
+++ b/plugin/test/authorized-keys.test.js
@@ -1,0 +1,156 @@
+import { test, suite, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  authorizedKeysPath,
+  bootstrapLine,
+  editAuthorizedKeys,
+  removeBootstrapLine,
+  sweepExpiredBootstrapLines,
+  appendDeviceKeyLine,
+} from "../src/authorized-keys.js";
+
+const PUBLIC_LINE =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMYSCTemrZWEXptQyehHLI9kbqjHxNUGtQN2lF1ucCce";
+const USER_LINE =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBPd+KiPbQwFzIFqVCaK0me6kR0BrPZ9HFcsl7WKcFXC laptop";
+
+let home;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "pair-ak-"));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+function readKeys() {
+  return readFileSync(authorizedKeysPath(home), "utf8");
+}
+
+function mode(path) {
+  return statSync(path).mode & 0o777;
+}
+
+suite("bootstrapLine", () => {
+  test("carries restrict, the forced command, and the marker comment", () => {
+    const line = bootstrapLine({
+      publicLine: PUBLIC_LINE,
+      pairingId: "abc123",
+      expiresAt: 1753305600,
+      command: "'/usr/local/bin/node' '/plug/src/pair-accept.js' --pairing-id abc123",
+    });
+    assert.equal(
+      line,
+      `restrict,command="'/usr/local/bin/node' '/plug/src/pair-accept.js' --pairing-id abc123" ${PUBLIC_LINE} herdr-pairing:abc123:exp:1753305600`,
+    );
+  });
+
+  test("rejects a command containing a double quote or newline", () => {
+    for (const command of ['echo "hi"', "line1\nline2"]) {
+      assert.throws(() =>
+        bootstrapLine({ publicLine: PUBLIC_LINE, pairingId: "a", expiresAt: 1, command }),
+      );
+    }
+  });
+});
+
+suite("editAuthorizedKeys", () => {
+  test("creates ~/.ssh and authorized_keys with StrictModes-safe permissions", async () => {
+    await editAuthorizedKeys(home, (lines) => [...lines, USER_LINE]);
+    assert.equal(readKeys(), `${USER_LINE}\n`);
+    assert.equal(mode(join(home, ".ssh")), 0o700);
+    assert.equal(mode(authorizedKeysPath(home)), 0o600);
+  });
+
+  test("preserves existing content, order, and file mode", async () => {
+    mkdirSync(join(home, ".ssh"), { mode: 0o700 });
+    writeFileSync(authorizedKeysPath(home), `# comment\n\n${USER_LINE}\n`);
+    chmodSync(authorizedKeysPath(home), 0o644);
+    await editAuthorizedKeys(home, (lines) => [...lines, PUBLIC_LINE]);
+    assert.equal(readKeys(), `# comment\n\n${USER_LINE}\n${PUBLIC_LINE}\n`);
+    assert.equal(mode(authorizedKeysPath(home)), 0o644);
+  });
+
+  test("serializes concurrent edits", async () => {
+    const appends = Array.from({ length: 8 }, (_, i) =>
+      editAuthorizedKeys(home, (lines) => [...lines, `${PUBLIC_LINE} key-${i}`]),
+    );
+    await Promise.all(appends);
+    const lines = readKeys().trimEnd().split("\n");
+    assert.equal(lines.length, 8);
+    for (let i = 0; i < 8; i += 1) {
+      assert.ok(lines.includes(`${PUBLIC_LINE} key-${i}`), `missing key-${i}`);
+    }
+  });
+});
+
+suite("removeBootstrapLine", () => {
+  test("removes only the line with the given pairing id", async () => {
+    const mine = bootstrapLine({
+      publicLine: PUBLIC_LINE,
+      pairingId: "mine",
+      expiresAt: 2000000000,
+      command: "cmd",
+    });
+    const other = bootstrapLine({
+      publicLine: PUBLIC_LINE,
+      pairingId: "other",
+      expiresAt: 2000000000,
+      command: "cmd",
+    });
+    await editAuthorizedKeys(home, () => [USER_LINE, mine, other]);
+    await removeBootstrapLine(home, "mine");
+    assert.equal(readKeys(), `${USER_LINE}\n${other}\n`);
+  });
+
+  test("is a no-op when the file does not exist", async () => {
+    await removeBootstrapLine(home, "mine");
+    assert.equal(existsSync(authorizedKeysPath(home)), false);
+  });
+});
+
+suite("sweepExpiredBootstrapLines", () => {
+  test("removes expired pairing lines, keeps live ones and user lines", async () => {
+    const now = 1753305600;
+    const expired = bootstrapLine({
+      publicLine: PUBLIC_LINE,
+      pairingId: "old",
+      expiresAt: now - 1,
+      command: "cmd",
+    });
+    const live = bootstrapLine({
+      publicLine: PUBLIC_LINE,
+      pairingId: "new",
+      expiresAt: now + 60,
+      command: "cmd",
+    });
+    await editAuthorizedKeys(home, () => [USER_LINE, expired, live]);
+    const removed = await sweepExpiredBootstrapLines(home, now);
+    assert.equal(removed, 1);
+    assert.equal(readKeys(), `${USER_LINE}\n${live}\n`);
+  });
+
+  test("is a no-op when the file does not exist", async () => {
+    assert.equal(await sweepExpiredBootstrapLines(home, 1753305600), 0);
+    assert.equal(existsSync(authorizedKeysPath(home)), false);
+  });
+});
+
+suite("appendDeviceKeyLine", () => {
+  test("appends the line", async () => {
+    await editAuthorizedKeys(home, () => [USER_LINE]);
+    await appendDeviceKeyLine(home, `${PUBLIC_LINE} phone`);
+    assert.equal(readKeys(), `${USER_LINE}\n${PUBLIC_LINE} phone\n`);
+  });
+
+  test("does not duplicate an already-authorized key", async () => {
+    await editAuthorizedKeys(home, () => [`${PUBLIC_LINE} phone`]);
+    await appendDeviceKeyLine(home, `${PUBLIC_LINE} renamed-phone`);
+    assert.equal(readKeys(), `${PUBLIC_LINE} phone\n`);
+  });
+});

--- a/plugin/test/authorized-keys.test.js
+++ b/plugin/test/authorized-keys.test.js
@@ -10,7 +10,6 @@ import {
   editAuthorizedKeys,
   removeBootstrapLine,
   sweepExpiredBootstrapLines,
-  appendDeviceKeyLine,
 } from "../src/authorized-keys.js";
 
 const PUBLIC_LINE =
@@ -138,19 +137,5 @@ suite("sweepExpiredBootstrapLines", () => {
   test("is a no-op when the file does not exist", async () => {
     assert.equal(await sweepExpiredBootstrapLines(home, 1753305600), 0);
     assert.equal(existsSync(authorizedKeysPath(home)), false);
-  });
-});
-
-suite("appendDeviceKeyLine", () => {
-  test("appends the line", async () => {
-    await editAuthorizedKeys(home, () => [USER_LINE]);
-    await appendDeviceKeyLine(home, `${PUBLIC_LINE} phone`);
-    assert.equal(readKeys(), `${USER_LINE}\n${PUBLIC_LINE} phone\n`);
-  });
-
-  test("does not duplicate an already-authorized key", async () => {
-    await editAuthorizedKeys(home, () => [`${PUBLIC_LINE} phone`]);
-    await appendDeviceKeyLine(home, `${PUBLIC_LINE} renamed-phone`);
-    assert.equal(readKeys(), `${PUBLIC_LINE} phone\n`);
   });
 });

--- a/plugin/test/bootstrap-key.test.js
+++ b/plugin/test/bootstrap-key.test.js
@@ -1,0 +1,41 @@
+import { test, suite } from "node:test";
+import assert from "node:assert/strict";
+
+import { generateBootstrapKey, publicLineFromSeed } from "../src/bootstrap-key.js";
+import { fingerprintPublicKeyLine } from "../src/host-key.js";
+
+// Key generated with `ssh-keygen -t ed25519`; the seed was extracted from the
+// openssh-key-v1 private file, so the expected line is independent of the
+// implementation under test.
+const VECTOR_SEED = Buffer.from("1n6mUQHut1FJ4pJcfRp09db_30WxtZPx7lGUIYAl0Hk", "base64url");
+const VECTOR_PUBLIC_LINE =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMYSCTemrZWEXptQyehHLI9kbqjHxNUGtQN2lF1ucCce";
+const VECTOR_FINGERPRINT = "SHA256:ef+f9Jda6ZPkcW5GiL7pQZXJ57mCFnFAGkir3AcfTIM";
+
+suite("publicLineFromSeed", () => {
+  test("matches what ssh-keygen derives from the same seed", () => {
+    assert.equal(publicLineFromSeed(VECTOR_SEED), VECTOR_PUBLIC_LINE);
+  });
+
+  test("fingerprints like ssh-keygen -lf", () => {
+    const line = publicLineFromSeed(VECTOR_SEED);
+    assert.equal(fingerprintPublicKeyLine(line).fingerprint, VECTOR_FINGERPRINT);
+  });
+
+  test("rejects a seed that is not 32 bytes", () => {
+    assert.throws(() => publicLineFromSeed(Buffer.alloc(31)));
+    assert.throws(() => publicLineFromSeed(Buffer.alloc(33)));
+  });
+});
+
+suite("generateBootstrapKey", () => {
+  test("returns a 32-byte seed that re-derives the same public line", () => {
+    const { seed, publicLine } = generateBootstrapKey();
+    assert.equal(seed.length, 32);
+    assert.equal(publicLineFromSeed(seed), publicLine);
+  });
+
+  test("generates a distinct key each time", () => {
+    assert.notEqual(generateBootstrapKey().publicLine, generateBootstrapKey().publicLine);
+  });
+});

--- a/plugin/test/device-key.test.js
+++ b/plugin/test/device-key.test.js
@@ -1,0 +1,97 @@
+import { test, suite } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseDeviceKeyLine, DeviceKeyError } from "../src/device-key.js";
+
+// Generated with ssh-keygen; fingerprint confirmed via `ssh-keygen -lf`.
+const BLOB = "AAAAC3NzaC1lZDI1NTE5AAAAIMYSCTemrZWEXptQyehHLI9kbqjHxNUGtQN2lF1ucCce";
+const FINGERPRINT = "SHA256:ef+f9Jda6ZPkcW5GiL7pQZXJ57mCFnFAGkir3AcfTIM";
+
+function assertRejects(input) {
+  assert.throws(
+    () => parseDeviceKeyLine(input),
+    (error) => error instanceof DeviceKeyError,
+    `expected rejection for ${JSON.stringify(input)}`,
+  );
+}
+
+suite("parseDeviceKeyLine", () => {
+  test("accepts a bare ed25519 line", () => {
+    const parsed = parseDeviceKeyLine(`ssh-ed25519 ${BLOB}`);
+    assert.equal(parsed.line, `ssh-ed25519 ${BLOB}`);
+    assert.equal(parsed.fingerprint, FINGERPRINT);
+  });
+
+  test("accepts a comment and keeps it in the canonical line", () => {
+    const parsed = parseDeviceKeyLine(`ssh-ed25519 ${BLOB} herdr-mobile iPhone`);
+    assert.equal(parsed.line, `ssh-ed25519 ${BLOB} herdr-mobile iPhone`);
+    assert.equal(parsed.fingerprint, FINGERPRINT);
+  });
+
+  test("trims surrounding whitespace and a trailing newline", () => {
+    const parsed = parseDeviceKeyLine(`  ssh-ed25519 ${BLOB} phone\n`);
+    assert.equal(parsed.line, `ssh-ed25519 ${BLOB} phone`);
+  });
+
+  test("rejects non-ed25519 key types", () => {
+    assertRejects(`ssh-rsa ${BLOB}`);
+    assertRejects(`ecdsa-sha2-nistp256 ${BLOB}`);
+  });
+
+  test("rejects authorized_keys options smuggled before the key", () => {
+    assertRejects(`restrict,command="evil" ssh-ed25519 ${BLOB}`);
+    assertRejects(`command="evil" ssh-ed25519 ${BLOB}`);
+  });
+
+  test("rejects a blob whose inner type disagrees with the outer type", () => {
+    // Wire blob says ssh-rsa inside; outer says ssh-ed25519.
+    const key = Buffer.alloc(32, 7);
+    const type = Buffer.from("ssh-rsa", "utf8");
+    const parts = [];
+    for (const chunk of [type, key]) {
+      const length = Buffer.alloc(4);
+      length.writeUInt32BE(chunk.length);
+      parts.push(length, chunk);
+    }
+    assertRejects(`ssh-ed25519 ${Buffer.concat(parts).toString("base64")}`);
+  });
+
+  test("rejects a blob with the wrong key length", () => {
+    const key = Buffer.alloc(31, 7);
+    const type = Buffer.from("ssh-ed25519", "utf8");
+    const parts = [];
+    for (const chunk of [type, key]) {
+      const length = Buffer.alloc(4);
+      length.writeUInt32BE(chunk.length);
+      parts.push(length, chunk);
+    }
+    assertRejects(`ssh-ed25519 ${Buffer.concat(parts).toString("base64")}`);
+  });
+
+  test("rejects a blob with trailing bytes", () => {
+    const raw = Buffer.concat([Buffer.from(BLOB, "base64"), Buffer.from([1])]);
+    assertRejects(`ssh-ed25519 ${raw.toString("base64")}`);
+  });
+
+  test("rejects malformed input", () => {
+    assertRejects("");
+    assertRejects("   \n");
+    assertRejects("ssh-ed25519");
+    assertRejects("ssh-ed25519 !!!not-base64!!!");
+    assertRejects("just some words");
+  });
+
+  test("rejects embedded newlines (no second authorized_keys line)", () => {
+    assertRejects(`ssh-ed25519 ${BLOB} a\nssh-ed25519 ${BLOB} b`);
+  });
+
+  test("rejects comments with control or non-ASCII characters", () => {
+    assertRejects(`ssh-ed25519 ${BLOB} bad\tcomment`);
+    assertRejects(`ssh-ed25519 ${BLOB} bad\u0007comment`);
+    assertRejects(`ssh-ed25519 ${BLOB} téléphone`);
+  });
+
+  test("rejects an overlong line", () => {
+    assertRejects(`ssh-ed25519 ${BLOB} ${"x".repeat(2000)}`);
+  });
+});

--- a/plugin/test/envelope.test.js
+++ b/plugin/test/envelope.test.js
@@ -1,0 +1,110 @@
+import { test, suite } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  encodePairingCode,
+  decodePairingCode,
+  PairingCodeError,
+} from "../src/envelope.js";
+
+const vectors = JSON.parse(
+  readFileSync(new URL("../test-vectors/pairing-code-v1.json", import.meta.url), "utf8"),
+);
+
+/** Convert a decoded payload (seed as Buffer) to the vector shape (seed as base64url). */
+function toVectorShape(payload) {
+  const shape = {
+    addresses: payload.addresses,
+    port: payload.port,
+    username: payload.username,
+    hostKeyFingerprint: payload.hostKeyFingerprint,
+  };
+  if (payload.bootstrapSeed !== undefined) {
+    shape.bootstrapSeed = payload.bootstrapSeed.toString("base64url");
+  }
+  if (payload.expiresAt !== undefined) {
+    shape.expiresAt = payload.expiresAt;
+  }
+  return shape;
+}
+
+/** Convert a vector payload (seed as base64url) to the encode input shape (seed as Buffer). */
+function fromVectorShape(payload) {
+  const input = { ...payload };
+  if (input.bootstrapSeed !== undefined) {
+    input.bootstrapSeed = Buffer.from(input.bootstrapSeed, "base64url");
+  }
+  return input;
+}
+
+suite("shared vectors", () => {
+  test("vector file has cases", () => {
+    assert.ok(vectors.valid.length >= 3);
+    assert.ok(vectors.invalid.length >= 10);
+  });
+
+  for (const vector of vectors.valid) {
+    test(`decodes: ${vector.name}`, () => {
+      const decoded = decodePairingCode(vector.code);
+      assert.deepEqual(toVectorShape(decoded), vector.payload);
+    });
+  }
+
+  for (const vector of vectors.valid.filter((v) => !v.decodeOnly)) {
+    test(`encodes canonically: ${vector.name}`, () => {
+      assert.equal(encodePairingCode(fromVectorShape(vector.payload)), vector.code);
+    });
+  }
+
+  for (const vector of vectors.invalid) {
+    test(`rejects (${vector.error}): ${vector.name}`, () => {
+      assert.throws(
+        () => decodePairingCode(vector.code),
+        (error) => error instanceof PairingCodeError && error.code === vector.error,
+      );
+    });
+  }
+});
+
+suite("encodePairingCode", () => {
+  const base = {
+    addresses: ["192.168.1.42"],
+    port: 22,
+    username: "ada",
+    hostKeyFingerprint: "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg",
+  };
+
+  test("round-trips through decode", () => {
+    const decoded = decodePairingCode(encodePairingCode(base));
+    assert.deepEqual(decoded, base);
+  });
+
+  test("rejects invalid payloads before encoding", () => {
+    const bads = [
+      { ...base, addresses: [] },
+      { ...base, port: 0 },
+      { ...base, port: 22.5 },
+      { ...base, username: "" },
+      { ...base, hostKeyFingerprint: "MD5:abc" },
+      { ...base, bootstrapSeed: Buffer.alloc(31), expiresAt: 1753305600 },
+      { ...base, bootstrapSeed: Buffer.alloc(32) },
+      { ...base, expiresAt: 1753305600 },
+    ];
+    for (const bad of bads) {
+      assert.throws(
+        () => encodePairingCode(bad),
+        (error) => error instanceof PairingCodeError && error.code === "bad_payload",
+      );
+    }
+  });
+
+  test("round-trips a bootstrap seed as raw bytes", () => {
+    const seed = Buffer.from(Array.from({ length: 32 }, (_, i) => 255 - i));
+    const decoded = decodePairingCode(
+      encodePairingCode({ ...base, bootstrapSeed: seed, expiresAt: 1753305600 }),
+    );
+    assert.deepEqual(decoded.bootstrapSeed, seed);
+    assert.equal(decoded.expiresAt, 1753305600);
+  });
+});

--- a/plugin/test/host-key.test.js
+++ b/plugin/test/host-key.test.js
@@ -1,0 +1,68 @@
+import { test, suite } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { fingerprintPublicKeyLine, readHostKeyFingerprint } from "../src/host-key.js";
+
+// Generated with ssh-keygen; fingerprint confirmed via `ssh-keygen -lf`.
+const ED25519_PUB =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBPd+KiPbQwFzIFqVCaK0me6kR0BrPZ9HFcsl7WKcFXC vector";
+const ED25519_FP = "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg";
+
+suite("fingerprintPublicKeyLine", () => {
+  test("matches ssh-keygen -lf output", () => {
+    assert.deepEqual(fingerprintPublicKeyLine(ED25519_PUB), {
+      keyType: "ssh-ed25519",
+      fingerprint: ED25519_FP,
+    });
+  });
+
+  test("accepts a line without a comment", () => {
+    const [keyType, blob] = ED25519_PUB.split(" ");
+    assert.equal(fingerprintPublicKeyLine(`${keyType} ${blob}`).fingerprint, ED25519_FP);
+  });
+
+  test("rejects garbage", () => {
+    for (const line of ["", "ssh-ed25519", "ssh-ed25519 !!!", "just words here"]) {
+      assert.throws(() => fingerprintPublicKeyLine(line));
+    }
+  });
+});
+
+suite("readHostKeyFingerprint", () => {
+  test("prefers ed25519 over other host keys", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pair-hostkey-"));
+    try {
+      writeFileSync(join(dir, "ssh_host_rsa_key.pub"), `${ED25519_PUB}\n`);
+      writeFileSync(join(dir, "ssh_host_ed25519_key.pub"), `${ED25519_PUB}\n`);
+      const result = readHostKeyFingerprint(dir);
+      assert.equal(result.fingerprint, ED25519_FP);
+      assert.equal(result.path, join(dir, "ssh_host_ed25519_key.pub"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to the next key type when ed25519 is missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pair-hostkey-"));
+    try {
+      writeFileSync(join(dir, "ssh_host_rsa_key.pub"), `${ED25519_PUB}\n`);
+      const result = readHostKeyFingerprint(dir);
+      assert.equal(result.fingerprint, ED25519_FP);
+      assert.equal(result.path, join(dir, "ssh_host_rsa_key.pub"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns null when no host key exists", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pair-hostkey-"));
+    try {
+      assert.equal(readHostKeyFingerprint(dir), null);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugin/test/pair-accept.test.js
+++ b/plugin/test/pair-accept.test.js
@@ -13,7 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { beginPairing, pendingPath } from "../src/pairing-session.js";
+import { beginPairing, pendingPath, readEnrollment } from "../src/pairing-session.js";
 import { authorizedKeysPath, editAuthorizedKeys, parseBootstrapLine } from "../src/authorized-keys.js";
 
 const ACCEPT_SCRIPT = fileURLToPath(new URL("../src/pair-accept.js", import.meta.url));
@@ -88,6 +88,18 @@ suite("pair-accept", () => {
     assert.equal(result.stdout.trim(), `HERDR-ENROLL:OK:${DEVICE_FINGERPRINT}`);
     assert.equal(readKeys(), `${USER_LINE}\n${DEVICE_LINE}\n`);
     assert.equal(existsSync(pendingPath(stateDir, session.pairingId)), false);
+    // The popup reads this record to show the enrolled fingerprint and revoke.
+    assert.deepEqual(readEnrollment(stateDir, session.pairingId), {
+      pairingId: session.pairingId,
+      fingerprint: DEVICE_FINGERPRINT,
+      line: DEVICE_LINE,
+    });
+  });
+
+  test("a rejected submission leaves no enrollment record", async () => {
+    const session = await beginPairing({ home, stateDir });
+    runAccept(session.pairingId, "ssh-rsa AAAAB3nope\n");
+    assert.equal(readEnrollment(stateDir, session.pairingId), null);
   });
 
   test("an invalid submission does not consume the bootstrap line; retry works", async () => {

--- a/plugin/test/pair-accept.test.js
+++ b/plugin/test/pair-accept.test.js
@@ -1,0 +1,139 @@
+// Lifecycle tests for the Enrollment accept entrypoint (ADR 0007).
+//
+// pair-accept.js runs as an sshd forced command, so these tests exercise it
+// the same way: a real child process with a faked minimal environment and a
+// temp HOME. Real sshd semantics (restrict, forced command, StrictModes) are
+// covered by the app-side e2e suite against localhost sshd.
+
+import { test, suite, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { beginPairing, pendingPath } from "../src/pairing-session.js";
+import { authorizedKeysPath, editAuthorizedKeys, parseBootstrapLine } from "../src/authorized-keys.js";
+
+const ACCEPT_SCRIPT = fileURLToPath(new URL("../src/pair-accept.js", import.meta.url));
+
+// Generated with ssh-keygen; fingerprint confirmed via `ssh-keygen -lf`.
+const DEVICE_LINE =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMYSCTemrZWEXptQyehHLI9kbqjHxNUGtQN2lF1ucCce herdr-mobile";
+const DEVICE_FINGERPRINT = "SHA256:ef+f9Jda6ZPkcW5GiL7pQZXJ57mCFnFAGkir3AcfTIM";
+const USER_LINE =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBPd+KiPbQwFzIFqVCaK0me6kR0BrPZ9HFcsl7WKcFXC laptop";
+
+let home;
+let stateDir;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "pair-accept-"));
+  stateDir = join(home, "plugin-state");
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+function runAccept(pairingId, input) {
+  const result = spawnSync(
+    process.execPath,
+    [ACCEPT_SCRIPT, "--state-dir", stateDir, "--pairing-id", pairingId],
+    { input, encoding: "utf8", env: { HOME: home, PATH: process.env.PATH }, timeout: 15_000 },
+  );
+  assert.equal(result.error, undefined);
+  return result;
+}
+
+function readKeys() {
+  return readFileSync(authorizedKeysPath(home), "utf8");
+}
+
+function bootstrapLinesIn(content) {
+  return content
+    .trimEnd()
+    .split("\n")
+    .filter((line) => parseBootstrapLine(line) !== null);
+}
+
+suite("pair-accept", () => {
+  test("enrolls a valid Device Key and self-revokes the bootstrap line", async () => {
+    await editAuthorizedKeys(home, () => [USER_LINE]);
+    const session = await beginPairing({ home, stateDir });
+
+    const result = runAccept(session.pairingId, `${DEVICE_LINE}\n`);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), `HERDR-ENROLL:OK:${DEVICE_FINGERPRINT}`);
+    assert.equal(readKeys(), `${USER_LINE}\n${DEVICE_LINE}\n`);
+    assert.equal(existsSync(pendingPath(stateDir, session.pairingId)), false);
+  });
+
+  test("an invalid submission does not consume the bootstrap line; retry works", async () => {
+    const session = await beginPairing({ home, stateDir });
+
+    const invalid = runAccept(session.pairingId, "ssh-rsa AAAAB3nope\n");
+    assert.equal(invalid.status, 1);
+    assert.equal(invalid.stdout.trim(), "HERDR-ENROLL:ERR:invalid_key");
+    assert.equal(bootstrapLinesIn(readKeys()).length, 1);
+    assert.equal(existsSync(pendingPath(stateDir, session.pairingId)), true);
+
+    const retry = runAccept(session.pairingId, `${DEVICE_LINE}\n`);
+    assert.equal(retry.status, 0, retry.stderr);
+    assert.equal(readKeys(), `${DEVICE_LINE}\n`);
+  });
+
+  test("an empty submission is rejected without consuming the line", async () => {
+    const session = await beginPairing({ home, stateDir });
+    const result = runAccept(session.pairingId, "");
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout.trim(), "HERDR-ENROLL:ERR:no_input");
+    assert.equal(bootstrapLinesIn(readKeys()).length, 1);
+  });
+
+  test("an expired pairing removes its line and rejects", async () => {
+    const past = Math.floor(Date.now() / 1000) - 600;
+    const session = await beginPairing({ home, stateDir, now: past });
+
+    const result = runAccept(session.pairingId, `${DEVICE_LINE}\n`);
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout.trim(), "HERDR-ENROLL:ERR:expired");
+    assert.equal(bootstrapLinesIn(readKeys()).length, 0);
+    assert.equal(readKeys().includes(DEVICE_LINE), false);
+    assert.equal(existsSync(pendingPath(stateDir, session.pairingId)), false);
+  });
+
+  test("an unknown pairing id is rejected", async () => {
+    await beginPairing({ home, stateDir });
+    const result = runAccept("deadbeef0000", `${DEVICE_LINE}\n`);
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout.trim(), "HERDR-ENROLL:ERR:unknown_pairing");
+  });
+
+  test("the bootstrap line is single use", async () => {
+    const session = await beginPairing({ home, stateDir });
+
+    const first = runAccept(session.pairingId, `${DEVICE_LINE}\n`);
+    assert.equal(first.status, 0, first.stderr);
+
+    const second = runAccept(session.pairingId, `${DEVICE_LINE}\n`);
+    assert.equal(second.status, 1);
+    assert.equal(second.stdout.trim(), "HERDR-ENROLL:ERR:unknown_pairing");
+    assert.equal(readKeys(), `${DEVICE_LINE}\n`);
+  });
+
+  test("re-enrolling an already-authorized Device Key succeeds without a duplicate", async () => {
+    const first = await beginPairing({ home, stateDir });
+    runAccept(first.pairingId, `${DEVICE_LINE}\n`);
+
+    const second = await beginPairing({ home, stateDir });
+    const result = runAccept(second.pairingId, `${DEVICE_LINE}\n`);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), `HERDR-ENROLL:OK:${DEVICE_FINGERPRINT}`);
+    assert.equal(readKeys(), `${DEVICE_LINE}\n`);
+  });
+});

--- a/plugin/test/pair-accept.test.js
+++ b/plugin/test/pair-accept.test.js
@@ -13,7 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { beginPairing, pendingPath, readEnrollment } from "../src/pairing-session.js";
+import { beginPairing, expirePairing, pendingPath, readEnrollment } from "../src/pairing-session.js";
 import { authorizedKeysPath, editAuthorizedKeys, parseBootstrapLine } from "../src/authorized-keys.js";
 
 const ACCEPT_SCRIPT = fileURLToPath(new URL("../src/pair-accept.js", import.meta.url));
@@ -166,6 +166,54 @@ suite("pair-accept", () => {
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.stdout.trim(), `HERDR-ENROLL:OK:${DEVICE_FINGERPRINT}`);
     assert.equal(readKeys(), `${DEVICE_LINE}\n`);
+  });
+
+  test("expiring after an enroll returns the record instead of expiring", async () => {
+    const session = await beginPairing({ home, stateDir });
+    const accept = runAccept(session.pairingId, `${DEVICE_LINE}\n`);
+    assert.equal(accept.status, 0, accept.stderr);
+
+    const record = await expirePairing({ home, stateDir, pairingId: session.pairingId });
+
+    assert.equal(record?.fingerprint, DEVICE_FINGERPRINT);
+    assert.ok(readKeys().includes(DEVICE_LINE));
+    // The record survives so the popup can still offer the revoke.
+    assert.notEqual(readEnrollment(stateDir, session.pairingId), null);
+  });
+
+  test("expiring before the accept runs consumes the pairing", async () => {
+    const session = await beginPairing({ home, stateDir });
+
+    const record = await expirePairing({ home, stateDir, pairingId: session.pairingId });
+    assert.equal(record, null);
+
+    const result = runAccept(session.pairingId, `${DEVICE_LINE}\n`);
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout.trim(), "HERDR-ENROLL:ERR:unknown_pairing");
+    assert.equal(readKeys().includes(DEVICE_LINE), false);
+    assert.equal(readEnrollment(stateDir, session.pairingId), null);
+  });
+
+  test("an expiry racing an accept never enrolls a device silently", async () => {
+    const session = await beginPairing({ home, stateDir });
+
+    const [result, record] = await Promise.all([
+      runAcceptAsync(session.pairingId, `${DEVICE_LINE}\n`),
+      expirePairing({ home, stateDir, pairingId: session.pairingId }),
+    ]);
+
+    if (readKeys().includes(DEVICE_LINE)) {
+      // The accept won: the popup's locked expiry check must have seen the
+      // record, or it would render "expired" over a silently enrolled device.
+      assert.equal(result.stdout.trim(), `HERDR-ENROLL:OK:${DEVICE_FINGERPRINT}`);
+      assert.equal(record?.fingerprint, DEVICE_FINGERPRINT);
+    } else {
+      // The expiry won: nothing enrolled, no record, the accept rejected.
+      assert.equal(record, null);
+      assert.equal(result.status, 1);
+      assert.equal(readEnrollment(stateDir, session.pairingId), null);
+    }
+    assert.equal(bootstrapLinesIn(readKeys()).length, 0);
   });
 
   test("two concurrent accepts enroll the Device Key exactly once", async () => {

--- a/plugin/test/pair-accept.test.js
+++ b/plugin/test/pair-accept.test.js
@@ -88,9 +88,11 @@ suite("pair-accept", () => {
     assert.equal(result.stdout.trim(), `HERDR-ENROLL:OK:${DEVICE_FINGERPRINT}`);
     assert.equal(readKeys(), `${USER_LINE}\n${DEVICE_LINE}\n`);
     assert.equal(existsSync(pendingPath(stateDir, session.pairingId)), false);
-    // The popup reads this record to show the enrolled fingerprint and revoke.
+    // The popup reads this record to show the enrolled fingerprint and revoke;
+    // the expiry lets the startup sweep age out records a killed popup left.
     assert.deepEqual(readEnrollment(stateDir, session.pairingId), {
       pairingId: session.pairingId,
+      expiresAt: session.expiresAt,
       fingerprint: DEVICE_FINGERPRINT,
       line: DEVICE_LINE,
     });

--- a/plugin/test/pair-accept.test.js
+++ b/plugin/test/pair-accept.test.js
@@ -7,7 +7,7 @@
 
 import { test, suite, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -45,6 +45,25 @@ function runAccept(pairingId, input) {
   );
   assert.equal(result.error, undefined);
   return result;
+}
+
+// Async counterpart to runAccept: spawn without blocking so two accepts can
+// race against the same pairing in a single event loop.
+function runAcceptAsync(pairingId, input) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [ACCEPT_SCRIPT, "--state-dir", stateDir, "--pairing-id", pairingId],
+      { env: { HOME: home, PATH: process.env.PATH } },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("error", reject);
+    child.on("close", (status) => resolve({ status, stdout, stderr }));
+    child.stdin.end(input);
+  });
 }
 
 function readKeys() {
@@ -135,5 +154,27 @@ suite("pair-accept", () => {
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.stdout.trim(), `HERDR-ENROLL:OK:${DEVICE_FINGERPRINT}`);
     assert.equal(readKeys(), `${DEVICE_LINE}\n`);
+  });
+
+  test("two concurrent accepts enroll the Device Key exactly once", async () => {
+    await editAuthorizedKeys(home, () => [USER_LINE]);
+    const session = await beginPairing({ home, stateDir });
+
+    const [a, b] = await Promise.all([
+      runAcceptAsync(session.pairingId, `${DEVICE_LINE}\n`),
+      runAcceptAsync(session.pairingId, `${DEVICE_LINE}\n`),
+    ]);
+
+    // Exactly one winner enrolls; the loser sees the pairing already consumed.
+    const outcomes = [a.stdout.trim(), b.stdout.trim()].sort();
+    assert.deepEqual(outcomes, [
+      "HERDR-ENROLL:ERR:unknown_pairing",
+      `HERDR-ENROLL:OK:${DEVICE_FINGERPRINT}`,
+    ]);
+
+    // One Device Key line, no leftover bootstrap line.
+    assert.equal(readKeys(), `${USER_LINE}\n${DEVICE_LINE}\n`);
+    assert.equal(bootstrapLinesIn(readKeys()).length, 0);
+    assert.equal(existsSync(pendingPath(stateDir, session.pairingId)), false);
   });
 });

--- a/plugin/test/pairing-session.test.js
+++ b/plugin/test/pairing-session.test.js
@@ -1,6 +1,15 @@
 import { test, suite, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13,6 +22,7 @@ import {
   pendingPath,
   readEnrollment,
   recordEnrollment,
+  sweepExpiredStateFiles,
   PAIRING_TTL_SECONDS,
 } from "../src/pairing-session.js";
 import { authorizedKeysPath, parseBootstrapLine, editAuthorizedKeys } from "../src/authorized-keys.js";
@@ -86,15 +96,17 @@ const DEVICE_LINE =
 const DEVICE_FINGERPRINT = "SHA256:ef+f9Jda6ZPkcW5GiL7pQZXJ57mCFnFAGkir3AcfTIM";
 
 suite("enrollment record", () => {
-  test("round-trips fingerprint and line, written 0600", () => {
+  test("round-trips fingerprint, line, and expiry, written 0600", () => {
     recordEnrollment({
       stateDir,
       pairingId: "abc123",
+      expiresAt: NOW,
       fingerprint: DEVICE_FINGERPRINT,
       line: DEVICE_LINE,
     });
     assert.deepEqual(readEnrollment(stateDir, "abc123"), {
       pairingId: "abc123",
+      expiresAt: NOW,
       fingerprint: DEVICE_FINGERPRINT,
       line: DEVICE_LINE,
     });
@@ -103,6 +115,59 @@ suite("enrollment record", () => {
 
   test("readEnrollment is null when there is no record", () => {
     assert.equal(readEnrollment(stateDir, "missing"), null);
+  });
+});
+
+suite("sweepExpiredStateFiles", () => {
+  // Real clock: the sweep's fallback for unreadable files compares mtime.
+  const now = Math.floor(Date.now() / 1000);
+
+  function enrolledRecord(pairingId, expiresAt) {
+    recordEnrollment({
+      stateDir,
+      pairingId,
+      expiresAt,
+      fingerprint: DEVICE_FINGERPRINT,
+      line: DEVICE_LINE,
+    });
+  }
+
+  test("removes expired pending and stale enrolled records, keeps live ones", async () => {
+    const dead = await beginPairing({ home, stateDir, now: now - 10 * PAIRING_TTL_SECONDS });
+    const live = await beginPairing({ home, stateDir, now });
+    enrolledRecord("stale", now - 10 * PAIRING_TTL_SECONDS);
+    enrolledRecord("fresh", now + PAIRING_TTL_SECONDS);
+
+    assert.equal(sweepExpiredStateFiles(stateDir, now), 2);
+
+    assert.equal(existsSync(pendingPath(stateDir, dead.pairingId)), false);
+    assert.equal(existsSync(pendingPath(stateDir, live.pairingId)), true);
+    assert.equal(readEnrollment(stateDir, "stale"), null);
+    assert.notEqual(readEnrollment(stateDir, "fresh"), null);
+  });
+
+  test("keeps an enrolled record inside its grace window", () => {
+    // Just past its ceremony's expiry: a live popup may not have read it yet.
+    enrolledRecord("graceful", now - 1);
+    assert.equal(sweepExpiredStateFiles(stateDir, now), 0);
+    assert.notEqual(readEnrollment(stateDir, "graceful"), null);
+  });
+
+  test("ages out unreadable state files by mtime", () => {
+    mkdirSync(join(stateDir, "pending"), { recursive: true });
+    const stale = join(stateDir, "pending", "garbage-old.json");
+    writeFileSync(stale, "not json");
+    utimesSync(stale, now - 3600, now - 3600);
+    const fresh = join(stateDir, "pending", "garbage-new.json");
+    writeFileSync(fresh, "not json");
+
+    assert.equal(sweepExpiredStateFiles(stateDir, now), 1);
+    assert.equal(existsSync(stale), false);
+    assert.equal(existsSync(fresh), true);
+  });
+
+  test("is a no-op when the state dir does not exist yet", () => {
+    assert.equal(sweepExpiredStateFiles(join(home, "no-such-state")), 0);
   });
 });
 

--- a/plugin/test/pairing-session.test.js
+++ b/plugin/test/pairing-session.test.js
@@ -9,6 +9,7 @@ import {
   beginPairing,
   endPairing,
   enrolledPath,
+  expirePairing,
   pendingPath,
   readEnrollment,
   recordEnrollment,
@@ -102,6 +103,40 @@ suite("enrollment record", () => {
 
   test("readEnrollment is null when there is no record", () => {
     assert.equal(readEnrollment(stateDir, "missing"), null);
+  });
+});
+
+suite("expirePairing", () => {
+  test("removes the bootstrap line and pending state when nothing enrolled", async () => {
+    await editAuthorizedKeys(home, () => [USER_LINE]);
+    const session = await beginPairing({ home, stateDir, now: NOW });
+
+    const record = await expirePairing({ home, stateDir, pairingId: session.pairingId });
+
+    assert.equal(record, null);
+    assert.equal(readKeys(), `${USER_LINE}\n`);
+    assert.equal(existsSync(pendingPath(stateDir, session.pairingId)), false);
+  });
+
+  test("returns the enrollment record and touches nothing when a device enrolled", async () => {
+    await editAuthorizedKeys(home, () => [USER_LINE]);
+    const session = await beginPairing({ home, stateDir, now: NOW });
+    recordEnrollment({
+      stateDir,
+      pairingId: session.pairingId,
+      expiresAt: session.expiresAt,
+      fingerprint: DEVICE_FINGERPRINT,
+      line: DEVICE_LINE,
+    });
+    const keysBefore = readKeys();
+
+    const record = await expirePairing({ home, stateDir, pairingId: session.pairingId });
+
+    assert.equal(record?.fingerprint, DEVICE_FINGERPRINT);
+    assert.equal(record?.line, DEVICE_LINE);
+    assert.equal(readKeys(), keysBefore);
+    assert.equal(existsSync(pendingPath(stateDir, session.pairingId)), true);
+    assert.equal(existsSync(enrolledPath(stateDir, session.pairingId)), true);
   });
 });
 

--- a/plugin/test/pairing-session.test.js
+++ b/plugin/test/pairing-session.test.js
@@ -5,7 +5,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { beginPairing, endPairing, pendingPath, PAIRING_TTL_SECONDS } from "../src/pairing-session.js";
+import {
+  beginPairing,
+  endPairing,
+  enrolledPath,
+  pendingPath,
+  readEnrollment,
+  recordEnrollment,
+  PAIRING_TTL_SECONDS,
+} from "../src/pairing-session.js";
 import { authorizedKeysPath, parseBootstrapLine, editAuthorizedKeys } from "../src/authorized-keys.js";
 import { publicLineFromSeed } from "../src/bootstrap-key.js";
 
@@ -72,13 +80,45 @@ suite("beginPairing", () => {
   });
 });
 
+const DEVICE_LINE =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMYSCTemrZWEXptQyehHLI9kbqjHxNUGtQN2lF1ucCce herdr-mobile";
+const DEVICE_FINGERPRINT = "SHA256:ef+f9Jda6ZPkcW5GiL7pQZXJ57mCFnFAGkir3AcfTIM";
+
+suite("enrollment record", () => {
+  test("round-trips fingerprint and line, written 0600", () => {
+    recordEnrollment({
+      stateDir,
+      pairingId: "abc123",
+      fingerprint: DEVICE_FINGERPRINT,
+      line: DEVICE_LINE,
+    });
+    assert.deepEqual(readEnrollment(stateDir, "abc123"), {
+      pairingId: "abc123",
+      fingerprint: DEVICE_FINGERPRINT,
+      line: DEVICE_LINE,
+    });
+    assert.equal(statSync(enrolledPath(stateDir, "abc123")).mode & 0o777, 0o600);
+  });
+
+  test("readEnrollment is null when there is no record", () => {
+    assert.equal(readEnrollment(stateDir, "missing"), null);
+  });
+});
+
 suite("endPairing", () => {
-  test("removes the bootstrap line and the pending state", async () => {
+  test("removes the bootstrap line, the pending state, and the enrollment record", async () => {
     await editAuthorizedKeys(home, () => [USER_LINE]);
     const session = await beginPairing({ home, stateDir, now: NOW });
+    recordEnrollment({
+      stateDir,
+      pairingId: session.pairingId,
+      fingerprint: DEVICE_FINGERPRINT,
+      line: DEVICE_LINE,
+    });
     await endPairing({ home, stateDir, pairingId: session.pairingId });
     assert.equal(readKeys(), `${USER_LINE}\n`);
     assert.equal(existsSync(pendingPath(stateDir, session.pairingId)), false);
+    assert.equal(existsSync(enrolledPath(stateDir, session.pairingId)), false);
   });
 
   test("is idempotent", async () => {

--- a/plugin/test/pairing-session.test.js
+++ b/plugin/test/pairing-session.test.js
@@ -1,0 +1,90 @@
+import { test, suite, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { beginPairing, endPairing, pendingPath, PAIRING_TTL_SECONDS } from "../src/pairing-session.js";
+import { authorizedKeysPath, parseBootstrapLine, editAuthorizedKeys } from "../src/authorized-keys.js";
+import { publicLineFromSeed } from "../src/bootstrap-key.js";
+
+const ACCEPT_SCRIPT = fileURLToPath(new URL("../src/pair-accept.js", import.meta.url));
+const USER_LINE =
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBPd+KiPbQwFzIFqVCaK0me6kR0BrPZ9HFcsl7WKcFXC laptop";
+const NOW = 1753305600;
+
+let home;
+let stateDir;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "pair-home-"));
+  stateDir = join(home, "plugin-state");
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+function readKeys() {
+  return readFileSync(authorizedKeysPath(home), "utf8");
+}
+
+suite("beginPairing", () => {
+  test("writes a restricted bootstrap line and matching pending state", async () => {
+    const session = await beginPairing({ home, stateDir, now: NOW });
+
+    assert.equal(session.seed.length, 32);
+    assert.equal(session.expiresAt, NOW + PAIRING_TTL_SECONDS);
+    assert.equal(session.publicLine, publicLineFromSeed(session.seed));
+
+    const lines = readKeys().trimEnd().split("\n");
+    assert.equal(lines.length, 1);
+    const line = lines[0];
+    assert.ok(line.startsWith('restrict,command="'), "line must start with restrict,command=");
+    assert.ok(line.includes(`'${process.execPath}'`), "command must pin the node binary");
+    assert.ok(line.includes(`'${ACCEPT_SCRIPT}'`), "command must point at pair-accept.js");
+    assert.ok(line.includes(`--state-dir '${stateDir}'`), "command must carry the state dir");
+    assert.ok(line.includes(`--pairing-id ${session.pairingId}`), "command must carry the id");
+    assert.ok(line.includes(session.publicLine), "line must carry the bootstrap public key");
+    assert.deepEqual(parseBootstrapLine(line), {
+      pairingId: session.pairingId,
+      expiresAt: session.expiresAt,
+    });
+
+    const pending = JSON.parse(readFileSync(pendingPath(stateDir, session.pairingId), "utf8"));
+    assert.equal(pending.pairingId, session.pairingId);
+    assert.equal(pending.expiresAt, session.expiresAt);
+    assert.equal(pending.publicLine, session.publicLine);
+    assert.equal(statSync(pendingPath(stateDir, session.pairingId)).mode & 0o777, 0o600);
+  });
+
+  test("keeps existing authorized_keys entries", async () => {
+    await editAuthorizedKeys(home, () => [USER_LINE]);
+    await beginPairing({ home, stateDir, now: NOW });
+    assert.ok(readKeys().startsWith(`${USER_LINE}\n`));
+  });
+
+  test("rejects a state dir the forced command cannot quote", async () => {
+    await assert.rejects(
+      beginPairing({ home, stateDir: join(home, "state'dir"), now: NOW }),
+    );
+  });
+});
+
+suite("endPairing", () => {
+  test("removes the bootstrap line and the pending state", async () => {
+    await editAuthorizedKeys(home, () => [USER_LINE]);
+    const session = await beginPairing({ home, stateDir, now: NOW });
+    await endPairing({ home, stateDir, pairingId: session.pairingId });
+    assert.equal(readKeys(), `${USER_LINE}\n`);
+    assert.equal(existsSync(pendingPath(stateDir, session.pairingId)), false);
+  });
+
+  test("is idempotent", async () => {
+    const session = await beginPairing({ home, stateDir, now: NOW });
+    await endPairing({ home, stateDir, pairingId: session.pairingId });
+    await endPairing({ home, stateDir, pairingId: session.pairingId });
+    assert.equal(readKeys(), "");
+  });
+});

--- a/plugin/test/select-list.test.js
+++ b/plugin/test/select-list.test.js
@@ -1,0 +1,62 @@
+import { test, suite } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createSelection,
+  moveCursor,
+  toggleCurrent,
+  toggleAll,
+  selectedAddresses,
+} from "../src/select-list.js";
+
+const candidates = [
+  { address: "192.168.1.42", family: "IPv4", interfaceName: "en0", preChecked: true },
+  { address: "100.101.102.103", family: "IPv4", interfaceName: "utun3", preChecked: true },
+  { address: "203.0.113.9", family: "IPv4", interfaceName: "en1", preChecked: false },
+];
+
+suite("selection list", () => {
+  test("starts with pre-checked candidates selected and cursor on the first row", () => {
+    const state = createSelection(candidates);
+    assert.equal(state.cursor, 0);
+    assert.deepEqual(selectedAddresses(state), ["192.168.1.42", "100.101.102.103"]);
+  });
+
+  test("cursor movement clamps at both ends", () => {
+    let state = createSelection(candidates);
+    state = moveCursor(state, -1);
+    assert.equal(state.cursor, 0);
+    state = moveCursor(moveCursor(moveCursor(state, 1), 1), 1);
+    assert.equal(state.cursor, 2);
+  });
+
+  test("toggling flips only the row under the cursor", () => {
+    let state = createSelection(candidates);
+    state = toggleCurrent(moveCursor(state, 1));
+    assert.deepEqual(selectedAddresses(state), ["192.168.1.42"]);
+    state = toggleCurrent(state);
+    assert.deepEqual(selectedAddresses(state), ["192.168.1.42", "100.101.102.103"]);
+  });
+
+  test("toggle all checks everything, then unchecks everything", () => {
+    let state = createSelection(candidates);
+    state = toggleAll(state);
+    assert.deepEqual(
+      selectedAddresses(state),
+      ["192.168.1.42", "100.101.102.103", "203.0.113.9"],
+    );
+    state = toggleAll(state);
+    assert.deepEqual(selectedAddresses(state), []);
+  });
+
+  test("selected addresses keep candidate order regardless of toggle order", () => {
+    let state = createSelection(candidates);
+    state = moveCursor(state, 1);
+    state = moveCursor(state, 1);
+    state = toggleCurrent(state); // check 203.0.113.9 last
+    assert.deepEqual(
+      selectedAddresses(state),
+      ["192.168.1.42", "100.101.102.103", "203.0.113.9"],
+    );
+  });
+});

--- a/project.yml
+++ b/project.yml
@@ -22,7 +22,7 @@ packages:
   # libghostty's public API is still evolving independently from Ghostty.
   GhosttyTerminal:
     url: https://github.com/lakr233/libghostty-spm.git
-    exactVersion: "1.3.2"
+    exactVersion: "1.3.1"
 
 targets:
   HerdrMobile:

--- a/project.yml
+++ b/project.yml
@@ -57,6 +57,10 @@ targets:
     platform: iOS
     sources:
       - Tests/HerdrMobileTests
+      # Shared Pairing Code vectors (ADR 0007): the same file the Node plugin
+      # tests consume, bundled so the Swift tests cannot drift from it.
+      - path: plugin/test-vectors/pairing-code-v1.json
+        buildPhase: resources
     settings:
       base:
         GENERATE_INFOPLIST_FILE: YES

--- a/project.yml
+++ b/project.yml
@@ -40,6 +40,8 @@ targets:
         # speech-recognition usage key is set: the iOS 26 SpeechAnalyzer stack
         # is on-device and needs no legacy SFSpeechRecognizer authorization.
         INFOPLIST_KEY_NSMicrophoneUsageDescription: "herdr uses the microphone to transcribe your spoken reply into the message box. Audio is processed on device and never leaves your phone."
+        # Scan to Pair (#62) reads the Pairing Code QR from the computer screen.
+        INFOPLIST_KEY_NSCameraUsageDescription: "herdr uses the camera to scan the Pairing Code shown on your computer, so you can add that machine without typing anything."
         # iPhone + iPad.
         TARGETED_DEVICE_FAMILY: "1,2"
         INFOPLIST_KEY_UILaunchScreen_Generation: YES


### PR DESCRIPTION
## Summary

Implements the Pairing feature (refs #60, sub-issues #61-#66, design fixed in ADR 0007): adding a Host becomes one QR scan — no typed addresses, no hand-carried `authorized_keys` line, no blind TOFU prompt.

**Server side** — a Node >= 20 herdr plugin under `plugin/` (`herdr plugin link` for development):
- `pair` action opens a popup pane: address selection (non-loopback enumerated, private/Tailscale/ULA pre-checked) → QR of a versioned Pairing Code (addresses, port, username, host key fingerprint, Bootstrap Key seed, expiry).
- Bootstrap Key lifecycle: single-use, 2-minute TTL, `restrict,command=` line written atomically; the accept entrypoint strictly validates the submitted Device Key line, enrolls it and self-revokes inside one locked critical section; expiry, popup exit, and a startup sweep (lines + state files) leave no residue.
- Post-Enrollment screen shows the enrolled device fingerprint with a one-key revoke — the compensating control for fully automatic enrollment.

**App side**:
- Swift decoder for the Pairing Code envelope; Node and Swift test suites consume the same shared vectors (`plugin/test-vectors/pairing-code-v1.json`).
- VisionKit scanner as the primary add-Host action (manual form remains the fallback, reachable directly from the camera-denied/unsupported states).
- Ceremony client behind a `PairingConnector` protocol seam beside `SSHTransport`: candidate addresses in order with short timeouts, host key pinned from the code on every connect (no TOFU), enroll over exec, verified Device Key reconnect; failures classified per step (parse/reach/authenticate/enroll/verify).
- The Host is persisted only after the verified reconnect; failures leave nothing behind; success hands off to the existing preflight/session discovery.

## Testing

- Plugin: 102 Node tests (lifecycle against temp HOMEs, true-concurrency single-use race, ssh-keygen-derived vectors).
- App: full suite 358 tests / 48 suites green, including real-sshd e2e that runs the actual ceremony with the real accept script as forced command and restores `~/.ssh/authorized_keys` byte-exact (SHA-256 verified).
- Manual: live `herdr plugin link` demo of the popup; simulator UI pass over the scan flow (camera-denied fallback, manual handoff, add-Host regression) via scripted GUI run.
- CI gains a `plugin-test` job (first run happens on this PR — watch it).

## Known limitations / follow-ups

- Live-QR camera scan and the one-scan end-to-end demo require a physical device; tracked for on-device verification before closing #60.
- Pairing Code generation assumes SSH port 22 and reads host keys from `/etc/ssh` (documented in `plugin/README.md`); decoder and ceremony already honor arbitrary ports.
- Publishing the plugin via `herdr plugin install` requires this repo to become public; development flow is `herdr plugin link`.