### PR TITLE
feat(terminal): persist a global terminal zoom level

### DIFF
--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		8181681FBF45216B52EEBC1A /* NotificationKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F246F98BBDAEF3A331C14F9 /* NotificationKeyStore.swift */; };
 		8196491DBF3B6024B4DB214C /* SSHChannelBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13D82A3B3C17DBFB114AAF0A /* SSHChannelBudget.swift */; };
 		822F39E2EA06AE24955F8169 /* AgentNotificationBannerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA3E6B129B6CAD15FD3C5DE /* AgentNotificationBannerStoreTests.swift */; };
+		8381585C97479412A40A4FC8 /* TerminalZoomSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B1FCCEF619BD597ECD3353 /* TerminalZoomSettings.swift */; };
 		84A27FDC256CFA71D883A85A /* NotificationRelaySettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A20C4012D69BDE51F1FF25 /* NotificationRelaySettingsTests.swift */; };
 		8558806B5DFE751EB1FA3814 /* PairingCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1FDF65F7282EF79C3D376C /* PairingCodeTests.swift */; };
 		86B92C748144DAFC8D1E1609 /* AgentNotificationRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8461D2396E779D5A29631FD /* AgentNotificationRendererTests.swift */; };
@@ -152,6 +153,7 @@
 		E908289DF03C6732F7D91328 /* HerdrEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */; };
 		EAA349947E6AF58625E35481 /* HerdrNotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 0C40CAB15B8223BC58AB39F1 /* HerdrNotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		EB02A35634A4D6572637DEF4 /* HerdrMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */; };
+		ECC2A0575FFC9EB286B9F8AC /* TerminalZoomSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099B4DEE5E08C6246009D0EB /* TerminalZoomSettingsTests.swift */; };
 		EDC4E8E45B766F1EEB960B6F /* AgentNotificationRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA9FFBCEE377FCD4C1105690 /* AgentNotificationRouterTests.swift */; };
 		EDD038140CCF519A56D01C17 /* NotificationConfigFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41707BC35CC96B155E502D0D /* NotificationConfigFileTests.swift */; };
 		EDFEE058F85AF41DBFE351A7 /* TerminalTextSelectionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786B2BA8A0683BB9DC71D797 /* TerminalTextSelectionPresenter.swift */; };
@@ -203,6 +205,7 @@
 		066F4CB4F0E9D99693B44618 /* NotificationRegistrationFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRegistrationFile.swift; sourceTree = "<group>"; };
 		079394F4C6AC8FE4D7B0779C /* ConsoleStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleStoreTests.swift; sourceTree = "<group>"; };
 		08E14A4298DB015E6477F789 /* StartAgentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStore.swift; sourceTree = "<group>"; };
+		099B4DEE5E08C6246009D0EB /* TerminalZoomSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalZoomSettingsTests.swift; sourceTree = "<group>"; };
 		0ACA2329DD2A706A72E0754E /* notification-payload-v1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "notification-payload-v1.json"; sourceTree = "<group>"; };
 		0AE274F95CDC475196D7BFE8 /* NotificationRelaySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRelaySettings.swift; sourceTree = "<group>"; };
 		0B3FA15CCDC83C72DDA81BEB /* AgentCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentCardView.swift; sourceTree = "<group>"; };
@@ -310,6 +313,7 @@
 		BE8796AB629EF68A90C96B3D /* TerminalAttachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAttachTests.swift; sourceTree = "<group>"; };
 		BEBCD83AC5D4AF0193B2AF9B /* NotificationPrivacyCopyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPrivacyCopyTests.swift; sourceTree = "<group>"; };
 		C14983BD8988E4AAE79DC46A /* FakeTransportConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeTransportConnector.swift; sourceTree = "<group>"; };
+		C1B1FCCEF619BD597ECD3353 /* TerminalZoomSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalZoomSettings.swift; sourceTree = "<group>"; };
 		C232163905675760F37FD7A0 /* KnownHostsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStore.swift; sourceTree = "<group>"; };
 		C42040EDC53770F8227FA0C2 /* NotificationEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationEnvelope.swift; sourceTree = "<group>"; };
 		C44D9663DAB1E8942FBFCD1C /* ConsoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleView.swift; sourceTree = "<group>"; };
@@ -378,6 +382,7 @@
 				0AE274F95CDC475196D7BFE8 /* NotificationRelaySettings.swift */,
 				95B5EBF6C4EC88361E91CA2C /* SettingsView.swift */,
 				A961D26EDEAA03AFB0F9C408 /* TerminalThemeSettings.swift */,
