### PR TITLE
feat(terminal): report taps as mouse clicks to tracking TUIs

### DIFF
--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		7C3999C38A0126986F9CCC58 /* AgentNotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC309E333009D66F9757CD13 /* AgentNotificationRouter.swift */; };
 		7C453E2308A9E12532A24705 /* SSHChannelBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CA60F860890A7CAA368B268 /* SSHChannelBudgetTests.swift */; };
 		7EEB41E5CD728587D7DCEC96 /* StartAgentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18AE2DC88A745FB457350957 /* StartAgentView.swift */; };
+		807136B5C25AB1A0AF0E22C2 /* TerminalMouseReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 758FA750D152E92B878A0234 /* TerminalMouseReportingTests.swift */; };
 		8181681FBF45216B52EEBC1A /* NotificationKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F246F98BBDAEF3A331C14F9 /* NotificationKeyStore.swift */; };
 		8196491DBF3B6024B4DB214C /* SSHChannelBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13D82A3B3C17DBFB114AAF0A /* SSHChannelBudget.swift */; };
 		822F39E2EA06AE24955F8169 /* AgentNotificationBannerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA3E6B129B6CAD15FD3C5DE /* AgentNotificationBannerStoreTests.swift */; };
@@ -134,6 +135,7 @@
 		CEF401BC0306ACEA750F0C55 /* NotificationPreferencesStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6632B55C19D84583370BF788 /* NotificationPreferencesStoreTests.swift */; };
 		D11D524FCF49C49763C9F9D7 /* Host.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806A90DBCA99FD02E76D68C6 /* Host.swift */; };
 		D452508C8B08FA41C17AA54F /* NotificationEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42040EDC53770F8227FA0C2 /* NotificationEnvelope.swift */; };
+		D4DB3D327A8767025130B169 /* TerminalMouseReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D1D6AB56C4DA1CE0AF9A51 /* TerminalMouseReporting.swift */; };
 		D51F828E0AC4A2F6C23A0CBE /* TerminalThemeSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */; };
 		D6E9D6545089932306C4704F /* HostKeyFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CBE401E4A5FA5871809E540 /* HostKeyFingerprint.swift */; };
 		D818864671292BE9F965CAA6 /* AttachTerminalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A549DEB5B5CE8FDD29CE2A28 /* AttachTerminalStoreTests.swift */; };
@@ -258,6 +260,7 @@
 		7215D5A207076C7F7E8F1E63 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		73DB204D5F25D5375D5B2974 /* TerminalKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeyboard.swift; sourceTree = "<group>"; };
 		7474FD0BACB07ADB3570E5BE /* pairing-code-v1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "pairing-code-v1.json"; sourceTree = "<group>"; };
+		758FA750D152E92B878A0234 /* TerminalMouseReportingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalMouseReportingTests.swift; sourceTree = "<group>"; };
 		7730887B9AF1CE45D9FB9AAB /* ImagePreparer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreparer.swift; sourceTree = "<group>"; };
 		78437BCBAD02A5E0EB1A439B /* NotificationPreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPreferencesStore.swift; sourceTree = "<group>"; };
 		78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrMobileApp.swift; sourceTree = "<group>"; };
@@ -275,6 +278,7 @@
 		8323C68B13826B7388800B1F /* DeviceKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyStoreTests.swift; sourceTree = "<group>"; };
 		8683454E59970E4B9F8FF12E /* NotificationRegistrationFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRegistrationFileTests.swift; sourceTree = "<group>"; };
 		87B0377EAC5265E7A6FCD212 /* KnownHostsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStoreTests.swift; sourceTree = "<group>"; };
+		88D1D6AB56C4DA1CE0AF9A51 /* TerminalMouseReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalMouseReporting.swift; sourceTree = "<group>"; };
 		89863F261DC0C6F317D75786 /* PhotosPickerImageSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosPickerImageSelection.swift; sourceTree = "<group>"; };
 		8C9A0A8D0063285A276A28DA /* PairingConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingConnector.swift; sourceTree = "<group>"; };
 		8F609ED2F418C28EB5AB2D4B /* AgentNotificationBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationBannerView.swift; sourceTree = "<group>"; };
@@ -474,6 +478,7 @@
 				6F7C6974BD9BE77000016FCA /* TerminalByteFeed.swift */,
 				80E727A9081269681AD7581B /* TerminalInputController.swift */,
 				73DB204D5F25D5375D5B2974 /* TerminalKeyboard.swift */,
