### PR TITLE
feat(transport): discover the remote socat path over exec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Native iOS companion app for herdr (https://herdr.dev): an agent console over SS
 ## Architecture
 
 - **Stack**: SwiftUI, iOS 26+, iPhone + iPad. SSH via Citadel, terminal rendering via the pinned libghostty-spm `GhosttyTerminal` product. See ADR 0001 (native stack), ADR 0003 (iOS 26 target raise), and ADR 0004 (terminal engine).
-- **Transport**: herdr's JSON API (NDJSON over a remote Unix socket) reached through SSH exec channels running `socat - UNIX-CONNECT:<sock>`. Interactive terminals use a PTY exec channel running `herdr agent attach`. See ADR 0002.
+- **Transport**: herdr's JSON API (NDJSON over a remote Unix socket) reached through SSH exec channels running `socat - UNIX-CONNECT:<sock>`. The remote socat path is discovered once per connection (Host's configured path, then `command -v`) and always executed absolute. Interactive terminals use a PTY exec channel running `herdr agent attach`. See ADR 0002.
 - The UI layer must depend on a transport abstraction (protocol), never on Citadel types directly.
 
 ## Load-bearing herdr facts

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		B31E16D56EE1F19A3802625B /* TransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4476B101AA4B13190C7A7B7C /* TransportConnector.swift */; };
 		B32EA361C16DD5F87AEEEDEC /* PairingCeremonyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FDA76A0BFC199882EAF72B /* PairingCeremonyE2ETests.swift */; };
 		B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCA39340517CEF3DAA35A09B /* Preflight.swift */; };
+		B56DB49BC073C1F0F95365C3 /* SocatDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4347ECA58D4717BD40A788A4 /* SocatDiscoveryTests.swift */; };
 		B67206DA3D497FF8E75F79AC /* HostConsoleProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DA2856C9762E5E0BC147BA /* HostConsoleProjection.swift */; };
 		B6FE3517A821A081D9F6262C /* KnownHostsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C232163905675760F37FD7A0 /* KnownHostsStore.swift */; };
 		B8ACB86B152D44FC0C80DADA /* TerminalTouchScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB521B35951ABDA186FAFCF /* TerminalTouchScroll.swift */; };
@@ -238,6 +239,7 @@
 		3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedAsyncOperation.swift; sourceTree = "<group>"; };
 		4076B0E816625CD09EB29F2E /* EventsSubscribeE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSubscribeE2ETests.swift; sourceTree = "<group>"; };
 		41707BC35CC96B155E502D0D /* NotificationConfigFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationConfigFileTests.swift; sourceTree = "<group>"; };
+		4347ECA58D4717BD40A788A4 /* SocatDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocatDiscoveryTests.swift; sourceTree = "<group>"; };
 		4476B101AA4B13190C7A7B7C /* TransportConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConnector.swift; sourceTree = "<group>"; };
 		44F4B2F424E3FC8AB7DA69FC /* NotificationVectorFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationVectorFile.swift; sourceTree = "<group>"; };
 		45FC4FCCE9B94EC52FD930B1 /* Base64URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64URL.swift; sourceTree = "<group>"; };
@@ -538,6 +540,7 @@
 				F228DA55C08962C10F4AA2B8 /* PushRegistrationStoreTests.swift */,
 				B66B41C393D38FA09388E3E2 /* ReconnectPolicyTests.swift */,
 				D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */,
+				4347ECA58D4717BD40A788A4 /* SocatDiscoveryTests.swift */,
 				6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */,
 				7CA60F860890A7CAA368B268 /* SSHChannelBudgetTests.swift */,
 				5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */,
@@ -993,6 +996,7 @@
 				E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */,
 				473F834A4C680F18BA303DB9 /* ScriptedTransport.swift in Sources */,
 				6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */,
