### PR TITLE
feat(lifecycle): keep Host connections through a background grace period

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -96,3 +96,7 @@ _Avoid_: subscribe, enable push
 **Transport**:
 The app-side abstraction that executes herdr API requests and delivers event streams over SSH. UI code talks to Transport, never to SSH primitives.
 _Avoid_: client, bridge, tunnel
+
+**Background Grace Period**:
+The window after backgrounding during which the app keeps running under an iOS background-execution assertion and holds its Host connections, so a short trip out of the app costs nothing on return. Only when it elapses does the app suspend and tear the connections down. Bounded by what iOS grants (tens of seconds); staying reachable for longer is what Agent Notifications are for.
+_Avoid_: background mode, keep alive (that's the events session's ping)

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		8381585C97479412A40A4FC8 /* TerminalZoomSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B1FCCEF619BD597ECD3353 /* TerminalZoomSettings.swift */; };
 		84A27FDC256CFA71D883A85A /* NotificationRelaySettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A20C4012D69BDE51F1FF25 /* NotificationRelaySettingsTests.swift */; };
 		8558806B5DFE751EB1FA3814 /* PairingCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1FDF65F7282EF79C3D376C /* PairingCodeTests.swift */; };
+		862121A4D41D3E1EA1E56D84 /* AppActivityCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBF37BC147BBEEB4549FD21 /* AppActivityCoordinator.swift */; };
 		86B92C748144DAFC8D1E1609 /* AgentNotificationRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8461D2396E779D5A29631FD /* AgentNotificationRendererTests.swift */; };
 		86C5F3E2D17523948343DF09 /* GeneratedWireTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87B816CE7206B37622287C4 /* GeneratedWireTypesTests.swift */; };
 		8AC72F5564FB95D416D1F193 /* AgentNotificationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DD3637ABCBDDA9385F5FBD /* AgentNotificationRenderer.swift */; };
@@ -124,6 +125,7 @@
 		BF9FBA3462781177C6F78459 /* JSONValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3E2308A50D4744A24A874B /* JSONValue.swift */; };
 		C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB59377D34D0C652DF70F01 /* UnixSockets.swift */; };
 		C60E8E0398665C36520DDA8E /* HerdrEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABFC5E35C19F809355619E7 /* HerdrEvents.swift */; };
+		C6477DC21ED70DF2123A55E7 /* AppActivityCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C12DE28C85D2A9268260146 /* AppActivityCoordinatorTests.swift */; };
 		C6C215AB0B03BCFD20CFF1C4 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 03BEAFDD98C535CDCE9AE335 /* Citadel */; };
 		C70B492B9C358FDAFF7876CF /* GhosttyTheme in Frameworks */ = {isa = PBXBuildFile; productRef = 6AB21852B18619F247B07907 /* GhosttyTheme */; };
 		C863E192DD66E3689C012342 /* ImageAttachStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCDC5144D5AA6403150431A /* ImageAttachStoreTests.swift */; };
