### PR TITLE
fix(terminal): tone down the paste control in the keyboard accessory

### DIFF
--- a/Sources/HerdrMobile/Terminal/TerminalKeyboard.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalKeyboard.swift
@@ -142,6 +142,10 @@ final class TerminalKeyboardAccessory: UIInputView {
     static let preferredHeight: CGFloat = 48
     /// The accessory's own background, reused as the paste control's fill.
     private static let surface = UIColor.secondarySystemBackground
+    /// `UIPasteControl` draws its glyph at a fixed 12 pt (measured; the size
+    /// is not configurable). The dismiss button matches it, or the row reads
+    /// as two icons borrowed from different sets.
+    private static let glyphPointSize: CGFloat = 12
 
     private weak var terminalView: HerdrTerminalView?
     private let modeControl = UISegmentedControl(items: ["Text", "Keys"])
@@ -222,7 +226,11 @@ final class TerminalKeyboardAccessory: UIInputView {
 
     private func configureDismissButton() {
         var configuration = UIButton.Configuration.plain()
-        configuration.image = UIImage(systemName: "keyboard.chevron.compact.down")
+        let symbol = UIImage.SymbolConfiguration(
+            pointSize: Self.glyphPointSize, weight: .regular, scale: .medium)
+        configuration.image = UIImage(
+            systemName: "keyboard.chevron.compact.down", withConfiguration: symbol)
+        configuration.preferredSymbolConfigurationForImage = symbol
         configuration.baseForegroundColor = .label
         let button = UIButton(configuration: configuration)
         button.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
## What

The keyboard accessory's paste control shipped with the system default look: a filled accent-tinted tile that dominated the row next to the Text/Keys control and the dismiss button. This makes the row read as one set of peers.

- Paint the paste control's fill with the accessory's own background (`.secondarySystemBackground`), so the glyph reads as a bare icon.
- Match the dismiss button's glyph to the size `UIPasteControl` draws.

| before | after |
| --- | --- |
| blue filled tile, glyph ~12 pt; dismiss glyph ~19 pt | both glyphs bare at 12 pt |

## Two UIKit findings worth keeping

- **`UIPasteControl` refuses a clear fill.** With `baseBackgroundColor = .clear` it falls back to tinting the fill with `baseForegroundColor` (a black capsule when that is `.label`). Painting the fill with the surrounding surface colour is the only way to get a bare glyph; it tracks light/dark because both sides use the same dynamic colour.
- **`preferredSymbolConfigurationForImage` alone is not enough on iOS 26** — the button re-derives a config from its font — so the point size is baked into the image as well.

Also note: `UIPasteControl` is anti-spoofing protected and does not render through `layer.render(in:)`, so it cannot be snapshot-tested offscreen. Both changes were verified by screenshotting the running app (simulator + a physical iPhone).

## Test

`xcodebuild test -only-testing:HerdrMobileTests/TerminalAttachTests -only-testing:HerdrMobileTests/TerminalKeyboardTests` — 24 tests, green.