+				C1B1FCCEF619BD597ECD3353 /* TerminalZoomSettings.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -532,6 +537,7 @@
 				BE8796AB629EF68A90C96B3D /* TerminalAttachTests.swift */,
 				B75316F4E6B80E442C365765 /* TerminalInputControllerTests.swift */,
 				EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */,
+				099B4DEE5E08C6246009D0EB /* TerminalZoomSettingsTests.swift */,
 				A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */,
 				02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */,
 				CB45F25667AE3C5C2EFD76CB /* Support */,
@@ -905,6 +911,7 @@
 				EDFEE058F85AF41DBFE351A7 /* TerminalTextSelectionPresenter.swift in Sources */,
 				5D1B735C72D551ADE0D82D44 /* TerminalThemeSettings.swift in Sources */,
 				B8ACB86B152D44FC0C80DADA /* TerminalTouchScroll.swift in Sources */,
+				8381585C97479412A40A4FC8 /* TerminalZoomSettings.swift in Sources */,
 				49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */,
 				B31E16D56EE1F19A3802625B /* TransportConnector.swift in Sources */,
 			);
@@ -976,6 +983,7 @@
 				0CF1AA5AF7F2357186A5E486 /* TerminalAttachTests.swift in Sources */,
 				30A69209EA01A8DF784ABC52 /* TerminalInputControllerTests.swift in Sources */,
 				D51F828E0AC4A2F6C23A0CBE /* TerminalThemeSettingsTests.swift in Sources */,