+				88D1D6AB56C4DA1CE0AF9A51 /* TerminalMouseReporting.swift */,
 				597ACEE9D688E433B20108D7 /* TerminalScreenView.swift */,
 				786B2BA8A0683BB9DC71D797 /* TerminalTextSelectionPresenter.swift */,
 				FCB521B35951ABDA186FAFCF /* TerminalTouchScroll.swift */,
@@ -536,6 +541,7 @@
 				D83F34B22988623AD8E2093C /* TerminalAttachE2ETests.swift */,
 				BE8796AB629EF68A90C96B3D /* TerminalAttachTests.swift */,
 				B75316F4E6B80E442C365765 /* TerminalInputControllerTests.swift */,
+				758FA750D152E92B878A0234 /* TerminalMouseReportingTests.swift */,
 				EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */,
 				099B4DEE5E08C6246009D0EB /* TerminalZoomSettingsTests.swift */,
 				A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */,
@@ -907,6 +913,7 @@
 				BAC9F51A72EA9774DEDBC193 /* TerminalByteFeed.swift in Sources */,
 				98E83E883BCC8534910D7493 /* TerminalInputController.swift in Sources */,
 				8DF99F3257BCC6AE08595A45 /* TerminalKeyboard.swift in Sources */,
+				D4DB3D327A8767025130B169 /* TerminalMouseReporting.swift in Sources */,
 				F96C5D15E14B947BE426B2F3 /* TerminalScreenView.swift in Sources */,
 				EDFEE058F85AF41DBFE351A7 /* TerminalTextSelectionPresenter.swift in Sources */,
 				5D1B735C72D551ADE0D82D44 /* TerminalThemeSettings.swift in Sources */,
@@ -982,6 +989,7 @@
 				E8E50DCA9F56799E022F9252 /* TerminalAttachE2ETests.swift in Sources */,
 				0CF1AA5AF7F2357186A5E486 /* TerminalAttachTests.swift in Sources */,
 				30A69209EA01A8DF784ABC52 /* TerminalInputControllerTests.swift in Sources */,
+				807136B5C25AB1A0AF0E22C2 /* TerminalMouseReportingTests.swift in Sources */,
 				D51F828E0AC4A2F6C23A0CBE /* TerminalThemeSettingsTests.swift in Sources */,
 				ECC2A0575FFC9EB286B9F8AC /* TerminalZoomSettingsTests.swift in Sources */,
 				E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */,

