### PR TITLE
fix(build): match the notification extension version to the app

### DIFF
--- a/Sources/HerdrNotificationService/Info.plist
+++ b/Sources/HerdrNotificationService/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -95,6 +95,12 @@ targets:
     info:
       path: Sources/HerdrNotificationService/Info.plist
       properties:
+        # An app extension's versions must match its containing app's, or
+        # App Store validation rejects the bundle. XcodeGen would otherwise
+        # hardcode its own 1.0/1 defaults here; point at the build settings
+        # so both bundles stay in lockstep.
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         NSExtension:
           NSExtensionPointIdentifier: com.apple.usernotifications.service
           NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).NotificationService


### PR DESCRIPTION
XcodeGen writes its own `1.0`/`1` defaults into the Notification Service Extension's generated `Info.plist`, so every device build warned:

```
warning: The CFBundleShortVersionString of an app extension ('1.0') must match
that of its containing parent app ('0.1.0').
```

Today that is only a warning; App Store validation rejects the bundle outright on a version mismatch.

Fixed in both places, because editing the generated file alone would be undone by the next `xcodegen` run:

- `project.yml` — declare `CFBundleShortVersionString` / `CFBundleVersion` in the extension's `info.properties`, pointing at the build settings
- `Sources/HerdrNotificationService/Info.plist` — `$(MARKETING_VERSION)` / `$(CURRENT_PROJECT_VERSION)`

## Verification

- `xcodegen generate` re-run afterwards leaves the `Info.plist` unchanged (idempotent; `git status` shows only the two intended files)
- Device build succeeds with zero warnings
- `plutil` on the products: app and appex both resolve to `0.1.0` / `1`

`HerdrMobile.xcodeproj` needs no change: the extension target already carries `MARKETING_VERSION = 0.1.0`.