@@ -238,6 +240,7 @@
 		44F4B2F424E3FC8AB7DA69FC /* NotificationVectorFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationVectorFile.swift; sourceTree = "<group>"; };
 		45FC4FCCE9B94EC52FD930B1 /* Base64URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64URL.swift; sourceTree = "<group>"; };
 		498ECBCD631F9734C28861EA /* ConsoleAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleAgent.swift; sourceTree = "<group>"; };
+		4DBF37BC147BBEEB4549FD21 /* AppActivityCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivityCoordinator.swift; sourceTree = "<group>"; };
 		4FD32D8CF0FF5617AF7E3513 /* NotificationRegistrationCeremony.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRegistrationCeremony.swift; sourceTree = "<group>"; };
 		558159B2AF61C28F6B1391A2 /* DeviceKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyTests.swift; sourceTree = "<group>"; };
 		5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHHostKeyE2ETests.swift; sourceTree = "<group>"; };
@@ -276,6 +279,7 @@
 		8683454E59970E4B9F8FF12E /* NotificationRegistrationFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRegistrationFileTests.swift; sourceTree = "<group>"; };
 		87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStoreTests.swift; sourceTree = "<group>"; };
 		89863F261DC0C6F317D75786 /* PhotosPickerImageSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosPickerImageSelection.swift; sourceTree = "<group>"; };
+		8C12DE28C85D2A9268260146 /* AppActivityCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivityCoordinatorTests.swift; sourceTree = "<group>"; };
 		8C9A0A8D0063285A276A28DA /* PairingConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingConnector.swift; sourceTree = "<group>"; };
 		8F609ED2F418C28EB5AB2D4B /* AgentNotificationBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationBannerView.swift; sourceTree = "<group>"; };
 		904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSSHTestEnvironment.swift; sourceTree = "<group>"; };
@@ -488,6 +492,7 @@
 				D8461D2396E779D5A29631FD /* AgentNotificationRendererTests.swift */,
 				CA9FFBCEE377FCD4C1105690 /* AgentNotificationRouterTests.swift */,
 				C716FB1853560D9CFF3F1351 /* AgentNotificationRoutingTests.swift */,
+				8C12DE28C85D2A9268260146 /* AppActivityCoordinatorTests.swift */,
 				A549DEB5B5CE8FDD29CE2A28 /* AttachTerminalStoreTests.swift */,
 				BC2552636663F92A55D1DFF1 /* ClosePaneStoreTests.swift */,
 				646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */,
@@ -679,6 +684,7 @@
 		ECB08E026E7F9F850AAFC76B /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				4DBF37BC147BBEEB4549FD21 /* AppActivityCoordinator.swift */,
 				45FC4FCCE9B94EC52FD930B1 /* Base64URL.swift */,
 			);
 			path = Support;
@@ -846,6 +852,7 @@
 				8AC72F5564FB95D416D1F193 /* AgentNotificationRenderer.swift in Sources */,
 				7C3999C38A0126986F9CCC58 /* AgentNotificationRouter.swift in Sources */,
 				07594B18999B4ACCD9C590F9 /* AgentNotificationRouting.swift in Sources */,
+				862121A4D41D3E1EA1E56D84 /* AppActivityCoordinator.swift in Sources */,
 				225ECBDC69A7785559BC4D20 /* AttachTerminalStore.swift in Sources */,
 				664FBC89396DBDD1083749E0 /* Base64URL.swift in Sources */,
 				CC20BAD2AC1A725889F82A20 /* ClosePaneStore.swift in Sources */,
@@ -925,6 +932,7 @@
 				86B92C748144DAFC8D1E1609 /* AgentNotificationRendererTests.swift in Sources */,
 				EDC4E8E45B766F1EEB960B6F /* AgentNotificationRouterTests.swift in Sources */,
 				47E51B32528E78D6FC1C16B2 /* AgentNotificationRoutingTests.swift in Sources */,