--- a/Sources/HerdrMobile/Terminal/TerminalMouseReporting.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalMouseReporting.swift
@@ -1,0 +1,78 @@
+import CoreGraphics
+import Foundation
+
+/// Mouse reports for a remote application that enabled tracking.
+///
+/// Ghostty's UIKit layer only turns indirect pointers (trackpad, mouse) into
+/// mouse events; a direct touch never produces one. Touch input therefore has
+/// to be encoded here before it can reach a TUI behind the PTY.
+enum TerminalMouseEncoding {
+    /// Normal tracking (DECSET 1000): `ESC [ M Cb Cx Cy`, every value biased
+    /// by 32 and capped at 223.
+    case legacy
+    /// SGR extended tracking (DECSET 1006): `ESC [ < b ; col ; row M|m`, with
+    /// no coordinate limit and a distinct release terminator.
+    case sgr
+
+    /// Button codes as they appear on the wire, before the legacy +32 bias.
+    enum Button: Int {
+        case left = 0
+        case wheelUp = 64
+        case wheelDown = 65
+    }
+
+    /// Encodes one report for a 1-based cell coordinate.
+    func report(button: Button, column: Int, row: Int, isRelease: Bool = false) -> Data {
+        switch self {
+        case .sgr:
+            let terminator = isRelease ? "m" : "M"
+            return Data("\u{1B}[<\(button.rawValue);\(column);\(row)\(terminator)".utf8)
+        case .legacy:
+            // Legacy reports carry no button identity on release: the
+            // terminator stays 'M' and the button becomes 3, "released".
+            let code = isRelease ? 3 : button.rawValue
+            return Data([
+                0x1B, 0x5B, 0x4D,
+                UInt8(clamping: code + 32),
+                UInt8(clamping: min(column, 223) + 32),
+                UInt8(clamping: min(row, 223) + 32),
+            ])
+        }
+    }
+}
+
+/// Maps a touch in view coordinates onto a 1-based terminal cell.
+///
+/// ```
+///  view origin
+///  ┌───────────────────────────┐   Ghostty centres the grid: whatever does
+///  │        ↕ inset            │   not divide into whole cells is split
+///  │   ┌────┬────┬────┐        │   evenly between the opposite edges, so the
+///  │ ↔ │ 1,1│ 2,1│ 3,1│ …      │   first cell starts half a leftover in.
+///  │   ├────┼────┼────┤        │   Verified against the live surface in
+///  │   │ 1,2│ 2,2│ 3,2│        │   TerminalMouseReportingTests.
+/// ```
+struct TerminalGridPointMapper {
+    var viewSize: CGSize
+    var cellSize: CGSize
+    var columns: Int
+    var rows: Int
+
+    var gridOrigin: CGPoint {
+        CGPoint(
+            x: max(0, (viewSize.width - CGFloat(columns) * cellSize.width) / 2),
+            y: max(0, (viewSize.height - CGFloat(rows) * cellSize.height) / 2))
+    }
+
+    /// Returns the cell under `point`, clamped to the grid so a touch in the
+    /// surrounding inset still lands on the nearest edge cell.
+    func cell(at point: CGPoint) -> (column: Int, row: Int)? {
+        guard cellSize.width > 0, cellSize.height > 0, columns > 0, rows > 0 else {
+            return nil
+        }
+        let origin = gridOrigin
+        let column = Int(((point.x - origin.x) / cellSize.width).rounded(.down)) + 1
+        let row = Int(((point.y - origin.y) / cellSize.height).rounded(.down)) + 1
+        return (min(max(column, 1), columns), min(max(row, 1), rows))
+    }
+}

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -155,7 +155,7 @@ final class HerdrTerminalView: UITerminalView {
     private var allowsKeyboardActivation = false
     private(set) var isLocalInputEnabled = true
     private var terminalGridSize = (columns: 80, rows: 24)
-    private var touchScrollPointsPerRow: CGFloat = 16
+    private var terminalCellSize = CGSize(width: 8, height: 16)
     private var touchScrollAccumulator = TerminalTouchScrollAccumulator()
     private var touchScrollMomentumDisplayLink: CADisplayLink?
     private var touchScrollMomentumVelocityY: CGFloat = 0
@@ -170,9 +170,9 @@ final class HerdrTerminalView: UITerminalView {
         target: self,
         action: #selector(handleHerdrZoomGesture(_:)))
 
-    private lazy var keyboardActivationTapGesture = UITapGestureRecognizer(
+    private lazy var tapGesture = UITapGestureRecognizer(
         target: self,
-        action: #selector(handleKeyboardActivationTap(_:)))
+        action: #selector(handleHerdrTap(_:)))
 
     private lazy var terminalKeyboardAccessory = TerminalKeyboardAccessory(
         frame: CGRect(
@@ -359,9 +359,11 @@ final class HerdrTerminalView: UITerminalView {
             let velocity = touchScrollGesture.velocity(in: self)
             return abs(velocity.y) > abs(velocity.x)
         }
-        if gestureRecognizer === keyboardActivationTapGesture {
-            return keyboardActivationRegion.contains(
-                keyboardActivationTapGesture.location(in: self))
+        if gestureRecognizer === tapGesture {
+            // A TUI that tracks the mouse wants every tap; otherwise only the
+            // input row is interactive, and it just raises the keyboard.
+            return modeTracker.tracksMouse
+                || keyboardActivationRegion.contains(tapGesture.location(in: self))
         }
         return super.gestureRecognizerShouldBegin(gestureRecognizer)
     }
@@ -394,11 +396,36 @@ final class HerdrTerminalView: UITerminalView {
         return TerminalKeyboardTapTarget.region(caretRect: caret, in: bounds)
     }
 
+    /// Reports a touch as a left click when the remote application asked for
+    /// mouse tracking. Returns whether anything was sent.
+    @discardableResult
+    func clickTouch(at point: CGPoint) -> Bool {
+        guard isLocalInputEnabled,
+            let cell = gridPointMapper.cell(at: point),
+            let report = modeTracker.remoteClickSequence(
+                column: cell.column,
+                row: cell.row)
+        else { return false }
+
+        terminalSession.sendInput(report)
+        return true
+    }
+
+    /// Where Ghostty's grid currently sits inside the view, rebuilt from the
+    /// metrics of the last resize.
+    var gridPointMapper: TerminalGridPointMapper {
+        TerminalGridPointMapper(
+            viewSize: bounds.size,
+            cellSize: terminalCellSize,
+            columns: terminalGridSize.columns,
+            rows: terminalGridSize.rows)
+    }
+
     @discardableResult
     func scrollTouch(translationY: CGFloat) -> Int {
         let rows = touchScrollAccumulator.rows(
             for: translationY,
-            pointsPerRow: touchScrollPointsPerRow)
+            pointsPerRow: max(8, terminalCellSize.height))
         guard rows != 0 else { return 0 }
 
         let towardOlderContent = rows > 0
@@ -431,11 +458,11 @@ final class HerdrTerminalView: UITerminalView {
         touchScrollGesture.delegate = self
         addGestureRecognizer(touchScrollGesture)
 
-        keyboardActivationTapGesture.allowedTouchTypes = [directTouch]
-        keyboardActivationTapGesture.numberOfTouchesRequired = 1
-        keyboardActivationTapGesture.cancelsTouchesInView = false
-        keyboardActivationTapGesture.delegate = self
-        addGestureRecognizer(keyboardActivationTapGesture)
+        tapGesture.allowedTouchTypes = [directTouch]
+        tapGesture.numberOfTouchesRequired = 1
+        tapGesture.cancelsTouchesInView = false
+        tapGesture.delegate = self
+        addGestureRecognizer(tapGesture)
     }
 
     /// Ghostty ships its own pinch handler that mutates the surface font size
@@ -493,9 +520,15 @@ final class HerdrTerminalView: UITerminalView {
         }
     }
 
-    @objc private func handleKeyboardActivationTap(_ gesture: UITapGestureRecognizer) {
+    @objc private func handleHerdrTap(_ gesture: UITapGestureRecognizer) {
         guard gesture.state == .ended else { return }
-        requestKeyboard()
+        let location = gesture.location(in: self)
+        clickTouch(at: location)
+        // The click reaches the TUI, but the keyboard still only follows a tap
+        // on the input row — a tap meant for a menu item must not raise it.
+        if keyboardActivationRegion.contains(location) {
+            requestKeyboard()
+        }
     }
 
     @objc private func handleHerdrTouchScrollGesture(_ gesture: UIPanGestureRecognizer) {
@@ -516,12 +549,16 @@ final class HerdrTerminalView: UITerminalView {
         }
     }
 
+    /// Ghostty reports cell metrics in surface pixels; touches arrive in
+    /// points, so the grid has to be converted once per resize.
     private func updateTouchScrollMetrics(_ viewport: InMemoryTerminalViewport) {
         terminalGridSize = (Int(viewport.columns), Int(viewport.rows))
-        guard viewport.cellHeightPixels > 0 else { return }
+        guard viewport.cellWidthPixels > 0, viewport.cellHeightPixels > 0 else { return }
         let scale = window?.screen.nativeScale ?? traitCollection.displayScale
         guard scale > 0 else { return }
-        touchScrollPointsPerRow = max(8, CGFloat(viewport.cellHeightPixels) / scale)
+        terminalCellSize = CGSize(
+            width: CGFloat(viewport.cellWidthPixels) / scale,
+            height: CGFloat(viewport.cellHeightPixels) / scale)
     }
 
     private func startTouchScrollMomentum(velocityY: CGFloat) {

--- a/Sources/HerdrMobile/Terminal/TerminalTouchScroll.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalTouchScroll.swift
@@ -29,6 +29,10 @@ struct TerminalModeTracker {
         !mouseTrackingModes.isEmpty
     }
 
+    private var mouseEncoding: TerminalMouseEncoding {
+        usesSGRMouseEncoding ? .sgr : .legacy
+    }
+
     mutating func receive(_ data: Data) {
         pending.append(contentsOf: data)
 
@@ -62,17 +66,10 @@ struct TerminalModeTracker {
         rows: Int
     ) -> Data? {
         if tracksMouse {
-            let button = towardOlderContent ? 64 : 65
-            let column = max(1, columns / 2)
-            let row = max(1, rows / 2)
-
-            if usesSGRMouseEncoding {
-                return Data("\u{1B}[<\(button);\(column);\(row)M".utf8)
-            }
-
-            let legacyColumn = UInt8(clamping: min(column, 223) + 32)
-            let legacyRow = UInt8(clamping: min(row, 223) + 32)
-            return Data([0x1B, 0x5B, 0x4D, UInt8(button + 32), legacyColumn, legacyRow])
+            return mouseEncoding.report(
+                button: towardOlderContent ? .wheelUp : .wheelDown,
+                column: max(1, columns / 2),
+                row: max(1, rows / 2))
         }
 
         guard isAlternateScreen else { return nil }
@@ -86,6 +83,16 @@ struct TerminalModeTracker {
             usesApplicationCursorKeys
                 ? [0x1B, 0x4F, 0x42]
                 : [0x1B, 0x5B, 0x42])
+    }
+
+    /// A full left-button click on a 1-based cell, or nil when the remote
+    /// application never asked for mouse tracking — a plain shell has no use
+    /// for the report and would echo it as garbage.
+    func remoteClickSequence(column: Int, row: Int) -> Data? {
+        guard tracksMouse else { return nil }
+        let encoding = mouseEncoding
+        return encoding.report(button: .left, column: column, row: row)
+            + encoding.report(button: .left, column: column, row: row, isRelease: true)
     }
 
     private mutating func update(mode: Int, enabled: Bool) {

--- a/Tests/HerdrMobileTests/TerminalMouseReportingTests.swift
+++ b/Tests/HerdrMobileTests/TerminalMouseReportingTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Testing
+import UIKit
+
+@testable import HerdrMobile
+
+struct TerminalMouseReportingTests {
+    @Test func sgrEncodingSeparatesPressFromRelease() {
+        #expect(
+            TerminalMouseEncoding.sgr.report(button: .left, column: 20, row: 10)
+                == Data("\u{1B}[<0;20;10M".utf8))
+        #expect(
+            TerminalMouseEncoding.sgr.report(
+                button: .left, column: 20, row: 10, isRelease: true)
+                == Data("\u{1B}[<0;20;10m".utf8))
+    }
+
+    @Test func legacyEncodingBiasesEveryFieldByThirtyTwo() {
+        #expect(
+            TerminalMouseEncoding.legacy.report(button: .left, column: 1, row: 1)
+                == Data([0x1B, 0x5B, 0x4D, 32, 33, 33]))
+        // Release loses the button identity and reports 3 instead.
+        #expect(
+            TerminalMouseEncoding.legacy.report(
+                button: .left, column: 1, row: 1, isRelease: true)
+                == Data([0x1B, 0x5B, 0x4D, 35, 33, 33]))
+        // Coordinates beyond the encodable range saturate rather than wrap.
+        #expect(
+            TerminalMouseEncoding.legacy.report(button: .left, column: 400, row: 400)
+                == Data([0x1B, 0x5B, 0x4D, 32, 255, 255]))
+    }
+
+    @Test func clicksOnlyReportWhileTheApplicationTracksTheMouse() {
+        var tracker = TerminalModeTracker()
+        #expect(tracker.remoteClickSequence(column: 4, row: 2) == nil)
+
+        tracker.receive(Data("\u{1B}[?1000h".utf8))
+        #expect(
+            tracker.remoteClickSequence(column: 4, row: 2)
+                == Data([0x1B, 0x5B, 0x4D, 32, 36, 34, 0x1B, 0x5B, 0x4D, 35, 36, 34]))
+
+        tracker.receive(Data("\u{1B}[?1006h".utf8))
+        #expect(
+            tracker.remoteClickSequence(column: 4, row: 2)
+                == Data("\u{1B}[<0;4;2M\u{1B}[<0;4;2m".utf8))
+
+        tracker.receive(Data("\u{1B}[?1000l".utf8))
+        #expect(tracker.remoteClickSequence(column: 4, row: 2) == nil)
+    }
+
+    @Test func gridMapperClampsTouchesToTheCentredGrid() {
+        // 8×4 cells of 10×20 leaves 4 points across and 10 down: the grid
+        // starts 2 points in from the left and 5 down from the top.
+        let mapper = TerminalGridPointMapper(
+            viewSize: CGSize(width: 84, height: 90),
+            cellSize: CGSize(width: 10, height: 20),
+            columns: 8,
+            rows: 4)
+
+        #expect(mapper.gridOrigin == CGPoint(x: 2, y: 5))
+        #expect(mapper.cell(at: CGPoint(x: 2, y: 5)).map(Pair.init) == Pair(1, 1))
+        #expect(mapper.cell(at: CGPoint(x: 11, y: 24)).map(Pair.init) == Pair(1, 1))
+        #expect(mapper.cell(at: CGPoint(x: 12, y: 25)).map(Pair.init) == Pair(2, 2))
+        // Touches in the inset and past the last cell fall on the edge.
+        #expect(mapper.cell(at: CGPoint(x: 0, y: 0)).map(Pair.init) == Pair(1, 1))
+        #expect(mapper.cell(at: CGPoint(x: 999, y: 999)).map(Pair.init) == Pair(8, 4))
+    }
+
+    @Test func gridMapperRejectsAnUnmeasuredGrid() {
+        let mapper = TerminalGridPointMapper(
+            viewSize: CGSize(width: 390, height: 720),
+            cellSize: .zero,
+            columns: 80,
+            rows: 24)
+        #expect(mapper.cell(at: CGPoint(x: 10, y: 10)) == nil)
+    }
+
+    /// The mapper's padding assumption is only as good as Ghostty's layout, so
+    /// this drives the real surface: park the cursor on a known cell, tap where
+    /// Ghostty draws it, and require the report to name that same cell.
+    @MainActor
+    @Test func tapsOnTheRenderedCursorReportItsOwnCell() async throws {
+        var sent = Data()
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            onSend: { sent.append($0) })
+        terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 720)
+        let controller = UIViewController()
+        controller.view = terminal
+        let windowScene = try #require(
+            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
+        let window = UIWindow(windowScene: windowScene)
+        window.frame = terminal.bounds
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        terminal.receive(Data("\u{1B}[?1049h\u{1B}[?1000;1006h".utf8))
+        terminal.layoutIfNeeded()
+        try await settle()
+
+        let row = 10
+        let column = 20
+        terminal.receive(Data("\u{1B}[\(row);\(column)H".utf8))
+        try await settle()
+
+        // Ghostty's IME rect is not the cursor cell: its x is the cell's left
+        // edge but its y is the cell's vertical centre (the rect then extends
+        // one cell down, where an IME candidate window would sit). minY is
+        // therefore the one y inside the cursor's own row.
+        let caret = terminal.caretRect(for: terminal.endOfDocument)
+        #expect(!caret.isNull)
+        let cursorPoint = CGPoint(x: caret.midX, y: caret.minY)
+        let probe: Comment =
+            "caret=\(caret) mapper=\(terminal.gridPointMapper) bounds=\(terminal.bounds)"
+        #expect(terminal.clickTouch(at: cursorPoint))
+        await Task.yield()
+
+        #expect(
+            sent == Data("\u{1B}[<0;\(column);\(row)M\u{1B}[<0;\(column);\(row)m".utf8),
+            probe)
+    }
+
+    /// Without tracking a tap is only a keyboard affordance for the input row;
+    /// with it, every cell is a target the TUI wants to hear about.
+    @MainActor
+    @Test func mouseTrackingOpensTheWholeSurfaceToTaps() throws {
+        let terminal = TerminalScreenView.makeConfiguredTerminal()
+        let directTouch = NSNumber(value: UITouch.TouchType.direct.rawValue)
+        let tap = try #require(
+            terminal.gestureRecognizers?
+                .compactMap { $0 as? UITapGestureRecognizer }
+                .first { $0.allowedTouchTypes.contains(directTouch) })
+
+        // Off-window the caret has no rect, so there is no input row either.
+        #expect(!terminal.gestureRecognizerShouldBegin(tap))
+
+        terminal.receive(Data("\u{1B}[?1000h".utf8))
+        #expect(terminal.gestureRecognizerShouldBegin(tap))
+    }
+
+    @MainActor
+    @Test func tapsStaySilentWithoutMouseTracking() async {
+        var sent = Data()
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            onSend: { sent.append($0) })
+
+        #expect(!terminal.clickTouch(at: CGPoint(x: 40, y: 40)))
+        await Task.yield()
+        #expect(sent.isEmpty)
+    }
+
+    @MainActor
+    @Test func pausedInputSwallowsTheClick() async {
+        var sent = Data()
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            onSend: { sent.append($0) })
+        terminal.receive(Data("\u{1B}[?1000;1006h".utf8))
+        terminal.setLocalInputEnabled(false)
+
+        #expect(!terminal.clickTouch(at: CGPoint(x: 40, y: 40)))
+        await Task.yield()
+        #expect(sent.isEmpty)
+    }
+
+    /// Ghostty needs a few render passes before its grid metrics settle.
+    private func settle() async throws {
+        for _ in 0..<10 {
+            try await Task.sleep(for: .milliseconds(50))
+            await Task.yield()
+        }
+    }
+
+    /// Tuple results are not `Equatable`; this keeps the expectations readable.
+    private struct Pair: Equatable {
+        let column: Int
+        let row: Int
+
+        init(_ cell: (column: Int, row: Int)) {
+            column = cell.column
+            row = cell.row
+        }
+
+        init(_ column: Int, _ row: Int) {
+            self.column = column
+            self.row = row
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Tapping an option in a TUI did nothing on iOS. On a desktop terminal the same
menu is clickable, because the TUI enables mouse tracking and the terminal
reports the click.

The gap is in libghostty: `UITerminalView+Interaction.swift` only turns
`.indirectPointer` touches (mouse, trackpad) into mouse events. A direct finger
touch drives scrolling and long-press selection, never a button report — and
`surface.sendMouseButton` is internal, so the app cannot reach it. Touch
scrolling already worked around this by encoding wheel reports itself; clicks
now take the same path.

## Changes

- `TerminalMouseReporting.swift` (new): `TerminalMouseEncoding` encodes legacy
  (DECSET 1000) and SGR (1006) reports for both the wheel and the button, so
  there is one encoder instead of two; `TerminalGridPointMapper` maps a touch
  onto a 1-based cell.
- `TerminalModeTracker.remoteClickSequence(column:row:)` emits press + release,
  and returns nil when no application asked for tracking (a plain shell would
  echo the bytes as garbage). `remoteScrollSequence` now shares the encoder.
- `HerdrTerminalView.clickTouch(at:)` reports the tap through
  `terminalSession.sendInput`, the same route as the wheel, so the paused-input
  gate in `TerminalInputController` still applies. The tap recognizer now begins
  anywhere while the TUI tracks the mouse; without tracking it stays limited to
  the input row, where it only raises the keyboard.
- Cell metrics now track width as well as height (the scroll path only needed
  the row height).

## Grid geometry

Measured against the live surface rather than assumed:

- Ghostty **centres** the grid in the view — the leftover that does not divide
  into whole cells is split between opposite edges, not left as a fixed
  `window-padding`.
- `ghostty_surface_ime_point` reports the cursor cell's **left edge** but its
  **vertical centre**; the rect then extends one cell down, where an IME
  candidate window would sit.

Both facts are documented where they are used and pinned by a test, so a
libghostty bump that changes them fails loudly.

## Tests

`TerminalMouseReportingTests` (9 cases). The load-bearing one,
`tapsOnTheRenderedCursorReportItsOwnCell`, drives the real surface: park the
cursor on a known cell, tap where Ghostty actually draws it, and require the
report to name that same cell. The rest cover both encodings, the tracking
gate, clamping, and the paused-input gate.

48 tests across the four terminal suites pass.

Also verified on device against a mock TUI that enables `?1000h`/`?1006h`, draws
a menu, and paints a marker on the reported cell: taps land on the cell under
the finger. herdr's own TUI enables the same modes (`?1000h ?1002h ?1003h
?1006h` are all in the binary).

## Known limitation

`keyboardActivationRegion` derives its band from `caretRect.midY`, which per the
IME-rect semantics above is the *bottom* edge of the cursor row, so the band
sits half a row low. The 44 pt minimum height still covers the cursor row, so
behaviour is unchanged and this PR leaves it alone.