### PR TITLE
fix: give the Attach session status its own dialog

### DIFF
--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		36B674DF605ECAE382E51196 /* HostOnboardingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCAF31058B6430B514B2188 /* HostOnboardingStore.swift */; };
 		39F4A48A7BAC63BD4B458FB1 /* AgentNotificationBannerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB92C9C0B3E90920CAAA8AB3 /* AgentNotificationBannerStore.swift */; };
 		3B0FFA83C8F1751A86BD3EA5 /* FakePairingConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7448C8647569740BB956262 /* FakePairingConnector.swift */; };
+		3D70FC70FD0C9EAE47C96B06 /* TerminalStatusDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82301D476437A71BE8B9682E /* TerminalStatusDialog.swift */; };
 		3DC1B4DCC0E2CD73A0C13B64 /* SSHAuthE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */; };
 		3ECB4DD848A1C73AF0ED4B5F /* ConsoleAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498ECBCD631F9734C28861EA /* ConsoleAgent.swift */; };
 		3F3E89D840711FE7EA62A0E5 /* notification-payload-v1.json in Resources */ = {isa = PBXBuildFile; fileRef = 0ACA2329DD2A706A72E0754E /* notification-payload-v1.json */; };
@@ -121,6 +122,7 @@
 		A4A0A43303CF9F8DDAD78A75 /* NotificationRegistrationCeremony.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD32D8CF0FF5617AF7E3513 /* NotificationRegistrationCeremony.swift */; };
 		A50735C51FEFF58E6B83025B /* PairingScanStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC250A036B0CEE727A99C5B4 /* PairingScanStore.swift */; };
 		A98B00EED8EB80B5A99A43D4 /* NotificationEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42040EDC53770F8227FA0C2 /* NotificationEnvelope.swift */; };
+		AA2B03CF466688D5A4862273 /* TerminalStatusDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFE750ED67088B42B20020A /* TerminalStatusDialogTests.swift */; };
 		AB96C2BAEB5CABFDAD74F9AF /* OFL-IBMPlexMono.txt in Resources */ = {isa = PBXBuildFile; fileRef = 25360C87BABCC1F152D81A7C /* OFL-IBMPlexMono.txt */; };
 		AD28BE038C3F0BC6E72DFF1E /* SnippetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8222CAA17C89C53EF9D0706 /* SnippetTests.swift */; };
 		AD6B71FC22B287C4158B4DA4 /* SnippetStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B28543EDB460C28CDD6402 /* SnippetStore.swift */; };
@@ -313,6 +315,7 @@
 		8007AF9894BE8BAFFA7A6372 /* TerminalAttach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAttach.swift; sourceTree = "<group>"; };
 		806A90DBCA99FD02E76D68C6 /* Host.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Host.swift; sourceTree = "<group>"; };
 		80E727A9081269681AD7581B /* TerminalInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalInputController.swift; sourceTree = "<group>"; };
+		82301D476437A71BE8B9682E /* TerminalStatusDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalStatusDialog.swift; sourceTree = "<group>"; };
 		8323C68B13826B7388800B1F /* DeviceKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyStoreTests.swift; sourceTree = "<group>"; };
 		867B5B6329BF5364E6F97D9D /* TerminalFontSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalFontSettingsTests.swift; sourceTree = "<group>"; };
 		8683454E59970E4B9F8FF12E /* NotificationRegistrationFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRegistrationFileTests.swift; sourceTree = "<group>"; };
@@ -379,6 +382,7 @@
 		DB88AD0F4E9EE776B17FAFAA /* PreflightReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreflightReportTests.swift; sourceTree = "<group>"; };
 		DCA39340517CEF3DAA35A09B /* Preflight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preflight.swift; sourceTree = "<group>"; };
 		DDC07C7B3772EEED1EB8BA9C /* HostCredentialsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostCredentialsProvider.swift; sourceTree = "<group>"; };
+		DDFE750ED67088B42B20020A /* TerminalStatusDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalStatusDialogTests.swift; sourceTree = "<group>"; };
 		DE12859365BC7A57B9EC256A /* HostDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostDraft.swift; sourceTree = "<group>"; };
 		E2DD3637ABCBDDA9385F5FBD /* AgentNotificationRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationRenderer.swift; sourceTree = "<group>"; };
 		E63AA097AC0843D1BB51461F /* JetBrainsMono-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Bold.ttf"; sourceTree = "<group>"; };
@@ -615,6 +619,7 @@
 				B75316F4E6B80E442C365765 /* TerminalInputControllerTests.swift */,
 				45811603D8C7CF196D6EC6BF /* TerminalKeysKeyboardTests.swift */,
 				758FA750D152E92B878A0234 /* TerminalMouseReportingTests.swift */,