+				B56DB49BC073C1F0F95365C3 /* SocatDiscoveryTests.swift in Sources */,
 				488EF0DD844658122800A1A7 /* StartAgentStoreTests.swift in Sources */,
 				E8E50DCA9F56799E022F9252 /* TerminalAttachE2ETests.swift in Sources */,
 				0CF1AA5AF7F2357186A5E486 /* TerminalAttachTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The app speaks herdr's JSON API (newline-delimited JSON over a Unix socket) thro
 - **RPC + events**: a no-PTY SSH exec channel running `socat - UNIX-CONNECT:<herdr.sock>` per request, plus one long-lived channel for `events.subscribe`.
 - **Interactive terminal**: the Agent detail screen opens an SSH PTY shell channel bootstrapped with an injection-safe `exec herdr agent attach <pane>` line, then renders it through a host-managed libghostty-spm session with Metal output, persistent appearance-aware themes, input-row keyboard activation, IME input, long-press text selection, and app-routed touch scrolling for both local scrollback and remote TUIs.
 
-No herdr server changes required. The only remote prerequisite is `socat` installed on the host.
+No herdr server changes required. The only remote prerequisite is `socat` installed on the host; the app finds it via the Host's configured path or the Host's own PATH, and onboarding tells you where to point it if neither answers.
 
 ## Stack
 

--- a/Sources/HerdrMobile/Console/ConsoleView.swift
+++ b/Sources/HerdrMobile/Console/ConsoleView.swift
@@ -222,7 +222,7 @@ struct ConsoleView: View {
         case .socketNotFound:
             "The herdr socket was not found. Check the session in Hosts."
         case .socatMissing:
-            "socat was not found. Check its path in Hosts."
+            "socat was not found on the Host. Install it or set its path in Hosts."
         case .homeDirectoryUnresolvable:
             "The remote home directory could not be resolved. Check the Host login shell."
         case .malformedResponse:

--- a/Sources/HerdrMobile/Hosts/Host.swift
+++ b/Sources/HerdrMobile/Hosts/Host.swift
@@ -12,8 +12,9 @@ struct Host: Identifiable, Codable, Hashable, Sendable {
         case password
     }
 
-    /// Where socat usually lives on a stock Linux server; editable per Host
-    /// because login-shell PATH cannot be trusted (ADR 0002).
+    /// Where socat usually lives on a stock Linux server. Tried first, then
+    /// the Host's own PATH; editable per Host for the case where neither
+    /// answers (ADR 0002).
     static let defaultSocatPath = "/usr/bin/socat"
 
     let id: UUID
@@ -27,7 +28,7 @@ struct Host: Identifiable, Codable, Hashable, Sendable {
     /// while this field remains editable for older herdr versions. Blank
     /// means the default herdr session.
     var sessionName: String
-    /// Absolute socat path on the Host.
+    /// Preferred absolute socat path on the Host.
     var socatPath: String
 
     private enum CodingKeys: String, CodingKey {

--- a/Sources/HerdrMobile/Hosts/HostFormView.swift
+++ b/Sources/HerdrMobile/Hosts/HostFormView.swift
@@ -85,7 +85,9 @@ struct HostFormView: View {
                 } header: {
                     Text("Advanced")
                 } footer: {
-                    Text("Absolute path of socat on the Host.")
+                    Text(
+                        "Absolute path of socat on the Host. Tried first; "
+                            + "otherwise the Host's own PATH is searched.")
                 }
             }
             .navigationTitle(editing == nil ? "Add Host" : "Edit Host")

--- a/Sources/HerdrMobile/Hosts/Preflight.swift
+++ b/Sources/HerdrMobile/Hosts/Preflight.swift
@@ -9,7 +9,7 @@ enum PreflightCheck: CaseIterable, Sendable {
     case connection
     /// The login shell exposes a usable absolute home directory.
     case remoteEnvironment
-    /// socat answers at its configured absolute path.
+    /// A socat executable was found on the Host.
     case socat
     /// The herdr socket path exists on the Host.
     case herdrInstalled
@@ -92,9 +92,10 @@ struct PreflightReport: Equatable, Sendable {
         case .socatMissing(let path):
             check = .socat
             hint =
-                "socat was not found at \(path). Install it on the Host "
-                + "(apt install socat / brew install socat), or correct the path "
-                + "in this Host's settings."
+                "No socat on the Host: not at \(path), and not on the Host's PATH. "
+                + "Install it (apt install socat / brew install socat), or enter its "
+                + "absolute path in this Host's settings. Homebrew puts it at "
+                + "/opt/homebrew/bin/socat (Apple Silicon) or /usr/local/bin/socat (Intel)."
         case .socketNotFound(let path):
             check = .herdrInstalled
             hint =

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -7,6 +7,21 @@ import Logging
 import NIOCore
 @preconcurrency import NIOSSH
 
+/// How a Host connection locates the remote socat executable.
+///
+/// Two levels only: the Host's configured path, then whatever the Host's own
+/// PATH resolves `socat` to. There is deliberately no built-in list of
+/// package-manager prefixes — such a list is a bet on specific distro layouts
+/// that rots with every packaging change, and it can only ever name locations
+/// that are already on PATH anyway.
+enum SocatDiscovery: Sendable, Equatable {
+    /// The configured path first, then `command -v socat` on the Host.
+    case automatic
+    /// The configured path and nothing else. Keeps the "socat is absent" case
+    /// reproducible in tests, which run against machines that do have it.
+    case configuredPathOnly
+}
+
 /// How to reach one Host, authenticate against it, and find its herdr socket.
 struct SSHTransportSettings: Sendable {
     static let defaultSessionListCommand = "herdr session list --json"
@@ -24,9 +39,13 @@ struct SSHTransportSettings: Sendable {
     var hostKeyPolicy: HostKeyPolicy
     /// Which herdr socket to reach on the Host.
     var socket: HerdrSocketLocation
-    /// Absolute path of socat on the Host. Remote commands run through the
-    /// user's login shell, whose PATH cannot be trusted.
+    /// Preferred absolute path of socat on the Host, tried before anything
+    /// else. Execution never relies on the login shell resolving `socat`: the
+    /// path discovery settles on is absolute, so PATH is consulted at most
+    /// once per connection and never again (ADR 0002).
     var socatPath: String
+    /// How to locate socat when the preferred path is not executable.
+    var socatDiscovery: SocatDiscovery = .automatic
     /// Command that wakes a stopped herdr server, run over a no-PTY exec
     /// channel when a request hits connection-refused (#6). The default is
     /// the strategy from spec #16: `herdr remote-client-bridge` ensures the
@@ -100,7 +119,8 @@ actor SSHTransport: Transport {
 
     private let client: SSHClient
     private let socketLocation: HerdrSocketLocation
-    private let socatPath: String
+    private let preferredSocatPath: String
+    private let socatDiscovery: SocatDiscovery
     private let wakeCommand: String
     private let sessionListCommand: String
     private let attachCommand: String
@@ -115,6 +135,10 @@ actor SSHTransport: Transport {
     /// for the connection's lifetime, failure is not (the next request
     /// retries).
     private let homeDirectory = SharedAsyncOperation<String>(cachesSuccess: true)
+    /// The remote socat executable, resolved over exec once per connection
+    /// like the home directory. Failure is not cached: installing socat and
+    /// retrying must work on the same connection.
+    private let socatExecutable = SharedAsyncOperation<String>(cachesSuccess: true)
     /// The herdr-mobile plugin's config dir, resolved over exec once per
     /// Host like the home directory. Failure (plugin missing, probe broken)
     /// is not cached: installing the plugin and retrying must work on the
@@ -130,7 +154,8 @@ actor SSHTransport: Transport {
     private var imageStageClients: [UUID: SFTPClient] = [:]
 
     private init(
-        client: SSHClient, socketLocation: HerdrSocketLocation, socatPath: String,
+        client: SSHClient, socketLocation: HerdrSocketLocation,
+        preferredSocatPath: String, socatDiscovery: SocatDiscovery,
         wakeCommand: String, sessionListCommand: String, attachCommand: String,
         homeCommand: String, stageDirectoryCommand: String,
         pluginListCommand: String, notificationConfigDirCommand: String,
@@ -138,7 +163,8 @@ actor SSHTransport: Transport {
     ) {
         self.client = client
         self.socketLocation = socketLocation
-        self.socatPath = socatPath
+        self.preferredSocatPath = preferredSocatPath
+        self.socatDiscovery = socatDiscovery
         self.wakeCommand = wakeCommand
         self.sessionListCommand = sessionListCommand
         self.attachCommand = attachCommand
@@ -175,7 +201,8 @@ actor SSHTransport: Transport {
             throw Self.classifyConnectFailure(error)
         }
         return SSHTransport(
-            client: client, socketLocation: settings.socket, socatPath: settings.socatPath,
+            client: client, socketLocation: settings.socket,
+            preferredSocatPath: settings.socatPath, socatDiscovery: settings.socatDiscovery,
             wakeCommand: settings.wakeCommand, sessionListCommand: settings.sessionListCommand,
             attachCommand: settings.attachCommand, homeCommand: settings.homeCommand,
             stageDirectoryCommand: settings.stageDirectoryCommand,
@@ -800,6 +827,7 @@ actor SSHTransport: Transport {
         -> (HerdrEventStream, readerID: UInt64)
     {
         let socketPath = try await resolvedSocketPath()
+        let socatPath = try await resolvedSocatPath()
         let requestID = UUID().uuidString
         let requestLine = try HerdrWire.subscribeRequestLine(
             id: requestID, subscriptions: subscriptions)
@@ -819,6 +847,7 @@ actor SSHTransport: Transport {
         let readerTask = Task {
             await self.runEventsChannel(
                 readerID: readerID, requestLine: requestLine, socketPath: socketPath,
+                socatPath: socatPath,
                 ack: ackContinuation, events: eventContinuation)
         }
         do {
@@ -854,6 +883,7 @@ actor SSHTransport: Transport {
         readerID: UInt64,
         requestLine: String,
         socketPath: String,
+        socatPath: String,
         ack ackContinuation: AsyncThrowingStream<Data, any Error>.Continuation,
         events eventContinuation: AsyncThrowingStream<HerdrEvent, any Error>.Continuation
     ) async {
@@ -1263,26 +1293,27 @@ actor SSHTransport: Transport {
         let line = try HerdrWire.requestLine(id: requestID, method: method, params: params)
         let responseLine = try await Self.withRequestDeadline(requestTimeout) {
             let socketPath = try await self.resolvedSocketPath()
+            let socatPath = try await self.resolvedSocatPath()
             return try await self.performExchange(
-                line: line, socketPath: socketPath, method: method)
+                line: line, socketPath: socketPath, socatPath: socatPath, method: method)
         }
         return try HerdrWire.decodeResult(type, fromResponseLine: responseLine, requestID: requestID)
     }
 
     /// Takes a channel slot, runs one exec+socat exchange, and returns the
     /// raw response bytes (guaranteed to contain a full line).
-    private func performExchange(line: String, socketPath: String, method: String) async throws
-        -> Data
-    {
+    private func performExchange(
+        line: String, socketPath: String, socatPath: String, method: String
+    ) async throws -> Data {
         try await execChannelBudget.withChannel {
             var stdout = Data()
             var stderr = Data()
             do {
                 let command = try Self.socatCommand(
-                    socatPath: self.socatPath, socketPath: socketPath)
+                    socatPath: socatPath, socketPath: socketPath)
                 try await self.client.withExec(command) {
                     inbound, outbound in
-                    // A fast-failing command (socat missing, socket absent) can
+                    // A fast-failing command (socket absent, server stopped) can
                     // close the channel before this write lands; the read loop
                     // below still drains stderr and surfaces the real failure.
                     try? await outbound.write(ByteBuffer(string: line))
@@ -1382,16 +1413,59 @@ actor SSHTransport: Transport {
         }
     }
 
+    /// The absolute socat path on this Host, discovered once per connection.
+    /// Resolved after the socket path so a Host whose home directory cannot be
+    /// read fails at the remote-environment check rather than at socat.
+    private func resolvedSocatPath() async throws -> String {
+        try await Self.withRequestDeadline(requestTimeout) {
+            try await self.socatExecutable.value {
+                try await self.resolveSocatPathOverExec()
+            }
+        }
+    }
+
+    private func resolveSocatPathOverExec() async throws -> String {
+        try await execChannelBudget.withChannel {
+            let output: ByteBuffer
+            do {
+                output = try await self.client.executeCommand(
+                    Self.socatProbeCommand(
+                        preferredPath: self.preferredSocatPath,
+                        discovery: self.socatDiscovery))
+            } catch is CancellationError {
+                throw TransportError.cancelled
+            } catch {
+                throw TransportError.channelFailed(
+                    detail: "socat discovery: \(String(describing: error))")
+            }
+            guard
+                let path = Self.markerValue(
+                    in: Data(output.readableBytesView), prefix: Self.socatOutputPrefix),
+                RemoteShellPath.isQuotableAbsolute(path)
+            else {
+                throw TransportError.socatMissing(path: self.preferredSocatPath)
+            }
+            return path
+        }
+    }
+
     /// Maps the observable failure shapes (verified against herdr 0.7.4 in
     /// the #3 spike) onto taxonomy cases:
     /// - missing socket:  socat stderr `E connect(... "<sock>" ...): No such file or directory`
     /// - stale socket:    socat stderr `E connect(... "<sock>" ...): Connection refused`
-    /// - socat missing:   login-shell stderr naming the socat path
     ///
     /// socat connect diagnostics are keyed on their `E connect` marker plus
     /// the quoted socket path: shells like fish echo the whole failing
     /// command line (which contains both paths), so path presence alone
     /// cannot distinguish the shapes.
+    ///
+    /// socat's own absence is deliberately not classified here. Discovery
+    /// already proved the executable exists before any exchange ran, and the
+    /// alternative — matching the socat path against arbitrary login-shell
+    /// error text — reports every *other* reason an existing socat fails to
+    /// exec (no execute permission, a missing shared library, a noexec mount)
+    /// as "socat is not installed", sending the user to fix the one thing that
+    /// is already correct.
     private func classifyExecFailure(stderr: Data, socketPath: String) -> TransportError? {
         let text = String(decoding: stderr, as: UTF8.self)
         if text.contains("E connect"), text.contains("\"\(socketPath)\"") {
@@ -1402,9 +1476,6 @@ actor SSHTransport: Transport {
                 return .serverNotRunning(path: socketPath)
             }
         }
-        if text.contains(socatPath) {
-            return .socatMissing(path: socatPath)
-        }
         return nil
     }
 
@@ -1413,6 +1484,7 @@ actor SSHTransport: Transport {
     }
 
     private static let homeOutputPrefix = "__HERDR_MOBILE_HOME__="
+    private static let socatOutputPrefix = "__HERDR_MOBILE_SOCAT__="
     private static let stageDirectoryOutputPrefix = "__HERDR_MOBILE_STAGE_DIR__="
     private static let pluginConfigDirOutputPrefix = "__HERDR_MOBILE_PLUGIN_CONFIG_DIR__="
 
@@ -1449,6 +1521,38 @@ actor SSHTransport: Transport {
         }
         return try StagedImage(path: "\(directory)/placeholder").fileURL
             .deletingLastPathComponent().path
+    }
+
+    /// Prints the marker-delimited absolute socat path: the preferred path if
+    /// it is executable, otherwise whatever the Host's PATH resolves `socat`
+    /// to. Runs under POSIX sh because login shells do not share substitution
+    /// syntax, and passes both inputs as positional arguments so neither is
+    /// interpolated into the script body.
+    ///
+    /// Always exits 0. Absence is reported by the marker's absence, never by a
+    /// status code, so "no socat here" stays a classified `socatMissing`
+    /// instead of an opaque channel failure. A preferred path that cannot be
+    /// quoted safely is passed as the empty string, which `[ -x ]` rejects —
+    /// discovery then falls through to PATH exactly as it does for a path that
+    /// simply is not there.
+    ///
+    /// Not private: CI provisions no sshd, so the e2e coverage of discovery all
+    /// skips there and this command's shape is pinned by direct unit tests.
+    static func socatProbeCommand(
+        preferredPath: String, discovery: SocatDiscovery
+    ) -> String {
+        let quotedPreferredPath = RemoteShellPath.quotedAbsolute(preferredPath) ?? "''"
+        let searchesPath = discovery == .automatic ? "1" : "0"
+        let script =
+            "preferred=\"$1\"; searches_path=\"$2\"; "
+            + "if [ -x \"$preferred\" ]; then "
+            + "printf \"\(socatOutputPrefix)%s\\n\" \"$preferred\"; exit 0; fi; "
+            + "[ \"$searches_path\" = 1 ] || exit 0; "
+            + "found=$(command -v socat 2>/dev/null) || exit 0; "
+            + "case \"$found\" in /*) [ -x \"$found\" ] && "
+            + "printf \"\(socatOutputPrefix)%s\\n\" \"$found\";; esac; exit 0"
+        return cLocaleCommand(
+            "/bin/sh -c '\(script)' herdr-socat-probe \(quotedPreferredPath) \(searchesPath)")
     }
 
     private static func socatCommand(socatPath: String, socketPath: String) throws -> String {

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -346,7 +346,8 @@ enum TransportError: Error, Sendable, Equatable {
     /// The socket file exists but nothing accepts connections: the herdr
     /// server is not running (cold-start wake is #6).
     case serverNotRunning(path: String)
-    /// socat is not at its configured absolute path on the Host.
+    /// No socat executable was found: not at the Host's preferred path, and
+    /// not on the Host's PATH. `path` is the preferred path that was tried.
     case socatMissing(path: String)
     /// The server speaks a herdr protocol version this build does not support.
     case protocolVersionMismatch(server: Int, supported: Int)

--- a/Tests/HerdrMobileTests/PreflightReportTests.swift
+++ b/Tests/HerdrMobileTests/PreflightReportTests.swift
@@ -27,6 +27,13 @@ struct PreflightReportTests {
             return
         }
         #expect(hint.contains("/usr/bin/socat"))
+        // The hint has to say PATH was tried too, or "not at /usr/bin/socat"
+        // reads as "go fix that path" when the path was never the problem.
+        #expect(hint.contains("PATH"))
+        // macOS Hosts whose PATH the probe cannot see still need the answer
+        // spelled out; both Homebrew prefixes are candidates to type in (#42).
+        #expect(hint.contains("/opt/homebrew/bin/socat"))
+        #expect(hint.contains("/usr/local/bin/socat"))
         #expect(report[.herdrInstalled] == .blocked)
         #expect(report[.serverRunning] == .blocked)
         #expect(report[.protocolCompatible] == .blocked)

--- a/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHTransportE2ETests.swift
@@ -359,6 +359,97 @@ struct SSHTransportE2ETests {
         try await transport.close()
     }
 
+    @Test func missingPreferredSocatPathFallsBackToPathLookup() async throws {
+        // The Host's configured path is dead, so discovery asks the Host where
+        // socat actually is. This is the macOS/Homebrew case: the default
+        // /usr/bin/socat does not exist, but PATH resolves socat fine.
+        try await withPingingServer(
+            preferredSocatPath: "/tmp/herdr-absent-socat-\(UUID().uuidString.prefix(8))"
+        ) { transport, server in
+            let info = try await transport.ping()
+
+            #expect(info.protocolVersion == SSHTransport.supportedProtocolVersion)
+            #expect(server.receivedRequests.map(\.method) == ["ping"])
+        }
+    }
+
+    @Test func nonExecutablePreferredSocatPathFallsBackToPathLookup() async throws {
+        // The file at the configured path exists but cannot be executed (mode
+        // 000 here; a missing shared library or a noexec mount look the same
+        // to the probe). `[ -x ]` rejects it and discovery moves on to PATH,
+        // instead of reporting a socat that is present as "not installed".
+        let unusable = "/tmp/herdr-unusable-socat-\(UUID().uuidString.prefix(8))"
+        try Data().write(to: URL(fileURLWithPath: unusable))
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o000], ofItemAtPath: unusable)
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o600], ofItemAtPath: unusable)
+            try? FileManager.default.removeItem(atPath: unusable)
+        }
+
+        try await withPingingServer(preferredSocatPath: unusable) { transport, server in
+            let info = try await transport.ping()
+
+            #expect(info.protocolVersion == SSHTransport.supportedProtocolVersion)
+            #expect(server.receivedRequests.map(\.method) == ["ping"])
+        }
+    }
+
+    @Test func discoveredSocatPathIsCachedForTheConnection() async throws {
+        // Discovery runs once per connection. Proof: after the first request
+        // has settled on the PATH socat, plant a *usable-looking* executable at
+        // the preferred path that would win a fresh probe and then fail to
+        // bridge anything. The second request must still succeed, which it can
+        // only do by reusing the cached path.
+        let preferred = "/tmp/herdr-late-socat-\(UUID().uuidString.prefix(8))"
+        defer { try? FileManager.default.removeItem(atPath: preferred) }
+
+        try await withPingingServer(preferredSocatPath: preferred) { transport, server in
+            _ = try await transport.ping()
+
+            try "#!/bin/sh\nexit 1\n".write(
+                toFile: preferred, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755], ofItemAtPath: preferred)
+
+            let agents = try await transport.listAgents()
+
+            #expect(agents.isEmpty)
+            #expect(server.receivedRequests.map(\.method) == ["ping", "agent.list"])
+        }
+    }
+
+    /// A real transport whose fake server answers ping and agent.list, with the
+    /// Host's preferred socat path overridden and automatic discovery left on.
+    private func withPingingServer(
+        preferredSocatPath: String,
+        body: (SSHTransport, FakeHerdrServer) async throws -> Void
+    ) async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let server = try FakeHerdrServer { request in
+            switch request.method {
+            case "ping":
+                [#"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9-fake","protocol":17}}"#]
+            default:
+                [#"{"id":"\#(request.id)","result":{"type":"agent_list","agents":[]}}"#]
+            }
+        }
+        defer { server.stop() }
+
+        let transport = try await SSHTransport.connect(
+            settings: environment.makeSettings(
+                socket: .absolutePath(server.socketPath),
+                socatPath: preferredSocatPath))
+        do {
+            try await body(transport, server)
+        } catch {
+            try? await transport.close()
+            throw error
+        }
+        try await transport.close()
+    }
+
     @Test func namedSessionSocketPathResolvesOverRemoteHome() async throws {
         // The transport is given only a session name; it must resolve the
         // remote home directory over exec and find the socket at

--- a/Tests/HerdrMobileTests/SocatDiscoveryTests.swift
+++ b/Tests/HerdrMobileTests/SocatDiscoveryTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+// The probe command's shape, pinned without sshd: CI provisions none, so every
+// e2e test covering discovery skips there. Real-shell behavior (fish login
+// shell, POSIX sh probe, the fall-through cases) is covered by
+// SSHTransportE2ETests and TransportFailureModesE2ETests.
+@Suite("socat discovery probe")
+struct SocatDiscoveryTests {
+    private func probe(
+        _ preferredPath: String, _ discovery: SocatDiscovery = .automatic
+    ) -> String {
+        SSHTransport.socatProbeCommand(preferredPath: preferredPath, discovery: discovery)
+    }
+
+    @Test func runsUnderPOSIXShellWithAStableLocale() {
+        let command = probe("/usr/bin/socat")
+
+        // Login shells do not share substitution syntax, and error
+        // classification downstream must not shift with the Host's locale.
+        #expect(command.hasPrefix("LC_ALL=C /bin/sh -c '"))
+    }
+
+    @Test func passesThePreferredPathAsAQuotedArgument() {
+        let command = probe("/opt/homebrew/bin/socat")
+
+        // Trailing arguments, not interpolation into the script body.
+        #expect(command.hasSuffix(" herdr-socat-probe '/opt/homebrew/bin/socat' 1"))
+    }
+
+    @Test func automaticDiscoverySearchesPath() {
+        #expect(probe("/usr/bin/socat", .automatic).hasSuffix(" 1"))
+        #expect(probe("/usr/bin/socat", .automatic).contains("command -v socat"))
+    }
+
+    @Test func configuredPathOnlyDoesNotSearchPath() {
+        let command = probe("/usr/bin/socat", .configuredPathOnly)
+
+        // The flag is what disables the lookup; the branch stays in the script
+        // so both policies run byte-identical shell code.
+        #expect(command.hasSuffix(" '/usr/bin/socat' 0"))
+    }
+
+    @Test func emitsTheMarkerTheParserLooksFor() {
+        #expect(probe("/usr/bin/socat").contains("__HERDR_MOBILE_SOCAT__=%s"))
+    }
+
+    @Test(arguments: [
+        "/tmp/socat'; rm -rf ~; echo '",
+        "/tmp/back\\slash",
+        "/tmp/new\nline",
+        "relative/socat",
+        "",
+    ])
+    func unquotablePreferredPathIsNeverInterpolated(hostile: String) {
+        let command = probe(hostile)
+
+        // A path the quoting subset refuses is replaced by an empty argument,
+        // which `[ -x ]` rejects. The dangerous text must not reach the Host at
+        // all — not even inside quotes.
+        #expect(command.hasSuffix(" herdr-socat-probe '' 1"))
+        #expect(!command.contains(hostile) || hostile.isEmpty)
+    }
+
+    @Test func quotedPathsWithSpacesSurvive() {
+        // Spaces are inside the conservative subset: single quotes handle them
+        // identically in POSIX shells and fish.
+        let command = probe("/opt/my tools/socat")
+
+        #expect(command.hasSuffix(" herdr-socat-probe '/opt/my tools/socat' 1"))
+    }
+}

--- a/Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift
+++ b/Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift
@@ -75,6 +75,7 @@ struct LocalSSHTestEnvironment: Sendable {
     func makeSettings(
         socket: HerdrSocketLocation,
         socatPath: String? = nil,
+        socatDiscovery: SocatDiscovery? = nil,
         wakeCommand: String? = nil,
         requestTimeout: Duration? = nil,
         homeCommand: String? = nil,
@@ -91,6 +92,7 @@ struct LocalSSHTestEnvironment: Sendable {
                 ?? HostKeyPolicy(knownHosts: InMemoryKnownHostsStore()) { _ in true },
             socket: socket,
             socatPath: socatPath ?? self.socatPath)
+        if let socatDiscovery { settings.socatDiscovery = socatDiscovery }
         if let wakeCommand { settings.wakeCommand = wakeCommand }
         if let requestTimeout { settings.requestTimeout = requestTimeout }
         if let homeCommand { settings.homeCommand = homeCommand }

--- a/Tests/HerdrMobileTests/TransportFailureModesE2ETests.swift
+++ b/Tests/HerdrMobileTests/TransportFailureModesE2ETests.swift
@@ -40,15 +40,33 @@ struct TransportFailureModesE2ETests {
     }
 
     @Test func absentSocatBinaryMapsToSocatMissing() async throws {
-        // The login shell cannot launch socat; its stderr names the missing
-        // path (fish: "Unknown command", bash/zsh: "No such file or
-        // directory") and the channel fails.
+        // Discovery finds nothing: the preferred path does not exist, and PATH
+        // is not searched. Restricting the policy is what makes the absence
+        // reproducible — this machine does have a socat on PATH, which
+        // automatic discovery would (correctly) find.
         let bogusSocat = "/tmp/herdr-no-socat-\(UUID().uuidString.prefix(8))"
 
         try await withFailingTransport(
-            socketPath: "/tmp/herdr-irrelevant.sock", socatPath: bogusSocat
+            socketPath: "/tmp/herdr-irrelevant.sock", socatPath: bogusSocat,
+            socatDiscovery: .configuredPathOnly
         ) { transport in
             await #expect(throws: TransportError.socatMissing(path: bogusSocat)) {
+                try await transport.ping()
+            }
+        }
+    }
+
+    @Test func unquotableSocatPathMapsToSocatMissing() async throws {
+        // A path the conservative shell-quoting subset refuses is never
+        // interpolated into the probe; it simply fails `[ -x ]` like any other
+        // dead path, so the outcome stays a classified socatMissing.
+        let hostile = "/tmp/herdr-'quote-\(UUID().uuidString.prefix(8))"
+
+        try await withFailingTransport(
+            socketPath: "/tmp/herdr-irrelevant.sock", socatPath: hostile,
+            socatDiscovery: .configuredPathOnly
+        ) { transport in
+            await #expect(throws: TransportError.socatMissing(path: hostile)) {
                 try await transport.ping()
             }
         }
@@ -59,6 +77,7 @@ struct TransportFailureModesE2ETests {
     private func withFailingTransport(
         socketPath: String,
         socatPath: String? = nil,
+        socatDiscovery: SocatDiscovery? = nil,
         wakeCommand: String? = nil,
         body: (SSHTransport) async throws -> Void
     ) async throws {
@@ -66,6 +85,7 @@ struct TransportFailureModesE2ETests {
         let transport = try await SSHTransport.connect(
             settings: environment.makeSettings(
                 socket: .absolutePath(socketPath), socatPath: socatPath,
+                socatDiscovery: socatDiscovery,
                 wakeCommand: wakeCommand))
         do {
             try await body(transport)

--- a/docs/adr/0002-ssh-exec-socat-transport.md
+++ b/docs/adr/0002-ssh-exec-socat-transport.md
@@ -2,6 +2,31 @@
 
 The app reaches herdr's JSON API (NDJSON over a Unix domain socket, one request per connection) by opening a no-PTY SSH exec channel running `socat - UNIX-CONNECT:<sock>` per request, plus one long-lived channel for `events.subscribe`. Interactive terminals use a separate SSH PTY shell channel. Citadel 0.12.1 cannot combine a PTY request with an exec request, so the app writes an injection-safe `exec herdr agent attach <pane>` bootstrap line into that shell; `exec` replaces the shell, making the resulting channel mechanically equivalent to a PTY exec channel for lifecycle and byte streaming. We deliberately require `socat` on every host and change nothing in herdr.
 
+## Locating socat
+
+Execution always uses an absolute path: relying on the login shell to resolve
+`socat` on every exec would make each request depend on that shell's PATH, which
+differs between interactive and non-interactive invocations. That constraint says
+nothing about who must *supply* the path, so the app discovers it once per
+connection and caches it: the Host's configured path first, then `command -v
+socat` on the Host. Whatever it settles on is absolute, so PATH is consulted at
+most once and never participates in an exchange.
+
+There is deliberately no built-in list of package-manager prefixes to fall back
+through. Such a list is a bet on specific distro and Homebrew layouts that rots
+with every packaging change, and it can only ever name locations that are already
+on PATH. A Host where discovery fails keeps the editable per-Host path as its
+escape hatch, and the socat preflight hint names the usual Homebrew locations to
+type in.
+
+Discovery replaces the previous scheme, which inferred socat's absence by
+matching its configured path against login-shell stderr. That test cannot tell
+"not installed" apart from "installed but not executable" (no execute
+permission, a missing shared library, a noexec mount), and it misreported the
+latter as the former — sending the user to fix the one thing that was already
+right. `[ -x ]` on the Host answers the question directly, so
+`classifyExecFailure` no longer classifies socat at all.
+
 ## Considered Options
 
 - **SSH direct-streamlocal forwarding (the "obvious" answer)** — impossible in Swift: swift-nio-ssh's channel type is a closed enum (session / directTCPIP / forwardedTCPIP) with no extension point, so Citadel inherits the gap. Every workaround was evaluated and rejected: forking swift-nio-ssh (~150 lines but a permanent security-sensitive fork), libssh (LGPL, no iOS packaging), russh via UniFFI or Go x/crypto via gomobile (a whole foreign toolchain for one channel type). Since herdr serves one request per connection anyway, streamlocal would only save the remote process spawn (~tens of ms per request) — not worth any of those costs.
@@ -11,7 +36,8 @@ The app reaches herdr's JSON API (NDJSON over a Unix domain socket, one request 
 
 ## Consequences
 
-- Every host needs `socat` installed; onboarding must check for it and explain.
+- Every host needs `socat` installed. Onboarding finds it on its own where it can, and explains how to install it or where to point the app when it cannot.
+- Discovery spends one exec channel per connection, once, from the same bounded queue as the other short remote commands.
 - Exec channels are session channels: sshd's `MaxSessions` (default 10) caps concurrency, so all RPCs go through a bounding request queue.
 - Real-time events work today (`events.subscribe` on a dedicated channel); no polling needed while foregrounded.
 - If the Flutter Plan B is ever activated, dartssh2's `forwardLocalUnix` makes socat unnecessary — this ADR is stack-specific.


### PR DESCRIPTION
The Host's configured socat path becomes the *preferred* value rather than the only accepted one. Each connection tries it, then asks the Host itself with `command -v socat`, and caches the absolute result. Execution is still always by absolute path, so PATH is consulted at most once per connection and never participates in an exchange.

## Why, beyond onboarding convenience

The load-bearing change is a deletion. `classifyExecFailure` used to decide whether socat existed by matching its configured path against login-shell stderr:

```swift
if text.contains(socatPath) { return .socatMissing(path: socatPath) }
```

That test cannot tell "not installed" apart from "installed but not executable" — no execute permission, a missing shared library, a noexec mount. All of those put the path in stderr with no `E connect` marker, so they fell through to this branch and were reported as "socat is not installed. Install it, or correct the path", sending the user to fix the one thing that was already correct. It also pinned correctness to the error-message format of whatever shell the Host runs (`LC_ALL=C` stabilises the locale, not the shell).

`[ -x ]` on the Host answers the question directly, so the transport no longer classifies socat from stderr at all. Net effect is less code on the fragile path, not more machinery.

## Deliberately no fallback path list

Discovery is two levels: the configured path, then PATH. There is no built-in list of Homebrew/MacPorts/Linuxbrew/Nix prefixes. Such a list bets on specific distro layouts, rots with every packaging change, and can only ever name locations that are already on PATH.

Known limit, recorded in ADR 0002: on a Host whose shell rc does not run non-interactively (bash in particular — `.bashrc` is skipped for `ssh host cmd`), PATH may be trimmed to system defaults and a Homebrew socat will not be found. Those Hosts keep the editable per-Host path as the escape hatch, and the preflight hint now names the Homebrew locations to type in (which is what #42 asked for).

## Implementation

- `SocatDiscovery` (`.automatic` / `.configuredPathOnly`) — the second case exists so the "socat is absent" failure mode stays reproducible in tests on machines that do have socat
- `resolvedSocatPath()` reuses the existing `SharedAsyncOperation(cachesSuccess: true)`, same as home-directory resolution: concurrent first requests share one probe, success cached, failure not (installing socat and retrying must work on the same connection)
- Resolved *after* the socket path, so a Host whose home directory cannot be read still fails at the `remoteEnvironment` check rather than at socat
- The probe runs under `/bin/sh -c` (login shells do not share substitution syntax) and passes both inputs as positional arguments; nothing is interpolated into the script body. It always exits 0 — absence is signalled by the marker's absence, keeping it a classified `socatMissing` instead of an opaque channel failure
- A preferred path the shell-quoting subset refuses becomes an empty argument, which `[ -x ]` rejects; discovery falls through exactly as it does for a dead path

## Verification

Probe script exercised directly against this machine's real fish login shell over sshd — all five branches: preferred hit, preferred absent → PATH, `configuredPathOnly` silent, empty argument, and **preferred present but mode 000 → correctly skipped to PATH** (the case the old code misreported).

Tests: **526 tests / 67 suites pass.**

- New `SocatDiscoveryTests` (12 cases, pure). Necessary because CI provisions no sshd, so all e2e coverage of discovery skips there. This required lifting `socatProbeCommand` from `private` to internal; the reason is in a comment. Includes 5 hostile paths (e.g. `/tmp/socat'; rm -rf ~; echo '`) asserting the text never reaches the command
- 3 new e2e: missing preferred path → PATH, non-executable preferred path → PATH, and a cache proof (after the first request settles on the PATH socat, plant a plausible-looking `exit 1` executable at the preferred path; the second request still succeeds, which only reuse can explain)
- `absentSocatBinaryMapsToSocatMissing` now uses `.configuredPathOnly`, so it asserts discovery's own verdict rather than a guess from stderr
- `PreflightReportTests` asserts the hint mentions PATH and names both Homebrew prefixes

## Note on #42

That issue's triage picked Option A (hint + docs, explicitly no probing). This PR is Option B, chosen on a fresh technical review of the trade-off: the stderr-matching it removes was actively misdiagnosing a real failure mode. The issue's recorded decision and ADR 0002 now disagree with each other — ADR 0002 is updated here with the reasoning and the known limit, and #42's decision note should be amended to match.

Refs #42.
