### PR TITLE
feat(console): lead with the project, in the list and in notifications

### DIFF
--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		EDFEE058F85AF41DBFE351A7 /* TerminalTextSelectionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786B2BA8A0683BB9DC71D797 /* TerminalTextSelectionPresenter.swift */; };
 		EE22FB818F023585C4A07D9C /* PairingCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6851566A8DBF603AA768404 /* PairingCode.swift */; };
 		EF7F36C0E1C3ED3F6117B1EB /* FakeHerdrServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B781425ADF5353CEEED6A1 /* FakeHerdrServer.swift */; };
+		F1FCF5D4FF428B3A593AE636 /* RecentWorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B72A9326AE8FA1006B2EE18 /* RecentWorkspaceStore.swift */; };
 		F2CC5A27CA8B0623C486D9B2 /* LocalSSHTestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904FF6BF3E76BDFB2F76784D /* LocalSSHTestEnvironment.swift */; };
 		F62A9CD06CFB784550AF4977 /* DeviceKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558159B2AF61C28F6B1391A2 /* DeviceKeyTests.swift */; };
 		F96C5D15E14B947BE426B2F3 /* TerminalScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597ACEE9D688E433B20108D7 /* TerminalScreenView.swift */; };
@@ -221,6 +222,7 @@
 		17424B6972D7D7E6271350A5 /* PairingCodeVectorFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCodeVectorFile.swift; sourceTree = "<group>"; };
 		17F86744BFAC66D732CE7833 /* JSONValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueTests.swift; sourceTree = "<group>"; };
 		18AE2DC88A745FB457350957 /* StartAgentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentView.swift; sourceTree = "<group>"; };
+		1B72A9326AE8FA1006B2EE18 /* RecentWorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentWorkspaceStore.swift; sourceTree = "<group>"; };
 		1C3ACB2A319C5C1298A29F3F /* EventsSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSession.swift; sourceTree = "<group>"; };
 		1CBE401E4A5FA5871809E540 /* HostKeyFingerprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostKeyFingerprint.swift; sourceTree = "<group>"; };
 		1E3E2308A50D4744A24A874B /* JSONValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValue.swift; sourceTree = "<group>"; };
@@ -619,6 +621,7 @@
 				A95E62CA572C71B2C746E972 /* ConsoleStore.swift */,
 				C44D9663DAB1E8942FBFCD1C /* ConsoleView.swift */,
 				05DA2856C9762E5E0BC147BA /* HostConsoleProjection.swift */,
+				1B72A9326AE8FA1006B2EE18 /* RecentWorkspaceStore.swift */,
 				08E14A4298DB015E6477F789 /* StartAgentStore.swift */,
 				18AE2DC88A745FB457350957 /* StartAgentView.swift */,
 			);
@@ -909,6 +912,7 @@
 				A14E6D20D1216F7764E3298B /* PhotosPickerImageSelection.swift in Sources */,
 				B34AF64884F29EB050E5B9AF /* Preflight.swift in Sources */,
 				2F63F9E390ED79B5B87966D7 /* PushRegistrationStore.swift in Sources */,
+				F1FCF5D4FF428B3A593AE636 /* RecentWorkspaceStore.swift in Sources */,
 				8196491DBF3B6024B4DB214C /* SSHChannelBudget.swift in Sources */,
 				8C514AFC85DAED69A4988C13 /* SSHCredentials.swift in Sources */,
 				CD358CC16A58086C056E975D /* SSHPairingConnector.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		1F4B065DFCAF8E6656600F1E /* TOFUHostKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */; };
 		213116D3248CE7DCEAA6EBB9 /* ImageStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32D737E753ABEB2809975EA /* ImageStagingTests.swift */; };
 		225ECBDC69A7785559BC4D20 /* AttachTerminalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97970F4D535CC80592333995 /* AttachTerminalStore.swift */; };
+		27B2CC6D7285CA9A4E7CF558 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 46B11849C0824D5679BD9289 /* AppIcon.icon */; };
 		27C44B69FBE155A397F54B77 /* HostStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AECAD39A269D97DAB4ED194 /* HostStore.swift */; };
 		29832666B5E02B0D33453DB1 /* EventsSessionBufferingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641088A470B51F40C898830F /* EventsSessionBufferingTests.swift */; };
 		298FA49167E3CB1402B7B86B /* DeviceKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04EAA030D8329A1716714A8 /* DeviceKeyStore.swift */; };