+				ECC2A0575FFC9EB286B9F8AC /* TerminalZoomSettingsTests.swift in Sources */,
 				E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */,
 				782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */,
 				C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */,

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -8,6 +8,7 @@ struct AgentDetailView: View {
     let agent: ConsoleAgent
     private let console: ConsoleStore
     private let terminalThemes: TerminalThemeSettings
+    private let terminalZoom: TerminalZoomSettings
     private let pushRegistration: PushRegistrationStore
     private let notificationPreferences: NotificationPreferencesStore
     private let relaySettings: NotificationRelaySettings
@@ -23,6 +24,7 @@ struct AgentDetailView: View {
         agent: ConsoleAgent,
         console: ConsoleStore,
         terminalThemes: TerminalThemeSettings,
+        terminalZoom: TerminalZoomSettings,
         pushRegistration: PushRegistrationStore,
         notificationPreferences: NotificationPreferencesStore,
         relaySettings: NotificationRelaySettings
@@ -30,6 +32,7 @@ struct AgentDetailView: View {
         self.agent = agent
         self.console = console
         self.terminalThemes = terminalThemes
+        self.terminalZoom = terminalZoom
         self.pushRegistration = pushRegistration
         self.notificationPreferences = notificationPreferences
         self.relaySettings = relaySettings
@@ -54,7 +57,9 @@ struct AgentDetailView: View {
             onSend: { keystrokes in attach.send(keystrokes) },
             onPaste: { text in attach.requestPaste(text) },
             isLocalInputEnabled: attach.isLocalInputEnabled,
-            theme: terminalThemes.theme
+            theme: terminalThemes.theme,
+            fontSize: terminalZoom.fontSize,
+            onFontSizeChanged: { fontSize in terminalZoom.setFontSize(fontSize) }
         )
         .id(attach.terminalID)
         .overlay { statusOverlay }
@@ -90,6 +95,7 @@ struct AgentDetailView: View {
         .sheet(isPresented: $isShowingSettings) {
             SettingsView(
                 terminalThemes: terminalThemes,
+                terminalZoom: terminalZoom,
                 pushRegistration: pushRegistration,
                 notificationPreferences: notificationPreferences,
                 relaySettings: relaySettings)

--- a/Sources/HerdrMobile/Console/ConsoleView.swift
+++ b/Sources/HerdrMobile/Console/ConsoleView.swift
@@ -6,6 +6,7 @@ struct ConsoleView: View {
     let hosts: HostStore
     let console: ConsoleStore
     let terminalThemes: TerminalThemeSettings
+    let terminalZoom: TerminalZoomSettings
     let pushRegistration: PushRegistrationStore
     let notificationPreferences: NotificationPreferencesStore
     let relaySettings: NotificationRelaySettings
@@ -30,6 +31,7 @@ struct ConsoleView: View {
                             agent: agent,
                             console: console,
                             terminalThemes: terminalThemes,
+                            terminalZoom: terminalZoom,
                             pushRegistration: pushRegistration,
                             notificationPreferences: notificationPreferences,
                             relaySettings: relaySettings)
@@ -73,6 +75,7 @@ struct ConsoleView: View {
                 .sheet(isPresented: $isShowingSettings) {
                     SettingsView(
                         terminalThemes: terminalThemes,
+                        terminalZoom: terminalZoom,
                         pushRegistration: pushRegistration,
                         notificationPreferences: notificationPreferences,
                         relaySettings: relaySettings)

--- a/Sources/HerdrMobile/ContentView.swift
+++ b/Sources/HerdrMobile/ContentView.swift
@@ -10,6 +10,7 @@ struct ContentView: View {
     @State private var console: ConsoleStore
     @State private var notificationPreferences: NotificationPreferencesStore
     @State private var terminalThemes = TerminalThemeSettings()
+    @State private var terminalZoom = TerminalZoomSettings()
     @State private var relaySettings: NotificationRelaySettings
     @State private var bannerStore: AgentNotificationBannerStore
     @Environment(\.scenePhase) private var scenePhase
@@ -43,6 +44,7 @@ struct ContentView: View {
     var body: some View {
         ConsoleView(
             hosts: hostStore, console: console, terminalThemes: terminalThemes,
+            terminalZoom: terminalZoom,
             pushRegistration: pushRegistration,
             notificationPreferences: notificationPreferences,
             relaySettings: relaySettings,

--- a/Sources/HerdrMobile/Settings/SettingsView.swift
+++ b/Sources/HerdrMobile/Settings/SettingsView.swift
@@ -4,6 +4,7 @@ import UIKit
 
 struct SettingsView: View {
     let terminalThemes: TerminalThemeSettings
+    let terminalZoom: TerminalZoomSettings
     let pushRegistration: PushRegistrationStore
     let notificationPreferences: NotificationPreferencesStore
     @Bindable var relaySettings: NotificationRelaySettings
@@ -40,7 +41,10 @@ struct SettingsView: View {
                 customRelaySection
 
                 Section {
-                    TerminalThemePreview(theme: terminalThemes.theme)
+                    TerminalThemePreview(
+                        theme: terminalThemes.theme,
+                        fontSize: terminalZoom.fontSize
+                    )
                         .frame(height: 180)
                         .clipShape(.rect(cornerRadius: 16))
                         .overlay {
@@ -59,6 +63,8 @@ struct SettingsView: View {
                         "Changes apply instantly to current and future Attach terminals without reconnecting."
                     )
                 }
+
+                terminalTextSizeSection
 
                 Section("Terminal Theme") {
                     ForEach(TerminalThemeOption.allCases) { option in
@@ -87,6 +93,32 @@ struct SettingsView: View {
                     Task { await pushRegistration.enable() }
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    private var terminalTextSizeSection: some View {
+        Section {
+            Stepper(
+                value: Binding(
+                    get: { terminalZoom.fontSize },
+                    set: { terminalZoom.setFontSize($0) }),
+                in: TerminalZoomSettings.range,
+                step: 1
+            ) {
+                HStack {
+                    Text("Text Size")
+                    Spacer(minLength: 12)
+                    Text("\(Int(terminalZoom.fontSize)) pt")
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+            .accessibilityValue("\(Int(terminalZoom.fontSize)) points")
+        } header: {
+            Text("Terminal Text Size")
+        } footer: {
+            Text("Pinching a terminal to zoom changes this too, and it sticks.")
         }
     }
 
@@ -276,13 +308,15 @@ struct SettingsView: View {
 
 private struct TerminalThemePreview: UIViewRepresentable {
     let theme: TerminalTheme
+    let fontSize: Float
 
     func makeUIView(context _: Context) -> TerminalThemePreviewView {
-        TerminalThemePreviewView(theme: theme)
+        TerminalThemePreviewView(theme: theme, fontSize: fontSize)
     }
 
     func updateUIView(_ view: TerminalThemePreviewView, context _: Context) {
         view.applyTheme(theme)
+        view.applyFontSize(fontSize)
     }
 }
 
@@ -302,18 +336,17 @@ private final class TerminalThemePreviewView: UITerminalView {
     private let themeController: TerminalController
     private var hasLoadedPreview = false
 
-    init(theme: TerminalTheme) {
+    init(theme: TerminalTheme, fontSize: Float) {
         let session = InMemoryTerminalSession(write: { _ in }, resize: { _ in })
         previewSession = session
         themeController = TerminalController(theme: theme) { builder in
             builder.withWindowPaddingX(12)
             builder.withWindowPaddingY(10)
+            builder.withFontSize(TerminalZoomSettings.clamped(fontSize))
         }
         super.init(frame: .zero)
         inputAccessoryItems = []
-        configuration = TerminalSurfaceOptions(
-            backend: .inMemory(session),
-            fontSize: 13)
+        configuration = TerminalSurfaceOptions(backend: .inMemory(session))
         controller = themeController
         isUserInteractionEnabled = false
         isAccessibilityElement = true
@@ -334,5 +367,10 @@ private final class TerminalThemePreviewView: UITerminalView {
 
     func applyTheme(_ theme: TerminalTheme) {
         _ = themeController.setTheme(theme)
+    }
+
+    func applyFontSize(_ fontSize: Float) {
+        _ = themeController.setTerminalConfiguration(
+            TerminalConfiguration().fontSize(TerminalZoomSettings.clamped(fontSize)))
     }
 }

--- a/Sources/HerdrMobile/Settings/TerminalZoomSettings.swift
+++ b/Sources/HerdrMobile/Settings/TerminalZoomSettings.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Observation
+
+/// The app-wide terminal font size, in points. Pinch-to-zoom on an Attach
+/// terminal writes here, so a zoom survives leaving the screen and applies to
+/// every terminal the app opens afterwards.
+@MainActor
+@Observable
+final class TerminalZoomSettings {
+    static let defaultFontSize: Float = 14
+    /// Whole points only, inside the range libghostty accepts (4...64). The
+    /// narrower window keeps both ends legible on a phone.
+    static let range: ClosedRange<Float> = 8...32
+
+    private static let defaultsKey = "terminal-font-size"
+
+    private(set) var fontSize: Float
+    @ObservationIgnored private nonisolated(unsafe) let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        let stored =
+            defaults.object(forKey: Self.defaultsKey) == nil
+            ? Self.defaultFontSize
+            : defaults.float(forKey: Self.defaultsKey)
+        fontSize = Self.clamped(stored)
+    }
+
+    func setFontSize(_ size: Float) {
+        let clamped = Self.clamped(size)
+        guard clamped != fontSize else { return }
+        fontSize = clamped
+        defaults.set(clamped, forKey: Self.defaultsKey)
+    }
+
+    func adjust(by points: Float) {
+        setFontSize(fontSize + points)
+    }
+
+    /// The single clamping policy, shared by the settings control, pinch-zoom,
+    /// and the keyboard shortcut so they can never disagree on a boundary.
+    static func clamped(_ size: Float) -> Float {
+        guard size.isFinite else { return defaultFontSize }
+        return min(max(size.rounded(), range.lowerBound), range.upperBound)
+    }
+}

--- a/Sources/HerdrMobile/Settings/TerminalZoomSettings.swift
+++ b/Sources/HerdrMobile/Settings/TerminalZoomSettings.swift
@@ -8,9 +8,10 @@ import Observation
 @Observable
 final class TerminalZoomSettings {
     static let defaultFontSize: Float = 14
-    /// Whole points only, inside the range libghostty accepts (4...64). The
-    /// narrower window keeps both ends legible on a phone.
-    static let range: ClosedRange<Float> = 8...32
+    /// Whole points only. The low end goes all the way down to libghostty's
+    /// own minimum: 4 pt is unreadable, but it fits a wide TUI on screen, and
+    /// zooming out for the shape of a layout is a real thing people do.
+    static let range: ClosedRange<Float> = 4...32
 
     private static let defaultsKey = "terminal-font-size"
 

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -23,6 +23,10 @@ struct TerminalScreenView: UIViewRepresentable {
     var onPaste: ((String) -> Void)?
     var isLocalInputEnabled = true
     var theme: TerminalTheme = .default
+    var fontSize: Float = TerminalZoomSettings.defaultFontSize
+    /// Pinch-to-zoom and the ⌘+/⌘- shortcut change the size in place; the
+    /// screen forwards the new value so it lands in the global setting.
+    var onFontSizeChanged: ((Float) -> Void)?
     @Environment(\.openURL) private var openURL
 
     func makeUIView(context: Context) -> HerdrTerminalView {
@@ -30,7 +34,8 @@ struct TerminalScreenView: UIViewRepresentable {
             onSizeChanged: onSizeChanged,
             onSend: onSend,
             onPaste: onPaste,
-            theme: theme)
+            theme: theme,
+            fontSize: fontSize)
         view.delegate = context.coordinator
         context.coordinator.terminalView = view
         feed.attach { [weak view] data in
@@ -44,14 +49,16 @@ struct TerminalScreenView: UIViewRepresentable {
         onSizeChanged: ((_ cols: Int, _ rows: Int) -> Void)? = nil,
         onSend: ((Data) -> Void)? = nil,
         onPaste: ((String) -> Void)? = nil,
-        theme: TerminalTheme = .default
+        theme: TerminalTheme = .default,
+        fontSize: Float = TerminalZoomSettings.defaultFontSize
     ) -> HerdrTerminalView {
         let view = HerdrTerminalView(
             frame: .zero,
             onSizeChanged: onSizeChanged,
             onSend: onSend,
             onPaste: onPaste,
-            theme: theme)
+            theme: theme,
+            fontSize: fontSize)
         view.installKeyboardSwitcher()
         return view
     }
@@ -63,6 +70,8 @@ struct TerminalScreenView: UIViewRepresentable {
             onPaste: onPaste)
         view.setLocalInputEnabled(isLocalInputEnabled)
         view.applyTheme(theme)
+        view.applyFontSize(fontSize)
+        view.onFontSizeChanged = onFontSizeChanged
         context.coordinator.onOpenLink = { url in openURL(url) }
     }
 
@@ -137,6 +146,9 @@ final class HerdrTerminalView: UITerminalView {
     private let terminalController: TerminalController
     let terminalSession: InMemoryTerminalSession
     private(set) var appliedTheme: TerminalTheme
+    private(set) var appliedFontSize: Float
+    var onFontSizeChanged: ((Float) -> Void)?
+    private var zoomBaseFontSize: Float?
     private var terminalInputView: UIView?
     private var modeTracker = TerminalModeTracker()
     private var lastInputWindowSize: CGSize?
@@ -153,6 +165,10 @@ final class HerdrTerminalView: UITerminalView {
     private lazy var touchScrollGesture = UIPanGestureRecognizer(
         target: self,
         action: #selector(handleHerdrTouchScrollGesture(_:)))
+
+    private lazy var zoomGesture = UIPinchGestureRecognizer(
+        target: self,
+        action: #selector(handleHerdrZoomGesture(_:)))
 
     private lazy var keyboardActivationTapGesture = UITapGestureRecognizer(
         target: self,
@@ -183,7 +199,8 @@ final class HerdrTerminalView: UITerminalView {
         onSizeChanged: ((Int, Int) -> Void)?,
         onSend: ((Data) -> Void)?,
         onPaste: ((String) -> Void)?,
-        theme: TerminalTheme
+        theme: TerminalTheme,
+        fontSize: Float
     ) {
         let callbackBridge = TerminalSessionCallbackBridge(
             onSizeChanged: onSizeChanged,
@@ -197,8 +214,15 @@ final class HerdrTerminalView: UITerminalView {
             resize: { [weak callbackBridge] viewport in
                 callbackBridge?.resize(viewport)
             })
-        terminalController = TerminalController(theme: theme)
+        // Font size rides the controller's per-session configuration rather
+        // than the surface's one-shot option, so later changes reach the live
+        // surface through the same path the initial value took.
+        let clampedFontSize = TerminalZoomSettings.clamped(fontSize)
+        terminalController = TerminalController(
+            theme: theme,
+            terminalConfiguration: TerminalConfiguration().fontSize(clampedFontSize))
         appliedTheme = theme
+        appliedFontSize = clampedFontSize
         super.init(frame: frame)
         pasteConfiguration = UIPasteConfiguration(forAccepting: String.self)
         inputAccessoryItems = []
@@ -208,6 +232,7 @@ final class HerdrTerminalView: UITerminalView {
             self?.updateTouchScrollMetrics(viewport)
         }
         installTouchScrolling()
+        installZoom()
     }
 
     @available(*, unavailable)
@@ -232,6 +257,26 @@ final class HerdrTerminalView: UITerminalView {
         }
         appliedTheme = theme
         return true
+    }
+
+    @discardableResult
+    func applyFontSize(_ fontSize: Float) -> Bool {
+        let clamped = TerminalZoomSettings.clamped(fontSize)
+        guard clamped != appliedFontSize,
+            terminalController.setTerminalConfiguration(
+                TerminalConfiguration().fontSize(clamped))
+        else {
+            return false
+        }
+        appliedFontSize = clamped
+        return true
+    }
+
+    /// Applies a zoom the user performed on this terminal and reports it, so
+    /// the global setting follows the gesture instead of fighting it.
+    private func zoom(to fontSize: Float) {
+        guard applyFontSize(fontSize) else { return }
+        onFontSizeChanged?(appliedFontSize)
     }
 
     func receive(_ data: Data) {
@@ -391,6 +436,61 @@ final class HerdrTerminalView: UITerminalView {
         keyboardActivationTapGesture.cancelsTouchesInView = false
         keyboardActivationTapGesture.delegate = self
         addGestureRecognizer(keyboardActivationTapGesture)
+    }
+
+    /// Ghostty ships its own pinch handler that mutates the surface font size
+    /// behind the app's back. Zoom has to be app state to persist, so that
+    /// gesture steps aside for one that routes through `onFontSizeChanged`.
+    private func installZoom() {
+        for case let pinch as UIPinchGestureRecognizer in gestureRecognizers ?? [] {
+            pinch.isEnabled = false
+        }
+        addGestureRecognizer(zoomGesture)
+    }
+
+    @objc private func handleHerdrZoomGesture(_ gesture: UIPinchGestureRecognizer) {
+        switch gesture.state {
+        case .began:
+            zoomBaseFontSize = appliedFontSize
+        case .changed:
+            guard let zoomBaseFontSize else { return }
+            zoom(to: zoomBaseFontSize * Float(gesture.scale))
+        case .ended, .cancelled, .failed:
+            zoomBaseFontSize = nil
+        default:
+            break
+        }
+    }
+
+    /// ⌘+ / ⌘- would otherwise reach Ghostty's own font-size keybinds, which
+    /// leaves the global setting stale. Handle them here and swallow both the
+    /// press and its release so Ghostty never sees the shortcut.
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        var forwarded: Set<UIPress> = []
+        for press in presses {
+            guard let step = Self.zoomShortcutStep(for: press) else {
+                forwarded.insert(press)
+                continue
+            }
+            zoom(to: appliedFontSize + step)
+        }
+        guard !forwarded.isEmpty else { return }
+        super.pressesBegan(forwarded, with: event)
+    }
+
+    override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        let forwarded = presses.filter { Self.zoomShortcutStep(for: $0) == nil }
+        guard !forwarded.isEmpty else { return }
+        super.pressesEnded(Set(forwarded), with: event)
+    }
+
+    private static func zoomShortcutStep(for press: UIPress) -> Float? {
+        guard let key = press.key, key.modifierFlags.contains(.command) else { return nil }
+        switch key.charactersIgnoringModifiers {
+        case "+", "=": return 1
+        case "-", "_": return -1
+        default: return nil
+        }
     }
 
     @objc private func handleKeyboardActivationTap(_ gesture: UITapGestureRecognizer) {

--- a/Tests/HerdrMobileTests/TerminalZoomSettingsTests.swift
+++ b/Tests/HerdrMobileTests/TerminalZoomSettingsTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Testing
+import UIKit
+
+@testable import HerdrMobile
+
+@MainActor
+@Suite("Terminal zoom settings")
+struct TerminalZoomSettingsTests {
+    private func makeDefaults() throws -> (UserDefaults, cleanup: () -> Void) {
+        let suiteName = "hm-terminal-zoom-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        return (defaults, { defaults.removePersistentDomain(forName: suiteName) })
+    }
+
+    @Test func defaultsToFourteenPoints() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+
+        #expect(TerminalZoomSettings(defaults: defaults).fontSize == 14)
+    }
+
+    @Test func fontSizePersistsAcrossStoreInstances() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let settings = TerminalZoomSettings(defaults: defaults)
+
+        settings.setFontSize(21)
+
+        #expect(TerminalZoomSettings(defaults: defaults).fontSize == 21)
+    }
+
+    @Test func adjustingStepsFromTheCurrentSize() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let settings = TerminalZoomSettings(defaults: defaults)
+
+        settings.adjust(by: 1)
+        settings.adjust(by: 1)
+        settings.adjust(by: -1)
+
+        #expect(settings.fontSize == 15)
+    }
+
+    @Test func fractionalZoomLandsOnWholePoints() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let settings = TerminalZoomSettings(defaults: defaults)
+
+        settings.setFontSize(17.4)
+
+        #expect(settings.fontSize == 17)
+    }
+
+    @Test(arguments: [(Float(-3), Float(8)), (Float(2), Float(8)), (Float(400), Float(32))])
+    func outOfRangeSizesClampToTheSupportedWindow(requested: Float, expected: Float) throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let settings = TerminalZoomSettings(defaults: defaults)
+
+        settings.setFontSize(requested)
+
+        #expect(settings.fontSize == expected)
+    }
+
+    @Test func persistedSizeFromAWiderRangeIsClampedOnLoad() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        defaults.set(Float(64), forKey: "terminal-font-size")
+
+        #expect(TerminalZoomSettings(defaults: defaults).fontSize == 32)
+    }
+
+    @Test func terminalStartsAtTheRequestedFontSize() {
+        let terminal = TerminalScreenView.makeConfiguredTerminal(fontSize: 20)
+
+        #expect(terminal.appliedFontSize == 20)
+    }
+
+    @Test func changingFontSizeKeepsTheExistingTerminalSession() {
+        let terminal = TerminalScreenView.makeConfiguredTerminal(fontSize: 14)
+        let session = terminal.terminalSession
+
+        #expect(terminal.applyFontSize(18))
+        #expect(terminal.appliedFontSize == 18)
+        #expect(terminal.terminalSession === session)
+    }
+
+    /// The zoom rides the controller's configuration rather than a Ghostty
+    /// binding action, so prove it reaches the live surface: a bigger font on
+    /// the same view has to yield a smaller grid, which is what gets sent to
+    /// the remote PTY.
+    @Test func zoomingResizesTheLiveGrid() async throws {
+        let observed = GridObserver()
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            onSizeChanged: { columns, rows in observed.record(columns: columns, rows: rows) },
+            fontSize: 10)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 700))
+        window.addSubview(terminal)
+        terminal.frame = window.bounds
+        window.isHidden = false
+        terminal.layoutIfNeeded()
+
+        let small = try #require(await observed.settled())
+        terminal.applyFontSize(30)
+        let large = try #require(await observed.settled(after: small))
+
+        #expect(large.columns < small.columns)
+        #expect(large.rows < small.rows)
+    }
+
+    @Test func reapplyingTheSameFontSizeIsANoOp() {
+        let terminal = TerminalScreenView.makeConfiguredTerminal(fontSize: 16)
+
+        #expect(!terminal.applyFontSize(16))
+        // Rounding and clamping happen before the comparison, so neither a
+        // fractional nor an out-of-range repeat rebuilds the config.
+        #expect(!terminal.applyFontSize(16.2))
+        #expect(terminal.applyFontSize(1_000))
+        #expect(terminal.appliedFontSize == 32)
+    }
+}
+
+/// Ghostty reports grid changes through a callback that hops back to the main
+/// actor, so tests wait for the value to land instead of reading it inline.
+@MainActor
+private final class GridObserver {
+    struct Grid: Equatable {
+        let columns: Int
+        let rows: Int
+    }
+
+    private var latest: Grid?
+
+    func record(columns: Int, rows: Int) {
+        latest = Grid(columns: columns, rows: rows)
+    }
+
+    func settled(after previous: Grid? = nil) async -> Grid? {
+        for _ in 0..<100 {
+            if let latest, latest != previous { return latest }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return nil
+    }
+}

--- a/Tests/HerdrMobileTests/TerminalZoomSettingsTests.swift
+++ b/Tests/HerdrMobileTests/TerminalZoomSettingsTests.swift
@@ -96,14 +96,14 @@ struct TerminalZoomSettingsTests {
             onSizeChanged: { columns, rows in observed.record(columns: columns, rows: rows) },
             fontSize: 10)
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 700))
-        window.addSubview(terminal)
         terminal.frame = window.bounds
-        window.isHidden = false
-        terminal.layoutIfNeeded()
+        window.addSubview(terminal)
+        window.makeKeyAndVisible()
+        window.layoutIfNeeded()
 
         let small = try #require(await observed.settled())
         terminal.applyFontSize(30)
-        let large = try #require(await observed.settled(after: small))
+        let large = try #require(await observed.settled(changedFrom: small))
 
         #expect(large.columns < small.columns)
         #expect(large.rows < small.rows)
@@ -122,9 +122,14 @@ struct TerminalZoomSettingsTests {
 }
 
 /// Ghostty reports grid changes through a callback that hops back to the main
-/// actor, so tests wait for the value to land instead of reading it inline.
+/// actor, and a surface emits several of them while it boots. Tests therefore
+/// wait for the reports to go quiet rather than trusting the first one.
 @MainActor
 private final class GridObserver {
+    private static let quietPolls = 25
+    private static let pollInterval = Duration.milliseconds(10)
+    private static let timeoutPolls = 500
+
     struct Grid: Equatable {
         let columns: Int
         let rows: Int
@@ -136,10 +141,23 @@ private final class GridObserver {
         latest = Grid(columns: columns, rows: rows)
     }
 
-    func settled(after previous: Grid? = nil) async -> Grid? {
-        for _ in 0..<100 {
-            if let latest, latest != previous { return latest }
-            try? await Task.sleep(for: .milliseconds(10))
+    /// The last reported grid, once it has held still. `changedFrom` first
+    /// waits for the grid to move off a known value, so a caller that just
+    /// changed the font size cannot settle on the pre-change reading.
+    func settled(changedFrom previous: Grid? = nil) async -> Grid? {
+        var stable = 0
+        var candidate: Grid?
+        for _ in 0..<Self.timeoutPolls {
+            if let latest, latest != previous {
+                if latest == candidate {
+                    stable += 1
+                    if stable >= Self.quietPolls { return latest }
+                } else {
+                    candidate = latest
+                    stable = 0
+                }
+            }
+            try? await Task.sleep(for: Self.pollInterval)
         }
         return nil
     }

--- a/Tests/HerdrMobileTests/TerminalZoomSettingsTests.swift
+++ b/Tests/HerdrMobileTests/TerminalZoomSettingsTests.swift
@@ -52,7 +52,7 @@ struct TerminalZoomSettingsTests {
         #expect(settings.fontSize == 17)
     }
 
-    @Test(arguments: [(Float(-3), Float(8)), (Float(2), Float(8)), (Float(400), Float(32))])
+    @Test(arguments: [(Float(-3), Float(4)), (Float(1), Float(4)), (Float(400), Float(32))])
     func outOfRangeSizesClampToTheSupportedWindow(requested: Float, expected: Float) throws {
         let (defaults, cleanup) = try makeDefaults()
         defer { cleanup() }

--- a/docs/adr/0004-libghostty-terminal.md
+++ b/docs/adr/0004-libghostty-terminal.md
@@ -49,6 +49,13 @@ the native text-selection presentation requested by Ghostty's iOS delegate.
   encode SGR or legacy terminal wheel events through the session's public input
   seam. DEC private-mode tracking is incremental so split SSH packets remain
   correct.
+- Terminal zoom is app state, not surface state. The package's own pinch
+  handler mutates the surface font size through a private counter the host app
+  cannot read, so `HerdrTerminalView` disables that gesture and owns pinch and
+  ⌘+/⌘- itself, routing every change through `TerminalController`'s per-session
+  configuration. That keeps one persisted app-wide size, applies it to open and
+  future Attach terminals alike, and lets Ghostty's cell-size callback resize
+  the remote PTY as usual.
 - Theme selection uses the package's `GhosttyTheme` catalog but exposes only a
   small curated set. The persisted selection resolves to a light/dark
   `TerminalTheme`; `TerminalController.setTheme` updates existing Attach


### PR DESCRIPTION
Pinch-to-zoom changed the Ghostty surface font size in place, so it died with
the view: leaving an Attach terminal and coming back reset the size. Zoom is now
app state — one persisted, app-wide font size.

## What changed

- **`TerminalZoomSettings`** — a `UserDefaults`-backed store (`terminal-font-size`,
  default 14 pt, whole points, 4...32). Its `clamped(_:)` is the single clamping
  policy shared by the settings control, pinch, and the keyboard shortcut, so no
  two paths can disagree on a boundary.
- **`HerdrTerminalView` owns zoom.** libghostty-spm's own pinch handler mutates
  the surface font size through an internal counter the host app cannot read
  (still true on the pinned 1.3.1, the latest release), so that gesture is
  disabled and replaced with one that reports every change through
  `onFontSizeChanged`. ⌘+/⌘- are intercepted for the same reason — they would
  otherwise hit Ghostty's own font-size keybinds and leave the setting stale.
- **Application goes through `TerminalController`'s per-session configuration**,
  the same seam the theme already uses, for both the initial value and later
  changes. Ghostty's cell-size callback then resizes the remote PTY as usual.
- **Settings** gains a "Terminal Text Size" stepper, and the theme preview now
  renders at the chosen size so the control shows its own effect.

## Verification

`xcodebuild test` — 500 tests, all green. Beyond the store's persistence and
clamping tests, `zoomingResizesTheLiveGrid` puts a terminal in a real window and
proves a bigger font yields a smaller reported grid: the config path really does
reach the live surface, which is what gets sent to the remote PTY.

Also installed on a physical iPhone (Debug, `devicectl`) for the pinch itself.

## Notes

- ADR 0004 gains a Consequence recording why zoom is app state rather than
  surface state.
- Each font-size step rebuilds the package's config (temp file write + reparse).
  A pinch triggers that at most ~28 times, typically 5-10. It felt fine, but if
  it ever drags, the fix is binding actions during the gesture and one config
  write on release.