### PR TITLE
feat: add SSH jump host remote access

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,6 +8,13 @@ A native iOS agent console for herdr. One context: the app. Terms owned by herdr
 A remote machine reachable over SSH that runs a herdr server. The unit a user adds, names, and authenticates against.
 _Avoid_: server, machine, connection
 
+**Jump Host**:
+An SSH endpoint that forwards a Host connection when the Host is not directly
+reachable from the device. The Host's address and port are resolved from the
+Jump Host, normally through a loopback-only reverse tunnel. The app authenticates
+and verifies host keys independently at both hops.
+_Avoid_: bastion, proxy server
+
 **Device Key**:
 The device's SSH identity: an Ed25519 keypair generated on this device. The private key never leaves the Keychain; the public half is what a Host authorizes.
 _Avoid_: app key, client key

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		527D9FD128FA6F9C7BC8B572 /* AuthorizedKeysTestLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98770FDE6BA9A8EEC4FECA3 /* AuthorizedKeysTestLock.swift */; };
 		535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */; };
 		54C4A61E21C2C7D8A618E462 /* PairingCeremony.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D4C26D457FF045C3E7D3EF9 /* PairingCeremony.swift */; };
+		54DA59BA15FE610619EEF3D1 /* SSHJumpHostE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEFE71E302772A774FA4EE /* SSHJumpHostE2ETests.swift */; };
 		59400DF89B4D869F1391F8BD /* NotificationRegistrationFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F4CB4F0E9D99693B44618 /* NotificationRegistrationFile.swift */; };
 		5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */; };
 		5D1B735C72D551ADE0D82D44 /* TerminalThemeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A961D26EDEAA03AFB0F9C408 /* TerminalThemeSettings.swift */; };
@@ -248,6 +249,7 @@
 		45FC4FCCE9B94EC52FD930B1 /* Base64URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64URL.swift; sourceTree = "<group>"; };
 		46B11849C0824D5679BD9289 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		498ECBCD631F9734C28861EA /* ConsoleAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleAgent.swift; sourceTree = "<group>"; };
+		4BEEFE71E302772A774FA4EE /* SSHJumpHostE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHJumpHostE2ETests.swift; sourceTree = "<group>"; };
 		4DBF37BC147BBEEB4549FD21 /* AppActivityCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivityCoordinator.swift; sourceTree = "<group>"; };
 		4FD32D8CF0FF5617AF7E3513 /* NotificationRegistrationCeremony.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRegistrationCeremony.swift; sourceTree = "<group>"; };
 		558159B2AF61C28F6B1391A2 /* DeviceKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyTests.swift; sourceTree = "<group>"; };
@@ -548,6 +550,7 @@
 				6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */,
 				7CA60F860890A7CAA368B268 /* SSHChannelBudgetTests.swift */,
 				5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */,
+				4BEEFE71E302772A774FA4EE /* SSHJumpHostE2ETests.swift */,
 				F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */,
 				A71CE71D20ABB90D7E94264E /* StartAgentStoreTests.swift */,
 				D83F34B22988623AD8E2093C /* TerminalAttachE2ETests.swift */,
@@ -1009,6 +1012,7 @@
 				3DC1B4DCC0E2CD73A0C13B64 /* SSHAuthE2ETests.swift in Sources */,
 				7C453E2308A9E12532A24705 /* SSHChannelBudgetTests.swift in Sources */,
 				5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */,
+				54DA59BA15FE610619EEF3D1 /* SSHJumpHostE2ETests.swift in Sources */,
 				E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */,
 				473F834A4C680F18BA303DB9 /* ScriptedTransport.swift in Sources */,
 				6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		527D9FD128FA6F9C7BC8B572 /* AuthorizedKeysTestLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98770FDE6BA9A8EEC4FECA3 /* AuthorizedKeysTestLock.swift */; };
 		535C6AF099A43002029F2C2F /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BC80136A26B477439ACFA /* HerdrSocketLocationTests.swift */; };
 		54C4A61E21C2C7D8A618E462 /* PairingCeremony.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D4C26D457FF045C3E7D3EF9 /* PairingCeremony.swift */; };
+		54DA59BA15FE610619EEF3D1 /* SSHJumpHostE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEEFE71E302772A774FA4EE /* SSHJumpHostE2ETests.swift */; };
 		59400DF89B4D869F1391F8BD /* NotificationRegistrationFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F4CB4F0E9D99693B44618 /* NotificationRegistrationFile.swift */; };
 		5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */; };
 		5D1B735C72D551ADE0D82D44 /* TerminalThemeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A961D26EDEAA03AFB0F9C408 /* TerminalThemeSettings.swift */; };
@@ -238,6 +239,7 @@
 		44F4B2F424E3FC8AB7DA69FC /* NotificationVectorFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationVectorFile.swift; sourceTree = "<group>"; };
 		45FC4FCCE9B94EC52FD930B1 /* Base64URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64URL.swift; sourceTree = "<group>"; };
 		498ECBCD631F9734C28861EA /* ConsoleAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleAgent.swift; sourceTree = "<group>"; };
+		4BEEFE71E302772A774FA4EE /* SSHJumpHostE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHJumpHostE2ETests.swift; sourceTree = "<group>"; };
 		4FD32D8CF0FF5617AF7E3513 /* NotificationRegistrationCeremony.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRegistrationCeremony.swift; sourceTree = "<group>"; };
 		558159B2AF61C28F6B1391A2 /* DeviceKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyTests.swift; sourceTree = "<group>"; };
 		5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHHostKeyE2ETests.swift; sourceTree = "<group>"; };
@@ -531,6 +533,7 @@
 				6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */,
 				7CA60F860890A7CAA368B268 /* SSHChannelBudgetTests.swift */,
 				5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */,
+				4BEEFE71E302772A774FA4EE /* SSHJumpHostE2ETests.swift */,
 				F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */,
 				A71CE71D20ABB90D7E94264E /* StartAgentStoreTests.swift */,
 				D83F34B22988623AD8E2093C /* TerminalAttachE2ETests.swift */,
@@ -975,6 +978,7 @@
 				3DC1B4DCC0E2CD73A0C13B64 /* SSHAuthE2ETests.swift in Sources */,
 				7C453E2308A9E12532A24705 /* SSHChannelBudgetTests.swift in Sources */,
 				5C41DBF68FFE6D2924709A5A /* SSHHostKeyE2ETests.swift in Sources */,
