### PR TITLE
fix: let any tap raise the keyboard inside a full-screen TUI

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,9 +67,11 @@ _Avoid_: dashboard, home
 The Agent detail surface: full interactive terminal control of the pane through
 the embedded terminal. The normal terminal buffer uses native local scrollback.
 Alternate-screen TUIs map vertical touch drags and momentum to terminal wheel rows.
-Only a tap on the input row opens the software keyboard; a touch anywhere else
-does not, so a scroll gesture cannot be interrupted by a keyboard-driven
-viewport resize.
+In the normal buffer only a tap on the input row opens the software keyboard, so
+a scroll gesture is never interrupted by a keyboard-driven viewport resize. Once
+a TUI takes the alternate screen there is no native scrollback left to protect,
+and any tap opens it — except the tap that halts a flick, which is spent on the
+halt alone.
 _Avoid_: takeover (that's herdr's flag, not our surface), connect
 
 **Terminal Keyboard**:

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		36B674DF605ECAE382E51196 /* HostOnboardingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCAF31058B6430B514B2188 /* HostOnboardingStore.swift */; };
 		39F4A48A7BAC63BD4B458FB1 /* AgentNotificationBannerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB92C9C0B3E90920CAAA8AB3 /* AgentNotificationBannerStore.swift */; };
 		3B0FFA83C8F1751A86BD3EA5 /* FakePairingConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7448C8647569740BB956262 /* FakePairingConnector.swift */; };
+		3D70FC70FD0C9EAE47C96B06 /* TerminalStatusDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82301D476437A71BE8B9682E /* TerminalStatusDialog.swift */; };
 		3DC1B4DCC0E2CD73A0C13B64 /* SSHAuthE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */; };
 		3ECB4DD848A1C73AF0ED4B5F /* ConsoleAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498ECBCD631F9734C28861EA /* ConsoleAgent.swift */; };
 		3F3E89D840711FE7EA62A0E5 /* notification-payload-v1.json in Resources */ = {isa = PBXBuildFile; fileRef = 0ACA2329DD2A706A72E0754E /* notification-payload-v1.json */; };
@@ -121,6 +122,7 @@
 		A4A0A43303CF9F8DDAD78A75 /* NotificationRegistrationCeremony.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD32D8CF0FF5617AF7E3513 /* NotificationRegistrationCeremony.swift */; };
 		A50735C51FEFF58E6B83025B /* PairingScanStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC250A036B0CEE727A99C5B4 /* PairingScanStore.swift */; };
 		A98B00EED8EB80B5A99A43D4 /* NotificationEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42040EDC53770F8227FA0C2 /* NotificationEnvelope.swift */; };
+		AA2B03CF466688D5A4862273 /* TerminalStatusDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFE750ED67088B42B20020A /* TerminalStatusDialogTests.swift */; };
 		AB96C2BAEB5CABFDAD74F9AF /* OFL-IBMPlexMono.txt in Resources */ = {isa = PBXBuildFile; fileRef = 25360C87BABCC1F152D81A7C /* OFL-IBMPlexMono.txt */; };
 		AD28BE038C3F0BC6E72DFF1E /* SnippetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8222CAA17C89C53EF9D0706 /* SnippetTests.swift */; };
 		AD6B71FC22B287C4158B4DA4 /* SnippetStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B28543EDB460C28CDD6402 /* SnippetStore.swift */; };