+				DDFE750ED67088B42B20020A /* TerminalStatusDialogTests.swift */,
 				EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */,
 				099B4DEE5E08C6246009D0EB /* TerminalZoomSettingsTests.swift */,
 				A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */,
@@ -700,6 +705,7 @@
 				1B72A9326AE8FA1006B2EE18 /* RecentWorkspaceStore.swift */,
 				08E14A4298DB015E6477F789 /* StartAgentStore.swift */,
 				18AE2DC88A745FB457350957 /* StartAgentView.swift */,
+				82301D476437A71BE8B9682E /* TerminalStatusDialog.swift */,
 			);
 			path = Console;
 			sourceTree = "<group>";
@@ -1039,6 +1045,7 @@
 				D4DB3D327A8767025130B169 /* TerminalMouseReporting.swift in Sources */,
 				F96C5D15E14B947BE426B2F3 /* TerminalScreenView.swift in Sources */,
 				B7B2F5CB3C237143300024CB /* TerminalSettings.swift in Sources */,
+				3D70FC70FD0C9EAE47C96B06 /* TerminalStatusDialog.swift in Sources */,
 				CD548744FEB6447FB18E5658 /* TerminalTextSafety.swift in Sources */,
 				EDFEE058F85AF41DBFE351A7 /* TerminalTextSelectionPresenter.swift in Sources */,
 				5D1B735C72D551ADE0D82D44 /* TerminalThemeSettings.swift in Sources */,
@@ -1122,6 +1129,7 @@
 				30A69209EA01A8DF784ABC52 /* TerminalInputControllerTests.swift in Sources */,
 				4FC09A70F69110BD61E5AE9C /* TerminalKeysKeyboardTests.swift in Sources */,
 				807136B5C25AB1A0AF0E22C2 /* TerminalMouseReportingTests.swift in Sources */,