+				54DA59BA15FE610619EEF3D1 /* SSHJumpHostE2ETests.swift in Sources */,
 				E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */,
 				473F834A4C680F18BA303DB9 /* ScriptedTransport.swift in Sources */,
 				6680D1827A0A0E5A60BE44F8 /* SkeletonTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ No herdr server changes required. The only remote prerequisite is `socat` instal
 
 Hosts that are not directly reachable can be placed behind an SSH Jump Host.
 The recommended deployment keeps the reverse-forwarded port on the VPS
-loopback interface instead of publishing the Mac's SSH port. See
-[VPS Jump Host and reverse-tunnel deployment](docs/guides/vps-jump-host.md)
-for the architecture, hardening rules, setup procedure, and VPS migration
-runbook.
+loopback interface instead of publishing the Mac's SSH port.
+
+- [Set up remote access step by step](docs/guides/vps-jump-host-setup.md)
+- [Understand the architecture, security boundaries, and VPS migration runbook](docs/guides/vps-jump-host.md)
 
 ## Stack
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ The app speaks herdr's JSON API (newline-delimited JSON over a Unix socket) thro
 
 No herdr server changes required. The only remote prerequisite is `socat` installed on the host; the app finds it via the Host's configured path or the Host's own PATH, and onboarding tells you where to point it if neither answers.
 
+Hosts that are not directly reachable can be placed behind an SSH Jump Host.
+The recommended deployment keeps the reverse-forwarded port on the VPS
+loopback interface instead of publishing the Mac's SSH port. See
+[VPS Jump Host and reverse-tunnel deployment](docs/guides/vps-jump-host.md)
+for the architecture, hardening rules, setup procedure, and VPS migration
+runbook.
+
 ## Stack
 
 - SwiftUI, iOS 26+, iPhone + iPad

--- a/Sources/HerdrMobile/Hosts/Host.swift
+++ b/Sources/HerdrMobile/Hosts/Host.swift
@@ -29,9 +29,29 @@ struct Host: Identifiable, Codable, Hashable, Sendable {
     var sessionName: String
     /// Absolute socat path on the Host.
     var socatPath: String
+    /// Optional bastion this Host is reached through. Blank means a direct
+    /// connection; when set, `address`/`port` are resolved *from the bastion*
+    /// and normally point at a loopback port held open by a reverse tunnel.
+    var jumpAddress: String
+    var jumpPort: Int
+    /// Account on the bastion. Blank reuses `username`, which is the common
+    /// case only when both machines share an account name.
+    var jumpUsername: String
 
     private enum CodingKeys: String, CodingKey {
         case id, name, address, port, username, authMethod, sessionName, socatPath
+        case jumpAddress, jumpPort, jumpUsername
+    }
+
+    /// Whether this Host is reached through a bastion.
+    var usesJumpHost: Bool {
+        !jumpAddress.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    /// The bastion account, falling back to the Host's own username.
+    var resolvedJumpUsername: String {
+        let trimmed = jumpUsername.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? username : trimmed
     }
 
     init(
@@ -42,7 +62,10 @@ struct Host: Identifiable, Codable, Hashable, Sendable {
         username: String,
         authMethod: AuthMethod = .deviceKey,
         sessionName: String = "",
-        socatPath: String = Host.defaultSocatPath
+        socatPath: String = Host.defaultSocatPath,
+        jumpAddress: String = "",
+        jumpPort: Int = 22,
+        jumpUsername: String = ""
     ) {
         self.id = id
         self.name = name
@@ -52,6 +75,9 @@ struct Host: Identifiable, Codable, Hashable, Sendable {
         self.authMethod = authMethod
         self.sessionName = sessionName
         self.socatPath = socatPath
+        self.jumpAddress = jumpAddress
+        self.jumpPort = jumpPort
+        self.jumpUsername = jumpUsername
     }
 
     init(from decoder: any Decoder) throws {
@@ -65,6 +91,11 @@ struct Host: Identifiable, Codable, Hashable, Sendable {
         sessionName = try container.decodeIfPresent(String.self, forKey: .sessionName) ?? ""
         socatPath =
             try container.decodeIfPresent(String.self, forKey: .socatPath) ?? Self.defaultSocatPath
+        // Absent in Hosts saved before jump-host support; a blank address
+        // decodes as the direct connection those Hosts already had.
+        jumpAddress = try container.decodeIfPresent(String.self, forKey: .jumpAddress) ?? ""
+        jumpPort = try container.decodeIfPresent(Int.self, forKey: .jumpPort) ?? 22
+        jumpUsername = try container.decodeIfPresent(String.self, forKey: .jumpUsername) ?? ""
 
         let trimmedSessionName = sessionName.trimmingCharacters(in: .whitespaces)
         guard trimmedSessionName.isEmpty || HerdrSessionName.isValid(trimmedSessionName) else {

--- a/Sources/HerdrMobile/Hosts/Host.swift
+++ b/Sources/HerdrMobile/Hosts/Host.swift
@@ -30,9 +30,29 @@ struct Host: Identifiable, Codable, Hashable, Sendable {
     var sessionName: String
     /// Preferred absolute socat path on the Host.
     var socatPath: String
+    /// Optional Jump Host this Host is reached through. Blank means a direct
+    /// connection; when set, `address`/`port` are resolved from the Jump Host
+    /// and normally point at a loopback port held open by a reverse tunnel.
+    var jumpAddress: String
+    var jumpPort: Int
+    /// Account on the Jump Host. Blank reuses `username`, which is the common
+    /// case only when both machines share an account name.
+    var jumpUsername: String
 
     private enum CodingKeys: String, CodingKey {
         case id, name, address, port, username, authMethod, sessionName, socatPath
+        case jumpAddress, jumpPort, jumpUsername
+    }
+
+    /// Whether this Host is reached through a Jump Host.
+    var usesJumpHost: Bool {
+        !jumpAddress.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    /// The Jump Host account, falling back to the Host's own username.
+    var resolvedJumpUsername: String {
+        let trimmed = jumpUsername.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? username : trimmed
     }
 
     init(
@@ -43,7 +63,10 @@ struct Host: Identifiable, Codable, Hashable, Sendable {
         username: String,
         authMethod: AuthMethod = .deviceKey,
         sessionName: String = "",
-        socatPath: String = Host.defaultSocatPath
+        socatPath: String = Host.defaultSocatPath,
+        jumpAddress: String = "",
+        jumpPort: Int = 22,
+        jumpUsername: String = ""
     ) {
         self.id = id
         self.name = name
@@ -53,6 +76,9 @@ struct Host: Identifiable, Codable, Hashable, Sendable {
         self.authMethod = authMethod
         self.sessionName = sessionName
         self.socatPath = socatPath
+        self.jumpAddress = jumpAddress
+        self.jumpPort = jumpPort
+        self.jumpUsername = jumpUsername
     }
 
     init(from decoder: any Decoder) throws {
@@ -66,6 +92,11 @@ struct Host: Identifiable, Codable, Hashable, Sendable {
         sessionName = try container.decodeIfPresent(String.self, forKey: .sessionName) ?? ""
         socatPath =
             try container.decodeIfPresent(String.self, forKey: .socatPath) ?? Self.defaultSocatPath
+        // Absent in Hosts saved before jump-host support; a blank address
+        // decodes as the direct connection those Hosts already had.
+        jumpAddress = try container.decodeIfPresent(String.self, forKey: .jumpAddress) ?? ""
+        jumpPort = try container.decodeIfPresent(Int.self, forKey: .jumpPort) ?? 22
+        jumpUsername = try container.decodeIfPresent(String.self, forKey: .jumpUsername) ?? ""
 
         let trimmedSessionName = sessionName.trimmingCharacters(in: .whitespaces)
         guard trimmedSessionName.isEmpty || HerdrSessionName.isValid(trimmedSessionName) else {

--- a/Sources/HerdrMobile/Hosts/HostDraft.swift
+++ b/Sources/HerdrMobile/Hosts/HostDraft.swift
@@ -13,6 +13,12 @@ struct HostDraft: Equatable, Sendable {
     var password = ""
     var sessionName = ""
     var socatPath = Host.defaultSocatPath
+    /// Blank means a direct connection. When set, Address/Port above are
+    /// resolved from the Jump Host, not from this device.
+    var jumpAddress = ""
+    var jumpPort = "22"
+    /// Blank reuses the Host's own username.
+    var jumpUsername = ""
 
     init() {}
 
@@ -25,11 +31,23 @@ struct HostDraft: Equatable, Sendable {
         authMethod = host.authMethod
         sessionName = host.sessionName
         socatPath = host.socatPath
+        jumpAddress = host.jumpAddress
+        jumpPort = String(host.jumpPort)
+        jumpUsername = host.jumpUsername
     }
 
     var portNumber: Int? {
         guard let value = Int(port), (1...65535).contains(value) else { return nil }
         return value
+    }
+
+    var jumpPortNumber: Int? {
+        guard let value = Int(jumpPort), (1...65535).contains(value) else { return nil }
+        return value
+    }
+
+    var usesJumpHost: Bool {
+        !jumpAddress.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
     var isValid: Bool {
@@ -40,6 +58,9 @@ struct HostDraft: Equatable, Sendable {
             && portNumber != nil
             && (trimmedSessionName.isEmpty || HerdrSessionName.isValid(trimmedSessionName))
             && RemoteShellPath.isQuotableAbsolute(trimmedSocatPath)
+            // A blank jump address disables the hop entirely, so its port only
+            // has to parse when the hop is actually in use.
+            && (!usesJumpHost || jumpPortNumber != nil)
     }
 
     /// Form-level validity including credential intent. A blank password can
@@ -65,7 +86,10 @@ struct HostDraft: Equatable, Sendable {
             username: username.trimmingCharacters(in: .whitespaces),
             authMethod: authMethod,
             sessionName: sessionName.trimmingCharacters(in: .whitespaces),
-            socatPath: socatPath.trimmingCharacters(in: .whitespaces))
+            socatPath: socatPath.trimmingCharacters(in: .whitespaces),
+            jumpAddress: jumpAddress.trimmingCharacters(in: .whitespaces),
+            jumpPort: jumpPortNumber ?? 22,
+            jumpUsername: jumpUsername.trimmingCharacters(in: .whitespaces))
     }
 
     /// What to hand `HostStore.add/update` as the password argument: a new

--- a/Sources/HerdrMobile/Hosts/HostDraft.swift
+++ b/Sources/HerdrMobile/Hosts/HostDraft.swift
@@ -13,6 +13,12 @@ struct HostDraft: Equatable, Sendable {
     var password = ""
     var sessionName = ""
     var socatPath = Host.defaultSocatPath
+    /// Blank means a direct connection. When set, Address/Port above are
+    /// resolved from the jump host, not from this device.
+    var jumpAddress = ""
+    var jumpPort = "22"
+    /// Blank reuses the Host's own username.
+    var jumpUsername = ""
 
     init() {}
 
@@ -25,11 +31,23 @@ struct HostDraft: Equatable, Sendable {
         authMethod = host.authMethod
         sessionName = host.sessionName
         socatPath = host.socatPath
+        jumpAddress = host.jumpAddress
+        jumpPort = String(host.jumpPort)
+        jumpUsername = host.jumpUsername
     }
 
     var portNumber: Int? {
         guard let value = Int(port), (1...65535).contains(value) else { return nil }
         return value
+    }
+
+    var jumpPortNumber: Int? {
+        guard let value = Int(jumpPort), (1...65535).contains(value) else { return nil }
+        return value
+    }
+
+    var usesJumpHost: Bool {
+        !jumpAddress.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
     var isValid: Bool {
@@ -40,6 +58,9 @@ struct HostDraft: Equatable, Sendable {
             && portNumber != nil
             && (trimmedSessionName.isEmpty || HerdrSessionName.isValid(trimmedSessionName))
             && RemoteShellPath.isQuotableAbsolute(trimmedSocatPath)
+            // A blank jump address disables the hop entirely, so its port only
+            // has to parse when the hop is actually in use.
+            && (!usesJumpHost || jumpPortNumber != nil)
     }
 
     /// Form-level validity including credential intent. A blank password can
@@ -65,7 +86,10 @@ struct HostDraft: Equatable, Sendable {
             username: username.trimmingCharacters(in: .whitespaces),
             authMethod: authMethod,
             sessionName: sessionName.trimmingCharacters(in: .whitespaces),
-            socatPath: socatPath.trimmingCharacters(in: .whitespaces))
+            socatPath: socatPath.trimmingCharacters(in: .whitespaces),
+            jumpAddress: jumpAddress.trimmingCharacters(in: .whitespaces),
+            jumpPort: jumpPortNumber ?? 22,
+            jumpUsername: jumpUsername.trimmingCharacters(in: .whitespaces))
     }
 
     /// What to hand `HostStore.add/update` as the password argument: a new

--- a/Sources/HerdrMobile/Hosts/HostFormView.swift
+++ b/Sources/HerdrMobile/Hosts/HostFormView.swift
@@ -78,6 +78,34 @@ struct HostFormView: View {
                 }
 
                 Section {
+                    TextField("Jump host address (optional)", text: $draft.jumpAddress)
+                        .textContentType(.URL)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                    if draft.usesJumpHost {
+                        TextField("Jump host port", text: $draft.jumpPort)
+                            .keyboardType(.numberPad)
+                        TextField("Jump host user (blank = same as Host)", text: $draft.jumpUsername)
+                            .textContentType(.username)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                    }
+                } header: {
+                    Text("Jump Host")
+                } footer: {
+                    if draft.usesJumpHost {
+                        Text(
+                            "The Host is reached through this machine, so its Address and Port "
+                                + "above are resolved from the jump host — usually a loopback "
+                                + "port held open by a reverse tunnel. Both machines must "
+                                + "authorize this Host's key, and you confirm both host key "
+                                + "fingerprints on first connect.")
+                    } else {
+                        Text("Leave blank to connect to the Host directly.")
+                    }
+                }
+
+                Section {
                     TextField("socat path", text: $draft.socatPath)
                         .font(.callout.monospaced())
                         .autocorrectionDisabled()

--- a/Sources/HerdrMobile/Hosts/HostFormView.swift
+++ b/Sources/HerdrMobile/Hosts/HostFormView.swift
@@ -78,6 +78,29 @@ struct HostFormView: View {
                 }
 
                 Section {
+                    TextField("Jump Host address (optional)", text: $draft.jumpAddress)
+                        .textContentType(.URL)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                    if draft.usesJumpHost {
+                        TextField("Jump Host port", text: $draft.jumpPort)
+                            .keyboardType(.numberPad)
+                        TextField("Jump Host user (blank = same as Host)", text: $draft.jumpUsername)
+                            .textContentType(.username)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                    }
+                } header: {
+                    Text("Jump Host")
+                } footer: {
+                    if draft.usesJumpHost {
+                        Text(jumpHostFooter)
+                    } else {
+                        Text("Leave blank to connect to the Host directly.")
+                    }
+                }
+
+                Section {
                     TextField("socat path", text: $draft.socatPath)
                         .font(.callout.monospaced())
                         .autocorrectionDisabled()
@@ -130,6 +153,19 @@ struct HostFormView: View {
                 loadDeviceKey()
             }
         }
+    }
+
+    private var jumpHostFooter: String {
+        let credentialRequirement =
+            switch draft.authMethod {
+            case .deviceKey:
+                "Both machines must authorize the Device Key."
+            case .password:
+                "Both machines must accept the same password; separate passwords are not supported."
+            }
+        return "The Host's Address and Port are resolved from the Jump Host, usually through "
+            + "a loopback-only reverse tunnel. \(credentialRequirement) You confirm each "
+            + "machine's host key fingerprint independently on first connect."
     }
 
     @ViewBuilder

--- a/Sources/HerdrMobile/Hosts/Preflight.swift
+++ b/Sources/HerdrMobile/Hosts/Preflight.swift
@@ -133,8 +133,51 @@ struct PreflightReport: Equatable, Sendable {
             // taxonomy total anyway.
             check = .connection
             hint = "The connection is busy. Try again."
+        case .jumpHostFailed(let underlying):
+            // The first hop broke, so the Host itself was never contacted and
+            // nothing about it has been disproved. Name the Jump Host as the
+            // thing to fix, or the user goes and debugs the wrong machine.
+            check = .connection
+            hint = Self.jumpHostHint(underlying, authMethod: authMethod)
         }
         return PreflightReport(failure: Failure(check: check, hint: hint))
+    }
+
+    /// Guidance for a first-hop failure. Deliberately not a recursive call
+    /// into the Host-facing hints: every one of those tells the user to go fix
+    /// something on the Host, which is exactly the wrong machine here.
+    private static func jumpHostHint(
+        _ error: TransportError, authMethod: Host.AuthMethod
+    ) -> String {
+        switch error {
+        case .sshUnreachable(let detail):
+            "Could not reach the Jump Host. Check its address and port. (\(detail))"
+        case .authenticationFailed:
+            switch authMethod {
+            case .deviceKey:
+                "The Jump Host rejected the Device Key. Add this Host's key line to "
+                    + "~/.ssh/authorized_keys there, then run the checks again."
+            case .password:
+                "The Jump Host rejected the login. It must accept the same password configured "
+                    + "for this Host; separate passwords are not supported."
+            }
+        case .hostKeyRejected:
+            "The Jump Host's key was not confirmed. Run the checks again and confirm "
+                + "the fingerprint."
+        case .hostKeyMismatch(let known, let presented):
+            "Jump Host key changed: trusted \(known.displayString), it presented "
+                + "\(presented.displayString). This can be a reinstalled server or an "
+                + "attack — verify with its owner before trusting it."
+        case .deviceKeyCorrupt:
+            "The Device Key is corrupted, so the Jump Host could not be reached. Edit "
+                + "this Host and choose Replace Device Key."
+        case .timedOut:
+            "The Jump Host did not answer in time. Check the connection and try again."
+        case .cancelled:
+            "The check was cancelled before it finished."
+        default:
+            "Could not connect through the Jump Host. (\(String(describing: error)))"
+        }
     }
 
     subscript(check: PreflightCheck) -> PreflightCheckStatus {

--- a/Sources/HerdrMobile/Hosts/Preflight.swift
+++ b/Sources/HerdrMobile/Hosts/Preflight.swift
@@ -132,8 +132,50 @@ struct PreflightReport: Equatable, Sendable {
             // taxonomy total anyway.
             check = .connection
             hint = "The connection is busy. Try again."
+        case .jumpHostFailed(let underlying):
+            // The first hop broke, so the Host itself was never contacted and
+            // nothing about it has been disproved. Name the jump host as the
+            // thing to fix, or the user goes and debugs the wrong machine.
+            check = .connection
+            hint = Self.jumpHostHint(underlying, authMethod: authMethod)
         }
         return PreflightReport(failure: Failure(check: check, hint: hint))
+    }
+
+    /// Guidance for a first-hop failure. Deliberately not a recursive call
+    /// into the Host-facing hints: every one of those tells the user to go fix
+    /// something on the Host, which is exactly the wrong machine here.
+    private static func jumpHostHint(
+        _ error: TransportError, authMethod: Host.AuthMethod
+    ) -> String {
+        switch error {
+        case .sshUnreachable(let detail):
+            "Could not reach the jump host. Check its address and port. (\(detail))"
+        case .authenticationFailed:
+            switch authMethod {
+            case .deviceKey:
+                "The jump host rejected the device key. Add this Host's key line to "
+                    + "~/.ssh/authorized_keys on the jump host, then run the checks again."
+            case .password:
+                "The jump host rejected the login. Check the jump host username and password."
+            }
+        case .hostKeyRejected:
+            "The jump host's key was not confirmed. Run the checks again and confirm "
+                + "the fingerprint."
+        case .hostKeyMismatch(let known, let presented):
+            "Jump host key changed: trusted \(known.displayString), it presented "
+                + "\(presented.displayString). This can be a reinstalled server or an "
+                + "attack — verify with its owner before trusting it."
+        case .deviceKeyCorrupt:
+            "The Device Key is corrupted, so the jump host could not be reached. Edit "
+                + "this Host and choose Replace Device Key."
+        case .timedOut:
+            "The jump host did not answer in time. Check the connection and try again."
+        case .cancelled:
+            "The check was cancelled before it finished."
+        default:
+            "Could not connect through the jump host. (\(String(describing: error)))"
+        }
     }
 
     subscript(check: PreflightCheck) -> PreflightCheckStatus {

--- a/Sources/HerdrMobile/Hosts/TransportConnector.swift
+++ b/Sources/HerdrMobile/Hosts/TransportConnector.swift
@@ -24,6 +24,15 @@ extension SSHTransportSettings {
             credentials: credentials,
             hostKeyPolicy: hostKeyPolicy,
             socket: host.socketLocation,
-            socatPath: host.socatPath)
+            socatPath: host.socatPath,
+            // Both hops use the Host's resolved credential. Device Key is the
+            // normal case; password Hosts require the same password at both hops.
+            jump: host.usesJumpHost
+                ? SSHJumpSettings(
+                    host: host.jumpAddress.trimmingCharacters(in: .whitespaces),
+                    port: host.jumpPort,
+                    username: host.resolvedJumpUsername,
+                    credentials: credentials)
+                : nil)
     }
 }

--- a/Sources/HerdrMobile/Hosts/TransportConnector.swift
+++ b/Sources/HerdrMobile/Hosts/TransportConnector.swift
@@ -24,6 +24,15 @@ extension SSHTransportSettings {
             credentials: credentials,
             hostKeyPolicy: hostKeyPolicy,
             socket: host.socketLocation,
-            socatPath: host.socatPath)
+            socatPath: host.socatPath,
+            // The bastion authenticates with the same Device Key; it is the
+            // Host's authorized_keys line that differs, not the key.
+            jump: host.usesJumpHost
+                ? SSHJumpSettings(
+                    host: host.jumpAddress.trimmingCharacters(in: .whitespaces),
+                    port: host.jumpPort,
+                    username: host.resolvedJumpUsername,
+                    credentials: credentials)
+                : nil)
     }
 }

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -46,6 +46,10 @@ struct SSHTransportSettings: Sendable {
     var socatPath: String
     /// How to locate socat when the preferred path is not executable.
     var socatDiscovery: SocatDiscovery = .automatic
+    /// Optional Jump Host. When set, the Transport authenticates against the
+    /// jump host first and opens the Host connection through it, so the Host
+    /// needs no inbound reachability of its own. nil is a direct connection.
+    var jump: SSHJumpSettings? = nil
     /// Command that wakes a stopped herdr server, run over a no-PTY exec
     /// channel when a request hits connection-refused (#6). The default is
     /// the strategy from spec #16: `herdr remote-client-bridge` ensures the
@@ -94,6 +98,28 @@ struct SSHTransportSettings: Sendable {
     var requestTimeout: Duration = .seconds(15)
 }
 
+/// The Jump Host in front of a Host: its own coordinates and credentials. Its
+/// host key is verified under the same TOFU policy as the Host's, keyed by
+/// its own endpoint, so both hops must be confirmed before either is trusted.
+///
+/// The Host's `address`/`port` are resolved from the Jump Host, which is
+/// normally a loopback port held open by a reverse tunnel. Two Hosts behind
+/// one Jump Host therefore need distinct tunnel ports: known-hosts entries are
+/// keyed by endpoint, so a shared `127.0.0.1:12222` would collide.
+struct SSHJumpSettings: Sendable {
+    var host: String
+    var port: Int
+    var username: String
+    var credentials: SSHCredentials
+
+    init(host: String, port: Int = 22, username: String, credentials: SSHCredentials) {
+        self.host = host
+        self.port = port
+        self.username = username
+        self.credentials = credentials
+    }
+}
+
 private struct HerdrSessionListResponse: Decodable {
     let sessions: [HerdrSession]
 }
@@ -118,6 +144,9 @@ actor SSHTransport: Transport {
     static let maxConcurrentExecChannels = SSHChannelBudget.defaultOrdinaryChannelCapacity
 
     private let client: SSHClient
+    /// The outer connection owns the direct-tcpip channel carrying `client`.
+    /// Citadel requires both clients to be closed explicitly.
+    private let jumpClient: SSHClient?
     private let socketLocation: HerdrSocketLocation
     private let preferredSocatPath: String
     private let socatDiscovery: SocatDiscovery
@@ -154,7 +183,7 @@ actor SSHTransport: Transport {
     private var imageStageClients: [UUID: SFTPClient] = [:]
 
     private init(
-        client: SSHClient, socketLocation: HerdrSocketLocation,
+        client: SSHClient, jumpClient: SSHClient?, socketLocation: HerdrSocketLocation,
         preferredSocatPath: String, socatDiscovery: SocatDiscovery,
         wakeCommand: String, sessionListCommand: String, attachCommand: String,
         homeCommand: String, stageDirectoryCommand: String,
@@ -162,6 +191,7 @@ actor SSHTransport: Transport {
         requestTimeout: Duration
     ) {
         self.client = client
+        self.jumpClient = jumpClient
         self.socketLocation = socketLocation
         self.preferredSocatPath = preferredSocatPath
         self.socatDiscovery = socatDiscovery
@@ -180,11 +210,28 @@ actor SSHTransport: Transport {
     /// authenticates — but sends nothing yet: callers must `ping` first to
     /// verify the protocol version.
     static func connect(settings: SSHTransportSettings) async throws -> SSHTransport {
+        let clients: (target: SSHClient, jump: SSHClient?)
+        if let jump = settings.jump {
+            clients = try await connectThroughJumpHost(jump, settings: settings)
+        } else {
+            clients = (try await connectDirectly(settings: settings), nil)
+        }
+        return SSHTransport(
+            client: clients.target, jumpClient: clients.jump, socketLocation: settings.socket,
+            preferredSocatPath: settings.socatPath, socatDiscovery: settings.socatDiscovery,
+            wakeCommand: settings.wakeCommand, sessionListCommand: settings.sessionListCommand,
+            attachCommand: settings.attachCommand, homeCommand: settings.homeCommand,
+            stageDirectoryCommand: settings.stageDirectoryCommand,
+            pluginListCommand: settings.pluginListCommand,
+            notificationConfigDirCommand: settings.notificationConfigDirCommand,
+            requestTimeout: settings.requestTimeout)
+    }
+
+    private static func connectDirectly(settings: SSHTransportSettings) async throws -> SSHClient {
         let validator = TOFUHostKeyValidator(
             host: settings.host, port: settings.port, policy: settings.hostKeyPolicy)
-        let client: SSHClient
         do {
-            client = try await SSHClient.connect(
+            return try await SSHClient.connect(
                 host: settings.host,
                 port: settings.port,
                 authenticationMethod: settings.credentials.citadelMethod(
@@ -200,15 +247,53 @@ actor SSHTransport: Transport {
             }
             throw Self.classifyConnectFailure(error)
         }
-        return SSHTransport(
-            client: client, socketLocation: settings.socket,
-            preferredSocatPath: settings.socatPath, socatDiscovery: settings.socatDiscovery,
-            wakeCommand: settings.wakeCommand, sessionListCommand: settings.sessionListCommand,
-            attachCommand: settings.attachCommand, homeCommand: settings.homeCommand,
-            stageDirectoryCommand: settings.stageDirectoryCommand,
-            pluginListCommand: settings.pluginListCommand,
-            notificationConfigDirCommand: settings.notificationConfigDirCommand,
-            requestTimeout: settings.requestTimeout)
+    }
+
+    /// Authenticates against the Jump Host, then opens the Host connection over
+    /// a direct-tcpip channel through it. Both hops run the same TOFU policy
+    /// against their own endpoints; the Host hop's session keys are negotiated
+    /// end to end, so the Jump Host forwards ciphertext it cannot read.
+    ///
+    /// First-hop failures are wrapped in `.jumpHostFailed` so the UI can name
+    /// the Jump Host rather than blaming the Host.
+    private static func connectThroughJumpHost(
+        _ jump: SSHJumpSettings, settings: SSHTransportSettings
+    ) async throws -> (target: SSHClient, jump: SSHClient) {
+        let jumpValidator = TOFUHostKeyValidator(
+            host: jump.host, port: jump.port, policy: settings.hostKeyPolicy)
+        let hop: SSHClient
+        do {
+            hop = try await SSHClient.connect(
+                host: jump.host,
+                port: jump.port,
+                authenticationMethod: jump.credentials.citadelMethod(username: jump.username),
+                hostKeyValidator: .custom(jumpValidator),
+                reconnect: .never
+            )
+        } catch {
+            throw TransportError.jumpHostFailed(
+                jumpValidator.failure ?? Self.classifyConnectFailure(error))
+        }
+
+        let validator = TOFUHostKeyValidator(
+            host: settings.host, port: settings.port, policy: settings.hostKeyPolicy)
+        do {
+            let target = try await hop.jump(
+                to: SSHClientSettings(
+                    host: settings.host,
+                    port: settings.port,
+                    authenticationMethod: {
+                        settings.credentials.citadelMethod(username: settings.username)
+                    },
+                    hostKeyValidator: .custom(validator)))
+            return (target, hop)
+        } catch {
+            try? await hop.close()
+            if let hostKeyFailure = validator.failure {
+                throw hostKeyFailure
+            }
+            throw Self.classifyConnectFailure(error)
+        }
     }
 
     /// Maps connect-time failures onto the taxonomy: credential rejection is
@@ -1170,6 +1255,13 @@ actor SSHTransport: Transport {
         client.isConnected
     }
 
+    /// The first hop's liveness when this Transport uses a Jump Host.
+    /// Internal so the real-SSH lifecycle test can verify both Citadel clients
+    /// are torn down; direct connections return nil.
+    var jumpHostIsConnected: Bool? {
+        jumpClient?.isConnected
+    }
+
     /// Closes the SSH connection. Explicit close is the only way to end
     /// Citadel channels — a live exec channel ignores task cancellation.
     func close() async throws {
@@ -1178,7 +1270,17 @@ actor SSHTransport: Transport {
         for sftp in stagingClients {
             try? await sftp.close()
         }
-        try await client.close()
+        do {
+            try await client.close()
+        } catch {
+            if let jumpClient {
+                try? await jumpClient.close()
+            }
+            throw error
+        }
+        if let jumpClient {
+            try await jumpClient.close()
+        }
     }
 
     /// Executes one parameterless request with cold-start recovery.

--- a/Sources/HerdrMobile/Transport/SSHTransport.swift
+++ b/Sources/HerdrMobile/Transport/SSHTransport.swift
@@ -27,6 +27,10 @@ struct SSHTransportSettings: Sendable {
     /// Absolute path of socat on the Host. Remote commands run through the
     /// user's login shell, whose PATH cannot be trusted.
     var socatPath: String
+    /// Optional bastion. When set, the Transport authenticates against the
+    /// jump host first and opens the Host connection through it, so the Host
+    /// needs no inbound reachability of its own. nil is a direct connection.
+    var jump: SSHJumpSettings? = nil
     /// Command that wakes a stopped herdr server, run over a no-PTY exec
     /// channel when a request hits connection-refused (#6). The default is
     /// the strategy from spec #16: `herdr remote-client-bridge` ensures the
@@ -73,6 +77,28 @@ struct SSHTransportSettings: Sendable {
     /// closed. Short in tests, generous by default: a hung host should
     /// degrade gracefully, a slow one should still answer.
     var requestTimeout: Duration = .seconds(15)
+}
+
+/// The bastion in front of a Host: its own coordinates and credentials. Its
+/// host key is verified under the same TOFU policy as the Host's, keyed by
+/// its own endpoint, so both hops must be confirmed before either is trusted.
+///
+/// The Host's `address`/`port` are resolved *from the bastion*, which is
+/// normally a loopback port held open by a reverse tunnel. Two Hosts behind
+/// one bastion therefore need distinct tunnel ports: known-hosts entries are
+/// keyed by endpoint, so a shared `127.0.0.1:12222` would collide.
+struct SSHJumpSettings: Sendable {
+    var host: String
+    var port: Int
+    var username: String
+    var credentials: SSHCredentials
+
+    init(host: String, port: Int = 22, username: String, credentials: SSHCredentials) {
+        self.host = host
+        self.port = port
+        self.username = username
+        self.credentials = credentials
+    }
 }
 
 private struct HerdrSessionListResponse: Decodable {
@@ -154,11 +180,27 @@ actor SSHTransport: Transport {
     /// authenticates — but sends nothing yet: callers must `ping` first to
     /// verify the protocol version.
     static func connect(settings: SSHTransportSettings) async throws -> SSHTransport {
+        let client =
+            if let jump = settings.jump {
+                try await connectThroughJumpHost(jump, settings: settings)
+            } else {
+                try await connectDirectly(settings: settings)
+            }
+        return SSHTransport(
+            client: client, socketLocation: settings.socket, socatPath: settings.socatPath,
+            wakeCommand: settings.wakeCommand, sessionListCommand: settings.sessionListCommand,
+            attachCommand: settings.attachCommand, homeCommand: settings.homeCommand,
+            stageDirectoryCommand: settings.stageDirectoryCommand,
+            pluginListCommand: settings.pluginListCommand,
+            notificationConfigDirCommand: settings.notificationConfigDirCommand,
+            requestTimeout: settings.requestTimeout)
+    }
+
+    private static func connectDirectly(settings: SSHTransportSettings) async throws -> SSHClient {
         let validator = TOFUHostKeyValidator(
             host: settings.host, port: settings.port, policy: settings.hostKeyPolicy)
-        let client: SSHClient
         do {
-            client = try await SSHClient.connect(
+            return try await SSHClient.connect(
                 host: settings.host,
                 port: settings.port,
                 authenticationMethod: settings.credentials.citadelMethod(
@@ -174,14 +216,52 @@ actor SSHTransport: Transport {
             }
             throw Self.classifyConnectFailure(error)
         }
-        return SSHTransport(
-            client: client, socketLocation: settings.socket, socatPath: settings.socatPath,
-            wakeCommand: settings.wakeCommand, sessionListCommand: settings.sessionListCommand,
-            attachCommand: settings.attachCommand, homeCommand: settings.homeCommand,
-            stageDirectoryCommand: settings.stageDirectoryCommand,
-            pluginListCommand: settings.pluginListCommand,
-            notificationConfigDirCommand: settings.notificationConfigDirCommand,
-            requestTimeout: settings.requestTimeout)
+    }
+
+    /// Authenticates against the bastion, then opens the Host connection over
+    /// a direct-tcpip channel through it. Both hops run the same TOFU policy
+    /// against their own endpoints; the Host hop's session keys are negotiated
+    /// end to end, so the bastion forwards ciphertext it cannot read.
+    ///
+    /// Bastion-side failures are wrapped in `.jumpHostFailed` so the UI can
+    /// say "your bastion is unreachable" rather than blaming the Host.
+    private static func connectThroughJumpHost(
+        _ jump: SSHJumpSettings, settings: SSHTransportSettings
+    ) async throws -> SSHClient {
+        let jumpValidator = TOFUHostKeyValidator(
+            host: jump.host, port: jump.port, policy: settings.hostKeyPolicy)
+        let hop: SSHClient
+        do {
+            hop = try await SSHClient.connect(
+                host: jump.host,
+                port: jump.port,
+                authenticationMethod: jump.credentials.citadelMethod(username: jump.username),
+                hostKeyValidator: .custom(jumpValidator),
+                reconnect: .never
+            )
+        } catch {
+            throw TransportError.jumpHostFailed(
+                jumpValidator.failure ?? Self.classifyConnectFailure(error))
+        }
+
+        let validator = TOFUHostKeyValidator(
+            host: settings.host, port: settings.port, policy: settings.hostKeyPolicy)
+        do {
+            return try await hop.jump(
+                to: SSHClientSettings(
+                    host: settings.host,
+                    port: settings.port,
+                    authenticationMethod: {
+                        settings.credentials.citadelMethod(username: settings.username)
+                    },
+                    hostKeyValidator: .custom(validator)))
+        } catch {
+            try? await hop.close()
+            if let hostKeyFailure = validator.failure {
+                throw hostKeyFailure
+            }
+            throw Self.classifyConnectFailure(error)
+        }
     }
 
     /// Maps connect-time failures onto the taxonomy: credential rejection is

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -323,10 +323,15 @@ enum HerdrSocketLocation: Sendable, Equatable {
 
 /// Transport-level failures: a closed taxonomy so every screen maps errors to
 /// user guidance consistently instead of string-matching.
-enum TransportError: Error, Sendable, Equatable {
+indirect enum TransportError: Error, Sendable, Equatable {
     /// The SSH server could not be reached: connection refused, no route,
     /// or the connection died before authentication.
     case sshUnreachable(detail: String)
+    /// The first hop failed: the Host may be perfectly healthy, but the
+    /// Jump Host in front of it is unreachable, rejected our key, or presented
+    /// an unexpected host key. Carries the underlying failure so screens can
+    /// reuse the existing guidance while naming the Jump Host as the culprit.
+    case jumpHostFailed(TransportError)
     /// The Host rejected our credentials (key not authorized, wrong
     /// password, or the offered auth method is unavailable).
     case authenticationFailed
@@ -384,6 +389,10 @@ enum TransportError: Error, Sendable, Equatable {
             .homeDirectoryUnresolvable, .eventsChannelAlreadyOpen,
             .terminalChannelAlreadyOpen, .malformedResponse:
             false
+        // A Jump Host is retryable exactly when the failure behind it is: a
+        // rebooting VPS should reconnect on its own, a rejected key should not.
+        case .jumpHostFailed(let underlying):
+            underlying.isRetryable
         }
     }
 }

--- a/Sources/HerdrMobile/Transport/Transport.swift
+++ b/Sources/HerdrMobile/Transport/Transport.swift
@@ -323,10 +323,16 @@ enum HerdrSocketLocation: Sendable, Equatable {
 
 /// Transport-level failures: a closed taxonomy so every screen maps errors to
 /// user guidance consistently instead of string-matching.
-enum TransportError: Error, Sendable, Equatable {
+indirect enum TransportError: Error, Sendable, Equatable {
     /// The SSH server could not be reached: connection refused, no route,
     /// or the connection died before authentication.
     case sshUnreachable(detail: String)
+    /// The first hop failed: the Host may be perfectly healthy, but the
+    /// bastion in front of it is unreachable, rejected our key, or presented
+    /// an unexpected host key. Carries the underlying failure so screens can
+    /// reuse the existing guidance while naming the bastion as the culprit —
+    /// "the Host is down" and "your bastion is down" need different actions.
+    case jumpHostFailed(TransportError)
     /// The Host rejected our credentials (key not authorized, wrong
     /// password, or the offered auth method is unavailable).
     case authenticationFailed
@@ -383,6 +389,10 @@ enum TransportError: Error, Sendable, Equatable {
             .homeDirectoryUnresolvable, .eventsChannelAlreadyOpen,
             .terminalChannelAlreadyOpen, .malformedResponse:
             false
+        // A bastion is retryable exactly when the failure behind it is: a
+        // rebooting VPS should reconnect on its own, a rejected key should not.
+        case .jumpHostFailed(let underlying):
+            underlying.isRetryable
         }
     }
 }

--- a/Tests/HerdrMobileTests/HostDraftTests.swift
+++ b/Tests/HerdrMobileTests/HostDraftTests.swift
@@ -17,6 +17,57 @@ struct HostDraftTests {
         #expect(rebuilt == host)
     }
 
+    @Test func prefillsAndRoundTripsAJumpHost() throws {
+        let host = Host(
+            id: UUID(), name: "Behind NAT", address: "127.0.0.1", port: 12_222,
+            username: "dev", sessionName: "work", socatPath: "/usr/bin/socat",
+            jumpAddress: "bastion.example", jumpPort: 2022, jumpUsername: "tunnel")
+
+        let draft = HostDraft(host: host)
+        let rebuilt = try #require(draft.makeHost(id: host.id))
+
+        #expect(rebuilt == host)
+    }
+
+    @Test func blankJumpAddressMeansDirectConnection() throws {
+        var draft = HostDraft()
+        draft.address = "box.example"
+        draft.username = "dev"
+
+        let host = try #require(draft.makeHost())
+
+        #expect(!host.usesJumpHost)
+        #expect(host.jumpAddress.isEmpty)
+    }
+
+    // The jump port sits in the form even when unused, so a leftover invalid
+    // value must not block saving a Host that connects directly.
+    @Test func jumpPortOnlyHasToParseWhenAJumpHostIsSet() throws {
+        var draft = HostDraft()
+        draft.address = "box.example"
+        draft.username = "dev"
+        draft.jumpPort = "not-a-port"
+        #expect(draft.isValid)
+
+        draft.jumpAddress = "bastion.example"
+        #expect(!draft.isValid)
+
+        draft.jumpPort = "2022"
+        #expect(draft.isValid)
+    }
+
+    @Test func blankJumpUsernameFallsBackToTheHostAccount() throws {
+        var draft = HostDraft()
+        draft.address = "127.0.0.1"
+        draft.username = "dev"
+        draft.jumpAddress = "bastion.example"
+
+        let host = try #require(draft.makeHost())
+
+        #expect(host.jumpUsername.isEmpty)
+        #expect(host.resolvedJumpUsername == "dev")
+    }
+
     @Test func trimsFieldsOnSave() throws {
         var draft = HostDraft()
         draft.name = " Workbox "

--- a/Tests/HerdrMobileTests/HostDraftTests.swift
+++ b/Tests/HerdrMobileTests/HostDraftTests.swift
@@ -17,6 +17,57 @@ struct HostDraftTests {
         #expect(rebuilt == host)
     }
 
+    @Test func prefillsAndRoundTripsAJumpHost() throws {
+        let host = Host(
+            id: UUID(), name: "Behind NAT", address: "127.0.0.1", port: 12_222,
+            username: "dev", sessionName: "work", socatPath: "/usr/bin/socat",
+            jumpAddress: "jump.example", jumpPort: 2022, jumpUsername: "tunnel")
+
+        let draft = HostDraft(host: host)
+        let rebuilt = try #require(draft.makeHost(id: host.id))
+
+        #expect(rebuilt == host)
+    }
+
+    @Test func blankJumpAddressMeansDirectConnection() throws {
+        var draft = HostDraft()
+        draft.address = "box.example"
+        draft.username = "dev"
+
+        let host = try #require(draft.makeHost())
+
+        #expect(!host.usesJumpHost)
+        #expect(host.jumpAddress.isEmpty)
+    }
+
+    // The Jump Host port sits in the form even when unused, so an invalid
+    // value must not block saving a Host that connects directly.
+    @Test func jumpPortOnlyHasToParseWhenAJumpHostIsSet() throws {
+        var draft = HostDraft()
+        draft.address = "box.example"
+        draft.username = "dev"
+        draft.jumpPort = "not-a-port"
+        #expect(draft.isValid)
+
+        draft.jumpAddress = "jump.example"
+        #expect(!draft.isValid)
+
+        draft.jumpPort = "2022"
+        #expect(draft.isValid)
+    }
+
+    @Test func blankJumpUsernameFallsBackToTheHostAccount() throws {
+        var draft = HostDraft()
+        draft.address = "127.0.0.1"
+        draft.username = "dev"
+        draft.jumpAddress = "jump.example"
+
+        let host = try #require(draft.makeHost())
+
+        #expect(host.jumpUsername.isEmpty)
+        #expect(host.resolvedJumpUsername == "dev")
+    }
+
     @Test func trimsFieldsOnSave() throws {
         var draft = HostDraft()
         draft.name = " Workbox "

--- a/Tests/HerdrMobileTests/HostStoreTests.swift
+++ b/Tests/HerdrMobileTests/HostStoreTests.swift
@@ -64,6 +64,9 @@ struct HostStoreTests {
         let host = try #require(store.hosts.first)
         #expect(host.sessionName == "")
         #expect(host.socatPath == Host.defaultSocatPath)
+        // Hosts saved before jump-host support must keep connecting directly.
+        #expect(!host.usesJumpHost)
+        #expect(host.jumpPort == 22)
     }
 
     @Test func corruptCatalogCannotBeSilentlyOverwritten() throws {

--- a/Tests/HerdrMobileTests/PreflightReportTests.swift
+++ b/Tests/HerdrMobileTests/PreflightReportTests.swift
@@ -50,6 +50,7 @@ struct PreflightReportTests {
         (.cancelled, .connection),
         (.channelFailed(detail: "boom"), .connection),
         (.eventsChannelAlreadyOpen, .connection),
+        (.jumpHostFailed(.sshUnreachable(detail: "refused")), .connection),
         (.socatMissing(path: "/usr/bin/socat"), .socat),
         (.socketNotFound(path: "/home/dev/.config/herdr/herdr.sock"), .herdrInstalled),
         (.homeDirectoryUnresolvable(detail: "no $HOME"), .remoteEnvironment),
@@ -87,6 +88,17 @@ struct PreflightReportTests {
         }
         #expect(keyHint.contains("authorized_keys"))
         #expect(passwordHint.contains("password"))
+    }
+
+    @Test func jumpHostFailureHintNamesTheFirstHop() {
+        let report = PreflightReport.failure(
+            .jumpHostFailed(.authenticationFailed), authMethod: .password)
+        guard case .failed(let hint) = report[.connection] else {
+            Issue.record("connection check should fail")
+            return
+        }
+        #expect(hint.contains("Jump Host"))
+        #expect(hint.contains("same password"))
     }
 
     @Test func protocolMismatchHintNamesBothVersions() {

--- a/Tests/HerdrMobileTests/SSHJumpHostE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHJumpHostE2ETests.swift
@@ -1,0 +1,205 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+// Two-hop connections over the real stack: Citadel -> localhost sshd (standing
+// in for the Jump Host) -> direct-tcpip -> localhost sshd again -> login shell ->
+// real socat -> in-test fake herdr server.
+//
+// The point of these tests is that everything below `SSHTransport.connect` is
+// unchanged: once the second hop is up, the Transport does not know or care
+// that it is tunnelled. So the coverage here is the connect path, the failure
+// taxonomy, and proof that the ordinary capabilities still work through it.
+@Suite(
+    "SSH jump host e2e",
+    .enabled(
+        if: LocalSSHTestEnvironment.isAvailable,
+        "requires localhost sshd, socat, and an authorized Ed25519 test key"))
+struct SSHJumpHostE2ETests {
+    @Test func pingRoundTripsThroughTheJumpHost() async throws {
+        try await withJumpedTransport { request in
+            [
+                #"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9-fake","protocol":17}}"#
+            ]
+        } body: { transport, server in
+            let info = try await transport.ping()
+
+            #expect(info == ServerInfo(version: "9.9.9-fake", protocolVersion: 17))
+            #expect(server.receivedRequests.map(\.method) == ["ping"])
+        }
+    }
+
+    // Each request opens its own exec channel (ADR 0002). Through a Jump Host
+    // those channels live on the second hop, so the channel budget and the
+    // one-request-per-connection dance have to survive the tunnel.
+    @Test func sequentialRequestsReuseTheTunnelledConnection() async throws {
+        try await withJumpedTransport { request in
+            [
+                #"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9-fake","protocol":17}}"#
+            ]
+        } body: { transport, server in
+            for _ in 0..<3 {
+                _ = try await transport.ping()
+            }
+
+            #expect(server.receivedRequests.count == 3)
+        }
+    }
+
+    @Test func unreachableJumpHostIsReportedAsJumpHostFailure() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        // Port 1 is reserved and never listening, so this fails at connect
+        // rather than at authentication.
+        let deadJumpHost = SSHJumpSettings(
+            host: "127.0.0.1", port: 1, username: environment.username,
+            credentials: .ed25519(environment.privateKey))
+
+        let error = await #expect(throws: TransportError.self) {
+            _ = try await SSHTransport.connect(
+                settings: environment.makeSettings(
+                    socket: .absolutePath("/tmp/herdr-irrelevant.sock"), jump: deadJumpHost))
+        }
+
+        guard case .jumpHostFailed(let underlying) = error else {
+            Issue.record("expected .jumpHostFailed, got \(String(describing: error))")
+            return
+        }
+        guard case .sshUnreachable = underlying else {
+            Issue.record("expected .sshUnreachable behind the Jump Host, got \(underlying)")
+            return
+        }
+        // A Jump Host that is merely down must not stop the reconnect machinery.
+        #expect(error?.isRetryable == true)
+    }
+
+    @Test func jumpHostRejectingOurKeyIsNotRetryable() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let unauthorized = try DeviceKeyStore(secrets: InMemorySecretStore()).loadOrCreate()
+        let jumpHost = SSHJumpSettings(
+            host: environment.host, port: environment.port, username: environment.username,
+            credentials: .ed25519(unauthorized.privateKey))
+
+        let error = await #expect(throws: TransportError.self) {
+            _ = try await SSHTransport.connect(
+                settings: environment.makeSettings(
+                    socket: .absolutePath("/tmp/herdr-irrelevant.sock"), jump: jumpHost))
+        }
+
+        #expect(error == .jumpHostFailed(.authenticationFailed))
+        #expect(error?.isRetryable == false)
+    }
+
+    // Both endpoints are trusted on their own terms: sitting behind a trusted
+    // Jump Host must not, by itself, make a Host trusted.
+    //
+    // Known-hosts entries are keyed by endpoint, so proving this needs two
+    // distinct endpoints. "127.0.0.1" and "localhost" are two endpoint keys
+    // reaching the same sshd — enough to exercise the real thing under test
+    // (two validators, two endpoints, two independent store writes) without
+    // standing up a second daemon. A real deployment separates them by port
+    // instead, which the store treats identically.
+    @Test func bothHopsAreRecordedInKnownHostsSeparately() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let knownHosts = InMemoryKnownHostsStore()
+        let policy = HostKeyPolicy(knownHosts: knownHosts) { _ in true }
+        let server = try FakeHerdrServer { request in
+            [#"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9","protocol":17}}"#]
+        }
+        defer { server.stop() }
+
+        var settings = environment.makeSettings(
+            socket: .absolutePath(server.socketPath),
+            hostKeyPolicy: policy,
+            jump: environment.loopbackJump)
+        settings.host = "localhost"
+        let transport = try await SSHTransport.connect(settings: settings)
+        try await transport.close()
+
+        let jumpHostFingerprint = await knownHosts.fingerprint(
+            host: environment.host, port: environment.port)
+        let hostFingerprint = await knownHosts.fingerprint(
+            host: "localhost", port: environment.port)
+        #expect(jumpHostFingerprint != nil, "the Jump Host endpoint should be recorded")
+        #expect(hostFingerprint != nil, "the Host endpoint should be recorded on its own")
+    }
+
+    @Test func imageStagingWorksThroughTheJumpHost() async throws {
+        try await withJumpedTransport { request in
+            [#"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9","protocol":17}}"#]
+        } body: { transport, _ in
+            let payload = Data("staged through a Jump Host".utf8)
+            let localURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("herdr-jump-\(UUID().uuidString).png")
+            try payload.write(to: localURL)
+            defer { try? FileManager.default.removeItem(at: localURL) }
+
+            let staged = try await transport.stageImage(
+                PreparedImage(
+                    fileURL: localURL,
+                    format: .png,
+                    pixelWidth: 1,
+                    pixelHeight: 1,
+                    byteCount: Int64(payload.count))
+            ) { _ in }
+
+            #expect(staged.path.hasSuffix(".png"))
+        }
+    }
+
+    @Test func closeTearsDownBothHops() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let server = try FakeHerdrServer { request in
+            [#"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9","protocol":17}}"#]
+        }
+        let transport: SSHTransport
+        do {
+            transport = try await SSHTransport.connect(
+                settings: environment.makeSettings(
+                    socket: .absolutePath(server.socketPath), jump: environment.loopbackJump))
+        } catch {
+            server.stop()
+            throw error
+        }
+
+        #expect(await transport.isConnected)
+        #expect(await transport.jumpHostIsConnected == true)
+
+        do {
+            try await transport.close()
+        } catch {
+            server.stop()
+            throw error
+        }
+        server.stop()
+
+        #expect(await !transport.isConnected)
+        #expect(await transport.jumpHostIsConnected == false)
+    }
+
+    private func withJumpedTransport(
+        script: @escaping FakeHerdrServer.Script,
+        body: (SSHTransport, FakeHerdrServer) async throws -> Void
+    ) async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let server = try FakeHerdrServer(script: script)
+        let transport: SSHTransport
+        do {
+            transport = try await SSHTransport.connect(
+                settings: environment.makeSettings(
+                    socket: .absolutePath(server.socketPath), jump: environment.loopbackJump))
+        } catch {
+            server.stop()
+            throw error
+        }
+        do {
+            try await body(transport, server)
+        } catch {
+            try? await transport.close()
+            server.stop()
+            throw error
+        }
+        try await transport.close()
+        server.stop()
+    }
+}

--- a/Tests/HerdrMobileTests/SSHJumpHostE2ETests.swift
+++ b/Tests/HerdrMobileTests/SSHJumpHostE2ETests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+// Two-hop connections over the real stack: Citadel -> localhost sshd (standing
+// in for the bastion) -> direct-tcpip -> localhost sshd again -> login shell ->
+// real socat -> in-test fake herdr server.
+//
+// The point of these tests is that everything below `SSHTransport.connect` is
+// unchanged: once the second hop is up, the Transport does not know or care
+// that it is tunnelled. So the coverage here is the connect path, the failure
+// taxonomy, and proof that the ordinary capabilities still work through it.
+@Suite(
+    "SSH jump host e2e",
+    .enabled(
+        if: LocalSSHTestEnvironment.isAvailable,
+        "requires localhost sshd, socat, and an authorized Ed25519 test key"))
+struct SSHJumpHostE2ETests {
+    @Test func pingRoundTripsThroughTheBastion() async throws {
+        try await withJumpedTransport { request in
+            [
+                #"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9-fake","protocol":17}}"#
+            ]
+        } body: { transport, server in
+            let info = try await transport.ping()
+
+            #expect(info == ServerInfo(version: "9.9.9-fake", protocolVersion: 17))
+            #expect(server.receivedRequests.map(\.method) == ["ping"])
+        }
+    }
+
+    // Each request opens its own exec channel (ADR 0002). Through a bastion
+    // those channels live on the second hop, so the channel budget and the
+    // one-request-per-connection dance have to survive the tunnel.
+    @Test func sequentialRequestsReuseTheTunnelledConnection() async throws {
+        try await withJumpedTransport { request in
+            [
+                #"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9-fake","protocol":17}}"#
+            ]
+        } body: { transport, server in
+            for _ in 0..<3 {
+                _ = try await transport.ping()
+            }
+
+            #expect(server.receivedRequests.count == 3)
+        }
+    }
+
+    @Test func unreachableBastionIsReportedAsJumpHostFailure() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        // Port 1 is reserved and never listening, so this fails at connect
+        // rather than at authentication.
+        let deadBastion = SSHJumpSettings(
+            host: "127.0.0.1", port: 1, username: environment.username,
+            credentials: .ed25519(environment.privateKey))
+
+        let error = await #expect(throws: TransportError.self) {
+            _ = try await SSHTransport.connect(
+                settings: environment.makeSettings(
+                    socket: .absolutePath("/tmp/herdr-irrelevant.sock"), jump: deadBastion))
+        }
+
+        guard case .jumpHostFailed(let underlying) = error else {
+            Issue.record("expected .jumpHostFailed, got \(String(describing: error))")
+            return
+        }
+        guard case .sshUnreachable = underlying else {
+            Issue.record("expected .sshUnreachable behind the bastion, got \(underlying)")
+            return
+        }
+        // A bastion that is merely down must not stop the reconnect machinery.
+        #expect(error?.isRetryable == true)
+    }
+
+    @Test func bastionRejectingOurKeyIsNotRetryable() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let unauthorized = try DeviceKeyStore(secrets: InMemorySecretStore()).loadOrCreate()
+        let bastion = SSHJumpSettings(
+            host: environment.host, port: environment.port, username: environment.username,
+            credentials: .ed25519(unauthorized.privateKey))
+
+        let error = await #expect(throws: TransportError.self) {
+            _ = try await SSHTransport.connect(
+                settings: environment.makeSettings(
+                    socket: .absolutePath("/tmp/herdr-irrelevant.sock"), jump: bastion))
+        }
+
+        #expect(error == .jumpHostFailed(.authenticationFailed))
+        #expect(error?.isRetryable == false)
+    }
+
+    // Both endpoints are trusted on their own terms: sitting behind a trusted
+    // bastion must not, by itself, make a Host trusted.
+    //
+    // Known-hosts entries are keyed by endpoint, so proving this needs two
+    // distinct endpoints. "127.0.0.1" and "localhost" are two endpoint keys
+    // reaching the same sshd — enough to exercise the real thing under test
+    // (two validators, two endpoints, two independent store writes) without
+    // standing up a second daemon. A real deployment separates them by port
+    // instead, which the store treats identically.
+    @Test func bothHopsAreRecordedInKnownHostsSeparately() async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let knownHosts = InMemoryKnownHostsStore()
+        let policy = HostKeyPolicy(knownHosts: knownHosts) { _ in true }
+        let server = try FakeHerdrServer { request in
+            [#"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9","protocol":17}}"#]
+        }
+        defer { server.stop() }
+
+        var settings = environment.makeSettings(
+            socket: .absolutePath(server.socketPath),
+            hostKeyPolicy: policy,
+            jump: environment.loopbackJump)
+        settings.host = "localhost"
+        let transport = try await SSHTransport.connect(settings: settings)
+        try await transport.close()
+
+        let bastionFingerprint = await knownHosts.fingerprint(
+            host: environment.host, port: environment.port)
+        let hostFingerprint = await knownHosts.fingerprint(
+            host: "localhost", port: environment.port)
+        #expect(bastionFingerprint != nil, "the bastion endpoint should be recorded")
+        #expect(hostFingerprint != nil, "the Host endpoint should be recorded on its own")
+    }
+
+    @Test func imageStagingWorksThroughTheBastion() async throws {
+        try await withJumpedTransport { request in
+            [#"{"id":"\#(request.id)","result":{"type":"pong","version":"9.9.9","protocol":17}}"#]
+        } body: { transport, _ in
+            let payload = Data("staged through a bastion".utf8)
+            let localURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("herdr-jump-\(UUID().uuidString).png")
+            try payload.write(to: localURL)
+            defer { try? FileManager.default.removeItem(at: localURL) }
+
+            let staged = try await transport.stageImage(
+                PreparedImage(
+                    fileURL: localURL,
+                    format: .png,
+                    pixelWidth: 1,
+                    pixelHeight: 1,
+                    byteCount: Int64(payload.count))
+            ) { _ in }
+
+            #expect(staged.path.hasSuffix(".png"))
+        }
+    }
+
+    private func withJumpedTransport(
+        script: @escaping FakeHerdrServer.Script,
+        body: (SSHTransport, FakeHerdrServer) async throws -> Void
+    ) async throws {
+        let environment = try #require(LocalSSHTestEnvironment.current)
+        let server = try FakeHerdrServer(script: script)
+        let transport: SSHTransport
+        do {
+            transport = try await SSHTransport.connect(
+                settings: environment.makeSettings(
+                    socket: .absolutePath(server.socketPath), jump: environment.loopbackJump))
+        } catch {
+            server.stop()
+            throw error
+        }
+        do {
+            try await body(transport, server)
+        } catch {
+            try? await transport.close()
+            server.stop()
+            throw error
+        }
+        try await transport.close()
+        server.stop()
+    }
+}

--- a/Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift
+++ b/Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift
@@ -68,6 +68,14 @@ struct LocalSSHTestEnvironment: Sendable {
         return components[2]
     }
 
+    /// The harness sshd standing in for a Jump Host. Hopping 127.0.0.1 ->
+    /// 127.0.0.1 drives the same direct-tcpip path a real Jump Host would,
+    /// without needing a second machine.
+    var loopbackJump: SSHJumpSettings {
+        SSHJumpSettings(
+            host: host, port: port, username: username, credentials: .ed25519(privateKey))
+    }
+
     /// Transport settings for the harness Host with test defaults: seeded-key
     /// credentials and an auto-accepting TOFU policy over a fresh in-memory
     /// store. Host key behavior itself is under test only in
@@ -81,7 +89,8 @@ struct LocalSSHTestEnvironment: Sendable {
         homeCommand: String? = nil,
         stageDirectoryCommand: String? = nil,
         credentials: SSHCredentials? = nil,
-        hostKeyPolicy: HostKeyPolicy? = nil
+        hostKeyPolicy: HostKeyPolicy? = nil,
+        jump: SSHJumpSettings? = nil
     ) -> SSHTransportSettings {
         var settings = SSHTransportSettings(
             host: host,
@@ -91,7 +100,8 @@ struct LocalSSHTestEnvironment: Sendable {
             hostKeyPolicy: hostKeyPolicy
                 ?? HostKeyPolicy(knownHosts: InMemoryKnownHostsStore()) { _ in true },
             socket: socket,
-            socatPath: socatPath ?? self.socatPath)
+            socatPath: socatPath ?? self.socatPath,
+            jump: jump)
         if let socatDiscovery { settings.socatDiscovery = socatDiscovery }
         if let wakeCommand { settings.wakeCommand = wakeCommand }
         if let requestTimeout { settings.requestTimeout = requestTimeout }

--- a/Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift
+++ b/Tests/HerdrMobileTests/Support/LocalSSHTestEnvironment.swift
@@ -68,6 +68,14 @@ struct LocalSSHTestEnvironment: Sendable {
         return components[2]
     }
 
+    /// The harness sshd standing in for a bastion. Hopping 127.0.0.1 ->
+    /// 127.0.0.1 drives the same direct-tcpip path a real bastion would,
+    /// without needing a second machine.
+    var loopbackJump: SSHJumpSettings {
+        SSHJumpSettings(
+            host: host, port: port, username: username, credentials: .ed25519(privateKey))
+    }
+
     /// Transport settings for the harness Host with test defaults: seeded-key
     /// credentials and an auto-accepting TOFU policy over a fresh in-memory
     /// store. Host key behavior itself is under test only in
@@ -80,7 +88,8 @@ struct LocalSSHTestEnvironment: Sendable {
         homeCommand: String? = nil,
         stageDirectoryCommand: String? = nil,
         credentials: SSHCredentials? = nil,
-        hostKeyPolicy: HostKeyPolicy? = nil
+        hostKeyPolicy: HostKeyPolicy? = nil,
+        jump: SSHJumpSettings? = nil
     ) -> SSHTransportSettings {
         var settings = SSHTransportSettings(
             host: host,
@@ -90,7 +99,8 @@ struct LocalSSHTestEnvironment: Sendable {
             hostKeyPolicy: hostKeyPolicy
                 ?? HostKeyPolicy(knownHosts: InMemoryKnownHostsStore()) { _ in true },
             socket: socket,
-            socatPath: socatPath ?? self.socatPath)
+            socatPath: socatPath ?? self.socatPath,
+            jump: jump)
         if let wakeCommand { settings.wakeCommand = wakeCommand }
         if let requestTimeout { settings.requestTimeout = requestTimeout }
         if let homeCommand { settings.homeCommand = homeCommand }

--- a/docs/guides/vps-jump-host-setup.md
+++ b/docs/guides/vps-jump-host-setup.md
@@ -1,0 +1,664 @@
+# Set Up Remote Access Through a VPS
+
+Follow this guide when the Mac running herdr is behind NAT and Herdr Mobile
+cannot reach it directly. The result is:
+
+```text
+iPhone -> VPS public SSH port -> VPS 127.0.0.1:2222 -> Mac SSH port 22
+```
+
+The VPS exposes only its normal SSH service. Port `2222` remains on the VPS
+loopback interface and is never opened in a public firewall.
+
+For design rationale, threat boundaries, key rotation, and a full migration
+runbook, see [VPS Jump Host and Reverse-Tunnel Deployment](vps-jump-host.md).
+
+## Before You Start
+
+You need:
+
+- an iPhone with Herdr Mobile installed;
+- a Mac with herdr and `socat` installed;
+- administrator access to a maintained Debian or Ubuntu VPS;
+- the VPS public IP address;
+- the VPS SSH service port, normally `22`;
+- a recovery path to the VPS, such as the provider console.
+
+Keep the current VPS administrator session open until the restricted accounts
+have passed validation.
+
+Choose values for these placeholders:
+
+| Placeholder | Example | Meaning |
+|---|---|---|
+| `VPS_PUBLIC_IP` | `203.0.113.10` | Public VPS address |
+| `VPS_SSH_PORT` | `22` | Public VPS SSH port |
+| `VPS_NAME` | `work-vps` | Short local alias |
+| `MAC_USER` | `alice` | macOS login account |
+| `TUNNEL_PORT` | `2222` | VPS loopback port for this Mac |
+
+Replace uppercase placeholders before running a command. Do not paste commands
+containing unresolved placeholders.
+
+If several Macs share one VPS, give each Mac a different `TUNNEL_PORT`.
+
+## Step 1: Enable Remote Login on the Mac
+
+**Run on: macOS**
+
+Open:
+
+```text
+System Settings -> General -> Sharing -> Remote Login
+```
+
+Turn on Remote Login and allow only the Mac account Herdr Mobile should use.
+Full Disk Access is not required by this network setup.
+
+Confirm the SSH listener:
+
+```bash
+nc -z 127.0.0.1 22 && echo 'Mac SSH is reachable'
+```
+
+Expected:
+
+```text
+Mac SSH is reachable
+```
+
+Do not continue until this succeeds.
+
+## Step 2: Create a Dedicated Tunnel Key
+
+**Run on: macOS**
+
+This key keeps the reverse tunnel alive. It must not be reused for administrator
+or interactive login.
+
+```bash
+ssh-keygen \
+  -t ed25519 \
+  -a 100 \
+  -N '' \
+  -f ~/.ssh/VPS_NAME-tunnel \
+  -C VPS_NAME-tunnel
+```
+
+For example, when `VPS_NAME` is `work-vps`:
+
+```bash
+ssh-keygen \
+  -t ed25519 \
+  -a 100 \
+  -N '' \
+  -f ~/.ssh/work-vps-tunnel \
+  -C work-vps-tunnel
+```
+
+Display the public key and fingerprint:
+
+```bash
+cat ~/.ssh/VPS_NAME-tunnel.pub
+ssh-keygen -lf ~/.ssh/VPS_NAME-tunnel.pub
+```
+
+Copy the public-key line. Never copy or upload the file without `.pub`.
+
+Checkpoint:
+
+- [ ] The private key is mode `600`.
+- [ ] The public key starts with `ssh-ed25519`.
+- [ ] The public key has a recorded SHA-256 fingerprint.
+
+## Step 3: Copy the Herdr Mobile Device Key
+
+**Run on: iOS**
+
+In Herdr Mobile, begin adding a Host and copy the Device Key public-key line.
+It looks like:
+
+```text
+ssh-ed25519 AAAA... herdr-mobile
+```
+
+The private key remains in the iOS Keychain. Only the public line is copied.
+
+Record this line as `DEVICE_PUBLIC_KEY`. It must be authorized on both the VPS
+Jump account and the Mac account.
+
+## Step 4: Authorize the Device Key on the Mac
+
+**Run on: macOS**
+
+Replace `DEVICE_PUBLIC_KEY` with the complete public-key line copied from Herdr
+Mobile:
+
+```bash
+DEVICE_KEY='DEVICE_PUBLIC_KEY'
+DEVICE_ENTRY="no-agent-forwarding,no-port-forwarding,no-X11-forwarding,no-user-rc $DEVICE_KEY"
+
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+grep -qxF "$DEVICE_ENTRY" ~/.ssh/authorized_keys 2>/dev/null \
+  || printf '%s\n' "$DEVICE_ENTRY" >> ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
+```
+
+These options keep the PTY, exec, and SFTP features Herdr Mobile needs while
+disabling agent, TCP, and X11 forwarding.
+
+Checkpoint:
+
+```bash
+grep -F "$DEVICE_KEY" ~/.ssh/authorized_keys
+```
+
+The command must print exactly one matching authorized-key line.
+
+## Step 5: Create the Restricted VPS Accounts
+
+**Run on: VPS**
+
+```bash
+id -u herdr-tunnel >/dev/null 2>&1 \
+  || sudo adduser --disabled-password --gecos '' herdr-tunnel
+
+id -u herdr-jump >/dev/null 2>&1 \
+  || sudo adduser --disabled-password --gecos '' herdr-jump
+
+sudo install -d -m 700 \
+  -o herdr-tunnel \
+  -g herdr-tunnel \
+  /home/herdr-tunnel/.ssh
+
+sudo install -d -m 700 \
+  -o herdr-jump \
+  -g herdr-jump \
+  /home/herdr-jump/.ssh
+```
+
+If an account already exists, inspect it instead of blindly recreating it:
+
+```bash
+getent passwd herdr-tunnel
+getent passwd herdr-jump
+```
+
+The accounts have no password. The SSH policy added later prevents shell and
+subsystem sessions while still permitting the one required forwarding mode.
+
+## Step 6: Install the Restricted Public Keys on the VPS
+
+**Run on: VPS**
+
+First install the Mac tunnel public key. Replace `TUNNEL_PUBLIC_KEY` with the
+complete contents of `~/.ssh/VPS_NAME-tunnel.pub`:
+
+```bash
+TUNNEL_PORT='2222'
+TUNNEL_KEY='TUNNEL_PUBLIC_KEY'
+TUNNEL_ENTRY="restrict,port-forwarding,permitlisten=\"127.0.0.1:${TUNNEL_PORT}\" $TUNNEL_KEY"
+
+printf '%s\n' "$TUNNEL_ENTRY" \
+  | sudo tee /home/herdr-tunnel/.ssh/authorized_keys >/dev/null
+```
+
+Replace `2222` before running the block if this Mac uses another loopback port.
+
+Now append the Herdr Mobile Device Key. Replace `DEVICE_PUBLIC_KEY` and
+change `2222` if needed:
+
+```bash
+TUNNEL_PORT='2222'
+DEVICE_KEY='DEVICE_PUBLIC_KEY'
+DEVICE_ENTRY="restrict,port-forwarding,permitopen=\"127.0.0.1:${TUNNEL_PORT}\" $DEVICE_KEY"
+
+sudo grep -qxF "$DEVICE_ENTRY" /home/herdr-jump/.ssh/authorized_keys 2>/dev/null \
+  || printf '%s\n' "$DEVICE_ENTRY" \
+  | sudo tee -a /home/herdr-jump/.ssh/authorized_keys >/dev/null
+```
+
+Apply ownership and permissions:
+
+```bash
+sudo chown -R herdr-tunnel:herdr-tunnel /home/herdr-tunnel/.ssh
+sudo chmod 700 /home/herdr-tunnel/.ssh
+sudo chmod 600 /home/herdr-tunnel/.ssh/authorized_keys
+
+sudo chown -R herdr-jump:herdr-jump /home/herdr-jump/.ssh
+sudo chmod 700 /home/herdr-jump/.ssh
+sudo chmod 600 /home/herdr-jump/.ssh/authorized_keys
+```
+
+Inspect both files:
+
+```bash
+sudo cat /home/herdr-tunnel/.ssh/authorized_keys
+sudo cat /home/herdr-jump/.ssh/authorized_keys
+```
+
+Checkpoint:
+
+- [ ] The tunnel line contains `permitlisten="127.0.0.1:TUNNEL_PORT"`.
+- [ ] The Device Key line contains `permitopen="127.0.0.1:TUNNEL_PORT"`.
+- [ ] Neither file contains a private key.
+
+## Step 7: Restrict Both VPS Accounts in OpenSSH
+
+**Run on: VPS**
+
+Confirm the main SSH configuration includes drop-ins:
+
+```bash
+grep -nE '^[[:space:]]*Include[[:space:]]+.*/sshd_config\.d/' \
+  /etc/ssh/sshd_config
+```
+
+If there is no matching line, stop and consult the VPS distribution
+documentation before continuing.
+
+Create `/etc/ssh/sshd_config.d/60-herdr-forwarding.conf`:
+
+```bash
+sudoedit /etc/ssh/sshd_config.d/60-herdr-forwarding.conf
+```
+
+Insert the following, replacing both instances of `TUNNEL_PORT`:
+
+```sshconfig
+# Restrict the persistent reverse-tunnel account.
+Match User herdr-tunnel
+    AuthenticationMethods publickey
+    PubkeyAuthentication yes
+    PasswordAuthentication no
+    KbdInteractiveAuthentication no
+    AllowTcpForwarding remote
+    AllowStreamLocalForwarding no
+    PermitListen 127.0.0.1:TUNNEL_PORT
+    PermitOpen none
+    GatewayPorts no
+    PermitTTY no
+    PermitTunnel no
+    PermitUserRC no
+    X11Forwarding no
+    AllowAgentForwarding no
+    MaxSessions 0
+
+# Restrict the external Jump Host account.
+Match User herdr-jump
+    AuthenticationMethods publickey
+    PubkeyAuthentication yes
+    PasswordAuthentication no
+    KbdInteractiveAuthentication no
+    AllowTcpForwarding local
+    AllowStreamLocalForwarding no
+    PermitListen none
+    PermitOpen 127.0.0.1:TUNNEL_PORT
+    GatewayPorts no
+    PermitTTY no
+    PermitTunnel no
+    PermitUserRC no
+    X11Forwarding no
+    AllowAgentForwarding no
+    MaxSessions 0
+
+Match all
+```
+
+Validate before reloading:
+
+```bash
+sudo /usr/sbin/sshd -t
+```
+
+No output means the syntax is valid. Do not reload if this command reports an
+error.
+
+Inspect the effective restrictions:
+
+```bash
+sudo /usr/sbin/sshd -T \
+  -C user=herdr-tunnel,host=localhost,addr=127.0.0.1 \
+  | grep -E 'allowtcpforwarding|permitlisten|permitopen|gatewayports|maxsessions'
+
+sudo /usr/sbin/sshd -T \
+  -C user=herdr-jump,host=localhost,addr=127.0.0.1 \
+  | grep -E 'allowtcpforwarding|permitlisten|permitopen|gatewayports|maxsessions'
+```
+
+Reload on Debian or Ubuntu:
+
+```bash
+sudo systemctl reload ssh
+```
+
+Some distributions name the service `sshd`.
+
+Open a second administrator connection before closing the first one.
+
+## Step 8: Configure the VPS Firewall
+
+**Run on: VPS provider console and VPS**
+
+Allow inbound TCP only for the VPS SSH service port:
+
+```text
+VPS_SSH_PORT
+```
+
+Do not create a public rule for `TUNNEL_PORT`.
+
+Inspect the host firewall without enabling or replacing it blindly:
+
+```bash
+sudo ufw status verbose
+sudo nft list ruleset
+```
+
+The exact firewall tool depends on the distribution and provider. The required
+result is:
+
+```text
+Public: VPS_SSH_PORT
+Private loopback only: TUNNEL_PORT
+```
+
+Preserve deliberate rules for unrelated services already hosted on the VPS.
+This guide requires no additional public port beyond the selected SSH port.
+
+## Step 9: Verify the VPS Host Key
+
+**Run first on: VPS**
+
+```bash
+sudo ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub
+```
+
+Record the SHA-256 fingerprint through the provider console or the trusted
+administrator session.
+
+**Then run on: macOS**
+
+```bash
+ssh-keyscan -T 10 -t ed25519 -p VPS_SSH_PORT VPS_PUBLIC_IP 2>/dev/null \
+  | ssh-keygen -lf -
+```
+
+The fingerprints must match exactly. `ssh-keyscan` alone is discovery, not
+authentication. Stop if the fingerprints differ.
+
+## Step 10: Add the Mac SSH Tunnel Alias
+
+**Run on: macOS**
+
+Add this block to `~/.ssh/config`, replacing every placeholder:
+
+```sshconfig
+Host VPS_NAME-tunnel
+  HostName VPS_PUBLIC_IP
+  User herdr-tunnel
+  Port VPS_SSH_PORT
+  IdentityFile ~/.ssh/VPS_NAME-tunnel
+  IdentitiesOnly yes
+  BatchMode yes
+  ExitOnForwardFailure yes
+  ServerAliveInterval 30
+  ServerAliveCountMax 3
+  StrictHostKeyChecking yes
+```
+
+Check the resolved values:
+
+```bash
+ssh -G VPS_NAME-tunnel \
+  | grep -E '^(hostname|user|port|identityfile|stricthostkeychecking) '
+```
+
+Every value must point to the new VPS and dedicated tunnel identity.
+
+## Step 11: Test the Reverse Tunnel Manually
+
+**Run on: macOS**
+
+```bash
+ssh -NT \
+  -R 127.0.0.1:TUNNEL_PORT:127.0.0.1:22 \
+  VPS_NAME-tunnel
+```
+
+Leave this command running.
+
+**Run in another session on: VPS**
+
+```bash
+sudo ss -ltnp | grep ':TUNNEL_PORT'
+```
+
+The local-address column must show:
+
+```text
+127.0.0.1:TUNNEL_PORT
+```
+
+It must not show:
+
+```text
+0.0.0.0:TUNNEL_PORT
+[::]:TUNNEL_PORT
+```
+
+Stop the interactive tunnel with `Control-C` after this checkpoint passes.
+
+## Step 12: Install the Persistent macOS LaunchAgent
+
+**Run on: macOS**
+
+Create:
+
+```text
+~/Library/LaunchAgents/dev.herdr.VPS_NAME-reverse-ssh.plist
+```
+
+Use this template, replacing `MAC_USER`, `VPS_NAME`, and `TUNNEL_PORT`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>dev.herdr.VPS_NAME-reverse-ssh</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/ssh</string>
+        <string>-NT</string>
+        <string>-R</string>
+        <string>127.0.0.1:TUNNEL_PORT:127.0.0.1:22</string>
+        <string>VPS_NAME-tunnel</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>StandardOutPath</key>
+    <string>/Users/MAC_USER/Library/Logs/VPS_NAME-reverse-ssh.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/MAC_USER/Library/Logs/VPS_NAME-reverse-ssh.error.log</string>
+</dict>
+</plist>
+```
+
+Validate and load:
+
+```bash
+PLIST=~/Library/LaunchAgents/dev.herdr.VPS_NAME-reverse-ssh.plist
+LABEL=dev.herdr.VPS_NAME-reverse-ssh
+
+plutil -lint "$PLIST"
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+launchctl kickstart -k "gui/$(id -u)/$LABEL"
+launchctl print "gui/$(id -u)/$LABEL"
+```
+
+Expected state:
+
+```text
+state = running
+```
+
+Check the error log:
+
+```bash
+tail -n 50 ~/Library/Logs/VPS_NAME-reverse-ssh.error.log
+```
+
+An empty error log is expected.
+
+This user LaunchAgent starts after the Mac user logs in. It does not run at the
+pre-login FileVault screen.
+
+## Step 13: Add the Host in Herdr Mobile
+
+**Run on: iOS**
+
+Enter:
+
+```text
+Host name: any descriptive name
+Host address: 127.0.0.1
+Host port: TUNNEL_PORT
+Host user: MAC_USER
+Authentication: Device Key
+
+Jump Host address: VPS_PUBLIC_IP
+Jump Host port: VPS_SSH_PORT
+Jump Host user: herdr-jump
+```
+
+Run preflight.
+
+Herdr Mobile presents two independent host-key confirmations:
+
+1. the VPS Jump Host key;
+2. the Mac host key reached through the reverse tunnel.
+
+Confirm each fingerprint through its trusted system. Do not assume that
+trusting the VPS also trusts the Mac.
+
+Successful preflight must verify:
+
+- Jump Host authentication;
+- Mac authentication;
+- `socat` discovery;
+- herdr socket reachability;
+- protocol compatibility.
+
+Open an Agent through Attach to complete functional acceptance.
+
+## Step 14: Prove Automatic Recovery
+
+**Run on: macOS**
+
+Find the managed tunnel process:
+
+```bash
+ps -axo pid=,command= | grep '[s]sh .*VPS_NAME-tunnel'
+```
+
+Terminate only that PID:
+
+```bash
+kill TUNNEL_PROCESS_PID
+```
+
+Wait a few seconds, then inspect the LaunchAgent:
+
+```bash
+launchctl print "gui/$(id -u)/dev.herdr.VPS_NAME-reverse-ssh"
+```
+
+It must show a new PID and `state = running`.
+
+Repeat Herdr Mobile preflight or open an Agent. A restarted process without a
+working app connection is not sufficient proof.
+
+## Step 15: Harden Mac Authentication
+
+**Run on: macOS, only after Device Key access works**
+
+The VPS root user and every approved Jump Host key can reach the Mac SSH
+listener through the loopback tunnel. If macOS still offers password or
+keyboard-interactive authentication, those parties can attempt the Mac
+password.
+
+Check the advertised methods without entering a password:
+
+```bash
+ssh \
+  -o BatchMode=yes \
+  -o PubkeyAuthentication=no \
+  -o PreferredAuthentications=none \
+  MAC_USER@127.0.0.1 true
+```
+
+If the error lists `password` or `keyboard-interactive`, consider changing the
+Mac SSH server to:
+
+```sshconfig
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PubkeyAuthentication yes
+```
+
+Do this only while physically at the Mac and only after proving Device Key
+access and an independent recovery path. Validate the SSH configuration before
+restarting Remote Login.
+
+## Final Acceptance Checklist
+
+- [ ] Mac Remote Login is enabled for the intended account.
+- [ ] The Mac tunnel uses a dedicated key.
+- [ ] The iOS Device Key is authorized on both the VPS and Mac.
+- [ ] The VPS has separate tunnel and Jump accounts.
+- [ ] Both VPS accounts reject shell, password, PTY, and unrelated forwarding.
+- [ ] The provider firewall exposes only the VPS SSH service port.
+- [ ] The VPS listener is exactly `127.0.0.1:TUNNEL_PORT`.
+- [ ] VPS and Mac host-key fingerprints were independently verified.
+- [ ] The LaunchAgent reports `state = running`.
+- [ ] Killing the tunnel process produces a new PID.
+- [ ] Herdr Mobile preflight succeeds.
+- [ ] An Agent opens successfully through Attach.
+
+## Troubleshooting
+
+| Symptom | Likely boundary | Check |
+|---|---|---|
+| Jump Host rejects the Device Key | iOS -> VPS | Device Key line in `/home/herdr-jump/.ssh/authorized_keys` |
+| `remote port forwarding failed` | Mac -> VPS tunnel | Existing listener, `PermitListen`, tunnel account key |
+| VPS shows no `TUNNEL_PORT` listener | Mac -> VPS tunnel | LaunchAgent state and error log |
+| VPS shows `0.0.0.0:TUNNEL_PORT` | VPS security policy | Stop the tunnel; restore `GatewayPorts no` and explicit loopback binding |
+| Mac asks for a password | VPS -> Mac | Device Key missing from the Mac or wrong Mac user |
+| Mac host key changed | Inner SSH trust | Verify the Mac host key locally before accepting |
+| VPS host key changed | Outer SSH trust | Verify through the provider console before accepting |
+| App reaches Mac but not herdr | Mac application layer | herdr status, socket path, and `socat` |
+
+## Adding Another VPS
+
+Do not edit the working path in place:
+
+1. Create a fresh tunnel key for the new VPS.
+2. Configure new restricted accounts and a new VPS host key.
+3. Add the existing Device Key public line to the new Jump account.
+4. Create new Mac aliases and a second LaunchAgent.
+5. Validate the new loopback listener and automatic recovery.
+6. Change only the Jump Host fields in Herdr Mobile.
+7. Test preflight and Attach.
+8. Stop and remove the old path only after the new path works.
+
+See [Adding or Migrating to a New VPS](vps-jump-host.md#adding-or-migrating-to-a-new-vps)
+for the full staged cutover and rollback procedure.

--- a/docs/guides/vps-jump-host.md
+++ b/docs/guides/vps-jump-host.md
@@ -9,6 +9,10 @@ loopback interface.
 This is not a public port mapping. The Mac's SSH port must not be exposed as a
 public VPS listener.
 
+For a copy-and-check workflow organized by device, start with
+[Set Up Remote Access Through a VPS](vps-jump-host-setup.md). Return here for
+the complete trust model, operational details, and migration procedure.
+
 ## Architecture
 
 There are three systems and three distinct SSH identities:

--- a/docs/guides/vps-jump-host.md
+++ b/docs/guides/vps-jump-host.md
@@ -1,0 +1,650 @@
+# VPS Jump Host and Reverse-Tunnel Deployment
+
+This guide describes the recommended way to reach a Mac running herdr from
+Herdr Mobile when the Mac is behind NAT and has no stable public address. A
+public VPS acts as a restricted SSH Jump Host. The Mac creates an outbound
+reverse SSH tunnel to the VPS, and the VPS keeps the forwarded port on its
+loopback interface.
+
+This is not a public port mapping. The Mac's SSH port must not be exposed as a
+public VPS listener.
+
+## Architecture
+
+There are three systems and three distinct SSH identities:
+
+```text
+                                     persistent outbound SSH
+                              +-----------------------------------+
+                              |                                   |
+                              v                                   |
++------------------+    +-----------------------------+    +------------------+
+| iOS              |    | VPS                         |    | macOS            |
+| Herdr Mobile     |    | public TCP 22               |    | Remote Login    |
+|                  |    |                             |    | TCP 22           |
+| Device Key       +--->| restricted Jump account    |    |                  |
+| in Keychain      |    | direct-tcpip only           |    | launchd         |
+|                  |    |          |                  |    | reverse SSH     |
+| verifies both    |    |          v                  |    |                  |
+| host keys        |    | 127.0.0.1:2222 only        +--->| 127.0.0.1:22    |
++------------------+    +-----------------------------+    +--------+---------+
+                                                                   |
+                                                                   v
+                                                        herdr API and Attach
+```
+
+The persistent path is created by the Mac:
+
+```text
+VPS 127.0.0.1:2222 -> reverse SSH channel -> Mac 127.0.0.1:22
+```
+
+An iOS connection then uses two independent SSH handshakes:
+
+1. Herdr Mobile authenticates to the VPS Jump Host with its Device Key.
+2. The Jump Host opens only `127.0.0.1:2222`.
+3. Herdr Mobile performs a second SSH handshake with the Mac through that
+   forwarded byte stream.
+4. After authenticating to the Mac, the app reaches the herdr Unix socket
+   through SSH exec channels and opens Attach through an SSH PTY.
+
+The VPS terminates the first SSH connection and the Mac-to-VPS tunnel, but the
+payload passed between them is another SSH connection. The VPS can observe
+connection metadata and interrupt traffic. It cannot passively read the inner
+iOS-to-Mac SSH session while the app verifies the Mac host key correctly.
+
+## Public and Private Ports
+
+| Location | Listener | Reachability | Purpose |
+|---|---:|---|---|
+| VPS | `0.0.0.0:22` and/or `[::]:22` | Public, subject to firewall policy | VPS SSH service |
+| VPS | `127.0.0.1:2222` | VPS loopback only | Reverse-forwarded Mac SSH |
+| Mac | `127.0.0.1:22` as the tunnel target | Reached through the tunnel | macOS Remote Login |
+
+The Mac's SSH daemon may also listen on LAN interfaces when Remote Login is
+enabled. This guide controls the VPS path; it does not change LAN firewall or
+router policy.
+
+The VPS cloud firewall and host firewall need only allow the SSH service port.
+Do not add a public rule for `2222`.
+
+## Identities and Trust Boundaries
+
+Use separate identities for separate roles:
+
+| Identity | Stored on | Authorized on | Capability |
+|---|---|---|---|
+| VPS administrator key | Administrator device | VPS administrator account | VPS administration only |
+| Tunnel key | Mac filesystem | Restricted VPS tunnel account | Create one reverse listener |
+| Device Key | iOS Keychain | VPS Jump account and Mac login account | Reach the one forwarded endpoint, then authenticate to the Mac |
+
+Do not:
+
+- copy the VPS administrator private key to iOS;
+- use the VPS root account as the Jump Host;
+- reuse the tunnel key for interactive login;
+- put a private key in `authorized_keys`, documentation, shell history, or an
+  issue;
+- disable host-key verification to avoid a first-connection prompt.
+
+Herdr Mobile verifies the Jump Host and Host independently. Confirm a new VPS
+host-key fingerprint through the VPS console or another trusted administrative
+path before accepting it in the app.
+
+## Security Policy on the VPS
+
+The recommended VPS has two unprivileged accounts:
+
+- `herdr-tunnel`: accepts the Mac's automated connection and permits remote
+  forwarding only.
+- `herdr-jump`: accepts Device Keys and permits local forwarding only to
+  `127.0.0.1:2222`.
+
+Both accounts deny password login, keyboard-interactive login, shell sessions,
+commands, SFTP, PTY allocation, agent forwarding, X11 forwarding, Unix-socket
+forwarding, user SSH startup scripts, and TUN/TAP tunnels.
+
+`MaxSessions 0` is load-bearing. OpenSSH documents that it prevents shell,
+login, and subsystem sessions while still permitting forwarding.
+
+The restrictions are applied twice:
+
+1. `sshd_config` restricts every key accepted by the account.
+2. `authorized_keys` restricts each individual key.
+
+This defense in depth prevents an accidentally unqualified key line from
+turning either account into a general-purpose VPS login.
+
+## Prerequisites
+
+- A VPS running a maintained OpenSSH version with `PermitListen` and
+  `PermitOpen` support.
+- Administrative SSH or console access to the VPS.
+- macOS Remote Login enabled for the intended Mac user.
+- A public-key login path that has been tested before password authentication
+  is disabled anywhere.
+- `socat` and herdr installed on the Mac as described by the main transport
+  documentation.
+
+The examples use:
+
+```text
+VPS address: VPS_PUBLIC_IP
+VPS SSH port: 22
+VPS tunnel account: herdr-tunnel
+VPS Jump account: herdr-jump
+VPS loopback tunnel port: 2222
+Mac account: MAC_USER
+SSH aliases: work-vps-tunnel, work-vps-jump, work-mac
+```
+
+Replace these values consistently. If several Macs share one VPS, allocate a
+different loopback port to every Mac.
+
+## 1. Create a Dedicated Tunnel Key on the Mac
+
+The tunnel runs unattended, so use a dedicated key with an empty passphrase.
+Its restrictions on the VPS make it useless for shell access.
+
+```bash
+ssh-keygen \
+  -t ed25519 \
+  -a 100 \
+  -N '' \
+  -f ~/.ssh/work-vps-tunnel \
+  -C work-vps-tunnel
+```
+
+Record only the public half:
+
+```bash
+cat ~/.ssh/work-vps-tunnel.pub
+ssh-keygen -lf ~/.ssh/work-vps-tunnel.pub
+```
+
+## 2. Obtain the Herdr Mobile Device Key
+
+Copy the public-key line shown by Herdr Mobile. The private half remains in the
+iOS Keychain.
+
+The same Device Key public line must be authorized:
+
+- on the VPS Jump account, with forwarding-only restrictions; and
+- on the Mac account, so the second SSH handshake can authenticate.
+
+Authorizing the key on only one hop results in a password prompt or an
+authentication failure on the other hop.
+
+On the Mac, keep PTY, exec, and SFTP available for Herdr Mobile while disabling
+capabilities the app does not need:
+
+```text
+no-agent-forwarding,no-port-forwarding,no-X11-forwarding,no-user-rc DEVICE_PUBLIC_KEY
+```
+
+Append that line to `~/.ssh/authorized_keys`, then enforce:
+
+```bash
+chmod 700 ~/.ssh
+chmod 600 ~/.ssh/authorized_keys
+```
+
+## 3. Create Restricted Accounts on the VPS
+
+Run as a VPS administrator:
+
+```bash
+sudo adduser --disabled-password --gecos '' herdr-tunnel
+sudo adduser --disabled-password --gecos '' herdr-jump
+
+sudo install -d -m 700 \
+  -o herdr-tunnel \
+  -g herdr-tunnel \
+  /home/herdr-tunnel/.ssh
+
+sudo install -d -m 700 \
+  -o herdr-jump \
+  -g herdr-jump \
+  /home/herdr-jump/.ssh
+```
+
+Do not change the administrator login policy yet. Keep the current
+administrator session open until the new configuration has passed validation.
+
+## 4. Install Restricted Public Keys on the VPS
+
+Install the tunnel public key:
+
+```text
+restrict,port-forwarding,permitlisten="127.0.0.1:2222" TUNNEL_PUBLIC_KEY
+```
+
+Install every approved Device Key on the Jump account:
+
+```text
+restrict,port-forwarding,permitopen="127.0.0.1:2222" DEVICE_PUBLIC_KEY
+```
+
+Set ownership and permissions:
+
+```bash
+sudo chown -R herdr-tunnel:herdr-tunnel /home/herdr-tunnel/.ssh
+sudo chmod 700 /home/herdr-tunnel/.ssh
+sudo chmod 600 /home/herdr-tunnel/.ssh/authorized_keys
+
+sudo chown -R herdr-jump:herdr-jump /home/herdr-jump/.ssh
+sudo chmod 700 /home/herdr-jump/.ssh
+sudo chmod 600 /home/herdr-jump/.ssh/authorized_keys
+```
+
+`restrict` disables forwarding as part of its default restrictions.
+`port-forwarding` re-enables forwarding, then `permitlisten` or `permitopen`
+narrows it to the one required endpoint.
+
+## 5. Apply Account-Level OpenSSH Restrictions
+
+On Debian and Ubuntu, confirm the main configuration includes drop-ins:
+
+```bash
+grep -nE '^[[:space:]]*Include[[:space:]]+.*/sshd_config\.d/' \
+  /etc/ssh/sshd_config
+```
+
+Create `/etc/ssh/sshd_config.d/60-herdr-forwarding.conf`:
+
+```sshconfig
+# Restrict the persistent reverse-tunnel account.
+Match User herdr-tunnel
+    AuthenticationMethods publickey
+    PubkeyAuthentication yes
+    PasswordAuthentication no
+    KbdInteractiveAuthentication no
+    AllowTcpForwarding remote
+    AllowStreamLocalForwarding no
+    PermitListen 127.0.0.1:2222
+    PermitOpen none
+    GatewayPorts no
+    PermitTTY no
+    PermitTunnel no
+    PermitUserRC no
+    X11Forwarding no
+    AllowAgentForwarding no
+    MaxSessions 0
+
+# Restrict the external Jump Host account.
+Match User herdr-jump
+    AuthenticationMethods publickey
+    PubkeyAuthentication yes
+    PasswordAuthentication no
+    KbdInteractiveAuthentication no
+    AllowTcpForwarding local
+    AllowStreamLocalForwarding no
+    PermitListen none
+    PermitOpen 127.0.0.1:2222
+    GatewayPorts no
+    PermitTTY no
+    PermitTunnel no
+    PermitUserRC no
+    X11Forwarding no
+    AllowAgentForwarding no
+    MaxSessions 0
+
+Match all
+```
+
+`Match all` ends the second conditional block. It is especially important in a
+drop-in that may be included before later global directives.
+
+Validate before reloading:
+
+```bash
+sudo /usr/sbin/sshd -t
+
+sudo /usr/sbin/sshd -T \
+  -C user=herdr-tunnel,host=localhost,addr=127.0.0.1 \
+  | grep -E 'allowtcpforwarding|permitlisten|permitopen|gatewayports|maxsessions'
+
+sudo /usr/sbin/sshd -T \
+  -C user=herdr-jump,host=localhost,addr=127.0.0.1 \
+  | grep -E 'allowtcpforwarding|permitlisten|permitopen|gatewayports|maxsessions'
+```
+
+Reload only after `sshd -t` succeeds:
+
+```bash
+sudo systemctl reload ssh
+```
+
+Some distributions name the service `sshd` instead.
+
+## 6. Configure the Mac SSH Aliases
+
+Add entries like these to `~/.ssh/config`:
+
+```sshconfig
+Host work-vps-tunnel
+  HostName VPS_PUBLIC_IP
+  User herdr-tunnel
+  Port 22
+  IdentityFile ~/.ssh/work-vps-tunnel
+  IdentitiesOnly yes
+  BatchMode yes
+  ExitOnForwardFailure yes
+  ServerAliveInterval 30
+  ServerAliveCountMax 3
+  StrictHostKeyChecking yes
+
+Host work-vps-jump
+  HostName VPS_PUBLIC_IP
+  User herdr-jump
+  Port 22
+  IdentityFile ~/.ssh/work-client
+  IdentitiesOnly yes
+  BatchMode yes
+  StrictHostKeyChecking yes
+
+Host work-mac
+  HostName 127.0.0.1
+  User MAC_USER
+  Port 2222
+  IdentityFile ~/.ssh/work-client
+  IdentitiesOnly yes
+  ProxyJump work-vps-jump
+  HostKeyAlias work-mac-via-vps
+  StrictHostKeyChecking yes
+```
+
+The desktop client identity is only for command-line validation. Herdr Mobile
+uses its own Device Key.
+
+Verify the VPS host-key fingerprint through a trusted VPS console before adding
+it to `known_hosts`. Do not use `StrictHostKeyChecking no`.
+
+## 7. Test the Tunnel Interactively
+
+On the Mac:
+
+```bash
+ssh -NT \
+  -R 127.0.0.1:2222:127.0.0.1:22 \
+  work-vps-tunnel
+```
+
+On the VPS:
+
+```bash
+sudo ss -ltnp | grep ':2222'
+```
+
+The local-address column must show:
+
+```text
+127.0.0.1:2222
+```
+
+It must not show:
+
+```text
+0.0.0.0:2222
+[::]:2222
+```
+
+The `0.0.0.0:*` value commonly shown in the peer-address column is not a public
+listener. Read the local-address column.
+
+From a desktop client with the validation key:
+
+```bash
+ssh work-mac
+```
+
+This test proves more than process liveness: the Jump account authenticated,
+the direct TCP channel reached the loopback listener, the reverse tunnel
+reached the Mac, the Mac host key matched, and the Mac accepted the inner SSH
+identity.
+
+## 8. Make the Mac Tunnel Persistent
+
+Use a user LaunchAgent that runs:
+
+```text
+/usr/bin/ssh -NT -R 127.0.0.1:2222:127.0.0.1:22 work-vps-tunnel
+```
+
+The LaunchAgent should define:
+
+- a unique label;
+- `RunAtLoad`;
+- `KeepAlive`;
+- a retry throttle;
+- dedicated stdout and stderr log files.
+
+Validate both initial startup and recovery:
+
+```bash
+launchctl print gui/$(id -u)/YOUR_LAUNCH_AGENT_LABEL
+```
+
+Terminate the managed SSH process once, confirm `launchd` starts a new PID, and
+repeat the end-to-end `ssh work-mac` test. A running process alone does not
+prove the reverse listener or either authentication hop works.
+
+macOS user LaunchAgents start after that user logs in. If the Mac reboots but
+no user logs in, this user-level tunnel is not yet running.
+
+## 9. Configure Herdr Mobile
+
+Create or edit the Host:
+
+```text
+Host address: 127.0.0.1
+Host port: 2222
+Host user: MAC_USER
+
+Jump Host address: VPS_PUBLIC_IP
+Jump Host port: 22
+Jump Host user: herdr-jump
+Authentication: Device Key
+```
+
+Confirm both host keys independently:
+
+- the public VPS endpoint;
+- the Mac host key presented through `127.0.0.1:2222`.
+
+The Jump Host does not make the Mac trusted. A changed fingerprint on either
+hop is a separate security event.
+
+## macOS Authentication Hardening
+
+The reverse-tunnel design removes the Mac from the public Internet, but VPS
+root can reach the loopback tunnel endpoint. Anyone holding an approved Jump
+Host key can also reach it. If the Mac advertises password or
+keyboard-interactive authentication, those parties can attempt the Mac
+password.
+
+Prefer public-key-only Remote Login after validating a second administrative
+path:
+
+```sshconfig
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PubkeyAuthentication yes
+```
+
+Test the effective server authentication methods before ending the existing
+session. Do not disable passwords until Device Key access and an independent
+recovery path are proven.
+
+The Device Key intentionally grants the app the Mac capabilities needed by
+Herdr Mobile, including exec channels, SFTP, and PTY access. Losing an
+authorized iOS device therefore requires revoking its public key from both the
+VPS Jump account and the Mac.
+
+## Failure Behavior
+
+| Failure | Result |
+|---|---|
+| iOS is offline or the app is closed | The persistent Mac-to-VPS tunnel remains up |
+| Mac sleeps, shuts down, or loses networking | The VPS loopback listener disappears; `launchd` reconnects when macOS resumes |
+| VPS restarts | Both iOS and tunnel connections drop; `launchd` reconnects when the VPS SSH service returns |
+| Tunnel key is rejected | No reverse listener is created |
+| Jump Device Key is rejected | iOS cannot open the first hop |
+| Mac Device Key is rejected | The Jump Host succeeds, but the inner Mac authentication fails |
+| VPS host key changes | Stop and verify through the VPS console before trusting it |
+| Mac host key changes | Stop and verify the Mac before trusting it |
+
+## Adding or Migrating to a New VPS
+
+Treat a new VPS as a new security boundary. Do not overwrite the working path
+in place.
+
+### Phase 1: Prepare the New VPS in Parallel
+
+1. Patch the operating system and install the maintained OpenSSH server.
+2. Confirm the VPS host-key fingerprint through its provider console:
+
+   ```bash
+   sudo ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub
+   ```
+
+3. Allow only the VPS SSH port in the provider firewall. Do not open the
+   reverse-forward port.
+4. Create fresh restricted tunnel and Jump accounts.
+5. Generate a new tunnel key for the new VPS. Do not reuse the old VPS tunnel
+   key.
+6. Authorize the existing Herdr Mobile Device Key on the new Jump account. The
+   Device Key may remain the same because its private half never leaves iOS.
+7. Apply the `sshd_config` restrictions and validate them with `sshd -t` and
+   `sshd -T`.
+
+The old VPS and its tunnel remain untouched during this phase.
+
+### Phase 2: Stage a Separate Mac Path
+
+Create new Mac aliases rather than editing the old aliases:
+
+```text
+new-vps-tunnel
+new-vps-jump
+new-mac
+```
+
+Create a second LaunchAgent with:
+
+- a different label;
+- the new tunnel identity;
+- the new VPS alias;
+- separate log files.
+
+The same loopback port may be used on two different VPSs. If the new path
+shares one VPS with another Mac, allocate a unique port instead.
+
+Start the new tunnel and validate:
+
+```bash
+ssh new-mac
+```
+
+On the new VPS:
+
+```bash
+sudo ss -ltnp | grep ':2222'
+```
+
+Confirm the listener is exactly `127.0.0.1:2222`, then terminate the new tunnel
+process once and prove the new LaunchAgent reconnects.
+
+### Phase 3: Move Herdr Mobile
+
+Edit only the Jump Host fields:
+
+```text
+Jump Host address: NEW_VPS_PUBLIC_IP
+Jump Host port: NEW_VPS_SSH_PORT
+Jump Host user: new restricted Jump account
+```
+
+The Host remains:
+
+```text
+Address: 127.0.0.1
+Port: 2222
+User: MAC_USER
+```
+
+Confirm the new VPS fingerprint when prompted, then complete app preflight and
+open an Agent through Attach. This is the functional cutover point.
+
+### Phase 4: Retire the Old VPS
+
+Only after the new path has passed command-line and app validation:
+
+1. Stop and unload the old LaunchAgent.
+2. Confirm the new LaunchAgent remains healthy.
+3. Remove old SSH aliases and the old VPS host-key entry from the Mac.
+4. Remove the Device Key from the old Jump account.
+5. Remove the old tunnel public key and restricted accounts.
+6. Close the old VPS firewall rules or destroy the old VPS.
+
+Keep a short rollback window when practical, but do not leave two forgotten
+public Jump Hosts running indefinitely.
+
+If `remote port forwarding failed for listen port 2222` appears during a
+cutover, inspect tunnel ownership before changing security policy. It usually
+means two tunnel processes are competing for the same listener on one VPS.
+Never solve it by enabling `GatewayPorts yes` or publishing another unrestricted
+port.
+
+## Revocation and Rotation
+
+### Lost or Replaced iOS Device
+
+Remove its exact public-key line from:
+
+- `/home/herdr-jump/.ssh/authorized_keys` on every active VPS;
+- `~/.ssh/authorized_keys` on every reachable Mac.
+
+Generate a new Device Key on the replacement device and enroll it independently.
+
+### Compromised Tunnel Key
+
+1. Generate a new dedicated tunnel key on the Mac.
+2. Replace the old public key on the one VPS tunnel account.
+3. Update the Mac alias and LaunchAgent.
+4. Validate reconnection, then delete the old private key.
+
+A tunnel key alone cannot open a VPS shell or authenticate to the Mac.
+
+### Compromised VPS
+
+Build a clean VPS with a new host key and a new tunnel key. Treat the old VPS
+host key, restricted accounts, logs, and firewall policy as untrusted. The Mac
+Device Key does not need rotation unless the attacker obtained the corresponding
+private key or another Mac credential.
+
+## Validation Checklist
+
+- [ ] VPS SSH host-key fingerprint verified out of band.
+- [ ] VPS public firewall exposes only the intended SSH service port.
+- [ ] Tunnel and Jump accounts reject passwords.
+- [ ] Tunnel account permits only remote forwarding to
+      `127.0.0.1:2222`.
+- [ ] Jump account permits only local forwarding to
+      `127.0.0.1:2222`.
+- [ ] Both restricted accounts have `MaxSessions 0`.
+- [ ] VPS `ss` shows `127.0.0.1:2222`, never `0.0.0.0:2222`.
+- [ ] Mac-to-VPS tunnel is managed by `launchd`.
+- [ ] Killing the tunnel process produces a new PID and a working connection.
+- [ ] Herdr Mobile verifies both VPS and Mac host keys.
+- [ ] Device Key is authorized on both hops.
+- [ ] `ssh` or an equivalent real end-to-end test reaches the Mac.
+- [ ] Herdr Mobile preflight and Attach work through the Jump Host.
+
+## References
+
+- [OpenSSH `sshd_config`](https://man.openbsd.org/sshd_config)
+- [OpenSSH `authorized_keys` options](https://man.openbsd.org/sshd#AUTHORIZED_KEYS_FILE_FORMAT)
+- [Apple: Allow a remote computer to access your Mac](https://support.apple.com/guide/mac-help/mchlp1066/mac)
+- [Transport ADR](../adr/0002-ssh-exec-socat-transport.md)
+- [Pairing ADR](../adr/0007-pairing-via-herdr-plugin.md)


### PR DESCRIPTION
## Summary

- add optional SSH Jump Host settings to Host onboarding, persistence, and transport connection setup
- authenticate and verify host keys independently at both SSH hops, with first-hop-specific preflight failures
- cover Jump Host RPC, connection reuse, failure classification, known-host isolation, SFTP image staging, and teardown against a real local sshd
- document the loopback-only VPS reverse-tunnel architecture, account restrictions, step-by-step setup, recovery, and VPS migration

## Testing

- `xcodebuild test -project HerdrMobile.xcodeproj -scheme HerdrMobile -destination 'platform=iOS Simulator,id=4A6BEC2A-CAA7-49D0-9210-7C42186C82A9' -only-testing:HerdrMobileTests/HostTests -only-testing:HerdrMobileTests/HostStoreTests -only-testing:HerdrMobileTests/HostDraftTests -only-testing:HerdrMobileTests/PreflightReportTests -only-testing:HerdrMobileTests/SSHJumpHostE2ETests`
  - 44 tests in 5 suites passed
- Markdown local-link, code-fence, and whitespace checks passed