@@ -245,6 +246,7 @@
 		4476B101AA4B13190C7A7B7C /* TransportConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConnector.swift; sourceTree = "<group>"; };
 		44F4B2F424E3FC8AB7DA69FC /* NotificationVectorFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationVectorFile.swift; sourceTree = "<group>"; };
 		45FC4FCCE9B94EC52FD930B1 /* Base64URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64URL.swift; sourceTree = "<group>"; };
+		46B11849C0824D5679BD9289 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		498ECBCD631F9734C28861EA /* ConsoleAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleAgent.swift; sourceTree = "<group>"; };
 		4DBF37BC147BBEEB4549FD21 /* AppActivityCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivityCoordinator.swift; sourceTree = "<group>"; };
 		4FD32D8CF0FF5617AF7E3513 /* NotificationRegistrationCeremony.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRegistrationCeremony.swift; sourceTree = "<group>"; };
@@ -631,6 +633,7 @@
 		B5CBF3555504362CC1FFDFE5 /* HerdrMobile */ = {
 			isa = PBXGroup;
 			children = (
+				46B11849C0824D5679BD9289 /* AppIcon.icon */,
 				7D95D580BCF4FE792AEFE974 /* ContentView.swift */,
 				C87759E4BF8637BE43E7648B /* HerdrMobile.entitlements */,
 				78545B74736FD98DCA33B3C4 /* HerdrMobileApp.swift */,
@@ -719,6 +722,7 @@
 			buildConfigurationList = CEBFA8DB94A8EBC2E21D50C2 /* Build configuration list for PBXNativeTarget "HerdrMobile" */;
 			buildPhases = (
 				8A7F6144162C733E402E680E /* Sources */,
+				9640ED2E81DCC8FF77350051 /* Resources */,
 				0E81AC9535C8CAB6E6C756D9 /* Frameworks */,
 				F2840EDFAE6B942FE17EC123 /* Embed Foundation Extensions */,
 			);
@@ -824,6 +828,14 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		9640ED2E81DCC8FF77350051 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				27B2CC6D7285CA9A4E7CF558 /* AppIcon.icon in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		ADD4254368B6DA14497BD8B7 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;

--- a/Sources/HerdrMobile/AppIcon.icon/Assets/iconoir-server-connection-eyes.svg
+++ b/Sources/HerdrMobile/AppIcon.icon/Assets/iconoir-server-connection-eyes.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M9 9.01L9.01 8.99889" stroke="#000000" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12 9.01L12.01 8.99889" stroke="#000000" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Sources/HerdrMobile/AppIcon.icon/Assets/iconoir-server-connection.svg
+++ b/Sources/HerdrMobile/AppIcon.icon/Assets/iconoir-server-connection.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 19H12M21 19H12M12 19V13M12 13H18V5H6V13H12Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M9 9.01L9.01 8.99889" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12 9.01L12.01 8.99889" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Sources/HerdrMobile/AppIcon.icon/icon.json
+++ b/Sources/HerdrMobile/AppIcon.icon/icon.json
@@ -1,0 +1,79 @@
+{
+  "fill" : {
+    "automatic-gradient" : "srgb:1.00000,1.00000,1.00000,1.00000"
+  },
+  "groups" : [
+    {
+      "layers" : [
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "dark",
+              "value" : "none"
+            }
+          ],
+          "glass-specializations" : [
+            {
+              "appearance" : "dark",
+              "value" : false
+            }
+          ],
+          "image-name" : "iconoir-server-connection-eyes.svg",
+          "name" : "iconoir-server-connection-eyes",
+          "opacity-specializations" : [
+            {
+              "value" : 0
+            },
+            {
+              "appearance" : "dark",
+              "value" : 1
+            }
+          ],
+          "position" : {
+            "scale" : 40,
+            "translation-in-points" : [
+              0,
+              0
+            ]
+          }
+        },
+        {
+          "fill-specializations" : [
+            {
+              "appearance" : "dark",
+              "value" : "automatic"
+            }
+          ],
+          "glass-specializations" : [
+            {
+              "appearance" : "dark",
+              "value" : true
+            }
+          ],
+          "image-name" : "iconoir-server-connection.svg",
+          "name" : "iconoir-server-connection",
+          "position" : {
+            "scale" : 40,
+            "translation-in-points" : [
+              0,
+              0
+            ]
+          }
+        }
+      ],
+      "shadow" : {
+        "kind" : "neutral",
+        "opacity" : 0.5
+      },
+      "translucency" : {
+        "enabled" : true,
+        "value" : 0.3
+      }
+    }
+  ],
+  "supported-platforms" : {
+    "squares" : [
+      "iOS"
+    ]
+  }
+}

--- a/Sources/HerdrMobile/Console/AgentCardView.swift
+++ b/Sources/HerdrMobile/Console/AgentCardView.swift
@@ -1,17 +1,20 @@
 import SwiftUI
 
-/// One Console card (#8): agent name and status up front, Host, pane
-/// address, and workspace as context, plus the last-output snippet.
+/// One Console card (#8): the project and status up front, Host, agent kind,
+/// and pane address as context, plus the last-output snippet. The project
+/// leads because a console full of agents is usually a console full of
+/// `claude` — the workspace is what tells the rows apart.
 struct AgentCardView: View {
     let agent: ConsoleAgent
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .firstTextBaseline) {
-                Text(agent.agent.displayName)
+                Text(headline)
                     .font(.headline)
+                    .lineLimit(1)
                 AgentStatusBadge(status: agent.agent.status)
-                Spacer()
+                Spacer(minLength: 8)
                 Text(agent.hostName)
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -28,8 +31,8 @@ struct AgentCardView: View {
                     .lineLimit(2)
             }
             HStack(spacing: 6) {
-                if let context = workspaceContext {
-                    Text(context)
+                if let kind = agentKindTag {
+                    Text(kind)
                         .font(.caption2)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
@@ -43,7 +46,19 @@ struct AgentCardView: View {
         .padding(.vertical, 4)
     }
 
-    /// The workspace context tag: label, with the worktree repo when it adds
+    /// The card's lead line: the project the agent works in, falling back to
+    /// the agent's own name when the snapshot carried no workspace.
+    private var headline: String {
+        workspaceContext ?? agent.agent.displayName
+    }
+
+    /// The agent name, tagged at the foot of the card — dropped when the
+    /// headline already fell back to it.
+    private var agentKindTag: String? {
+        workspaceContext == nil ? nil : agent.agent.displayName
+    }
+
+    /// The workspace context: label, with the worktree repo when it adds
     /// information the label does not already carry.
     private var workspaceContext: String? {
         switch (agent.workspaceLabel, agent.repoName) {
@@ -96,5 +111,18 @@ struct AgentStatusBadge: View {
                 workspaceLabel: "proj",
                 repoName: "proj",
                 lastOutputSnippet: "Allow Claude to run rm -rf? 1. Yes 2. No"))
+        // No workspace in the snapshot: the agent name takes the lead line
+        // and the foot tag drops.
+        AgentCardView(
+            agent: ConsoleAgent(
+                hostID: UUID(),
+                hostName: "devbox",
+                agent: Agent(
+                    terminalID: "term_b", kind: "claude", title: "Draft the release notes",
+                    status: .working, workspaceID: "w2", tabID: "w2:t1", paneID: "w2:p1",
+                    cwd: "/tmp", revision: 1),
+                workspaceLabel: nil,
+                repoName: nil,
+                lastOutputSnippet: nil))
     }
 }

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -79,9 +79,6 @@ struct AgentDetailView: View {
                 .accessibilityLabel("Attach Image")
             }
             ToolbarItem(placement: .primaryAction) {
-                AgentStatusBadge(status: agent.agent.status)
-            }
-            ToolbarItem(placement: .primaryAction) {
                 Menu {
                     Button("Terminal Theme", systemImage: "paintpalette") {
                         isShowingSettings = true

--- a/Sources/HerdrMobile/Console/ConsoleView.swift
+++ b/Sources/HerdrMobile/Console/ConsoleView.swift
@@ -45,7 +45,7 @@ struct ConsoleView: View {
                             description: Text("This Agent's pane is no longer reported."))
                     }
                 }
-                .navigationTitle("Console")
+                .navigationTitle("Agents")
                 .toolbar {
                     ToolbarItem(placement: .primaryAction) {
                         Button("Hosts", systemImage: "server.rack") {

--- a/Sources/HerdrMobile/Console/RecentWorkspaceStore.swift
+++ b/Sources/HerdrMobile/Console/RecentWorkspaceStore.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// The workspace the user last started an agent in, remembered per Host (#12).
+///
+/// The new-agent sheet pre-selects it: launching several agents into the same
+/// project is the common case, and re-picking the workspace every time is pure
+/// tax. Keyed by Host because a workspace ID only means something inside one
+/// herdr session.
+struct RecentWorkspaceStore {
+    private static let defaultsKey = "recent-workspace-by-host"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func workspaceID(for hostID: Host.ID) -> String? {
+        byHost[hostID.uuidString]
+    }
+
+    func remember(_ workspaceID: String, for hostID: Host.ID) {
+        var updated = byHost
+        updated[hostID.uuidString] = workspaceID
+        defaults.set(updated, forKey: Self.defaultsKey)
+    }
+
+    /// Entries for Hosts that no longer exist are harmless (a few bytes each,
+    /// never read), so nothing prunes them.
+    private var byHost: [String: String] {
+        defaults.dictionary(forKey: Self.defaultsKey) as? [String: String] ?? [:]
+    }
+}

--- a/Sources/HerdrMobile/Console/StartAgentStore.swift
+++ b/Sources/HerdrMobile/Console/StartAgentStore.swift
@@ -30,11 +30,33 @@ final class StartAgentStore {
         didSet {
             // A workspace belongs to one Host; switching Hosts drops a stale
             // pick so it can never target the wrong session.
-            if selectedHostID != oldValue { selectedWorkspaceID = nil }
+            if selectedHostID != oldValue { pickedWorkspaceID = nil }
         }
     }
-    /// nil targets the Host's current workspace (omits `workspace_id`).
-    var selectedWorkspaceID: String?
+
+    /// The workspace the agent starts in: what the user picked, else the one
+    /// they last started an agent in on this Host, else the Host's first.
+    ///
+    /// Only nil while the Host reports no workspaces at all — then the request
+    /// omits `workspace_id` and herdr uses its current one.
+    var selectedWorkspaceID: String? {
+        get {
+            if let pickedWorkspaceID { return pickedWorkspaceID }
+            let available = workspaces
+            if let selectedHostID, let remembered = recents.workspaceID(for: selectedHostID),
+                available.contains(where: { $0.id == remembered })
+            {
+                return remembered
+            }
+            return available.first?.id
+        }
+        set { pickedWorkspaceID = newValue }
+    }
+
+    /// The user's explicit pick; nil means "follow the default above". Kept
+    /// separate so a snapshot arriving after the sheet opens still gets to
+    /// supply the default.
+    private var pickedWorkspaceID: String?
     /// The unique live-agent name required by herdr protocol 17.
     var name: String = ""
     /// The command line, tokenized into argv on submit.
@@ -44,6 +66,7 @@ final class StartAgentStore {
 
     private let workspacesProvider: (Host.ID) -> [ConsoleWorkspace]
     private let start: (AgentLaunchRequest, Host.ID) async throws -> Agent
+    @ObservationIgnored private let recents: RecentWorkspaceStore
     /// In-flight guard flipped synchronously before the first await, so a
     /// double-tap cannot dispatch the same command twice through the window
     /// before `state == .starting` disables the button.
@@ -52,11 +75,13 @@ final class StartAgentStore {
     init(
         hosts: [Host],
         workspaces: @escaping (Host.ID) -> [ConsoleWorkspace],
-        start: @escaping (AgentLaunchRequest, Host.ID) async throws -> Agent
+        start: @escaping (AgentLaunchRequest, Host.ID) async throws -> Agent,
+        recents: RecentWorkspaceStore = RecentWorkspaceStore()
     ) {
         self.hosts = hosts
         self.workspacesProvider = workspaces
         self.start = start
+        self.recents = recents
         // Pre-select when there is no choice to make.
         self.selectedHostID = hosts.count == 1 ? hosts.first?.id : nil
     }
@@ -90,13 +115,15 @@ final class StartAgentStore {
         isStarting = true
         state = .starting
         defer { isStarting = false }
+        let workspaceID = selectedWorkspaceID
         let request = AgentLaunchRequest(
             kind: kind,
             name: agentName,
             arguments: Array(tokens.dropFirst()),
-            workspaceID: selectedWorkspaceID)
+            workspaceID: workspaceID)
         do {
             _ = try await start(request, hostID)
+            if let workspaceID { recents.remember(workspaceID, for: hostID) }
             state = .started
         } catch {
             state = .failed(Self.message(for: error))

--- a/Sources/HerdrMobile/Console/StartAgentView.swift
+++ b/Sources/HerdrMobile/Console/StartAgentView.swift
@@ -33,16 +33,18 @@ struct StartAgentView: View {
 
                 Section {
                     Picker("Workspace", selection: $store.selectedWorkspaceID) {
-                        Text("Current workspace").tag(String?.none)
+                        if store.workspaces.isEmpty {
+                            Text("None reported").tag(String?.none)
+                        }
                         ForEach(store.workspaces) { workspace in
                             Text(workspace.label).tag(String?.some(workspace.id))
                         }
                     }
-                    .disabled(store.selectedHostID == nil)
+                    .disabled(store.selectedHostID == nil || store.workspaces.isEmpty)
                 } header: {
                     Text("Workspace")
                 } footer: {
-                    Text("Where the agent runs. Leave on the Host's current workspace if unsure.")
+                    Text("Where the agent runs. Defaults to the one you last started an agent in.")
                 }
 
                 Section {

--- a/Sources/HerdrMobile/Notifications/AgentNotificationBannerStore.swift
+++ b/Sources/HerdrMobile/Notifications/AgentNotificationBannerStore.swift
@@ -117,7 +117,7 @@ final class AgentNotificationBannerStore {
             target: target,
             alert: AgentNotificationRenderer.alert(
                 project: agent.workspaceLabel ?? agent.repoName, agentKind: agent.agent.kind,
-                hostName: agent.hostName, task: agent.agent.title, status: status))
+                task: agent.agent.title, status: status))
         playSound()
         armDismissal()
     }

--- a/Sources/HerdrMobile/Notifications/AgentNotificationBannerStore.swift
+++ b/Sources/HerdrMobile/Notifications/AgentNotificationBannerStore.swift
@@ -116,7 +116,8 @@ final class AgentNotificationBannerStore {
         banner = AgentNotificationBanner(
             target: target,
             alert: AgentNotificationRenderer.alert(
-                agentKind: agent.agent.kind, hostName: agent.hostName, status: status))
+                project: agent.workspaceLabel ?? agent.repoName, agentKind: agent.agent.kind,
+                hostName: agent.hostName, task: agent.agent.title, status: status))
         playSound()
         armDismissal()
     }

--- a/Sources/HerdrMobile/Notifications/AgentNotificationBannerView.swift
+++ b/Sources/HerdrMobile/Notifications/AgentNotificationBannerView.swift
@@ -14,9 +14,17 @@ struct AgentNotificationBannerView: View {
                 Text(banner.alert.title)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.primary)
+                    .lineLimit(1)
+                if let subtitle = banner.alert.subtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
                 Text(banner.alert.body)
                     .font(.footnote)
                     .foregroundStyle(.secondary)
+                    .lineLimit(2)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 14)
@@ -34,6 +42,7 @@ struct AgentNotificationBannerView: View {
         banner: AgentNotificationBanner(
             target: AgentNotificationTarget(hostID: UUID(), paneID: "%5"),
             alert: AgentNotificationAlert(
-                title: "claude on mac-studio", body: "Blocked: waiting for your input"))
+                title: "herdr-mobile", subtitle: "claude on mac-studio",
+                body: "Blocked · 排查修复 split 按钮 UI 结构问题"))
     ) {}
 }

--- a/Sources/HerdrMobile/Notifications/AgentNotificationBannerView.swift
+++ b/Sources/HerdrMobile/Notifications/AgentNotificationBannerView.swift
@@ -15,12 +15,6 @@ struct AgentNotificationBannerView: View {
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.primary)
                     .lineLimit(1)
-                if let subtitle = banner.alert.subtitle {
-                    Text(subtitle)
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                        .lineLimit(1)
-                }
                 Text(banner.alert.body)
                     .font(.footnote)
                     .foregroundStyle(.secondary)
@@ -42,7 +36,7 @@ struct AgentNotificationBannerView: View {
         banner: AgentNotificationBanner(
             target: AgentNotificationTarget(hostID: UUID(), paneID: "%5"),
             alert: AgentNotificationAlert(
-                title: "herdr-mobile", subtitle: "claude on mac-studio",
+                title: "herdr-mobile · claude",
                 body: "Blocked · 排查修复 split 按钮 UI 结构问题"))
     ) {}
 }

--- a/Sources/HerdrNotificationCore/AgentNotificationRenderer.swift
+++ b/Sources/HerdrNotificationCore/AgentNotificationRenderer.swift
@@ -4,16 +4,7 @@ import Foundation
 /// Agent Notification content or the generic fallback banner.
 struct AgentNotificationAlert: Sendable, Equatable {
     let title: String
-    /// The agent-and-Host attribution, demoted below the project when there
-    /// is one. Nil when the title already carries it.
-    let subtitle: String?
     let body: String
-
-    init(title: String, subtitle: String? = nil, body: String) {
-        self.title = title
-        self.subtitle = subtitle
-        self.body = body
-    }
 }
 
 /// The service extension's logic as a pure function (#71): take the push's
@@ -36,11 +27,11 @@ enum AgentNotificationRenderer {
     static func alert(
         userInfo: [AnyHashable: Any], keys: [NotificationKeyRecord]
     ) -> AgentNotificationAlert {
-        guard let (record, payload) = NotificationEnvelope.open(userInfo: userInfo, keys: keys)
+        guard let (_, payload) = NotificationEnvelope.open(userInfo: userInfo, keys: keys)
         else { return fallback }
         return alert(
-            project: payload.project, agentKind: payload.agentKind, hostName: record.hostName,
-            task: payload.title, status: payload.status)
+            project: payload.project, agentKind: payload.agentKind, task: payload.title,
+            status: payload.status)
     }
 
     /// The one phrasing of an Agent Notification, shared by the push path
@@ -48,18 +39,18 @@ enum AgentNotificationRenderer {
     /// drift between them.
     ///
     /// The project leads: with several agents running, it is what tells one
-    /// notification from another — the agent kind rarely differs. `project`
-    /// and `task` are best-effort (an older plugin sends neither), and the
-    /// copy degrades one step at a time rather than all at once.
+    /// notification from another — the agent kind rarely differs. The Host is
+    /// deliberately absent: it is the same machine every time and spends the
+    /// whole line on an address nobody reads. `project` and `task` are
+    /// best-effort (an older plugin sends neither), and the copy degrades one
+    /// step at a time rather than all at once.
     static func alert(
-        project: String?, agentKind: String, hostName: String, task: String?, status: AgentStatus
+        project: String?, agentKind: String, task: String?, status: AgentStatus
     ) -> AgentNotificationAlert {
-        let attribution = "\(agentKind) on \(hostName)"
         let project = trimmedNonEmpty(project)
         let task = trimmedNonEmpty(task)
         return AgentNotificationAlert(
-            title: project ?? attribution,
-            subtitle: project == nil ? nil : attribution,
+            title: project.map { "\($0) · \(agentKind)" } ?? agentKind,
             body: body(for: status, task: task))
     }
 

--- a/Sources/HerdrNotificationCore/AgentNotificationRenderer.swift
+++ b/Sources/HerdrNotificationCore/AgentNotificationRenderer.swift
@@ -4,12 +4,21 @@ import Foundation
 /// Agent Notification content or the generic fallback banner.
 struct AgentNotificationAlert: Sendable, Equatable {
     let title: String
+    /// The agent-and-Host attribution, demoted below the project when there
+    /// is one. Nil when the title already carries it.
+    let subtitle: String?
     let body: String
+
+    init(title: String, subtitle: String? = nil, body: String) {
+        self.title = title
+        self.subtitle = subtitle
+        self.body = body
+    }
 }
 
 /// The service extension's logic as a pure function (#71): take the push's
 /// `userInfo` and the registered Notification Keys, select the key by the
-/// envelope's kid, decrypt, and phrase the alert as Host, agent kind, and
+/// envelope's kid, decrypt, and phrase the alert as project, agent task, and
 /// status. Anything undecryptable — missing or non-string envelope, unknown
 /// kid, any `NotificationEnvelopeError` — degrades to `fallback`, which the
 /// extension applies unconditionally so a forged push can never render
@@ -18,25 +27,48 @@ enum AgentNotificationRenderer {
     /// Mirrors the relay's generic wrap copy; deliberately unalarming.
     static let fallback = AgentNotificationAlert(title: "herdr", body: "Agent update")
 
+    /// Terminal titles are whole task descriptions ("排查修复 split 按钮 UI
+    /// 结构问题") and can run to a full line of prose. iOS truncates the banner
+    /// itself, but only after the notification has spent its payload budget on
+    /// text nobody reads, so the phrasing cuts first.
+    static let taskLimit = 80
+
     static func alert(
         userInfo: [AnyHashable: Any], keys: [NotificationKeyRecord]
     ) -> AgentNotificationAlert {
         guard let (record, payload) = NotificationEnvelope.open(userInfo: userInfo, keys: keys)
         else { return fallback }
         return alert(
-            agentKind: payload.agentKind, hostName: record.hostName, status: payload.status)
+            project: payload.project, agentKind: payload.agentKind, hostName: record.hostName,
+            task: payload.title, status: payload.status)
     }
 
     /// The one phrasing of an Agent Notification, shared by the push path
     /// above and the in-app foreground banner (#77) so the wording cannot
     /// drift between them.
+    ///
+    /// The project leads: with several agents running, it is what tells one
+    /// notification from another — the agent kind rarely differs. `project`
+    /// and `task` are best-effort (an older plugin sends neither), and the
+    /// copy degrades one step at a time rather than all at once.
     static func alert(
-        agentKind: String, hostName: String, status: AgentStatus
+        project: String?, agentKind: String, hostName: String, task: String?, status: AgentStatus
     ) -> AgentNotificationAlert {
-        AgentNotificationAlert(title: "\(agentKind) on \(hostName)", body: body(for: status))
+        let attribution = "\(agentKind) on \(hostName)"
+        let project = trimmedNonEmpty(project)
+        let task = trimmedNonEmpty(task)
+        return AgentNotificationAlert(
+            title: project ?? attribution,
+            subtitle: project == nil ? nil : attribution,
+            body: body(for: status, task: task))
     }
 
-    private static func body(for status: AgentStatus) -> String {
+    private static func body(for status: AgentStatus, task: String?) -> String {
+        guard let task else { return statusOnlyBody(for: status) }
+        return "\(word(for: status)) · \(truncated(task))"
+    }
+
+    private static func statusOnlyBody(for status: AgentStatus) -> String {
         switch status {
         case .blocked: "Blocked: waiting for your input"
         case .done: "Done: the agent finished"
@@ -44,5 +76,27 @@ enum AgentNotificationRenderer {
         // factually instead of guessing at their meaning.
         default: "Status: \(status.rawValue)"
         }
+    }
+
+    private static func word(for status: AgentStatus) -> String {
+        switch status {
+        case .blocked: "Blocked"
+        case .done: "Done"
+        default: status.rawValue
+        }
+    }
+
+    private static func truncated(_ text: String) -> String {
+        guard text.count > taskLimit else { return text }
+        let head = text.prefix(taskLimit - 1)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return head + "…"
+    }
+
+    private static func trimmedNonEmpty(_ text: String?) -> String? {
+        guard let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !trimmed.isEmpty
+        else { return nil }
+        return trimmed
     }
 }

--- a/Sources/HerdrNotificationCore/NotificationEnvelope.swift
+++ b/Sources/HerdrNotificationCore/NotificationEnvelope.swift
@@ -13,6 +13,25 @@ struct NotificationPayload: Sendable, Equatable {
     let status: AgentStatus
     /// When the transition happened.
     let timestamp: Date
+    /// The workspace label the Agent runs in — the project name the alert
+    /// leads with. Nil when the Host could not resolve it, or when the plugin
+    /// predates the field.
+    let project: String?
+    /// The Agent's terminal title, stripped of status glyphs: what the agent
+    /// is working on. Nil under the same conditions as `project`.
+    let title: String?
+
+    init(
+        paneID: String, agentKind: String, status: AgentStatus, timestamp: Date,
+        project: String? = nil, title: String? = nil
+    ) {
+        self.paneID = paneID
+        self.agentKind = agentKind
+        self.status = status
+        self.timestamp = timestamp
+        self.project = project
+        self.title = title
+    }
 }
 
 /// The notification envelope v1: the encrypted payload carried from the
@@ -163,9 +182,18 @@ enum NotificationEnvelope {
         else {
             throw .badPayload(reason: "ts must be a positive unix-seconds integer")
         }
+        // Display-only and additive: a payload without them still renders,
+        // one step less specific. Empty strings mean "the Host had nothing",
+        // which is the same thing as absent.
         return NotificationPayload(
             paneID: pane, agentKind: kind, status: AgentStatus(rawValue: status),
-            timestamp: Date(timeIntervalSince1970: TimeInterval(timestamp)))
+            timestamp: Date(timeIntervalSince1970: TimeInterval(timestamp)),
+            project: nonEmpty(wire.project), title: nonEmpty(wire.title))
+    }
+
+    private static func nonEmpty(_ text: String?) -> String? {
+        guard let text, !text.isEmpty else { return nil }
+        return text
     }
 
     /// Cleartext JSON wire shape. Every field is optional and numbers are
@@ -178,12 +206,16 @@ enum NotificationEnvelope {
         var ct: String?
     }
 
-    /// Decrypted JSON wire shape, lenient for the same reason.
+    /// Decrypted JSON wire shape, lenient for the same reason. `project` and
+    /// `title` are the additive v1 display fields: absent from older plugins,
+    /// and never load-bearing for anything but copy.
     private struct WirePlaintext: Decodable {
         var pane: String?
         var kind: String?
         var status: String?
         var ts: Double?
+        var project: String?
+        var title: String?
     }
 }
 

--- a/Sources/HerdrNotificationService/NotificationService.swift
+++ b/Sources/HerdrNotificationService/NotificationService.swift
@@ -29,6 +29,9 @@ final class NotificationService: UNNotificationServiceExtension {
             return content
         }
         rewritten.title = alert.title
+        // Always assigned: an empty subtitle is how UNNotificationContent
+        // spells "no subtitle", and the relay's wrap may have set one.
+        rewritten.subtitle = alert.subtitle ?? ""
         rewritten.body = alert.body
         return rewritten
     }

--- a/Sources/HerdrNotificationService/NotificationService.swift
+++ b/Sources/HerdrNotificationService/NotificationService.swift
@@ -29,9 +29,9 @@ final class NotificationService: UNNotificationServiceExtension {
             return content
         }
         rewritten.title = alert.title
-        // Always assigned: an empty subtitle is how UNNotificationContent
-        // spells "no subtitle", and the relay's wrap may have set one.
-        rewritten.subtitle = alert.subtitle ?? ""
+        // Cleared, not left alone: the relay's generic wrap may have set a
+        // subtitle, and the decrypted copy has no use for one.
+        rewritten.subtitle = ""
         rewritten.body = alert.body
         return rewritten
     }

--- a/Tests/HerdrMobileTests/AgentNotificationBannerStoreTests.swift
+++ b/Tests/HerdrMobileTests/AgentNotificationBannerStoreTests.swift
@@ -38,12 +38,12 @@ struct AgentNotificationBannerStoreTests {
 
     private func agent(
         _ paneID: String, _ status: AgentStatus,
-        hostID: UUID? = nil, kind: String = "claude"
+        hostID: UUID? = nil, kind: String = "claude", workspaceLabel: String? = nil
     ) -> ConsoleAgent {
         ConsoleAgent(
             hostID: hostID ?? self.hostID, hostName: "mac-studio",
             agent: Agent(.fixture(paneID: paneID, status: status, kind: kind)),
-            workspaceLabel: nil, repoName: nil, lastOutputSnippet: nil)
+            workspaceLabel: workspaceLabel, repoName: nil, lastOutputSnippet: nil)
     }
 
     /// Polls until `condition` holds, yielding so the store's tasks progress.
@@ -83,8 +83,24 @@ struct AgentNotificationBannerStoreTests {
                     target: AgentNotificationTarget(hostID: hostID, paneID: "%5"),
                     alert: AgentNotificationAlert(
                         title: "claude on mac-studio",
-                        body: "Blocked: waiting for your input")))
+                        body: "Blocked · Task")))
         #expect(world.soundCount == 1)
+    }
+
+    /// The banner shares the push renderer, so a known workspace leads the
+    /// same way it does on a push.
+    @Test func aKnownWorkspaceLeadsTheBanner() async throws {
+        world.triggers[hostID] = NotificationTriggerPreferences()
+        let store = makeStore()
+        store.agentsDidChange([agent("%5", .working, workspaceLabel: "Caterm")])
+
+        store.agentsDidChange([agent("%5", .blocked, workspaceLabel: "Caterm")])
+
+        try await waitUntil("the banner should show") { store.banner != nil }
+        #expect(
+            store.banner?.alert
+                == AgentNotificationAlert(
+                    title: "Caterm", subtitle: "claude on mac-studio", body: "Blocked · Task"))
     }
 
     @Test func doneTransitionBannersWithTheDoneCopy() async throws {
@@ -97,8 +113,7 @@ struct AgentNotificationBannerStoreTests {
         try await waitUntil("the Done banner should show") { store.banner != nil }
         #expect(
             store.banner?.alert
-                == AgentNotificationAlert(
-                    title: "codex on mac-studio", body: "Done: the agent finished"))
+                == AgentNotificationAlert(title: "codex on mac-studio", body: "Done · Task"))
     }
 
     /// The first sight of a pane is baseline, not a transition: a killed-state

--- a/Tests/HerdrMobileTests/AgentNotificationBannerStoreTests.swift
+++ b/Tests/HerdrMobileTests/AgentNotificationBannerStoreTests.swift
@@ -81,9 +81,7 @@ struct AgentNotificationBannerStoreTests {
             store.banner
                 == AgentNotificationBanner(
                     target: AgentNotificationTarget(hostID: hostID, paneID: "%5"),
-                    alert: AgentNotificationAlert(
-                        title: "claude on mac-studio",
-                        body: "Blocked · Task")))
+                    alert: AgentNotificationAlert(title: "claude", body: "Blocked · Task")))
         #expect(world.soundCount == 1)
     }
 
@@ -100,7 +98,7 @@ struct AgentNotificationBannerStoreTests {
         #expect(
             store.banner?.alert
                 == AgentNotificationAlert(
-                    title: "Caterm", subtitle: "claude on mac-studio", body: "Blocked · Task"))
+                    title: "Caterm · claude", body: "Blocked · Task"))
     }
 
     @Test func doneTransitionBannersWithTheDoneCopy() async throws {
@@ -113,7 +111,7 @@ struct AgentNotificationBannerStoreTests {
         try await waitUntil("the Done banner should show") { store.banner != nil }
         #expect(
             store.banner?.alert
-                == AgentNotificationAlert(title: "codex on mac-studio", body: "Done · Task"))
+                == AgentNotificationAlert(title: "codex", body: "Done · Task"))
     }
 
     /// The first sight of a pane is baseline, not a transition: a killed-state

--- a/Tests/HerdrMobileTests/AgentNotificationRendererTests.swift
+++ b/Tests/HerdrMobileTests/AgentNotificationRendererTests.swift
@@ -24,8 +24,8 @@ struct AgentNotificationRendererTests {
     }
 
     /// A payload from a plugin that predates the display fields: the copy
-    /// degrades to the old attribution-and-status phrasing rather than
-    /// falling back to the generic banner.
+    /// degrades to the agent kind and a status sentence rather than falling
+    /// back to the generic banner.
     @Test func rewritesABlockedPushWithoutDisplayFields() throws {
         let vector = try Self.vector(named: "blocked claude agent")
         let record = try Self.record(forVector: vector, named: "mac-studio")
@@ -33,13 +33,12 @@ struct AgentNotificationRendererTests {
         let alert = AgentNotificationRenderer.alert(
             userInfo: ["envelope": vector.envelope], keys: [record])
 
-        #expect(alert.title == "claude on mac-studio")
-        #expect(alert.subtitle == nil)
+        #expect(alert.title == "claude")
         #expect(alert.body == "Blocked: waiting for your input")
     }
 
-    /// The shape the current plugin sends: the project leads, the attribution
-    /// drops to the subtitle, and the body says what the agent was doing.
+    /// The shape the current plugin sends: the project leads, the agent kind
+    /// trails it, and the body says what the agent was doing.
     @Test func leadsWithTheProjectAndTheAgentsTask() throws {
         let vector = try Self.vector(named: "blocked agent with a project and a task title")
         let record = try Self.record(forVector: vector, named: "mac-studio")
@@ -47,17 +46,28 @@ struct AgentNotificationRendererTests {
         let alert = AgentNotificationRenderer.alert(
             userInfo: ["envelope": vector.envelope], keys: [record])
 
-        #expect(alert.title == "Caterm")
-        #expect(alert.subtitle == "claude on mac-studio")
+        #expect(alert.title == "Caterm · claude")
         #expect(alert.body == "Blocked · 排查修复 split 按钮 UI 结构问题")
+    }
+
+    /// The Host is the same machine on every notification and would spend the
+    /// whole title on an address; it must never reach the alert.
+    @Test func neverNamesTheHost() throws {
+        let vector = try Self.vector(named: "blocked agent with a project and a task title")
+        let record = try Self.record(forVector: vector, named: "zingerbee@192.168.31.64")
+
+        let alert = AgentNotificationRenderer.alert(
+            userInfo: ["envelope": vector.envelope], keys: [record])
+
+        #expect(!alert.title.contains("zingerbee"))
+        #expect(!alert.body.contains("zingerbee"))
     }
 
     @Test func trimsATaskTitleThatWouldOverrunTheBanner() {
         let long = String(repeating: "重构传输层", count: 40)
 
         let alert = AgentNotificationRenderer.alert(
-            project: "herdr-mobile", agentKind: "claude", hostName: "mac-studio", task: long,
-            status: .done)
+            project: "herdr-mobile", agentKind: "claude", task: long, status: .done)
 
         let task = alert.body.dropFirst("Done · ".count)
         #expect(task.count == AgentNotificationRenderer.taskLimit)
@@ -66,14 +76,12 @@ struct AgentNotificationRendererTests {
     }
 
     /// Best-effort fields: whitespace-only is the same as absent, so a Host
-    /// that resolved a blank never renders an empty title or a bare separator.
+    /// that resolved a blank never renders a dangling separator.
     @Test func treatsBlankDisplayFieldsAsAbsent() {
         let alert = AgentNotificationRenderer.alert(
-            project: "  ", agentKind: "claude", hostName: "mac-studio", task: "\n",
-            status: .blocked)
+            project: "  ", agentKind: "claude", task: "\n", status: .blocked)
 
-        #expect(alert.title == "claude on mac-studio")
-        #expect(alert.subtitle == nil)
+        #expect(alert.title == "claude")
         #expect(alert.body == "Blocked: waiting for your input")
     }
 
@@ -81,8 +89,8 @@ struct AgentNotificationRendererTests {
     /// is a task to pair it with.
     @Test func pairsAnUnrecognizedStatusWithTheTask() {
         let alert = AgentNotificationRenderer.alert(
-            project: "herdr-mobile", agentKind: "claude", hostName: "mac-studio",
-            task: "Fix the flaky test", status: AgentStatus(rawValue: "exited"))
+            project: "herdr-mobile", agentKind: "claude", task: "Fix the flaky test",
+            status: AgentStatus(rawValue: "exited"))
 
         #expect(alert.body == "exited · Fix the flaky test")
     }
@@ -94,7 +102,7 @@ struct AgentNotificationRendererTests {
         let alert = AgentNotificationRenderer.alert(
             userInfo: ["envelope": vector.envelope], keys: [record])
 
-        #expect(alert.title == "codex on vps-1")
+        #expect(alert.title == "codex")
         #expect(alert.body == "Done: the agent finished")
     }
 
@@ -111,8 +119,9 @@ struct AgentNotificationRendererTests {
     }
 
     /// Several registered Hosts means several Notification Keys; the kid in
-    /// the cleartext header must select the right one — and thus the right
-    /// Host name — without trial decryption.
+    /// the cleartext header must select the right one without trial
+    /// decryption. Picking the wrong key yields the generic fallback, so
+    /// each envelope rendering its own payload is the proof.
     @Test func selectsTheRightKeyAmongSeveralHostsByKid() throws {
         let blocked = try Self.vector(named: "blocked claude agent")
         let done = try Self.vector(named: "done codex agent under a second key")
@@ -126,8 +135,10 @@ struct AgentNotificationRendererTests {
         let doneAlert = AgentNotificationRenderer.alert(
             userInfo: ["envelope": done.envelope], keys: records)
 
-        #expect(blockedAlert.title == "claude on mac-studio")
-        #expect(doneAlert.title == "codex on vps-1")
+        #expect(blockedAlert.title == "claude")
+        #expect(blockedAlert.body == "Blocked: waiting for your input")
+        #expect(doneAlert.title == "codex")
+        #expect(doneAlert.body == "Done: the agent finished")
     }
 
     @Test func unknownKidFallsBackToTheGenericBanner() throws {

--- a/Tests/HerdrMobileTests/AgentNotificationRendererTests.swift
+++ b/Tests/HerdrMobileTests/AgentNotificationRendererTests.swift
@@ -23,7 +23,10 @@ struct AgentNotificationRendererTests {
         try #require(vectors.valid.first { $0.name == name })
     }
 
-    @Test func rewritesABlockedPushToHostKindAndStatus() throws {
+    /// A payload from a plugin that predates the display fields: the copy
+    /// degrades to the old attribution-and-status phrasing rather than
+    /// falling back to the generic banner.
+    @Test func rewritesABlockedPushWithoutDisplayFields() throws {
         let vector = try Self.vector(named: "blocked claude agent")
         let record = try Self.record(forVector: vector, named: "mac-studio")
 
@@ -31,7 +34,57 @@ struct AgentNotificationRendererTests {
             userInfo: ["envelope": vector.envelope], keys: [record])
 
         #expect(alert.title == "claude on mac-studio")
+        #expect(alert.subtitle == nil)
         #expect(alert.body == "Blocked: waiting for your input")
+    }
+
+    /// The shape the current plugin sends: the project leads, the attribution
+    /// drops to the subtitle, and the body says what the agent was doing.
+    @Test func leadsWithTheProjectAndTheAgentsTask() throws {
+        let vector = try Self.vector(named: "blocked agent with a project and a task title")
+        let record = try Self.record(forVector: vector, named: "mac-studio")
+
+        let alert = AgentNotificationRenderer.alert(
+            userInfo: ["envelope": vector.envelope], keys: [record])
+
+        #expect(alert.title == "Caterm")
+        #expect(alert.subtitle == "claude on mac-studio")
+        #expect(alert.body == "Blocked · 排查修复 split 按钮 UI 结构问题")
+    }
+
+    @Test func trimsATaskTitleThatWouldOverrunTheBanner() {
+        let long = String(repeating: "重构传输层", count: 40)
+
+        let alert = AgentNotificationRenderer.alert(
+            project: "herdr-mobile", agentKind: "claude", hostName: "mac-studio", task: long,
+            status: .done)
+
+        let task = alert.body.dropFirst("Done · ".count)
+        #expect(task.count == AgentNotificationRenderer.taskLimit)
+        #expect(task.hasSuffix("…"))
+        #expect(long.hasPrefix(task.dropLast()))
+    }
+
+    /// Best-effort fields: whitespace-only is the same as absent, so a Host
+    /// that resolved a blank never renders an empty title or a bare separator.
+    @Test func treatsBlankDisplayFieldsAsAbsent() {
+        let alert = AgentNotificationRenderer.alert(
+            project: "  ", agentKind: "claude", hostName: "mac-studio", task: "\n",
+            status: .blocked)
+
+        #expect(alert.title == "claude on mac-studio")
+        #expect(alert.subtitle == nil)
+        #expect(alert.body == "Blocked: waiting for your input")
+    }
+
+    /// An unrecognized status still names itself in the short form when there
+    /// is a task to pair it with.
+    @Test func pairsAnUnrecognizedStatusWithTheTask() {
+        let alert = AgentNotificationRenderer.alert(
+            project: "herdr-mobile", agentKind: "claude", hostName: "mac-studio",
+            task: "Fix the flaky test", status: AgentStatus(rawValue: "exited"))
+
+        #expect(alert.body == "exited · Fix the flaky test")
     }
 
     @Test func rewritesADonePush() throws {

--- a/Tests/HerdrMobileTests/NotificationEnvelopeTests.swift
+++ b/Tests/HerdrMobileTests/NotificationEnvelopeTests.swift
@@ -32,6 +32,8 @@ struct NotificationEnvelopeTests {
         #expect(
             payload.timestamp
                 == Date(timeIntervalSince1970: TimeInterval(vector.payload.timestamp)))
+        #expect(payload.project == vector.payload.project)
+        #expect(payload.title == vector.payload.title)
     }
 
     /// The key id is derived, never stored: both ends must agree on the

--- a/Tests/HerdrMobileTests/StartAgentStoreTests.swift
+++ b/Tests/HerdrMobileTests/StartAgentStoreTests.swift
@@ -24,14 +24,25 @@ struct StartAgentStoreTests {
         }
     }
 
+    /// A throwaway defaults domain per test, so the remembered-workspace
+    /// persistence is real but isolated.
+    private func makeRecents() -> RecentWorkspaceStore {
+        let name = "recent-workspace-test-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return RecentWorkspaceStore(defaults: defaults)
+    }
+
     private func makeStore(
         hosts: [Host],
         workspaces: @escaping (Host.ID) -> [ConsoleWorkspace] = { _ in [] },
+        recents: RecentWorkspaceStore? = nil,
         recorder: StartRecorder
     ) -> StartAgentStore {
         StartAgentStore(
             hosts: hosts, workspaces: workspaces,
-            start: { params, hostID in try recorder.record(params, hostID) })
+            start: { params, hostID in try recorder.record(params, hostID) },
+            recents: recents ?? makeRecents())
     }
 
     @Test func tokenizeSplitsOnWhitespaceAndDropsEmpties() {
@@ -71,16 +82,110 @@ struct StartAgentStoreTests {
         let hostB = Host.fixture(address: "b.example")
         let store = makeStore(
             hosts: [hostA, hostB],
-            workspaces: { $0 == hostA.id ? [ConsoleWorkspace(id: "w1", label: "Proj")] : [] },
+            workspaces: {
+                $0 == hostA.id
+                    ? [ConsoleWorkspace(id: "w1", label: "Proj"),
+                        ConsoleWorkspace(id: "w2", label: "Other")]
+                    : []
+            },
             recorder: StartRecorder())
 
         store.selectedHostID = hostA.id
-        store.selectedWorkspaceID = "w1"
-        #expect(store.workspaces.map(\.id) == ["w1"])
+        store.selectedWorkspaceID = "w2"
+        #expect(store.workspaces.map(\.id) == ["w1", "w2"])
 
         store.selectedHostID = hostB.id
         #expect(store.selectedWorkspaceID == nil)
         #expect(store.workspaces.isEmpty)
+    }
+
+    @Test func defaultsToTheHostsFirstWorkspaceWithNothingRemembered() {
+        let host = Host.fixture()
+        let store = makeStore(
+            hosts: [host],
+            workspaces: { _ in
+                [ConsoleWorkspace(id: "w1", label: "Proj"),
+                    ConsoleWorkspace(id: "w2", label: "Other")]
+            },
+            recorder: StartRecorder())
+
+        #expect(store.selectedWorkspaceID == "w1")
+    }
+
+    /// The snapshot often lands after the sheet opens; the default has to
+    /// follow it rather than latch on the empty list.
+    @Test func defaultFollowsAWorkspaceListThatArrivesLate() {
+        let host = Host.fixture()
+        final class Snapshot { var workspaces: [ConsoleWorkspace] = [] }
+        let snapshot = Snapshot()
+        let store = makeStore(
+            hosts: [host], workspaces: { _ in snapshot.workspaces }, recorder: StartRecorder())
+
+        #expect(store.selectedWorkspaceID == nil)
+        snapshot.workspaces = [ConsoleWorkspace(id: "w1", label: "Proj")]
+        #expect(store.selectedWorkspaceID == "w1")
+    }
+
+    @Test func defaultsToTheWorkspaceLastStartedInOnThatHost() async {
+        let host = Host.fixture()
+        let other = Host.fixture(address: "b.example")
+        let recents = makeRecents()
+        let workspaces: (Host.ID) -> [ConsoleWorkspace] = { _ in
+            [ConsoleWorkspace(id: "w1", label: "Proj"), ConsoleWorkspace(id: "w2", label: "Other")]
+        }
+
+        let first = makeStore(
+            hosts: [host], workspaces: workspaces, recents: recents, recorder: StartRecorder())
+        first.selectedWorkspaceID = "w2"
+        first.name = "reviewer"
+        first.command = "claude"
+        await first.submit()
+        #expect(first.state == .started)
+
+        let next = makeStore(
+            hosts: [host], workspaces: workspaces, recents: recents, recorder: StartRecorder())
+        #expect(next.selectedWorkspaceID == "w2")
+
+        // Remembered per Host: another Host falls back to its own first.
+        let elsewhere = makeStore(
+            hosts: [other], workspaces: workspaces, recents: recents, recorder: StartRecorder())
+        #expect(elsewhere.selectedWorkspaceID == "w1")
+    }
+
+    @Test func ignoresARememberedWorkspaceTheHostNoLongerReports() async {
+        let host = Host.fixture()
+        let recents = makeRecents()
+        let gone = makeStore(
+            hosts: [host], workspaces: { _ in [ConsoleWorkspace(id: "w9", label: "Gone")] },
+            recents: recents, recorder: StartRecorder())
+        gone.name = "reviewer"
+        gone.command = "claude"
+        await gone.submit()
+
+        let next = makeStore(
+            hosts: [host], workspaces: { _ in [ConsoleWorkspace(id: "w1", label: "Proj")] },
+            recents: recents, recorder: StartRecorder())
+        #expect(next.selectedWorkspaceID == "w1")
+    }
+
+    @Test func aFailedStartIsNotRemembered() async {
+        let host = Host.fixture()
+        let recents = makeRecents()
+        let recorder = StartRecorder()
+        recorder.error = HerdrAPIError(code: "400", message: "no such workspace")
+        let workspaces: (Host.ID) -> [ConsoleWorkspace] = { _ in
+            [ConsoleWorkspace(id: "w1", label: "Proj"), ConsoleWorkspace(id: "w2", label: "Other")]
+        }
+        let store = makeStore(
+            hosts: [host], workspaces: workspaces, recents: recents, recorder: recorder)
+        store.selectedWorkspaceID = "w2"
+        store.name = "reviewer"
+        store.command = "claude"
+        await store.submit()
+
+        let next = makeStore(
+            hosts: [host], workspaces: workspaces, recents: recents, recorder: StartRecorder())
+        #expect(next.selectedWorkspaceID == "w1")
     }
 
     @Test func submitForwardsTheAssembledParamsAndSucceeds() async {
@@ -101,7 +206,7 @@ struct StartAgentStoreTests {
         #expect(recorder.params.first?.workspaceID == "w1")
     }
 
-    @Test func submitOmitsTheWorkspaceWhenTargetingTheCurrentOne() async {
+    @Test func submitOmitsTheWorkspaceWhenTheHostReportsNone() async {
         let host = Host.fixture()
         let recorder = StartRecorder()
         let store = makeStore(hosts: [host], recorder: recorder)

--- a/Tests/HerdrMobileTests/Support/NotificationVectorFile.swift
+++ b/Tests/HerdrMobileTests/Support/NotificationVectorFile.swift
@@ -27,6 +27,9 @@ struct NotificationVectorFile: Decodable, Sendable {
         let agentKind: String
         let status: String
         let timestamp: Int
+        /// The optional display fields; absent from vectors predating them.
+        let project: String?
+        let title: String?
     }
 
     struct Invalid: Decodable, Sendable, CustomStringConvertible {

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -185,6 +185,8 @@ plaintext is compact JSON:
 | `kind`   | string  | Agent kind as herdr reports it (`claude`, `codex`, ...). Non-empty. |
 | `status` | string  | The new Agent Status. An open set: decoders pass unrecognized values through. Non-empty. |
 | `ts`     | integer | Unix-seconds of the status transition. Positive. |
+| `project`| string  | Optional, display only: the workspace label the Agent runs in — the project name the app's alert leads with. Omitted when the Host cannot resolve it. At most 256 characters (the hook trims to 80 before encrypting). |
+| `title`  | string  | Optional, display only: the Agent's terminal title with status glyphs stripped — what it is working on. Same absence and length rules as `project`. |
 
 A plaintext that is not JSON or violates these rules is rejected
 (`bad_payload`). Every rejection is a typed error on the app side; the
@@ -195,9 +197,11 @@ a crash.
 
 Encoders emit both JSON objects with the keys in table order and no
 whitespace, so given inputs yield exactly one envelope; the shared vectors
-assert on the exact string. Decoders do not depend on key order and ignore
-unknown fields at either layer (additive v1 metadata). Any breaking change
-bumps `v`, and both implementations must be updated together.
+assert on the exact string. An optional field with no value is omitted
+entirely rather than sent empty, so absent, null, and `""` all encode
+identically. Decoders do not depend on key order and ignore unknown fields at
+either layer (additive v1 metadata). Any breaking change bumps `v`, and both
+implementations must be updated together.
 
 ### Shared test vectors
 

--- a/plugin/src/notification-envelope.js
+++ b/plugin/src/notification-envelope.js
@@ -4,7 +4,8 @@
 // through the Push Relay and APNs to the app's service extension. Wire
 // format: a compact JSON object `{"v":1,"kid":...,"n":...,"ct":...}` whose
 // `ct` is the AES-256-GCM ciphertext (plus tag) of a compact JSON plaintext
-// `{"pane":...,"kind":...,"status":...,"ts":...}`. See README.md for the
+// `{"pane":...,"kind":...,"status":...,"ts":...}` plus the optional display
+// fields `project` and `title`. See README.md for the
 // schema and test-vectors/notification-payload-v1.json for the
 // cross-implementation vectors: this side proves the encrypt direction, the
 // Swift side proves the decrypt direction. Breaking changes bump the
@@ -53,14 +54,24 @@ export function notificationKeyId(key) {
   return createHash("sha256").update(key).digest().subarray(0, KEY_ID_BYTES).toString("base64url");
 }
 
+// Hard ceiling for the display-only strings. The notify hook trims to
+// something shorter still (see DISPLAY_LIMIT there); this is the contract's
+// backstop keeping an APNs payload well inside its 4 KB budget once the
+// ciphertext is base64url'd.
+const DISPLAY_FIELD_MAX = 256;
+
 /**
- * Validate the notification payload shape.
+ * Validate the notification payload shape. `project` and `title` are the
+ * optional display fields: omit them (or pass null) and the app renders one
+ * step less specific.
  *
  * @param {object} payload
  * @param {string} payload.paneId herdr pane id the Agent lives in
  * @param {string} payload.agentKind agent kind as herdr reports it
  * @param {string} payload.status the new Agent Status (lenient open set)
  * @param {number} payload.timestamp unix-seconds of the status transition
+ * @param {string|null} [payload.project] workspace label the Agent runs in
+ * @param {string|null} [payload.title] Agent terminal title, glyphs stripped
  */
 function validatePayload(payload) {
   const { paneId, agentKind, status, timestamp } = payload;
@@ -75,6 +86,14 @@ function validatePayload(payload) {
   }
   if (!Number.isInteger(timestamp) || timestamp <= 0) {
     fail("bad_payload", `timestamp must be a positive unix-seconds integer, got ${timestamp}`);
+  }
+  for (const field of ["project", "title"]) {
+    const value = payload[field];
+    if (value === undefined || value === null) continue;
+    if (typeof value !== "string") fail("bad_payload", `${field} must be a string when present`);
+    if (value.length > DISPLAY_FIELD_MAX) {
+      fail("bad_payload", `${field} must be at most ${DISPLAY_FIELD_MAX} characters`);
+    }
   }
 }
 
@@ -100,11 +119,15 @@ export function encryptNotificationEnvelope(payload, key, { nonce } = {}) {
   }
   validatePayload(payload);
 
+  // Empty display fields are omitted rather than sent blank, so the encoding
+  // stays canonical whichever way the Host failed to resolve them.
   const plaintext = JSON.stringify({
     pane: payload.paneId,
     kind: payload.agentKind,
     status: payload.status,
     ts: payload.timestamp,
+    ...(payload.project ? { project: payload.project } : {}),
+    ...(payload.title ? { title: payload.title } : {}),
   });
   const cipher = createCipheriv("aes-256-gcm", key, nonce);
   cipher.setAAD(AAD);

--- a/plugin/src/notify-hook.js
+++ b/plugin/src/notify-hook.js
@@ -44,6 +44,24 @@ const SEND_ATTEMPTS = 3;
 const REQUEST_TIMEOUT_MS = 10_000;
 const KEY_BYTES = 32;
 const APNS_ENVIRONMENTS = new Set(["production", "sandbox"]);
+// Agent terminal titles are whole task descriptions and run long. The app
+// trims to the same length for display; trimming here keeps the encrypted
+// payload small on the wire too.
+const DISPLAY_LIMIT = 80;
+
+/** A non-empty string or null; the display fields are all best-effort. */
+function optionalText(value) {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/** Trim a display string to DISPLAY_LIMIT graphemes, ellipsis included. */
+function forDisplay(value) {
+  const text = optionalText(value);
+  if (text === null) return null;
+  const graphemes = [...text];
+  if (graphemes.length <= DISPLAY_LIMIT) return text;
+  return `${graphemes.slice(0, DISPLAY_LIMIT - 1).join("").trimEnd()}…`;
+}
 
 /** Parse HERDR_PLUGIN_EVENT_JSON leniently: require pane id and status only. */
 function parseStatusEvent(raw) {
@@ -62,8 +80,13 @@ function parseStatusEvent(raw) {
   if (typeof status !== "string" || status.length === 0) {
     throw new Error("event data.agent_status missing");
   }
-  const agentKind = typeof data.agent === "string" && data.agent.length > 0 ? data.agent : null;
-  return { paneId, status: status.toLowerCase(), agentKind };
+  return {
+    paneId,
+    status: status.toLowerCase(),
+    agentKind: optionalText(data.agent),
+    workspaceId: optionalText(data.workspace_id),
+    title: optionalText(data.title),
+  };
 }
 
 /**
@@ -165,6 +188,19 @@ function clearLastNotified(stateDir, paneId) {
   rmSync(statePath(stateDir, paneId), { force: true });
 }
 
+/** Run a herdr CLI subcommand and collect its exit code and streams. */
+function runHerdr(binPath, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(binPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
 /**
  * Re-check the pane's current Agent Status through the herdr CLI
  * (`herdr agent get <pane>` answers `{"result":{"agent":{"agent_status":...}}}`
@@ -173,17 +209,7 @@ function clearLastNotified(stateDir, paneId) {
  * throws, so an un-runnable re-check fails closed instead of notifying blind.
  */
 async function currentAgentStatus(binPath, paneId) {
-  const result = await new Promise((resolve, reject) => {
-    const child = spawn(binPath, ["agent", "get", paneId], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => (stdout += chunk));
-    child.stderr.on("data", (chunk) => (stderr += chunk));
-    child.on("error", reject);
-    child.on("close", (code) => resolve({ code, stdout, stderr }));
-  });
+  const result = await runHerdr(binPath, ["agent", "get", paneId]);
   let parsed;
   try {
     parsed = JSON.parse(result.stdout);
@@ -202,8 +228,30 @@ async function currentAgentStatus(binPath, paneId) {
   }
   return {
     status: agent.agent_status.toLowerCase(),
-    agentKind: typeof agent.agent === "string" && agent.agent.length > 0 ? agent.agent : null,
+    agentKind: optionalText(agent.agent),
+    workspaceId: optionalText(agent.workspace_id),
+    // Prefer the stripped title: the raw one carries herdr's spinner glyphs.
+    title: optionalText(agent.terminal_title_stripped) ?? optionalText(agent.terminal_title),
   };
+}
+
+/**
+ * Resolve a workspace's display label — the project name the app's alert
+ * leads with (`herdr workspace get <id>` answers
+ * `{"result":{"workspace":{"label":...}}}`; verified against herdr 0.7.5).
+ *
+ * Purely decorative, so every failure yields null: a Host that cannot answer
+ * still notifies, one step less specific.
+ */
+async function workspaceLabel(binPath, workspaceId) {
+  if (workspaceId === null) return null;
+  try {
+    const result = await runHerdr(binPath, ["workspace", "get", workspaceId]);
+    if (result.code !== 0) return null;
+    return optionalText(JSON.parse(result.stdout)?.result?.workspace?.label);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -302,11 +350,17 @@ async function main() {
   const devices = readEligibleDevices(configDir, event.status);
   if (devices.length === 0) return;
 
+  // The re-check is the fresher read for anything that can change while the
+  // debounce sleeps (the title moves with the agent's task); the event is the
+  // fallback for whatever it did not carry.
+  const workspaceId = current.workspaceId ?? event.workspaceId;
   const payload = {
     paneId: event.paneId,
     agentKind: event.agentKind ?? current.agentKind ?? "unknown",
     status: event.status,
     timestamp,
+    project: forDisplay(await workspaceLabel(binPath, workspaceId)),
+    title: forDisplay(current.title ?? event.title),
   };
   const pruned = new Set();
   const failures = [];

--- a/plugin/test-vectors/notification-payload-v1.json
+++ b/plugin/test-vectors/notification-payload-v1.json
@@ -1,5 +1,5 @@
 {
-  "description": "Shared notification envelope v1 test vectors (ADR 0008). Single source of truth for the encrypted Agent Notification payload, consumed by both the Node plugin tests (encrypt direction) and the Swift app tests (decrypt direction). Envelopes were generated with raw AES-256-GCM calls, independent of both implementations. `key` is the 32-byte Notification Key and `keyId` its derived id, both unpadded base64url. `envelope` is the exact canonical envelope string; non-`decodeOnly` valid vectors must be reproduced byte-for-byte by the encrypt side. `decodeOnly: true` marks envelopes that must decrypt to `payload` but are not a canonical encoding of it. Invalid vectors must fail decryption with the given typed error.",
+  "description": "Shared notification envelope v1 test vectors (ADR 0008). Single source of truth for the encrypted Agent Notification payload, consumed by both the Node plugin tests (encrypt direction) and the Swift app tests (decrypt direction). Envelopes were generated with raw AES-256-GCM calls, independent of both implementations. `key` is the 32-byte Notification Key and `keyId` its derived id, both unpadded base64url. `envelope` is the exact canonical envelope string; non-`decodeOnly` valid vectors must be reproduced byte-for-byte by the encrypt side. `decodeOnly: true` marks envelopes that must decrypt to `payload` but are not a canonical encoding of it. `project` and `title` are the optional display fields, omitted from the plaintext when absent. Invalid vectors must fail decryption with the given typed error.",
   "valid": [
     {
       "name": "blocked claude agent",
@@ -35,6 +35,20 @@
         "agentKind": "claude",
         "status": "exited",
         "timestamp": 1753305601
+      }
+    },
+    {
+      "name": "blocked agent with a project and a task title",
+      "key": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+      "keyId": "Yw3NKWbEM2Y",
+      "envelope": "{\"v\":1,\"kid\":\"Yw3NKWbEM2Y\",\"n\":\"ICEiIyQlJicoKSor\",\"ct\":\"qRjWEQL9ODQ4WXfs7TqfkL4tzqal4w-PGZIJMGWoLX0U-pB3rB8XuHiSDfk9bT3kwF6frKANGlT9UU8oeoI68fpWv2T88obiqVDLZNopXBO4tR8mw5Lycqpt-Aj8kgw6nfHK6WahOn7p79RryoLt9fwYZtA__vpEcBW8nBMZBsGrSpQ8o8x-1NZS4JFecRGPOQyPpnwNXA\"}",
+      "payload": {
+        "paneId": "%5",
+        "agentKind": "claude",
+        "status": "blocked",
+        "timestamp": 1753305600,
+        "project": "Caterm",
+        "title": "排查修复 split 按钮 UI 结构问题"
       }
     },
     {

--- a/plugin/test/notification-envelope.test.js
+++ b/plugin/test/notification-envelope.test.js
@@ -67,6 +67,9 @@ suite("encryptNotificationEnvelope", () => {
       { ...payload, timestamp: 0 },
       { ...payload, timestamp: 17.5 },
       { ...payload, timestamp: "1753305600" },
+      { ...payload, project: 5 },
+      { ...payload, title: {} },
+      { ...payload, title: "x".repeat(257) },
     ];
     for (const bad of bads) {
       assert.throws(
@@ -74,6 +77,24 @@ suite("encryptNotificationEnvelope", () => {
         (error) => error instanceof NotificationEnvelopeError && error.code === "bad_payload",
       );
     }
+  });
+
+  /// Absent, null, and empty must all encode the same way, so a Host that
+  /// failed to resolve a display field still produces a canonical envelope.
+  test("omits display fields that are absent, null, or empty", () => {
+    const nonce = Buffer.alloc(12);
+    const baseline = encryptNotificationEnvelope(payload, key, { nonce });
+    for (const variant of [
+      { ...payload, project: null, title: null },
+      { ...payload, project: "", title: "" },
+      { ...payload, project: undefined, title: undefined },
+    ]) {
+      assert.equal(encryptNotificationEnvelope(variant, key, { nonce }), baseline);
+    }
+    assert.notEqual(
+      encryptNotificationEnvelope({ ...payload, project: "Caterm" }, key, { nonce }),
+      baseline,
+    );
   });
 
   test("rejects a key that is not 32 bytes", () => {

--- a/plugin/test/notify-hook.test.js
+++ b/plugin/test/notify-hook.test.js
@@ -88,31 +88,54 @@ async function startFakeRelay(respond = () => ({ status: 200, body: { apnsId: "x
 }
 
 /**
- * Write the HERDR_BIN_PATH stub: logs every invocation, answers `agent get`
- * with a canned agent status (or an agent_not_found error when status is
- * null), like the real herdr CLI does.
+ * Write the HERDR_BIN_PATH stub: logs every invocation and answers the two
+ * subcommands the hook runs, like the real herdr CLI does — `agent get` with
+ * a canned status (or an agent_not_found error when status is null) and
+ * `workspace get` with a canned label (or a failure when it is null).
  */
-function writeHerdrStub({ status, agent = "claude" }) {
+function writeHerdrStub({
+  status,
+  agent = "claude",
+  title = undefined,
+  workspaceLabel = "Proj",
+}) {
   const binPath = join(stubDir, "herdr");
-  const response =
-    status === null
-      ? {
-          out: {
-            error: { code: "agent_not_found", message: "agent target not found" },
-            id: "cli:agent:get",
-          },
-          code: 1,
-        }
-      : {
-          out: {
-            id: "cli:agent:get",
-            result: {
-              agent: { agent, agent_status: status, pane_id: PANE_ID, workspace_id: "w1" },
-              type: "agent_info",
+  const agentInfo = { agent, agent_status: status, pane_id: PANE_ID, workspace_id: "w1" };
+  if (title !== undefined) {
+    agentInfo.terminal_title = `⠂ ${title}`;
+    agentInfo.terminal_title_stripped = title;
+  }
+  const response = {
+    agent:
+      status === null
+        ? {
+            out: {
+              error: { code: "agent_not_found", message: "agent target not found" },
+              id: "cli:agent:get",
             },
+            code: 1,
+          }
+        : {
+            out: { id: "cli:agent:get", result: { agent: agentInfo, type: "agent_info" } },
+            code: 0,
           },
-          code: 0,
-        };
+    workspace:
+      workspaceLabel === null
+        ? {
+            out: { error: { code: "workspace_not_found", message: "no such workspace" }, id: "x" },
+            code: 1,
+          }
+        : {
+            out: {
+              id: "cli:workspace:get",
+              result: {
+                workspace: { workspace_id: "w1", label: workspaceLabel },
+                type: "workspace_info",
+              },
+            },
+            code: 0,
+          },
+  };
   writeFileSync(join(stubDir, "response.json"), JSON.stringify(response));
   // The stub is CommonJS on purpose: it lives outside the plugin package, so
   // no "type": "module" applies to it.
@@ -123,17 +146,28 @@ function writeHerdrStub({ status, agent = "claude" }) {
       'const fs = require("node:fs");',
       'const path = require("node:path");',
       "const dir = __dirname;",
+      "const args = process.argv.slice(2);",
       "fs.appendFileSync(",
       '  path.join(dir, "invocations.log"),',
-      '  JSON.stringify({ args: process.argv.slice(2), at: Date.now() }) + "\\n",',
+      '  JSON.stringify({ args, at: Date.now() }) + "\\n",',
       ");",
       'const response = JSON.parse(fs.readFileSync(path.join(dir, "response.json"), "utf8"));',
-      "process.stdout.write(JSON.stringify(response.out));",
-      "process.exit(response.code);",
+      "const answer = response[args[0]];",
+      "if (answer === undefined) {",
+      '  process.stderr.write(`stub: unexpected subcommand ${args.join(" ")}`);',
+      "  process.exit(64);",
+      "}",
+      "process.stdout.write(JSON.stringify(answer.out));",
+      "process.exit(answer.code);",
     ].join("\n"),
     { mode: 0o755 },
   );
   return binPath;
+}
+
+/** The invocations of one herdr subcommand, in order. */
+function stubInvocationsOf(subcommand) {
+  return stubInvocations().filter((entry) => entry.args[0] === subcommand);
 }
 
 function stubInvocations() {
@@ -298,6 +332,69 @@ suite("notify-hook: sending", () => {
     assert.equal(payload.status, "done");
   });
 
+  test("the payload carries the project name and the agent's task title", async () => {
+    await startFakeRelay();
+    writeConfig();
+    writeRegistration([device()]);
+    writeHerdrStub({
+      status: "blocked",
+      title: "排查修复 split 按钮 UI 结构问题",
+      workspaceLabel: "Caterm",
+    });
+
+    const result = await runHook(statusEvent("blocked"));
+
+    assert.equal(result.status, 0, result.stderr);
+    const { payload } = decryptEnvelope(relay.requests[0].body.envelope, KEY_A);
+    assert.equal(payload.project, "Caterm");
+    assert.equal(payload.title, "排查修复 split 按钮 UI 结构问题");
+    // The label is resolved for the workspace the re-check reports.
+    assert.deepEqual(stubInvocationsOf("workspace")[0].args, ["workspace", "get", "w1"]);
+  });
+
+  test("a title longer than the display limit is trimmed with an ellipsis", async () => {
+    await startFakeRelay();
+    writeConfig();
+    writeRegistration([device()]);
+    const long = "重构传输层".repeat(40);
+    writeHerdrStub({ status: "blocked", title: long });
+
+    await runHook(statusEvent("blocked"));
+
+    const { payload } = decryptEnvelope(relay.requests[0].body.envelope, KEY_A);
+    assert.equal([...payload.title].length, 80);
+    assert.ok(payload.title.endsWith("…"));
+    assert.ok(long.startsWith([...payload.title].slice(0, 79).join("")));
+  });
+
+  test("an unresolvable workspace label just omits the project", async () => {
+    await startFakeRelay();
+    writeConfig();
+    writeRegistration([device()]);
+    writeHerdrStub({ status: "blocked", title: "Fix the flaky test", workspaceLabel: null });
+
+    const result = await runHook(statusEvent("blocked"));
+
+    assert.equal(result.status, 0, result.stderr);
+    const { payload } = decryptEnvelope(relay.requests[0].body.envelope, KEY_A);
+    assert.equal("project" in payload, false);
+    assert.equal(payload.title, "Fix the flaky test");
+  });
+
+  test("an agent with no title at all still notifies", async () => {
+    await startFakeRelay();
+    writeConfig();
+    writeRegistration([device()]);
+    writeHerdrStub({ status: "done" });
+
+    const result = await runHook(statusEvent("done"));
+
+    assert.equal(result.status, 0, result.stderr);
+    const { payload } = decryptEnvelope(relay.requests[0].body.envelope, KEY_A);
+    assert.equal("title" in payload, false);
+    assert.equal(payload.status, "done");
+  });
+
   test("unknown event fields are ignored (lenient parse)", async () => {
     await startFakeRelay();
     writeConfig();
@@ -323,7 +420,7 @@ suite("notify-hook: debounce", () => {
 
     await runHook(statusEvent("blocked"));
 
-    const invocations = stubInvocations();
+    const invocations = stubInvocationsOf("agent");
     assert.equal(invocations.length, 1);
     assert.deepEqual(invocations[0].args, ["agent", "get", PANE_ID]);
     assert.ok(


### PR DESCRIPTION
Six UI/copy changes plus an app icon. The through-line: a console full of
agents is usually a console full of `claude` on one machine, so the project
is what tells the rows (and the notifications) apart. It leads everywhere;
the agent kind, the Host, and the pane address step back.

## Console list

- The agent card leads with the project and tags the agent name at the foot,
  the reverse of before. Falls back to the agent name in the headline (and
  drops the tag) when the snapshot carries no workspace.
- The screen is titled **Agents**, not Console.
- The agent detail toolbar no longer carries a status badge: the live
  terminal already shows what the agent is doing, and the badge only crowded
  the title.

## New Agent

The workspace picker dropped its "Current workspace" option. It read as a
safe default but meant "wherever the Host happens to point", which is not
something this screen shows you. The picker now offers only real workspaces
and pre-selects the one this Host last started an agent in, persisted per
Host in `RecentWorkspaceStore`, falling back to the Host's first.

`selectedWorkspaceID` became computed over a private explicit pick, so a
session snapshot that lands *after* the sheet opens still gets to supply the
default instead of leaving the picker blank.

## Notifications

The banner said `claude on zingerbee@192.168.31.64 / Done: the agent
finished` — the same text for every agent on the machine. It tells you
something happened, not what or where.

The payload now carries two additive display fields, `project` (workspace
label) and `title` (the agent's terminal title). Both are optional on the
wire and best-effort on the plugin side, so an older plugin still renders
the previous copy rather than degrading to the generic fallback banner.

```
Caterm · claude
Blocked · 排查修复 split 按钮 UI 结构问题
```

The Host is deliberately absent: it is the same machine on every
notification and spent the whole line on an address nobody reads.

Terminal titles are whole task descriptions, so both ends trim them — the
hook to 80 graphemes before encrypting, the renderer to the same length for
display. Worst case (both fields 80 CJK characters) the APNs body is 949
bytes against the relay's 4096 limit.

**No relay redeploy needed.** The relay never parses the envelope; the
request shape is unchanged and only the ciphertext grew.

## Also here

`c823bb4` adds the Icon Composer app icon (not mine — it landed on this
branch separately).

## Testing

- Swift: 537 tests pass (`xcodebuild test`, iPhone 17 Pro / iOS 26.5).
- Plugin: 148 tests pass (`npm test` in `plugin/`), including four new
  notify-hook cases covering the display fields, the trim, and an
  unresolvable workspace label.
- New shared vector `blocked agent with a project and a task title`,
  generated with raw AES-GCM independent of both implementations.
- `herdr agent get` / `herdr workspace get` response shapes verified against
  a live herdr 0.7.5.
- Installed and launched on a physical iPhone and in the simulator; the list,
  detail, and New Agent screens were driven and screenshotted.

Push copy end-to-end is **not** verified: that would need an envelope
encrypted with the Host's Notification Key from the Keychain. The render
path is covered by unit tests against the shared vectors, and the plugin
side by process-boundary tests with a real stub CLI.