### PR TITLE
fix(terminal): keep the keyboard recoverable after a system resign

### DIFF
--- a/Sources/HerdrMobile/Terminal/TerminalKeyboard.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalKeyboard.swift
@@ -254,7 +254,16 @@ final class TerminalKeyboardAccessory: UIInputView {
     }
 
     @objc private func dismissKeyboard() {
-        _ = terminalView?.resignFirstResponder()
+        if let terminalView, terminalView.isFirstResponder {
+            terminalView.dismissKeyboard()
+            return
+        }
+        // The accessory can outlive its terminal view's first-responder
+        // status (a rebuilt terminal after a reconnect). Resigning through the
+        // responder chain still takes the keyboard down, so the button is
+        // never a dead control.
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
 }
 

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -190,6 +190,13 @@ final class HerdrTerminalView: UITerminalView {
         terminalKeyboardAccessory
     }
 
+    /// Only a tap on the input row raises the keyboard, so the surface refuses
+    /// first responder until asked. The flag tracks the *user's* intent and
+    /// survives a UIKit-initiated resign on purpose: backgrounding the app or
+    /// presenting a sheet resigns the first responder, and UIKit restores it
+    /// afterwards by asking again. Clearing the flag there would have UIKit
+    /// refused — leaving the accessory bar on screen with no keyboard behind
+    /// it and no way to type. `dismissKeyboard()` is what clears it.
     override var canBecomeFirstResponder: Bool {
         allowsKeyboardActivation
     }
@@ -284,9 +291,20 @@ final class HerdrTerminalView: UITerminalView {
         terminalSession.receive(data)
     }
 
+    /// Raises the keyboard, and records that the user wants it up.
     func requestKeyboard() {
         allowsKeyboardActivation = true
         _ = becomeFirstResponder()
+    }
+
+    /// Takes the keyboard down on the user's behalf. This is the *only* way
+    /// the keyboard goes away for good: a plain `resignFirstResponder()` is
+    /// something UIKit does on its own (backgrounding, a sheet taking focus)
+    /// and must stay recoverable.
+    @discardableResult
+    func dismissKeyboard() -> Bool {
+        allowsKeyboardActivation = false
+        return resignFirstResponder()
     }
 
     func setLocalInputEnabled(_ isEnabled: Bool) {
@@ -331,13 +349,6 @@ final class HerdrTerminalView: UITerminalView {
             return isLocalInputEnabled && UIPasteboard.general.hasStrings
         }
         return super.canPerformAction(action, withSender: sender)
-    }
-
-    @discardableResult
-    override func resignFirstResponder() -> Bool {
-        let resigned = super.resignFirstResponder()
-        allowsKeyboardActivation = false
-        return resigned
     }
 
     override func layoutSubviews() {

--- a/Tests/HerdrMobileTests/TerminalAttachTests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachTests.swift
@@ -101,8 +101,24 @@ struct TerminalAttachTests {
         terminal.requestKeyboard()
         #expect(terminal.canBecomeFirstResponder)
 
-        _ = terminal.resignFirstResponder()
+        terminal.dismissKeyboard()
         #expect(!terminal.canBecomeFirstResponder)
+    }
+
+    /// UIKit resigns the first responder on its own — backgrounding the app,
+    /// presenting a sheet — and restores it afterwards by asking the view to
+    /// become first responder again. If those resigns also cleared the user's
+    /// intent, the view would refuse, and the accessory bar would come back
+    /// with no keyboard behind it and no way to type (the >20s-in-background
+    /// report). Only an explicit dismiss ends the session.
+    @MainActor
+    @Test func aSystemResignLeavesTheKeyboardRecoverable() {
+        let terminal = TerminalScreenView.makeConfiguredTerminal()
+        terminal.requestKeyboard()
+
+        _ = terminal.resignFirstResponder()
+
+        #expect(terminal.canBecomeFirstResponder)
     }
 
     @Test func keyboardTapTargetCoversOnlyTheCurrentInputRow() {
@@ -173,6 +189,32 @@ struct TerminalAttachTests {
         terminal.setKeyboardMode(.text)
         #expect(terminal.keyboardMode == .text)
         #expect(terminal.inputView == nil)
+    }
+
+    /// The dismiss button is the only way out of the keyboard, so it must
+    /// work even when the accessory has outlived its terminal's first
+    /// responder status.
+    @MainActor
+    @Test func dismissButtonTakesTheKeyboardDownFromTheAccessory() throws {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: 874))
+        let terminal = TerminalScreenView.makeConfiguredTerminal()
+        window.addSubview(terminal)
+        window.makeKeyAndVisible()
+        terminal.requestKeyboard()
+        let accessory = try #require(
+            terminal.inputAccessoryView as? TerminalKeyboardAccessory)
+        let dismiss = try #require(
+            accessory.subviews.compactMap { $0 as? UIButton }.first {
+                $0.accessibilityLabel == "Dismiss keyboard"
+            })
+
+        dismiss.sendActions(for: .touchUpInside)
+        #expect(!terminal.isFirstResponder)
+
+        // Stranded accessory: no first responder left to ask, and the button
+        // must still be a no-crash no-op rather than a dead end.
+        dismiss.sendActions(for: .touchUpInside)
+        #expect(!terminal.isFirstResponder)
     }
 
     @MainActor


### PR DESCRIPTION
The terminal treated *every* `resignFirstResponder` as the user putting the
keyboard away, clearing the flag that gates `canBecomeFirstResponder`. But
UIKit resigns on its own — backgrounding the app, a sheet taking focus — and
restores the responder afterwards by asking again. The terminal refused.

The result: the accessory bar comes back with no keyboard behind it, over a
surface that can no longer be typed into. The only way out is leaving the
screen.

## The fix

Split the user's intent from UIKit's lifecycle. The flag now tracks *only*
what the user asked for, and `dismissKeyboard()` is the one thing that ends
a keyboard session. A UIKit-initiated resign leaves the intent intact, so
the restore that follows is allowed through.

The accessory's dismiss button also falls back to the responder chain when
its terminal view is no longer first responder (a rebuilt terminal after a
reconnect), so a bar that outlived its view is never a dead control.

## Testing

- 528 tests pass (`xcodebuild test`, iPhone 17 Pro / iOS 26.5).

The bug itself is a UIKit responder-lifecycle interaction and is not covered
by a test — reproducing it needs a real backgrounding or sheet presentation
against a live terminal view.