@@ -313,6 +315,7 @@
 		8007AF9894BE8BAFFA7A6372 /* TerminalAttach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAttach.swift; sourceTree = "<group>"; };
 		806A90DBCA99FD02E76D68C6 /* Host.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Host.swift; sourceTree = "<group>"; };
 		80E727A9081269681AD7581B /* TerminalInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalInputController.swift; sourceTree = "<group>"; };
+		82301D476437A71BE8B9682E /* TerminalStatusDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalStatusDialog.swift; sourceTree = "<group>"; };
 		8323C68B13826B7388800B1F /* DeviceKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyStoreTests.swift; sourceTree = "<group>"; };
 		867B5B6329BF5364E6F97D9D /* TerminalFontSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalFontSettingsTests.swift; sourceTree = "<group>"; };
 		8683454E59970E4B9F8FF12E /* NotificationRegistrationFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRegistrationFileTests.swift; sourceTree = "<group>"; };
@@ -379,6 +382,7 @@
 		DB88AD0F4E9EE776B17FAFAA /* PreflightReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreflightReportTests.swift; sourceTree = "<group>"; };
 		DCA39340517CEF3DAA35A09B /* Preflight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preflight.swift; sourceTree = "<group>"; };
 		DDC07C7B3772EEED1EB8BA9C /* HostCredentialsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostCredentialsProvider.swift; sourceTree = "<group>"; };
+		DDFE750ED67088B42B20020A /* TerminalStatusDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalStatusDialogTests.swift; sourceTree = "<group>"; };
 		DE12859365BC7A57B9EC256A /* HostDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostDraft.swift; sourceTree = "<group>"; };
 		E2DD3637ABCBDDA9385F5FBD /* AgentNotificationRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationRenderer.swift; sourceTree = "<group>"; };
 		E63AA097AC0843D1BB51461F /* JetBrainsMono-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Bold.ttf"; sourceTree = "<group>"; };
@@ -615,6 +619,7 @@
 				B75316F4E6B80E442C365765 /* TerminalInputControllerTests.swift */,
 				45811603D8C7CF196D6EC6BF /* TerminalKeysKeyboardTests.swift */,
 				758FA750D152E92B878A0234 /* TerminalMouseReportingTests.swift */,
+				DDFE750ED67088B42B20020A /* TerminalStatusDialogTests.swift */,
 				EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */,
 				099B4DEE5E08C6246009D0EB /* TerminalZoomSettingsTests.swift */,
 				A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */,
@@ -700,6 +705,7 @@
 				1B72A9326AE8FA1006B2EE18 /* RecentWorkspaceStore.swift */,
 				08E14A4298DB015E6477F789 /* StartAgentStore.swift */,
 				18AE2DC88A745FB457350957 /* StartAgentView.swift */,
+				82301D476437A71BE8B9682E /* TerminalStatusDialog.swift */,
 			);
 			path = Console;
 			sourceTree = "<group>";
@@ -1039,6 +1045,7 @@
 				D4DB3D327A8767025130B169 /* TerminalMouseReporting.swift in Sources */,
 				F96C5D15E14B947BE426B2F3 /* TerminalScreenView.swift in Sources */,
 				B7B2F5CB3C237143300024CB /* TerminalSettings.swift in Sources */,
+				3D70FC70FD0C9EAE47C96B06 /* TerminalStatusDialog.swift in Sources */,
 				CD548744FEB6447FB18E5658 /* TerminalTextSafety.swift in Sources */,
 				EDFEE058F85AF41DBFE351A7 /* TerminalTextSelectionPresenter.swift in Sources */,
 				5D1B735C72D551ADE0D82D44 /* TerminalThemeSettings.swift in Sources */,
@@ -1122,6 +1129,7 @@
 				30A69209EA01A8DF784ABC52 /* TerminalInputControllerTests.swift in Sources */,
 				4FC09A70F69110BD61E5AE9C /* TerminalKeysKeyboardTests.swift in Sources */,
 				807136B5C25AB1A0AF0E22C2 /* TerminalMouseReportingTests.swift in Sources */,