+				AA2B03CF466688D5A4862273 /* TerminalStatusDialogTests.swift in Sources */,
 				D51F828E0AC4A2F6C23A0CBE /* TerminalThemeSettingsTests.swift in Sources */,
 				ECC2A0575FFC9EB286B9F8AC /* TerminalZoomSettingsTests.swift in Sources */,
 				E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */,

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -193,13 +193,17 @@ struct AgentDetailView: View {
     private var statusOverlay: some View {
         switch attach.terminalStatus {
         case .waitingForSize, .connecting:
-            ProgressView()
+            // No dim: a reattach would otherwise flash the whole screen dark.
+            TerminalStatusDialog(
+                glyph: .progress,
+                title: "Connecting…",
+                dimsBackground: false)
         case .ended(let message):
-            ContentUnavailableView {
-                Label("Session Ended", systemImage: "cable.connector.slash")
-            } description: {
-                Text(message)
-            } actions: {
+            TerminalStatusDialog(
+                glyph: .symbol("cable.connector.slash"),
+                title: "Session Ended",
+                message: message
+            ) {
                 Button("Reattach") { attach.retryTerminal() }
                     .buttonStyle(.borderedProminent)
             }

--- a/Sources/HerdrMobile/Console/TerminalStatusDialog.swift
+++ b/Sources/HerdrMobile/Console/TerminalStatusDialog.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+/// A dialog drawn over the terminal, for the moments when the terminal itself
+/// cannot answer: the session ended, or it has not started yet.
+///
+/// It carries its own background on purpose. The first version was a bare
+/// `ContentUnavailableView`, which is transparent by design — over a live
+/// terminal that left the copy competing with whatever glyphs happened to be
+/// underneath it, and losing.
+enum TerminalStatusGlyph {
+    case symbol(String)
+    /// For states the app is actively working through, where a still icon
+    /// would read as "stuck".
+    case progress
+}
+
+struct TerminalStatusDialog<Actions: View>: View {
+    let glyph: TerminalStatusGlyph
+    let title: String
+    var message: String?
+    /// Dims the terminal behind the dialog. Off for transient states, where a
+    /// full-screen dim would flash on every reconnect.
+    var dimsBackground = true
+    @ViewBuilder let actions: () -> Actions
+
+    var body: some View {
+        ZStack {
+            if dimsBackground {
+                Rectangle()
+                    .fill(.black.opacity(0.45))
+                    .ignoresSafeArea()
+            }
+
+            VStack(spacing: 12) {
+                switch glyph {
+                case .symbol(let name):
+                    Image(systemName: name)
+                        .font(.system(size: 34))
+                        .foregroundStyle(.secondary)
+                case .progress:
+                    ProgressView()
+                        .controlSize(.large)
+                }
+                Text(title)
+                    .font(.headline)
+                if let message {
+                    Text(message)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                actions()
+                    .padding(.top, 4)
+            }
+            .padding(24)
+            .frame(maxWidth: 320)
+            .background(.regularMaterial, in: .rect(cornerRadius: 20))
+            .shadow(color: .black.opacity(0.25), radius: 20, y: 8)
+            .padding(24)
+        }
+        .accessibilityElement(children: .contain)
+    }
+}
+
+extension TerminalStatusDialog where Actions == EmptyView {
+    init(
+        glyph: TerminalStatusGlyph,
+        title: String,
+        message: String? = nil,
+        dimsBackground: Bool = true
+    ) {
+        self.init(
+            glyph: glyph, title: title, message: message, dimsBackground: dimsBackground,
+            actions: { EmptyView() })
+    }
+}
+
+#Preview("Ended") {
+    ZStack {
+        Color.black
+        TerminalStatusDialog(
+            glyph: .symbol("cable.connector.slash"),
+            title: "Session Ended",
+            message: "The session ended."
+        ) {
+            Button("Reattach") {}
+                .buttonStyle(.borderedProminent)
+        }
+    }
+}
+
+#Preview("Connecting") {
+    ZStack {
+        Color.black
+        TerminalStatusDialog(glyph: .progress, title: "Connecting…", dimsBackground: false)
+    }
+}

--- a/Tests/HerdrMobileTests/TerminalStatusDialogTests.swift
+++ b/Tests/HerdrMobileTests/TerminalStatusDialogTests.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+import Testing
+import UIKit
+
+@testable import HerdrMobile
+
+/// The dialog's whole job is to be legible over a live terminal. Its first
+/// version was a bare `ContentUnavailableView`, which draws no background at
+/// all, so the copy sat directly on top of whatever glyphs happened to be
+/// underneath. That is invisible to every kind of test except one that looks
+/// at the pixels, so this suite looks at the pixels.
+@MainActor
+@Suite("Terminal status dialog")
+struct TerminalStatusDialogTests {
+    @Test func theDialogCoversWhateverTheTerminalWasShowing() throws {
+        let image = try Self.render(
+            TerminalStatusDialog(
+                glyph: .symbol("cable.connector.slash"),
+                title: "Session Ended",
+                message: "The session ended."
+            ) {
+                Button("Reattach") {}
+                    .buttonStyle(.borderedProminent)
+            })
+
+        let behind = try #require(Self.color(in: image, atUnit: CGPoint(x: 0.5, y: 0.5)))
+        #expect(behind != Self.backdrop, "the dialog let the terminal through")
+    }
+
+    @Test func theDimOnlyAppliesWhereItIsAskedFor() throws {
+        // A corner is outside the card but inside the scrim.
+        let corner = CGPoint(x: 0.03, y: 0.06)
+
+        let dimmed = try Self.render(
+            TerminalStatusDialog(
+                glyph: .symbol("cable.connector.slash"), title: "Session Ended"))
+        let undimmed = try Self.render(
+            TerminalStatusDialog(glyph: .progress, title: "Connecting…", dimsBackground: false))
+
+        #expect(try #require(Self.color(in: dimmed, atUnit: corner)) != Self.backdrop)
+        // Transient states leave the terminal alone; dimming on every reconnect
+        // would flash the screen.
+        #expect(try #require(Self.color(in: undimmed, atUnit: corner)) == Self.backdrop)
+    }
+
+    /// Pure red, so anything drawn over it is unmistakable.
+    private static let backdrop: UInt32 = 0xFF00_0000 >> 8
+
+    private static func render(_ dialog: some View) throws -> UIImage {
+        let bounds = CGRect(x: 0, y: 0, width: 390, height: 720)
+        let controller = UIHostingController(
+            rootView: ZStack {
+                Color(red: 1, green: 0, blue: 0).ignoresSafeArea()
+                dialog
+            })
+        controller.view.frame = bounds
+
+        let windowScene = try #require(
+            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
+        let window = UIWindow(windowScene: windowScene)
+        window.frame = bounds
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+
+        return UIGraphicsImageRenderer(bounds: bounds).image { _ in
+            window.drawHierarchy(in: bounds, afterScreenUpdates: true)
+        }
+    }
+
+    private static func color(in image: UIImage, atUnit point: CGPoint) -> UInt32? {
+        guard let cgImage = image.cgImage else { return nil }
+        let width = cgImage.width, height = cgImage.height
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        guard
+            let context = CGContext(
+                data: &pixels, width: width, height: height, bitsPerComponent: 8,
+                bytesPerRow: width * 4, space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else { return nil }
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        let x = min(width - 1, max(0, Int(point.x * CGFloat(width))))
+        let y = min(height - 1, max(0, Int(point.y * CGFloat(height))))
+        let i = (y * width + x) * 4
+        return UInt32(pixels[i]) << 16 | UInt32(pixels[i + 1]) << 8 | UInt32(pixels[i + 2])
+    }
+}


### PR DESCRIPTION
Closes #93

Third in the stack: #91 → #92 → this. It is based on `fix/keyboard-tap-target`
because both touch `AgentDetailView`. Merging the two below it retargets this
cleanly.

## The problem

The session-ended state was a `ContentUnavailableView` overlaid on the
terminal. That view draws no background by design, so its copy sat directly on
the last frame of terminal output and was hard to read. The connecting state
had the same shape — a bare `ProgressView` over whatever the terminal last
drew.

## The fix

A `TerminalStatusDialog`: a material card carrying its own background, over a
dimmed terminal.

The connecting state reuses the card **without** the dim, because dimming the
whole screen on every reconnect would flash. It keeps a `ProgressView` rather
than a still icon, which would read as "stuck" — that is what the
`TerminalStatusGlyph` enum is for.

## Test

`TerminalStatusDialogTests` renders the dialog over a known colour and reads
the pixels back, because a missing background is invisible to every other kind
of test.

It is not a vacuous check: the same suite asserts that the *undimmed* variant
leaves a corner at exactly the backdrop colour. That proves the renderer really
does capture the backdrop, so a transparent card would fail the first case
rather than quietly pass it.

## Also in this branch

Merged up from #91/#92, so this branch is what has been running on device:
Snippets, the tabbed Keys keyboard, the tap-target fix, and two rounds of
device feedback on the keyboard layout (Backspace traded places with Control-Z
so the rows stay 5/5/5, `Manage Snippets` pinned below the list, the management
sheet's redundant Done button dropped).