+				C6477DC21ED70DF2123A55E7 /* AppActivityCoordinatorTests.swift in Sources */,
 				D818864671292BE9F965CAA6 /* AttachTerminalStoreTests.swift in Sources */,
 				527D9FD128FA6F9C7BC8B572 /* AuthorizedKeysTestLock.swift in Sources */,
 				6092F63FF2DE77AD7D087A7C /* ClosePaneStoreTests.swift in Sources */,

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -12,13 +12,13 @@ struct AgentDetailView: View {
     private let pushRegistration: PushRegistrationStore
     private let notificationPreferences: NotificationPreferencesStore
     private let relaySettings: NotificationRelaySettings
+    private let activity: AppActivityCoordinator
     @State private var attach: AgentAttachStore
     @State private var selectedPhoto: PhotosPickerItem?
     @State private var isConfirmingClose = false
     @State private var isShowingSettings = false
     @State private var closeErrorMessage: String?
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.scenePhase) private var scenePhase
 
     init(
         agent: ConsoleAgent,
@@ -27,7 +27,8 @@ struct AgentDetailView: View {
         terminalZoom: TerminalZoomSettings,
         pushRegistration: PushRegistrationStore,
         notificationPreferences: NotificationPreferencesStore,
-        relaySettings: NotificationRelaySettings
+        relaySettings: NotificationRelaySettings,
+        activity: AppActivityCoordinator
     ) {
         self.agent = agent
         self.console = console
@@ -36,6 +37,7 @@ struct AgentDetailView: View {
         self.pushRegistration = pushRegistration
         self.notificationPreferences = notificationPreferences
         self.relaySettings = relaySettings
+        self.activity = activity
         _attach = State(
             initialValue: AgentAttachStore(
                 target: agent.agent.paneID,
@@ -146,16 +148,15 @@ struct AgentDetailView: View {
             selectedPhoto = nil
             attach.selectImage(PhotosPickerImageSelection(item: item))
         }
-        .onChange(of: scenePhase) { _, phase in
+        // Follows the grace period, not the raw scene phase: an image upload
+        // is exactly the work worth finishing while the app is briefly out of
+        // sight, and it is cancelled only once the app really suspends.
+        .onChange(of: activity.phase) { _, phase in
             switch phase {
             case .active:
                 attach.didBecomeActive()
-            case .background:
+            case .suspended:
                 attach.didEnterBackground()
-            case .inactive:
-                break
-            @unknown default:
-                break
             }
         }
         .onChange(of: console.hostConnectionGenerations[agent.hostID]) { _, generation in

--- a/Sources/HerdrMobile/Console/ConsoleStore.swift
+++ b/Sources/HerdrMobile/Console/ConsoleStore.swift
@@ -19,6 +19,11 @@ final class ConsoleStore {
         @Sendable (Host, [EventSubscription]) -> EventsSession
     @ObservationIgnored private let snapshotRetryDelay: Duration
     @ObservationIgnored private var isActive = false
+    /// The most recently enqueued lifecycle transition. Suspend and resume
+    /// are each several awaits long, so without a chain a resume racing a
+    /// suspend can finish first and leave every Host suspended with nothing
+    /// left to re-activate it.
+    @ObservationIgnored private var lifecycleTask: Task<Void, Never>?
 
     init(
         snapshotRetryDelay: Duration = .seconds(2),
@@ -44,17 +49,36 @@ final class ConsoleStore {
     }
 
     func resume() async {
-        isActive = true
-        for projection in projections.values {
-            await projection.resume()
+        await enqueueLifecycleTransition { [self] in
+            isActive = true
+            for projection in projections.values {
+                await projection.resume()
+            }
         }
     }
 
     func suspend() async {
-        isActive = false
-        for projection in projections.values {
-            await projection.suspend()
+        await enqueueLifecycleTransition { [self] in
+            isActive = false
+            for projection in projections.values {
+                await projection.suspend()
+            }
         }
+    }
+
+    /// Chains `transition` behind the previously enqueued one and waits for
+    /// it. Enqueueing is synchronous on the main actor, so the chain order is
+    /// the call order.
+    private func enqueueLifecycleTransition(
+        _ transition: @escaping @MainActor () async -> Void
+    ) async {
+        let previous = lifecycleTask
+        let task = Task { @MainActor in
+            await previous?.value
+            await transition()
+        }
+        lifecycleTask = task
+        await task.value
     }
 
     func retryFailedHosts() async {

--- a/Sources/HerdrMobile/Console/ConsoleView.swift
+++ b/Sources/HerdrMobile/Console/ConsoleView.swift
@@ -15,6 +15,9 @@ struct ConsoleView: View {
     @Bindable var notificationRouter: AgentNotificationRouter
     /// Announces foreground Blocked/Done transitions in-app (#77).
     let bannerStore: AgentNotificationBannerStore
+    /// Scene phase widened by the background grace period; the Attach screen
+    /// pauses its work on real suspensions only.
+    let activity: AppActivityCoordinator
     @State private var isManagingHosts = false
     @State private var isStartingAgent = false
     @State private var isShowingSettings = false
@@ -34,7 +37,8 @@ struct ConsoleView: View {
                             terminalZoom: terminalZoom,
                             pushRegistration: pushRegistration,
                             notificationPreferences: notificationPreferences,
-                            relaySettings: relaySettings)
+                            relaySettings: relaySettings,
+                            activity: activity)
                     } else {
                         ContentUnavailableView(
                             "Agent Gone", systemImage: "rectangle.on.rectangle.slash",

--- a/Sources/HerdrMobile/ContentView.swift
+++ b/Sources/HerdrMobile/ContentView.swift
@@ -1,8 +1,10 @@
 import SwiftUI
 
-/// Root view: the Console (#8), with Host management (#14) behind it. Scene
-/// phase drives the events sessions' suspend/resume (spec #20): background
-/// tears connections down deliberately, foreground re-syncs.
+/// Root view: the Console (#8), with Host management (#14) behind it. App
+/// activity drives the events sessions' suspend/resume (spec #20): the
+/// connections survive a backgrounding for the length of the grace period
+/// (see AppActivityCoordinator), then are torn down deliberately; returning
+/// to the foreground after a real suspension re-syncs.
 struct ContentView: View {
     let pushRegistration: PushRegistrationStore
     let notificationRouter: AgentNotificationRouter
@@ -13,6 +15,7 @@ struct ContentView: View {
     @State private var terminalZoom = TerminalZoomSettings()
     @State private var relaySettings: NotificationRelaySettings
     @State private var bannerStore: AgentNotificationBannerStore
+    @State private var activity = AppActivityCoordinator()
     @Environment(\.scenePhase) private var scenePhase
 
     init(pushRegistration: PushRegistrationStore, notificationRouter: AgentNotificationRouter) {
@@ -49,7 +52,8 @@ struct ContentView: View {
             notificationPreferences: notificationPreferences,
             relaySettings: relaySettings,
             notificationRouter: notificationRouter,
-            bannerStore: bannerStore
+            bannerStore: bannerStore,
+            activity: activity
         )
         .task {
             console.setHosts(hostStore.hosts)
@@ -81,14 +85,31 @@ struct ContentView: View {
         .onChange(of: scenePhase) {
             switch scenePhase {
             case .active:
-                // Also re-probes notification permission: the user may have
-                // flipped it in the Settings app while we were backgrounded.
-                Task { await console.resume() }
+                activity.didBecomeActive()
+                // Re-probes notification permission on every return, grace
+                // period or not: the user may have flipped it in the
+                // Settings app while we were backgrounded.
                 Task { await pushRegistration.refresh() }
             case .background:
-                Task { await console.suspend() }
+                activity.didEnterBackground()
             default:
                 break
+            }
+        }
+        // Only a real suspension moves the connections. A backgrounding the
+        // grace period absorbed never reaches here, so a quick trip out of
+        // the app leaves the events sessions and Attach terminals untouched.
+        .onChange(of: activity.phase) {
+            switch activity.phase {
+            case .active:
+                Task { await console.resume() }
+            case .suspended:
+                // The background assertion is held until this returns, so
+                // the SSH teardown finishes before the process freezes.
+                Task {
+                    await console.suspend()
+                    activity.didFinishSuspending()
+                }
             }
         }
         .task { await pushRegistration.refresh() }

--- a/Sources/HerdrMobile/Support/AppActivityCoordinator.swift
+++ b/Sources/HerdrMobile/Support/AppActivityCoordinator.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Observation
+import UIKit
+
+/// The app's *effective* activity, which is deliberately not `scenePhase`.
+///
+/// Backgrounding opens a grace period: the app keeps running under a UIKit
+/// background-execution assertion and holds its Host connections, so glancing
+/// at another app, pulling down the notification shade, or answering a
+/// message costs nothing on return. Only when the grace period elapses — or
+/// the system reclaims its time — does the app consider itself suspended and
+/// tear the connections down (the deliberate teardown of ADR 0002; iOS
+/// freezes the sockets anyway once the process is suspended).
+enum AppActivityPhase: Sendable, Equatable {
+    case active
+    case suspended
+}
+
+/// A UIKit background-execution assertion, reduced to what the coordinator
+/// needs so it can be tested without a running `UIApplication`.
+struct BackgroundExecutionToken: Hashable, Sendable {
+    let rawValue: Int
+}
+
+@MainActor
+protocol BackgroundExecutionGranting: AnyObject {
+    /// Asks the system for background execution time. Returns nil when the
+    /// request is refused, in which case there is no grace period to be had.
+    /// `onExpiration` runs on the main actor shortly before the system takes
+    /// the time back; the assertion must be ended from it or the app is
+    /// killed.
+    func begin(
+        onExpiration: @escaping @MainActor @Sendable () -> Void
+    ) -> BackgroundExecutionToken?
+
+    func end(_ token: BackgroundExecutionToken)
+}
+
+@MainActor
+final class UIKitBackgroundExecutionGranter: BackgroundExecutionGranting {
+    func begin(
+        onExpiration: @escaping @MainActor @Sendable () -> Void
+    ) -> BackgroundExecutionToken? {
+        let identifier = UIApplication.shared.beginBackgroundTask(
+            withName: "dev.herdr.mobile.background-grace"
+        ) {
+            // UIKit calls this on the main thread but the API is not
+            // annotated for it, so hop deliberately instead of asserting an
+            // isolation the compiler cannot check.
+            Task { @MainActor in onExpiration() }
+        }
+        guard identifier != .invalid else { return nil }
+        return BackgroundExecutionToken(rawValue: identifier.rawValue)
+    }
+
+    func end(_ token: BackgroundExecutionToken) {
+        UIApplication.shared.endBackgroundTask(
+            UIBackgroundTaskIdentifier(rawValue: token.rawValue))
+    }
+}
+
+/// Turns scene-phase edges into `AppActivityPhase`, holding a background
+/// execution assertion for the length of the grace period.
+///
+/// The assertion outlives the phase change on purpose: it is released only
+/// once the observer reports its teardown finished (`didFinishSuspending()`),
+/// so the SSH connections close cleanly instead of being frozen mid-close.
+/// The one exception is expiration, where the system wants its time back
+/// immediately and holding on any longer would kill the app.
+@MainActor
+@Observable
+final class AppActivityCoordinator {
+    /// iOS grants a background-execution assertion on the order of 30
+    /// seconds. Stopping well short of that keeps the deliberate teardown
+    /// inside our own budget rather than racing the expiration handler.
+    static let defaultGracePeriod: Duration = .seconds(20)
+
+    private(set) var phase: AppActivityPhase = .active
+
+    @ObservationIgnored private let gracePeriod: Duration
+    @ObservationIgnored private let granter: any BackgroundExecutionGranting
+    @ObservationIgnored private var token: BackgroundExecutionToken?
+    @ObservationIgnored private var graceTask: Task<Void, Never>?
+
+    init(
+        gracePeriod: Duration = AppActivityCoordinator.defaultGracePeriod,
+        granter: any BackgroundExecutionGranting = UIKitBackgroundExecutionGranter()
+    ) {
+        self.gracePeriod = gracePeriod
+        self.granter = granter
+    }
+
+    func didBecomeActive() {
+        graceTask?.cancel()
+        graceTask = nil
+        releaseBackgroundExecution()
+        phase = .active
+    }
+
+    func didEnterBackground() {
+        guard phase == .active, graceTask == nil else { return }
+        token = granter.begin { [weak self] in self?.backgroundTimeDidExpire() }
+        guard token != nil else {
+            // Without background time the process is about to freeze, so a
+            // later teardown would never run. Tear down now instead.
+            suspend()
+            return
+        }
+        graceTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await Task.sleep(for: gracePeriod)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            suspend()
+        }
+    }
+
+    /// The teardown that `.suspended` asked for has finished; the app no
+    /// longer needs to stay awake. No-op after a foreground bounce beat the
+    /// teardown home, or when expiration already took the assertion back.
+    func didFinishSuspending() {
+        guard phase == .suspended else { return }
+        releaseBackgroundExecution()
+    }
+
+    private func suspend() {
+        graceTask = nil
+        guard phase != .suspended else { return }
+        phase = .suspended
+    }
+
+    private func backgroundTimeDidExpire() {
+        // Give the assertion back before anything else: the teardown then
+        // races the process being frozen, which is the best outcome
+        // available — the Host sees the TCP connection drop either way.
+        graceTask?.cancel()
+        releaseBackgroundExecution()
+        suspend()
+    }
+
+    private func releaseBackgroundExecution() {
+        guard let token else { return }
+        self.token = nil
+        granter.end(token)
+    }
+}

--- a/Sources/HerdrMobile/Terminal/TerminalKeyboard.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalKeyboard.swift
@@ -140,12 +140,22 @@ enum TerminalControlKey: Equatable {
 
 final class TerminalKeyboardAccessory: UIInputView {
     static let preferredHeight: CGFloat = 48
+    /// The accessory's own background, reused as the paste control's fill.
+    private static let surface = UIColor.secondarySystemBackground
 
     private weak var terminalView: HerdrTerminalView?
     private let modeControl = UISegmentedControl(items: ["Text", "Keys"])
     private(set) lazy var pasteControl: UIPasteControl = {
         var configuration = UIPasteControl.Configuration()
         configuration.displayMode = .iconOnly
+        // The system default is a filled accent-tinted tile, which shouts next
+        // to the mode control and the dismiss button. UIPasteControl refuses a
+        // clear fill (it falls back to a tinted one), so paint the fill with
+        // the accessory's own background instead: the glyph is left reading as
+        // a bare icon, matching the dismiss button beside it.
+        configuration.cornerStyle = .capsule
+        configuration.baseBackgroundColor = Self.surface
+        configuration.baseForegroundColor = .label
         let control = UIPasteControl(configuration: configuration)
         control.target = terminalView
         control.accessibilityLabel = "Paste"
@@ -157,7 +167,7 @@ final class TerminalKeyboardAccessory: UIInputView {
         super.init(frame: frame, inputViewStyle: .keyboard)
         allowsSelfSizing = true
         autoresizingMask = [.flexibleWidth]
-        backgroundColor = .secondarySystemBackground
+        backgroundColor = Self.surface
         configureModeControl()
         configurePasteControl()
         configureDismissButton()

--- a/Sources/HerdrMobile/Transport/EventsSession.swift
+++ b/Sources/HerdrMobile/Transport/EventsSession.swift
@@ -54,8 +54,8 @@ enum EventsSessionStatus: Sendable, Equatable {
     /// Reconnecting cannot repair this failure. The session remains stopped
     /// until the caller retries after the Host's configuration is corrected.
     case failed(TransportError)
-    /// Deliberately torn down (app backgrounded); no reconnect activity
-    /// until `resume()`.
+    /// Deliberately torn down (the app's background grace period elapsed);
+    /// no reconnect activity until `resume()`.
     case suspended
     /// `end()` was called; the session is finished for good.
     case ended
@@ -82,8 +82,9 @@ enum EventsSessionUpdate: Sendable, Equatable {
 ///
 /// Lifecycle: a fresh session is suspended; `resume()` activates it (call on
 /// launch and on foregrounding), `suspend()` tears the channel and the SSH
-/// connection down deliberately (call on backgrounding — iOS suspends
-/// sockets anyway, an explicit close makes resume cheap and deterministic),
+/// connection down deliberately (call once the app's background grace period
+/// elapses — iOS freezes sockets anyway when the process suspends, and an
+/// explicit close makes resume cheap and deterministic),
 /// `end()` is terminal. All teardown is by explicit close, never by
 /// cancelling a live exec channel (ADR 0002). Lifecycle calls serialize
 /// internally — a `resume()` racing into a `suspend()`'s in-flight teardown

--- a/Tests/HerdrMobileTests/AppActivityCoordinatorTests.swift
+++ b/Tests/HerdrMobileTests/AppActivityCoordinatorTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+@MainActor
+@Suite("App activity coordinator")
+struct AppActivityCoordinatorTests {
+    @Test func backgroundingStaysActiveForTheGracePeriod() async throws {
+        let granter = FakeBackgroundExecutionGranter()
+        let coordinator = AppActivityCoordinator(
+            gracePeriod: .seconds(60), granter: granter)
+
+        coordinator.didEnterBackground()
+
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(coordinator.phase == .active)
+        #expect(granter.liveTokenCount == 1)
+    }
+
+    @Test func returningInsideTheGracePeriodNeverSuspends() async throws {
+        let granter = FakeBackgroundExecutionGranter()
+        let coordinator = AppActivityCoordinator(
+            gracePeriod: .seconds(60), granter: granter)
+
+        coordinator.didEnterBackground()
+        coordinator.didBecomeActive()
+
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(coordinator.phase == .active)
+        // The assertion goes back as soon as it is no longer needed;
+        // holding one while in the foreground is pure battery waste.
+        #expect(granter.liveTokenCount == 0)
+        #expect(granter.beginCount == 1)
+    }
+
+    @Test func gracePeriodElapsingSuspends() async throws {
+        let granter = FakeBackgroundExecutionGranter()
+        let coordinator = AppActivityCoordinator(
+            gracePeriod: .milliseconds(20), granter: granter)
+
+        coordinator.didEnterBackground()
+
+        try await waitUntil("the grace period should expire into a suspension") {
+            coordinator.phase == .suspended
+        }
+        // Still held: the teardown it just triggered needs the time.
+        #expect(granter.liveTokenCount == 1)
+
+        coordinator.didFinishSuspending()
+        #expect(granter.liveTokenCount == 0)
+    }
+
+    @Test func foregroundingAfterASuspensionReactivates() async throws {
+        let granter = FakeBackgroundExecutionGranter()
+        let coordinator = AppActivityCoordinator(
+            gracePeriod: .milliseconds(20), granter: granter)
+
+        coordinator.didEnterBackground()
+        try await waitUntil("the grace period should expire into a suspension") {
+            coordinator.phase == .suspended
+        }
+        coordinator.didBecomeActive()
+
+        #expect(coordinator.phase == .active)
+        #expect(granter.liveTokenCount == 0)
+    }
+
+    @Test func systemReclaimingItsTimeSuspendsAndReturnsTheAssertion() async throws {
+        let granter = FakeBackgroundExecutionGranter()
+        let coordinator = AppActivityCoordinator(
+            gracePeriod: .seconds(60), granter: granter)
+
+        coordinator.didEnterBackground()
+        granter.expireAll()
+
+        try await waitUntil("expiration should force a suspension") {
+            coordinator.phase == .suspended
+        }
+        // Holding an expired assertion is how an app gets killed, so it is
+        // returned before the teardown rather than after it.
+        #expect(granter.liveTokenCount == 0)
+    }
+
+    @Test func refusedBackgroundTimeSuspendsImmediately() {
+        let granter = FakeBackgroundExecutionGranter()
+        granter.grantsTime = false
+        let coordinator = AppActivityCoordinator(
+            gracePeriod: .seconds(60), granter: granter)
+
+        coordinator.didEnterBackground()
+
+        #expect(coordinator.phase == .suspended)
+        #expect(granter.liveTokenCount == 0)
+    }
+
+    @Test func repeatedBackgroundingDoesNotStackAssertions() async throws {
+        let granter = FakeBackgroundExecutionGranter()
+        let coordinator = AppActivityCoordinator(
+            gracePeriod: .seconds(60), granter: granter)
+
+        coordinator.didEnterBackground()
+        coordinator.didEnterBackground()
+
+        #expect(granter.beginCount == 1)
+        #expect(granter.liveTokenCount == 1)
+    }
+
+    /// Polls until `condition` holds, yielding so the coordinator's grace
+    /// task progresses.
+    private func waitUntil(
+        _ comment: Comment, timeout: Duration = .seconds(5),
+        condition: () -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if condition() { break }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(condition(), comment)
+    }
+}
+
+@MainActor
+private final class FakeBackgroundExecutionGranter: BackgroundExecutionGranting {
+    var grantsTime = true
+    private(set) var beginCount = 0
+    private var live: [BackgroundExecutionToken: @MainActor @Sendable () -> Void] = [:]
+    private var nextRawValue = 1
+
+    var liveTokenCount: Int { live.count }
+
+    func begin(
+        onExpiration: @escaping @MainActor @Sendable () -> Void
+    ) -> BackgroundExecutionToken? {
+        guard grantsTime else { return nil }
+        beginCount += 1
+        let token = BackgroundExecutionToken(rawValue: nextRawValue)
+        nextRawValue += 1
+        live[token] = onExpiration
+        return token
+    }
+
+    func end(_ token: BackgroundExecutionToken) {
+        live[token] = nil
+    }
+
+    /// Stands in for the system reclaiming its background time.
+    func expireAll() {
+        for handler in live.values {
+            handler()
+        }
+    }
+}


### PR DESCRIPTION
Backgrounding tore every SSH connection down immediately (spec #20), so even a two-second glance at another app cost a full reconnect on return: events session, Attach terminal, and any in-flight image upload all died.

## What changed

A new `AppActivityCoordinator` (`Sources/HerdrMobile/Support/AppActivityCoordinator.swift`) introduces the app's *effective* activity, deliberately distinct from `scenePhase`:

- Backgrounding takes a UIKit background-execution assertion and opens a grace period. Connections are untouched.
- Returning inside the grace period never suspends anything — the connections were never dropped, so there is nothing to re-sync.
- Once the grace period elapses, the app moves to `.suspended` and the existing deliberate teardown runs. The assertion is held until that teardown reports back (`didFinishSuspending()`), so SSH closes cleanly instead of being frozen mid-close.
- If the system reclaims its time first (`expirationHandler`), the assertion goes back *before* the teardown — holding an expired one is how an app gets killed.
- If the system refuses background time outright, the app suspends immediately: the process is about to freeze, so a later teardown would never run.

Wiring:

- `ContentView` feeds `scenePhase` to the coordinator and hangs `console.resume()`/`suspend()` off `activity.phase`. The notification-permission probe stays on the real `.active` edge — the user may have flipped it in the Settings app.
- `AgentDetailView` follows the grace period too, so an image upload is cancelled only on a real suspension. A brief trip out of the app lets it finish.

## Opportunistic fix

`ConsoleStore.resume()`/`suspend()` are now chained through a serial lifecycle task. Both are several awaits long, so a resume racing a suspend could finish first and leave every Host suspended with nothing left to re-activate it. This PR adds a second suspend trigger path, so the pre-existing race got closed rather than widened.

## The ceiling, stated plainly

iOS grants a background-execution assertion on the order of 30 seconds. That is a system limit, not a tunable. The grace period defaults to 20 seconds, leaving room for the deliberate teardown, with the expiration handler as a backstop. Staying reachable for longer is what Agent Notifications (#71) are for. Faking an indefinite background (a silent audio session and friends) is App Store rejection territory and was not done.

## Testing

- New `AppActivityCoordinatorTests`: 7 cases covering staying active through the grace period, returning inside it, elapsing into a suspension, foregrounding after one, system expiration, refused background time, and repeated backgrounding not stacking assertions. All pass.
- Regression run of `ConsoleStoreTests`, `ImageAttachStoreTests`, `AttachTerminalStoreTests`, `ColdStartE2ETests`: 64 tests, all pass.
- Installed on a physical iPhone 17 Pro Max and launched.

Note for reviewers: `-destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'` resolved to an iOS 27.0 runtime locally and the test host was killed during bootstrap, unrelated to this change. The runs above used an iOS 26.5 simulator.

## Docs

`CONTEXT.md` gains a **Background Grace Period** entry; the `EventsSession` lifecycle docs now say the teardown follows the grace period rather than backgrounding itself.