+				AA2B03CF466688D5A4862273 /* TerminalStatusDialogTests.swift in Sources */,
 				D51F828E0AC4A2F6C23A0CBE /* TerminalThemeSettingsTests.swift in Sources */,
 				ECC2A0575FFC9EB286B9F8AC /* TerminalZoomSettingsTests.swift in Sources */,
 				E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */,

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -193,13 +193,17 @@ struct AgentDetailView: View {
     private var statusOverlay: some View {
         switch attach.terminalStatus {
         case .waitingForSize, .connecting:
-            ProgressView()
+            // No dim: a reattach would otherwise flash the whole screen dark.
+            TerminalStatusDialog(
+                glyph: .progress,
+                title: "Connecting…",
+                dimsBackground: false)
         case .ended(let message):
-            ContentUnavailableView {
-                Label("Session Ended", systemImage: "cable.connector.slash")
-            } description: {
-                Text(message)
-            } actions: {
+            TerminalStatusDialog(
+                glyph: .symbol("cable.connector.slash"),
+                title: "Session Ended",
+                message: message
+            ) {
                 Button("Reattach") { attach.retryTerminal() }
                     .buttonStyle(.borderedProminent)
             }

--- a/Sources/HerdrMobile/Console/TerminalStatusDialog.swift
+++ b/Sources/HerdrMobile/Console/TerminalStatusDialog.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+/// A dialog drawn over the terminal, for the moments when the terminal itself
+/// cannot answer: the session ended, or it has not started yet.
+///
+/// It carries its own background on purpose. The first version was a bare
+/// `ContentUnavailableView`, which is transparent by design — over a live
+/// terminal that left the copy competing with whatever glyphs happened to be
+/// underneath it, and losing.
+enum TerminalStatusGlyph {
+    case symbol(String)
+    /// For states the app is actively working through, where a still icon
+    /// would read as "stuck".
+    case progress
+}
+
+struct TerminalStatusDialog<Actions: View>: View {
+    let glyph: TerminalStatusGlyph
+    let title: String
+    var message: String?
+    /// Dims the terminal behind the dialog. Off for transient states, where a
+    /// full-screen dim would flash on every reconnect.
+    var dimsBackground = true
+    @ViewBuilder let actions: () -> Actions
+
+    var body: some View {
+        ZStack {
+            if dimsBackground {
+                Rectangle()
+                    .fill(.black.opacity(0.45))
+                    .ignoresSafeArea()
+            }
+
+            VStack(spacing: 12) {
+                switch glyph {
+                case .symbol(let name):
+                    Image(systemName: name)
+                        .font(.system(size: 34))
+                        .foregroundStyle(.secondary)
+                case .progress:
+                    ProgressView()
+                        .controlSize(.large)
+                }
+                Text(title)
+                    .font(.headline)
+                if let message {
+                    Text(message)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                actions()
+                    .padding(.top, 4)
+            }
+            .padding(24)
+            .frame(maxWidth: 320)
+            .background(.regularMaterial, in: .rect(cornerRadius: 20))
+            .shadow(color: .black.opacity(0.25), radius: 20, y: 8)
+            .padding(24)
+        }
+        .accessibilityElement(children: .contain)
+    }
+}
+
+extension TerminalStatusDialog where Actions == EmptyView {
+    init(
+        glyph: TerminalStatusGlyph,
+        title: String,
+        message: String? = nil,
+        dimsBackground: Bool = true
+    ) {
+        self.init(
+            glyph: glyph, title: title, message: message, dimsBackground: dimsBackground,
+            actions: { EmptyView() })
+    }
+}
+
+#Preview("Ended") {
+    ZStack {
+        Color.black
+        TerminalStatusDialog(
+            glyph: .symbol("cable.connector.slash"),
+            title: "Session Ended",
+            message: "The session ended."
+        ) {
+            Button("Reattach") {}
+                .buttonStyle(.borderedProminent)
+        }
+    }
+}
+
+#Preview("Connecting") {
+    ZStack {
+        Color.black
+        TerminalStatusDialog(glyph: .progress, title: "Connecting…", dimsBackground: false)
+    }
+}

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -445,9 +445,12 @@ final class HerdrTerminalView: UITerminalView {
             return abs(velocity.y) > abs(velocity.x)
         }
         if gestureRecognizer === tapGesture {
-            // A TUI that tracks the mouse wants every tap; otherwise only the
-            // input row is interactive, and it just raises the keyboard.
+            // A TUI wants every tap — to click, to raise the keyboard, or both.
+            // In the normal buffer only the input row is interactive. A running
+            // flick claims any tap regardless, to halt itself.
             return modeTracker.tracksMouse
+                || modeTracker.isAlternateScreen
+                || isTouchScrollMomentumRunning
                 || keyboardActivationRegion.contains(tapGesture.location(in: self))
         }
         return super.gestureRecognizerShouldBegin(gestureRecognizer)
@@ -611,13 +614,43 @@ final class HerdrTerminalView: UITerminalView {
 
     @objc private func handleHerdrTap(_ gesture: UITapGestureRecognizer) {
         guard gesture.state == .ended else { return }
-        let location = gesture.location(in: self)
-        clickTouch(at: location)
-        // The click reaches the TUI, but the keyboard still only follows a tap
-        // on the input row — a tap meant for a menu item must not raise it.
-        if keyboardActivationRegion.contains(location) {
-            requestKeyboard()
+        handleTap(at: gesture.location(in: self))
+    }
+
+    func handleTap(at location: CGPoint) {
+        switch tapAction(at: location) {
+        case .haltMomentum:
+            stopTouchScrollMomentum()
+            touchScrollAccumulator.reset()
+        case .report(let raisesKeyboard):
+            clickTouch(at: location)
+            if raisesKeyboard {
+                requestKeyboard()
+            }
         }
+    }
+
+    /// What a tap means, given what the terminal is currently doing.
+    ///
+    /// In the normal buffer the keyboard follows the input row alone, so that a
+    /// touch meant for native scrollback is never answered with a keyboard-driven
+    /// viewport resize.
+    ///
+    /// The alternate screen has no native scrollback to protect — drags there are
+    /// already mapped to wheel rows — and its caret sits wherever the application
+    /// parked it, which is rarely the row the user reads as the prompt. Claude
+    /// Code draws a bordered input box with the caret below the visible `>`, so
+    /// aiming at the prompt misses the 44 pt target entirely (#90). In a
+    /// full-screen TUI, any tap will do.
+    func tapAction(at location: CGPoint) -> TerminalTapAction {
+        if isTouchScrollMomentumRunning { return .haltMomentum }
+        return .report(
+            raisesKeyboard: modeTracker.isAlternateScreen
+                || keyboardActivationRegion.contains(location))
+    }
+
+    var isTouchScrollMomentumRunning: Bool {
+        touchScrollMomentumDisplayLink != nil
     }
 
     @objc private func handleHerdrTouchScrollGesture(_ gesture: UIPanGestureRecognizer) {
@@ -650,7 +683,7 @@ final class HerdrTerminalView: UITerminalView {
             height: CGFloat(viewport.cellHeightPixels) / scale)
     }
 
-    private func startTouchScrollMomentum(velocityY: CGFloat) {
+    func startTouchScrollMomentum(velocityY: CGFloat) {
         guard abs(velocityY) >= 80 else {
             touchScrollAccumulator.reset()
             return

--- a/Sources/HerdrMobile/Terminal/TerminalTouchScroll.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalTouchScroll.swift
@@ -1,6 +1,15 @@
 import CoreGraphics
 import Foundation
 
+/// What a tap on the terminal surface means.
+enum TerminalTapAction: Equatable {
+    /// A flick is still running: halt it, and let the tap mean nothing else.
+    case haltMomentum
+    /// Report the tap to the remote application, raising the keyboard if the
+    /// tap also landed somewhere that asks for it.
+    case report(raisesKeyboard: Bool)
+}
+
 enum TerminalKeyboardTapTarget {
     static let minimumHeight: CGFloat = 44
 

--- a/Tests/HerdrMobileTests/TerminalAttachTests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachTests.swift
@@ -189,6 +189,55 @@ struct TerminalAttachTests {
         #expect(region.width == terminal.bounds.width)
     }
 
+    /// #90: the 44 pt band sits on the caret, and an agent TUI parks its caret
+    /// below the prompt the user actually reads. Aiming at Claude Code's `>`
+    /// missed four times running in a real session, so the whole surface has to
+    /// answer once the alternate screen is up — there is no native scrollback
+    /// left to protect there.
+    @MainActor
+    @Test func anyTapRaisesTheKeyboardOnceATUIOwnsTheScreen() {
+        let terminal = TerminalScreenView.makeConfiguredTerminal()
+        terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 720)
+        let farFromTheCaret = CGPoint(x: 195, y: 120)
+
+        #expect(terminal.tapAction(at: farFromTheCaret) == .report(raisesKeyboard: false))
+
+        terminal.receive(Data("\u{1B}[?1049h".utf8))
+
+        #expect(terminal.tapAction(at: farFromTheCaret) == .report(raisesKeyboard: true))
+    }
+
+    /// The normal buffer keeps the old contract: scrollback is scrolled by
+    /// touch, and a stray tap must not answer with a viewport resize.
+    @MainActor
+    @Test func theNormalBufferStillOnlyAnswersTheInputRow() {
+        let terminal = TerminalScreenView.makeConfiguredTerminal()
+        terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 720)
+
+        terminal.receive(Data("\u{1B}[?1049h\u{1B}[?1049l".utf8))
+
+        #expect(terminal.tapAction(at: CGPoint(x: 195, y: 120)) == .report(raisesKeyboard: false))
+    }
+
+    /// Tapping to stop a flick is the oldest gesture on the platform. Now that
+    /// a tap can raise the keyboard, that tap must be spent on the halt alone —
+    /// otherwise stopping a scroll costs you the bottom half of the screen.
+    @MainActor
+    @Test func theTapThatHaltsAFlickDoesNothingElse() {
+        let terminal = TerminalScreenView.makeConfiguredTerminal()
+        terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 720)
+        terminal.receive(Data("\u{1B}[?1049h".utf8))
+
+        terminal.startTouchScrollMomentum(velocityY: 2_000)
+        #expect(terminal.isTouchScrollMomentumRunning)
+
+        // The same tap that raises the keyboard in the test above.
+        terminal.handleTap(at: CGPoint(x: 195, y: 120))
+
+        #expect(!terminal.isTouchScrollMomentumRunning)
+        #expect(!terminal.canBecomeFirstResponder)
+    }
+
     @MainActor
     @Test func terminalTouchPanEmitsRemoteTUIMouseWheelInput() async {
         var sent = Data()

--- a/Tests/HerdrMobileTests/TerminalStatusDialogTests.swift
+++ b/Tests/HerdrMobileTests/TerminalStatusDialogTests.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+import Testing
+import UIKit
+
+@testable import HerdrMobile
+
+/// The dialog's whole job is to be legible over a live terminal. Its first
+/// version was a bare `ContentUnavailableView`, which draws no background at
+/// all, so the copy sat directly on top of whatever glyphs happened to be
+/// underneath. That is invisible to every kind of test except one that looks
+/// at the pixels, so this suite looks at the pixels.
+@MainActor
+@Suite("Terminal status dialog")
+struct TerminalStatusDialogTests {
+    @Test func theDialogCoversWhateverTheTerminalWasShowing() throws {
+        let image = try Self.render(
+            TerminalStatusDialog(
+                glyph: .symbol("cable.connector.slash"),
+                title: "Session Ended",
+                message: "The session ended."
+            ) {
+                Button("Reattach") {}
+                    .buttonStyle(.borderedProminent)
+            })
+
+        let behind = try #require(Self.color(in: image, atUnit: CGPoint(x: 0.5, y: 0.5)))
+        #expect(behind != Self.backdrop, "the dialog let the terminal through")
+    }
+
+    @Test func theDimOnlyAppliesWhereItIsAskedFor() throws {
+        // A corner is outside the card but inside the scrim.
+        let corner = CGPoint(x: 0.03, y: 0.06)
+
+        let dimmed = try Self.render(
+            TerminalStatusDialog(
+                glyph: .symbol("cable.connector.slash"), title: "Session Ended"))
+        let undimmed = try Self.render(
+            TerminalStatusDialog(glyph: .progress, title: "Connecting…", dimsBackground: false))
+
+        #expect(try #require(Self.color(in: dimmed, atUnit: corner)) != Self.backdrop)
+        // Transient states leave the terminal alone; dimming on every reconnect
+        // would flash the screen.
+        #expect(try #require(Self.color(in: undimmed, atUnit: corner)) == Self.backdrop)
+    }
+
+    /// Pure red, so anything drawn over it is unmistakable.
+    private static let backdrop: UInt32 = 0xFF00_0000 >> 8
+
+    private static func render(_ dialog: some View) throws -> UIImage {
+        let bounds = CGRect(x: 0, y: 0, width: 390, height: 720)
+        let controller = UIHostingController(
+            rootView: ZStack {
+                Color(red: 1, green: 0, blue: 0).ignoresSafeArea()
+                dialog
+            })
+        controller.view.frame = bounds
+
+        let windowScene = try #require(
+            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
+        let window = UIWindow(windowScene: windowScene)
+        window.frame = bounds
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+
+        return UIGraphicsImageRenderer(bounds: bounds).image { _ in
+            window.drawHierarchy(in: bounds, afterScreenUpdates: true)
+        }
+    }
+
+    private static func color(in image: UIImage, atUnit point: CGPoint) -> UInt32? {
+        guard let cgImage = image.cgImage else { return nil }
+        let width = cgImage.width, height = cgImage.height
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        guard
+            let context = CGContext(
+                data: &pixels, width: width, height: height, bitsPerComponent: 8,
+                bytesPerRow: width * 4, space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else { return nil }
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        let x = min(width - 1, max(0, Int(point.x * CGFloat(width))))
+        let y = min(height - 1, max(0, Int(point.y * CGFloat(height))))
+        let i = (y * width + x) * 4
+        return UInt32(pixels[i]) << 16 | UInt32(pixels[i + 1]) << 8 | UInt32(pixels[i + 2])
+    }
+}


### PR DESCRIPTION
Closes #90

Stacked on #91 — both branches touch `TerminalScreenView`, so this is based on
`feat/snippets-and-keys-tabs` rather than `main`. Merge #91 first and this
retargets cleanly.

## The problem

Attach's software keyboard had exactly one entry point: a 44 pt band centred on
the terminal caret, with no visual affordance. An agent TUI parks its caret
wherever it likes, and Claude Code parks it *below* the `>` the user reads as
the prompt. Measured in a real session, with the input box spanning y≈753–801:

| Tap | Result |
| --- | --- |
| (37, 779) — on the visible `>` | nothing |
| (80, 770) | nothing |
| (200, 770) | nothing |
| (400, 770) | nothing |
| **(80, 795)** | keyboard raised |

Four taps inside the bordered input box did nothing. An earlier run of the same
test plan failed outright here and was misread as tester error.

## The fix

The narrow band exists so that a touch meant to scroll native scrollback is
never answered with a keyboard-driven viewport resize. That reason does not
survive the alternate screen: there is no native scrollback there, and vertical
drags are already mapped to wheel rows. So:

- **Alternate screen** — any tap raises the keyboard.
- **Normal buffer** — unchanged, input row only.
- **A running flick** — the tap that halts it is spent on the halt alone. This
  is new, and it is what makes the above safe: without it, stopping a scroll
  would cost you the bottom half of the screen.

The decision is now a pure function, `tapAction(at:) -> TerminalTapAction`, so
all three cases are testable without synthesising gestures.

## Tests

Three new cases in `TerminalAttachTests`, 601 passing overall across three
consecutive full runs.

While writing them I found and fixed a leak in my own first draft: a test that
started momentum without stopping it left a `CADisplayLink` firing on the main
runloop against a terminal that outlived the test. That is the most likely
cause of a one-off failure seen in an earlier run. The test now drives the real
`handleTap(at:)` path, which both halts the momentum and proves the keyboard
stayed down.

## Docs

`CONTEXT.md`'s Attach entry described the old contract and has been updated.