### PR TITLE
terminal: keyboard tap policy, theme-owned chrome, per-appearance themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ relay/node_modules/
 
 # testloop scratch artifacts
 .testloop/
+
+# Agent workspace (research reports, scratch)
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to herdr-mobile are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Entries reference the pull request that landed them.
+
+## [Unreleased]
+
+### Added
+
+- Per-appearance terminal themes: Light Mode and Dark Mode each have their own
+  theme slot, so a dark terminal under a light system is one picker away. The
+  previously selected theme carries over to both slots on upgrade.
+- 20 more curated themes (30 total): Rosé Pine, Ayu, One Half, Kanagawa,
+  Everforest, GitHub, Night Owl, Iceberg, Flexoki, Selenized, Modus, Tomorrow,
+  Melange, Zenbones, One Dark, Snazzy, Oceanic Next, Poimandres, Horizon,
+  Zenburn.
+- The terminal theme now owns the whole Attach screen: its background extends
+  under the navigation bar and into the home-indicator area, and bar/status-bar
+  text follows the theme's luminance instead of the system appearance. (#95)
+
+### Fixed
+
+- Tapping the terminal body no longer toggles the software keyboard. Ghostty's
+  touch handling raised and dismissed the keyboard on any touch once it had
+  been raised once, including after returning from a short backgrounding; both
+  paths are now gated behind the input-row tap policy. (#95)
+- The keyboard tap target in full-screen agent TUIs is now a wider caret band
+  plus the bottom quarter of the screen, instead of the whole surface — output
+  areas stay inert while every chat TUI's pinned input box remains hittable,
+  whichever tool draws it. (#95, refs #90)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ Rediscovering these is expensive; they were verified against herdr 0.7.4 source 
 - Pin Citadel exactly in `Package.resolved` and review updates: Citadel 0.12.1 depends on a third-party fork of swift-nio-ssh (Wellz26), not Apple's repo.
 - Pin libghostty-spm exactly and review both its Swift sources and prebuilt XCFramework checksum before updating.
 - Tracker is GitHub issues in this repo (`gh issue ...`). Reference issues from commits with `refs #<n>`.
+- User-visible changes get a `CHANGELOG.md` entry under Unreleased, referencing the PR; internal refactors and test work stay out of it.
 - Update `CONTEXT.md` when domain terms change; add an ADR only for hard-to-reverse, surprising trade-offs.
 
 ## Agent skills

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,11 +67,11 @@ _Avoid_: dashboard, home
 The Agent detail surface: full interactive terminal control of the pane through
 the embedded terminal. The normal terminal buffer uses native local scrollback.
 Alternate-screen TUIs map vertical touch drags and momentum to terminal wheel rows.
-In the normal buffer only a tap on the input row opens the software keyboard, so
-a scroll gesture is never interrupted by a keyboard-driven viewport resize. Once
-a TUI takes the alternate screen there is no native scrollback left to protect,
-and any tap opens it — except the tap that halts a flick, which is spent on the
-halt alone.
+Only a tap near the input row opens the software keyboard, so a touch anywhere
+else is never answered with a keyboard-driven viewport resize. In the normal
+buffer the band is one row; on the alternate screen it stays caret-anchored but
+grows to cover the TUI's whole input box, because agent TUIs park the caret
+below the visible prompt. The tap that halts a flick is spent on the halt alone.
 _Avoid_: takeover (that's herdr's flag, not our surface), connect
 
 **Terminal Keyboard**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,11 +67,12 @@ _Avoid_: dashboard, home
 The Agent detail surface: full interactive terminal control of the pane through
 the embedded terminal. The normal terminal buffer uses native local scrollback.
 Alternate-screen TUIs map vertical touch drags and momentum to terminal wheel rows.
-Only a tap near the input row opens the software keyboard, so a touch anywhere
+Only a tap near the input area opens the software keyboard, so a touch anywhere
 else is never answered with a keyboard-driven viewport resize. In the normal
-buffer the band is one row; on the alternate screen it stays caret-anchored but
-grows to cover the TUI's whole input box, because agent TUIs park the caret
-below the visible prompt. The tap that halts a flick is spent on the halt alone.
+buffer that area is the caret's row; on the alternate screen the caret band
+grows (agent TUIs park the caret below the visible prompt) and the bottom
+quarter always answers, because chat-style TUIs pin their input box there. The
+tap that halts a flick is spent on the halt alone.
 _Avoid_: takeover (that's herdr's flag, not our surface), connect
 
 **Terminal Keyboard**:

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -19,6 +19,7 @@ struct AgentDetailView: View {
     @State private var isManagingSnippets = false
     @State private var closeErrorMessage: String?
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
 
     init(
         agent: ConsoleAgent,
@@ -78,6 +79,14 @@ struct AgentDetailView: View {
         .safeAreaInset(edge: .bottom, spacing: 0) {
             imageAttachStatus
         }
+        // background(_:ignoresSafeAreaEdges:) defaults to .all: the theme
+        // colour reaches under the transparent navigation bar and into the
+        // home-indicator area without moving the terminal grid or touching
+        // keyboard resize. Must stay outside the safeAreaInset above.
+        .background(terminal.themes.selection.surfaceBackground(for: colorScheme))
+        .toolbarColorScheme(
+            terminal.themes.selection.chromeColorScheme(for: colorScheme),
+            for: .navigationBar)
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -83,9 +83,12 @@ struct AgentDetailView: View {
         // colour reaches under the transparent navigation bar and into the
         // home-indicator area without moving the terminal grid or touching
         // keyboard resize. Must stay outside the safeAreaInset above.
-        .background(terminal.themes.selection.surfaceBackground(for: colorScheme))
+        .background(
+            terminal.themes.selection(for: colorScheme)
+                .surfaceBackground(for: colorScheme))
         .toolbarColorScheme(
-            terminal.themes.selection.chromeColorScheme(for: colorScheme),
+            terminal.themes.selection(for: colorScheme)
+                .chromeColorScheme(for: colorScheme),
             for: .navigationBar)
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)

--- a/Sources/HerdrMobile/Settings/SettingsView.swift
+++ b/Sources/HerdrMobile/Settings/SettingsView.swift
@@ -75,10 +75,16 @@ struct SettingsView: View {
                     Text("Bundled faces are registered with the app; no download needed.")
                 }
 
-                Section("Terminal Theme") {
-                    ForEach(TerminalThemeOption.allCases) { option in
-                        themeButton(option)
-                    }
+                Section {
+                    themePickerLink(for: .light)
+                    themePickerLink(for: .dark)
+                } header: {
+                    Text("Terminal Theme")
+                } footer: {
+                    Text(
+                        "Each appearance has its own theme. Picking a dark "
+                            + "theme for Light Mode keeps the terminal dark "
+                            + "under a light system.")
                 }
             }
             .navigationTitle("Settings")
@@ -296,12 +302,28 @@ struct SettingsView: View {
         }
     }
 
-    private func themeButton(_ option: TerminalThemeOption) -> some View {
+    private func themePickerLink(for scheme: ColorScheme) -> some View {
+        NavigationLink {
+            List {
+                ForEach(TerminalThemeOption.allCases) { option in
+                    themeButton(option, for: scheme)
+                }
+            }
+            .navigationTitle(scheme == .dark ? "Dark Mode Theme" : "Light Mode Theme")
+            .navigationBarTitleDisplayMode(.inline)
+        } label: {
+            LabeledContent(
+                scheme == .dark ? "Dark Mode" : "Light Mode",
+                value: terminal.themes.selection(for: scheme).title)
+        }
+    }
+
+    private func themeButton(_ option: TerminalThemeOption, for scheme: ColorScheme) -> some View {
         selectableRow(
             title: option.title, detail: option.detail,
-            isSelected: terminal.themes.selection == option
+            isSelected: terminal.themes.selection(for: scheme) == option
         ) {
-            terminal.themes.select(option)
+            terminal.themes.select(option, for: scheme)
         }
     }
 

--- a/Sources/HerdrMobile/Settings/TerminalAppearancePane.swift
+++ b/Sources/HerdrMobile/Settings/TerminalAppearancePane.swift
@@ -183,9 +183,12 @@ extension TerminalThemeOption {
 
     private func swatchDefinition(for colorScheme: ColorScheme) -> GhosttyThemeDefinition? {
         let isDark = colorScheme == .dark
-        let name: String? =
+        let name =
             switch self {
-            case .followSystem: nil
+            // libghostty's built-in default pair; the catalog carries the
+            // same themes under their own names (TerminalTheme+Defaults
+            // builds .default from Alabaster/Afterglow).
+            case .followSystem: isDark ? "Afterglow" : "Alabaster"
             case .vesper: "Vesper"
             case .appleSystemColors:
                 isDark ? "Apple System Colors" : "Apple System Colors Light"
@@ -197,10 +200,34 @@ extension TerminalThemeOption {
             case .nord: isDark ? "Nord" : "Nord Light"
             case .monokaiPro: isDark ? "Monokai Pro" : "Monokai Pro Light"
             }
-        // Follow System is libghostty's own default pair, which has no catalog
-        // entry to read colours from; it falls back to the system palette.
-        guard let name else { return nil }
         return GhosttyThemeCatalog.allThemes.first { $0.name == name }
+    }
+
+    /// The active theme's terminal background, for painting the chrome around
+    /// the terminal surface (the safe areas and the transparent bar region) so
+    /// the theme owns the whole screen instead of stopping at the grid.
+    func surfaceBackground(for colorScheme: ColorScheme) -> Color {
+        swatchPalette(for: colorScheme).background
+    }
+
+    /// Chrome legibility follows the theme's luminance rather than the system
+    /// appearance: a dark theme under a light system still needs light bar
+    /// titles and status-bar text (Ghostty's `window-theme = auto` semantics).
+    func chromeColorScheme(for colorScheme: ColorScheme) -> ColorScheme {
+        guard let definition = swatchDefinition(for: colorScheme) else {
+            return colorScheme
+        }
+        return Self.isDarkBackground(hex: definition.background) ? .dark : .light
+    }
+
+    private static func isDarkBackground(hex: String) -> Bool {
+        var text = hex.trimmingCharacters(in: .whitespaces)
+        if text.hasPrefix("#") { text.removeFirst() }
+        guard text.count == 6, let value = UInt32(text, radix: 16) else { return true }
+        let red = Double((value >> 16) & 0xFF)
+        let green = Double((value >> 8) & 0xFF)
+        let blue = Double(value & 0xFF)
+        return 0.299 * red + 0.587 * green + 0.114 * blue < 128
     }
 }
 

--- a/Sources/HerdrMobile/Settings/TerminalAppearancePane.swift
+++ b/Sources/HerdrMobile/Settings/TerminalAppearancePane.swift
@@ -11,6 +11,7 @@ struct TerminalAppearancePane: View {
     let themes: TerminalThemeSettings
     let zoom: TerminalZoomSettings
     let fonts: TerminalFontSettings
+    @Environment(\.colorScheme) private var colorScheme
 
     private let columns = [GridItem(.adaptive(minimum: 104), spacing: 10)]
 
@@ -80,19 +81,23 @@ struct TerminalAppearancePane: View {
         .accessibilityValue("\(Int(zoom.fontSize)) points")
     }
 
+    /// The grid edits the slot for the appearance in force: the pane's whole
+    /// premise is that every control applies instantly to the terminal above,
+    /// and that terminal is rendering the current appearance's slot.
     private var themeGrid: some View {
         LazyVGrid(columns: columns, spacing: 10) {
             ForEach(TerminalThemeOption.allCases) { option in
                 Button {
-                    themes.select(option)
+                    themes.select(option, for: colorScheme)
                 } label: {
                     TerminalThemeSwatch(
                         option: option,
-                        isSelected: themes.selection == option)
+                        isSelected: themes.selection(for: colorScheme) == option)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(option.title)
-                .accessibilityValue(themes.selection == option ? "Selected" : "")
+                .accessibilityValue(
+                    themes.selection(for: colorScheme) == option ? "Selected" : "")
             }
         }
     }
@@ -182,25 +187,7 @@ extension TerminalThemeOption {
     }
 
     private func swatchDefinition(for colorScheme: ColorScheme) -> GhosttyThemeDefinition? {
-        let isDark = colorScheme == .dark
-        let name =
-            switch self {
-            // libghostty's built-in default pair; the catalog carries the
-            // same themes under their own names (TerminalTheme+Defaults
-            // builds .default from Alabaster/Afterglow).
-            case .followSystem: isDark ? "Afterglow" : "Alabaster"
-            case .vesper: "Vesper"
-            case .appleSystemColors:
-                isDark ? "Apple System Colors" : "Apple System Colors Light"
-            case .dracula: "Dracula"
-            case .solarized: isDark ? "iTerm2 Solarized Dark" : "iTerm2 Solarized Light"
-            case .catppuccin: isDark ? "Catppuccin Mocha" : "Catppuccin Latte"
-            case .tokyoNight: isDark ? "TokyoNight Night" : "TokyoNight Day"
-            case .gruvbox: isDark ? "Gruvbox Dark" : "Gruvbox Light"
-            case .nord: isDark ? "Nord" : "Nord Light"
-            case .monokaiPro: isDark ? "Monokai Pro" : "Monokai Pro Light"
-            }
-        return GhosttyThemeCatalog.allThemes.first { $0.name == name }
+        Self.definitions[catalogName(isDark: colorScheme == .dark)]
     }
 
     /// The active theme's terminal background, for painting the chrome around

--- a/Sources/HerdrMobile/Settings/TerminalThemeSettings.swift
+++ b/Sources/HerdrMobile/Settings/TerminalThemeSettings.swift
@@ -2,7 +2,10 @@ import Foundation
 import GhosttyTerminal
 import GhosttyTheme
 import Observation
+import SwiftUI
 
+/// A curated theme choice. Paired options resolve to different catalog themes
+/// per appearance; single options render the same theme in both.
 enum TerminalThemeOption: String, CaseIterable, Identifiable, Sendable {
     case followSystem = "follow-system"
     case vesper
@@ -14,12 +17,32 @@ enum TerminalThemeOption: String, CaseIterable, Identifiable, Sendable {
     case gruvbox
     case nord
     case monokaiPro = "monokai-pro"
+    case rosePine = "rose-pine"
+    case ayu
+    case oneHalf = "one-half"
+    case kanagawa
+    case everforest
+    case github
+    case nightOwl = "night-owl"
+    case iceberg
+    case flexoki
+    case selenized
+    case modus
+    case tomorrow
+    case melange
+    case zenbones
+    case atomOneDark = "atom-one-dark"
+    case snazzy
+    case oceanicNext = "oceanic-next"
+    case poimandres
+    case horizon
+    case zenburn
 
     var id: Self { self }
 
     var title: String {
         switch self {
-        case .followSystem: "Follow System"
+        case .followSystem: "Default"
         case .vesper: "Vesper"
         case .appleSystemColors: "Apple System Colors"
         case .dracula: "Dracula"
@@ -29,6 +52,26 @@ enum TerminalThemeOption: String, CaseIterable, Identifiable, Sendable {
         case .gruvbox: "Gruvbox"
         case .nord: "Nord"
         case .monokaiPro: "Monokai Pro"
+        case .rosePine: "Rosé Pine"
+        case .ayu: "Ayu"
+        case .oneHalf: "One Half"
+        case .kanagawa: "Kanagawa"
+        case .everforest: "Everforest"
+        case .github: "GitHub"
+        case .nightOwl: "Night Owl"
+        case .iceberg: "Iceberg"
+        case .flexoki: "Flexoki"
+        case .selenized: "Selenized"
+        case .modus: "Modus"
+        case .tomorrow: "Tomorrow"
+        case .melange: "Melange"
+        case .zenbones: "Zenbones"
+        case .atomOneDark: "One Dark"
+        case .snazzy: "Snazzy"
+        case .oceanicNext: "Oceanic Next"
+        case .poimandres: "Poimandres"
+        case .horizon: "Horizon"
+        case .zenburn: "Zenburn"
         }
     }
 
@@ -44,114 +87,155 @@ enum TerminalThemeOption: String, CaseIterable, Identifiable, Sendable {
         case .gruvbox: "A warm retro palette for both appearances"
         case .nord: "A calm arctic palette for both appearances"
         case .monokaiPro: "The popular editor palette for both appearances"
+        case .rosePine: "Dawn in Light Mode, the classic in Dark Mode"
+        case .ayu: "Light and dark halves of the Ayu palette"
+        case .oneHalf: "One Half Light and One Half Dark"
+        case .kanagawa: "Lotus in Light Mode, Wave in Dark Mode"
+        case .everforest: "Forest greens for each appearance"
+        case .github: "GitHub's default palettes for each appearance"
+        case .nightOwl: "Owlish Light in Light Mode, Night Owl in Dark Mode"
+        case .iceberg: "Paired Iceberg light and dark themes"
+        case .flexoki: "Paired inky light and dark themes"
+        case .selenized: "A Solarized descendant for each appearance"
+        case .modus: "Operandi in Light Mode, Vivendi in Dark Mode"
+        case .tomorrow: "Tomorrow in Light Mode, Tomorrow Night in Dark Mode"
+        case .melange: "Warm paired light and dark themes"
+        case .zenbones: "Paired low-contrast light and dark themes"
+        case .atomOneDark: "Atom's One Dark for both appearances"
+        case .snazzy: "A vivid dark theme for both appearances"
+        case .oceanicNext: "A deep sea-blue dark theme for both appearances"
+        case .poimandres: "A cool minimal dark theme for both appearances"
+        case .horizon: "A warm dusk dark theme for both appearances"
+        case .zenburn: "The classic low-contrast dark theme for both appearances"
         }
+    }
+
+    /// The single source of the option → catalog-theme mapping. Everything
+    /// else — rendering configurations, swatches, chrome colours — derives
+    /// from this, so an option cannot render one theme and preview another.
+    func catalogName(isDark: Bool) -> String {
+        switch self {
+        // libghostty's built-in default pair; the catalog carries themes of
+        // the same names, matching backgrounds but not every accent — see
+        // `configuration(isDark:)`.
+        case .followSystem: isDark ? "Afterglow" : "Alabaster"
+        case .vesper: "Vesper"
+        case .appleSystemColors:
+            isDark ? "Apple System Colors" : "Apple System Colors Light"
+        case .dracula: "Dracula"
+        case .solarized: isDark ? "iTerm2 Solarized Dark" : "iTerm2 Solarized Light"
+        case .catppuccin: isDark ? "Catppuccin Mocha" : "Catppuccin Latte"
+        case .tokyoNight: isDark ? "TokyoNight Night" : "TokyoNight Day"
+        case .gruvbox: isDark ? "Gruvbox Dark" : "Gruvbox Light"
+        case .nord: isDark ? "Nord" : "Nord Light"
+        case .monokaiPro: isDark ? "Monokai Pro" : "Monokai Pro Light"
+        case .rosePine: isDark ? "Rose Pine" : "Rose Pine Dawn"
+        case .ayu: isDark ? "Ayu" : "Ayu Light"
+        case .oneHalf: isDark ? "One Half Dark" : "One Half Light"
+        case .kanagawa: isDark ? "Kanagawa Wave" : "Kanagawa Lotus"
+        case .everforest: isDark ? "Everforest Dark Hard" : "Everforest Light Med"
+        case .github: isDark ? "GitHub Dark Default" : "GitHub Light Default"
+        case .nightOwl: isDark ? "Night Owl" : "Night Owlish Light"
+        case .iceberg: isDark ? "Iceberg Dark" : "Iceberg Light"
+        case .flexoki: isDark ? "Flexoki Dark" : "Flexoki Light"
+        case .selenized: isDark ? "Selenized Dark" : "Selenized Light"
+        case .modus: isDark ? "Modus Vivendi" : "Modus Operandi"
+        case .tomorrow: isDark ? "Tomorrow Night" : "Tomorrow"
+        case .melange: isDark ? "Melange Dark" : "Melange Light"
+        case .zenbones: isDark ? "Zenbones Dark" : "Zenbones Light"
+        case .atomOneDark: "Atom One Dark"
+        case .snazzy: "Snazzy"
+        case .oceanicNext: "Oceanic Next"
+        case .poimandres: "Poimandres"
+        case .horizon: "Horizon"
+        case .zenburn: "Zenburn"
+        }
+    }
+
+    /// The rendering configuration for one appearance. Follow System keeps
+    /// libghostty's built-in Alabaster/Afterglow builders: the catalog entries
+    /// of the same names share their backgrounds but differ in selection and
+    /// bright-palette accents, and the built-ins are the pair every existing
+    /// install has been rendering.
+    func configuration(isDark: Bool) -> TerminalConfiguration {
+        if self == .followSystem {
+            return isDark ? .afterglow : .alabaster
+        }
+        return Self.definitions[catalogName(isDark: isDark)]?
+            .toTerminalConfiguration() ?? .default
     }
 
     var terminalTheme: TerminalTheme {
-        switch self {
-        case .followSystem:
-            .default
-        case .vesper:
-            Self.singleTheme(named: "Vesper")
-        case .appleSystemColors:
-            Self.pairedTheme(
-                light: "Apple System Colors Light",
-                dark: "Apple System Colors")
-        case .dracula:
-            Self.singleTheme(named: "Dracula")
-        case .solarized:
-            Self.pairedTheme(
-                light: "iTerm2 Solarized Light",
-                dark: "iTerm2 Solarized Dark")
-        case .catppuccin:
-            Self.pairedTheme(
-                light: "Catppuccin Latte",
-                dark: "Catppuccin Mocha")
-        case .tokyoNight:
-            Self.pairedTheme(
-                light: "TokyoNight Day",
-                dark: "TokyoNight Night")
-        case .gruvbox:
-            Self.pairedTheme(
-                light: "Gruvbox Light",
-                dark: "Gruvbox Dark")
-        case .nord:
-            Self.pairedTheme(
-                light: "Nord Light",
-                dark: "Nord")
-        case .monokaiPro:
-            Self.pairedTheme(
-                light: "Monokai Pro Light",
-                dark: "Monokai Pro")
-        }
+        TerminalTheme(
+            light: configuration(isDark: false),
+            dark: configuration(isDark: true))
     }
 
-    static let requiredCatalogThemeNames = [
-        "Vesper",
-        "Apple System Colors Light",
-        "Apple System Colors",
-        "Dracula",
-        "iTerm2 Solarized Light",
-        "iTerm2 Solarized Dark",
-        "Catppuccin Latte",
-        "Catppuccin Mocha",
-        "TokyoNight Day",
-        "TokyoNight Night",
-        "Gruvbox Light",
-        "Gruvbox Dark",
-        "Nord Light",
-        "Nord",
-        "Monokai Pro Light",
-        "Monokai Pro",
-    ]
+    static var requiredCatalogThemeNames: [String] {
+        var seen = Set<String>()
+        return allCases.flatMap { option in
+            [option.catalogName(isDark: false), option.catalogName(isDark: true)]
+        }.filter { seen.insert($0).inserted }
+    }
 
     static var missingCatalogThemeNames: [String] {
         requiredCatalogThemeNames.filter { definitions[$0] == nil }
     }
 
-    private static let definitions: [String: GhosttyThemeDefinition] =
+    static let definitions: [String: GhosttyThemeDefinition] =
         GhosttyThemeCatalog.allThemes.reduce(into: [:]) { result, definition in
             result[definition.name] = definition
         }
-
-    private static func singleTheme(named name: String) -> TerminalTheme {
-        let configuration = configuration(named: name)
-        return TerminalTheme(light: configuration, dark: configuration)
-    }
-
-    private static func pairedTheme(light: String, dark: String) -> TerminalTheme {
-        TerminalTheme(
-            light: configuration(named: light),
-            dark: configuration(named: dark))
-    }
-
-    private static func configuration(named name: String) -> TerminalConfiguration {
-        definitions[name]?.toTerminalConfiguration() ?? .default
-    }
 }
 
+/// Two independent theme slots, one per system appearance. A paired option in
+/// a slot contributes the half matching that slot; a single dark option in the
+/// light slot is how "dark terminal even in Light Mode" is expressed.
 @MainActor
 @Observable
 final class TerminalThemeSettings {
-    private static let defaultsKey = "terminal-theme"
+    /// Pre-slot releases persisted a single selection under this key; it seeds
+    /// both slots on first launch so the rendered pair does not change.
+    private static let legacyDefaultsKey = "terminal-theme"
+    private static let lightDefaultsKey = "terminal-theme-light"
+    private static let darkDefaultsKey = "terminal-theme-dark"
 
-    private(set) var selection: TerminalThemeOption
+    private(set) var lightSelection: TerminalThemeOption
+    private(set) var darkSelection: TerminalThemeOption
     @ObservationIgnored private nonisolated(unsafe) let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        selection =
-            defaults.string(forKey: Self.defaultsKey)
-            .flatMap(TerminalThemeOption.init(rawValue:)) ?? .followSystem
+        let legacy =
+            defaults.string(forKey: Self.legacyDefaultsKey)
+            .flatMap(TerminalThemeOption.init(rawValue:))
+        lightSelection =
+            defaults.string(forKey: Self.lightDefaultsKey)
+            .flatMap(TerminalThemeOption.init(rawValue:)) ?? legacy ?? .followSystem
+        darkSelection =
+            defaults.string(forKey: Self.darkDefaultsKey)
+            .flatMap(TerminalThemeOption.init(rawValue:)) ?? legacy ?? .followSystem
     }
 
     var theme: TerminalTheme {
-        selection.terminalTheme
+        TerminalTheme(
+            light: lightSelection.configuration(isDark: false),
+            dark: darkSelection.configuration(isDark: true))
     }
 
-    func select(_ selection: TerminalThemeOption) {
-        guard selection != self.selection else { return }
-        self.selection = selection
-        defaults.set(selection.rawValue, forKey: Self.defaultsKey)
+    func selection(for colorScheme: ColorScheme) -> TerminalThemeOption {
+        colorScheme == .dark ? darkSelection : lightSelection
+    }
+
+    func select(_ option: TerminalThemeOption, for colorScheme: ColorScheme) {
+        if colorScheme == .dark {
+            guard option != darkSelection else { return }
+            darkSelection = option
+            defaults.set(option.rawValue, forKey: Self.darkDefaultsKey)
+        } else {
+            guard option != lightSelection else { return }
+            lightSelection = option
+            defaults.set(option.rawValue, forKey: Self.lightDefaultsKey)
+        }
     }
 }

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -694,14 +694,23 @@ final class HerdrTerminalView: UITerminalView {
     /// touch meant for native scrollback is never answered with a keyboard-driven
     /// viewport resize.
     ///
-    /// The alternate screen keeps the caret anchor but reaches further: an agent
-    /// TUI parks its caret below the row the user reads as the prompt (Claude
-    /// Code's visible `>` measured 16–40 pt above it, #90), so the band grows to
-    /// cover the whole bordered input box. Whole-screen activation was tried
-    /// first (#92) and answered every output-area tap with the keyboard.
+    /// The alternate screen reaches further, two ways. The caret band grows to
+    /// three rows' worth, because an agent TUI parks its caret below the row
+    /// the user reads as the prompt (Claude Code's visible `>` measured
+    /// 16–40 pt above it, #90). And the bottom quarter always answers, because
+    /// chat-style TUIs (Claude Code, Codex, Amp, Droid, …) pin their input box
+    /// there while parking the caret in tool-specific spots the band cannot
+    /// chase. Whole-screen activation was tried first (#92) and answered every
+    /// output-area tap with the keyboard.
     func tapAction(at location: CGPoint) -> TerminalTapAction {
         if isTouchScrollMomentumRunning { return .haltMomentum }
-        return .report(raisesKeyboard: keyboardActivationRegion.contains(location))
+        if keyboardActivationRegion.contains(location) {
+            return .report(raisesKeyboard: true)
+        }
+        let inBottomBand = modeTracker.isAlternateScreen
+            && TerminalKeyboardTapTarget.alternateScreenBottomRegion(in: bounds)
+                .contains(location)
+        return .report(raisesKeyboard: inBottomBand)
     }
 
     var isTouchScrollMomentumRunning: Bool {

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -538,7 +538,12 @@ final class HerdrTerminalView: UITerminalView {
 
     var keyboardActivationRegion: CGRect {
         let caret = caretRect(for: endOfDocument)
-        return TerminalKeyboardTapTarget.region(caretRect: caret, in: bounds)
+        return TerminalKeyboardTapTarget.region(
+            caretRect: caret,
+            in: bounds,
+            minimumHeight: modeTracker.isAlternateScreen
+                ? TerminalKeyboardTapTarget.alternateScreenMinimumHeight
+                : TerminalKeyboardTapTarget.minimumHeight)
     }
 
     /// Reports a touch as a left click when the remote application asked for
@@ -689,17 +694,14 @@ final class HerdrTerminalView: UITerminalView {
     /// touch meant for native scrollback is never answered with a keyboard-driven
     /// viewport resize.
     ///
-    /// The alternate screen has no native scrollback to protect — drags there are
-    /// already mapped to wheel rows — and its caret sits wherever the application
-    /// parked it, which is rarely the row the user reads as the prompt. Claude
-    /// Code draws a bordered input box with the caret below the visible `>`, so
-    /// aiming at the prompt misses the 44 pt target entirely (#90). In a
-    /// full-screen TUI, any tap will do.
+    /// The alternate screen keeps the caret anchor but reaches further: an agent
+    /// TUI parks its caret below the row the user reads as the prompt (Claude
+    /// Code's visible `>` measured 16–40 pt above it, #90), so the band grows to
+    /// cover the whole bordered input box. Whole-screen activation was tried
+    /// first (#92) and answered every output-area tap with the keyboard.
     func tapAction(at location: CGPoint) -> TerminalTapAction {
         if isTouchScrollMomentumRunning { return .haltMomentum }
-        return .report(
-            raisesKeyboard: modeTracker.isAlternateScreen
-                || keyboardActivationRegion.contains(location))
+        return .report(raisesKeyboard: keyboardActivationRegion.contains(location))
     }
 
     var isTouchScrollMomentumRunning: Bool {

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -180,7 +180,7 @@ final class HerdrTerminalView: UITerminalView {
     private var terminalInputView: UIView?
     private var modeTracker = TerminalModeTracker()
     private var lastInputWindowSize: CGSize?
-    private var allowsKeyboardActivation = false
+    private var responderGate = TerminalKeyboardResponderGate()
     private(set) var isLocalInputEnabled = true
     private var terminalGridSize = (columns: 80, rows: 24)
     private var terminalCellSize = CGSize(width: 8, height: 16)
@@ -219,14 +219,30 @@ final class HerdrTerminalView: UITerminalView {
     }
 
     /// Only a tap on the input row raises the keyboard, so the surface refuses
-    /// first responder until asked. The flag tracks the *user's* intent and
-    /// survives a UIKit-initiated resign on purpose: backgrounding the app or
-    /// presenting a sheet resigns the first responder, and UIKit restores it
-    /// afterwards by asking again. Clearing the flag there would have UIKit
-    /// refused — leaving the accessory bar on screen with no keyboard behind
-    /// it and no way to type. `dismissKeyboard()` is what clears it.
+    /// first responder until asked. The gate tracks the *user's* intent, and
+    /// that intent survives a UIKit-initiated resign on purpose: backgrounding
+    /// the app or presenting a sheet resigns the first responder, and UIKit
+    /// restores it afterwards by asking again. Refusing there would leave the
+    /// accessory bar on screen with no keyboard behind it and no way to type.
+    /// `dismissKeyboard()` is what clears the intent.
+    ///
+    /// The gate also refuses mid-touch requests: Ghostty's `touchesBegan`
+    /// calls `becomeFirstResponder()` on every body touch, which with the
+    /// intent armed would raise the keyboard from taps the input-row policy
+    /// never approved.
     override var canBecomeFirstResponder: Bool {
-        allowsKeyboardActivation
+        responderGate.mayBecomeFirstResponder
+    }
+
+    /// Ghostty's `touchesEnded` dismisses the keyboard after any body tap or
+    /// scroll. The accessory's dismiss button is this app's only intended
+    /// dismissal, so a resign arriving mid-touch is Ghostty's and is refused;
+    /// UIKit's resigns (sheets, backgrounding) arrive outside touch sequences
+    /// and pass.
+    @discardableResult
+    override func resignFirstResponder() -> Bool {
+        guard responderGate.mayResignFirstResponder else { return false }
+        return super.resignFirstResponder()
     }
 
     init(
@@ -357,7 +373,8 @@ final class HerdrTerminalView: UITerminalView {
 
     /// Raises the keyboard, and records that the user wants it up.
     func requestKeyboard() {
-        allowsKeyboardActivation = true
+        responderGate.beginUserDrivenChange(wantsKeyboard: true)
+        defer { responderGate.endUserDrivenChange() }
         _ = becomeFirstResponder()
     }
 
@@ -367,7 +384,8 @@ final class HerdrTerminalView: UITerminalView {
     /// and must stay recoverable.
     @discardableResult
     func dismissKeyboard() -> Bool {
-        allowsKeyboardActivation = false
+        responderGate.beginUserDrivenChange(wantsKeyboard: false)
+        defer { responderGate.endUserDrivenChange() }
         return resignFirstResponder()
     }
 
@@ -434,7 +452,29 @@ final class HerdrTerminalView: UITerminalView {
         super.didMoveToWindow()
         if window == nil {
             stopTouchScrollMomentum()
+            responderGate.invalidateTouches()
         }
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        responderGate.directTouchesBegan(Self.directTouchCount(in: touches))
+        super.touchesBegan(touches, with: event)
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        // Ghostty's touchesEnded is where its tap-to-dismiss resign fires, so
+        // the touches stay counted until super returns.
+        super.touchesEnded(touches, with: event)
+        responderGate.directTouchesEnded(Self.directTouchCount(in: touches))
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesCancelled(touches, with: event)
+        responderGate.directTouchesEnded(Self.directTouchCount(in: touches))
+    }
+
+    private static func directTouchCount(in touches: Set<UITouch>) -> Int {
+        touches.count { $0.type == .direct }
     }
 
     override func gestureRecognizerShouldBegin(

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -234,6 +234,19 @@ final class HerdrTerminalView: UITerminalView {
         responderGate.mayBecomeFirstResponder
     }
 
+    /// UIKit skips the `canBecomeFirstResponder` check when the view already
+    /// *is* first responder — and a short backgrounding leaves exactly that
+    /// state behind: the keyboard hides but the first responder survives.
+    /// Ghostty's `touchesBegan` re-assert would then re-present the keyboard
+    /// from any body tap, so the gate has to be applied here as well.
+    @discardableResult
+    override func becomeFirstResponder() -> Bool {
+        if isFirstResponder, !responderGate.mayBecomeFirstResponder {
+            return true
+        }
+        return super.becomeFirstResponder()
+    }
+
     /// Ghostty's `touchesEnded` dismisses the keyboard after any body tap or
     /// scroll. The accessory's dismiss button is this app's only intended
     /// dismissal, so a resign arriving mid-touch is Ghostty's and is refused;

--- a/Sources/HerdrMobile/Terminal/TerminalTouchScroll.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalTouchScroll.swift
@@ -12,8 +12,19 @@ enum TerminalTapAction: Equatable {
 
 enum TerminalKeyboardTapTarget {
     static let minimumHeight: CGFloat = 44
+    /// An agent TUI parks its caret below the row the user reads as the
+    /// prompt: Claude Code's visible `>` measured 16–40 pt above the caret
+    /// inside its bordered input box (#90). Three times the normal band
+    /// covers that whole box with thumb margin while leaving the output area
+    /// inert — whole-screen activation (#92) overshot, answering every
+    /// output-area tap with a keyboard nobody asked for.
+    static let alternateScreenMinimumHeight: CGFloat = 132
 
-    static func region(caretRect: CGRect, in bounds: CGRect) -> CGRect {
+    static func region(
+        caretRect: CGRect,
+        in bounds: CGRect,
+        minimumHeight: CGFloat = TerminalKeyboardTapTarget.minimumHeight
+    ) -> CGRect {
         guard caretRect.height > 0, !bounds.isEmpty else { return .null }
         let height = max(caretRect.height, minimumHeight)
         let region = CGRect(

--- a/Sources/HerdrMobile/Terminal/TerminalTouchScroll.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalTouchScroll.swift
@@ -19,6 +19,22 @@ enum TerminalKeyboardTapTarget {
     /// inert — whole-screen activation (#92) overshot, answering every
     /// output-area tap with a keyboard nobody asked for.
     static let alternateScreenMinimumHeight: CGFloat = 132
+    /// Chat-style agent TUIs (Claude Code, Codex, Amp, Droid, …) all pin
+    /// their input box to the bottom rows but park the caret in tool-specific
+    /// spots the caret band cannot chase. The bottom quarter of the surface
+    /// is the tool-agnostic floor: on the alternate screen a tap there raises
+    /// the keyboard no matter where the caret sits.
+    static let alternateScreenBottomFraction: CGFloat = 0.25
+
+    static func alternateScreenBottomRegion(in bounds: CGRect) -> CGRect {
+        guard !bounds.isEmpty else { return .null }
+        let height = bounds.height * alternateScreenBottomFraction
+        return CGRect(
+            x: bounds.minX,
+            y: bounds.maxY - height,
+            width: bounds.width,
+            height: height)
+    }
 
     static func region(
         caretRect: CGRect,

--- a/Sources/HerdrMobile/Terminal/TerminalTouchScroll.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalTouchScroll.swift
@@ -25,6 +25,56 @@ enum TerminalKeyboardTapTarget {
     }
 }
 
+/// Gates first-responder changes on the terminal surface against Ghostty's own
+/// touch handling. Ghostty's `UITerminalView` raises the keyboard from
+/// `touchesBegan` and takes it down from `touchesEnded` — on any touch,
+/// anywhere in the body — bypassing this app's input-row tap policy. Both
+/// arrive in the middle of a direct-touch sequence, so a responder change
+/// during one is Ghostty's and is refused unless the app itself is driving it.
+/// UIKit's own resigns and restores (a sheet taking focus, backgrounding)
+/// arrive outside touch sequences and pass.
+struct TerminalKeyboardResponderGate {
+    /// The user's standing wish for the keyboard: set by the input-row tap,
+    /// cleared only by an explicit dismiss. It survives UIKit-initiated
+    /// resigns so UIKit can restore the keyboard afterwards by asking again.
+    private(set) var userWantsKeyboard = false
+    private var activeDirectTouchCount = 0
+    private var isUserDriven = false
+
+    var mayBecomeFirstResponder: Bool {
+        userWantsKeyboard && (isUserDriven || activeDirectTouchCount == 0)
+    }
+
+    var mayResignFirstResponder: Bool {
+        isUserDriven || activeDirectTouchCount == 0
+    }
+
+    /// Brackets a responder change the app makes on the user's behalf, so it
+    /// passes even mid-touch: the input-row tap fires while its own touch is
+    /// still active.
+    mutating func beginUserDrivenChange(wantsKeyboard: Bool) {
+        userWantsKeyboard = wantsKeyboard
+        isUserDriven = true
+    }
+
+    mutating func endUserDrivenChange() {
+        isUserDriven = false
+    }
+
+    mutating func directTouchesBegan(_ count: Int) {
+        activeDirectTouchCount += count
+    }
+
+    mutating func directTouchesEnded(_ count: Int) {
+        activeDirectTouchCount = max(0, activeDirectTouchCount - count)
+    }
+
+    /// A view leaving its window may never see `touchesCancelled`.
+    mutating func invalidateTouches() {
+        activeDirectTouchCount = 0
+    }
+}
+
 struct TerminalModeTracker {
     private static let privateModePrefix: [UInt8] = [0x1B, 0x5B, 0x3F]
 

--- a/Tests/HerdrMobileTests/TerminalAttachTests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachTests.swift
@@ -222,6 +222,17 @@ struct TerminalAttachTests {
         #expect(region == CGRect(x: 0, y: 344, width: 390, height: 132))
     }
 
+    /// Every chat-style agent TUI pins its input box to the bottom rows, but
+    /// each parks the caret somewhere of its own, so the bottom quarter is
+    /// the tool-agnostic floor the caret band cannot be.
+    @Test func alternateScreenBottomQuarterIsAlwaysATapTarget() {
+        let bounds = CGRect(x: 0, y: 0, width: 390, height: 720)
+        let region = TerminalKeyboardTapTarget.alternateScreenBottomRegion(in: bounds)
+
+        #expect(region == CGRect(x: 0, y: 540, width: 390, height: 180))
+        #expect(TerminalKeyboardTapTarget.alternateScreenBottomRegion(in: .zero).isNull)
+    }
+
     @MainActor
     @Test func ghosttyCursorProvidesAVisibleKeyboardTapTarget() async throws {
         let terminal = TerminalScreenView.makeConfiguredTerminal()
@@ -307,9 +318,13 @@ struct TerminalAttachTests {
         let region = terminal.keyboardActivationRegion
         let insideTheBand = CGPoint(x: 195, y: region.midY)
         let outputArea = CGPoint(x: 195, y: 20)
+        // Chat TUIs pin the input box to the bottom rows; a tap there must
+        // answer even when the caret band sits elsewhere.
+        let bottomQuarter = CGPoint(x: 195, y: 700)
         #expect(!region.contains(outputArea))
         #expect(terminal.tapAction(at: insideTheBand) == .report(raisesKeyboard: true))
         #expect(terminal.tapAction(at: outputArea) == .report(raisesKeyboard: false))
+        #expect(terminal.tapAction(at: bottomQuarter) == .report(raisesKeyboard: true))
     }
 
     /// The normal buffer keeps the old contract: scrollback is scrolled by

--- a/Tests/HerdrMobileTests/TerminalAttachTests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachTests.swift
@@ -210,6 +210,18 @@ struct TerminalAttachTests {
         #expect(!region.contains(CGPoint(x: 20, y: 500)))
     }
 
+    /// The alternate-screen band stays caret-centred, just three times as
+    /// tall — wide enough for the whole bordered input box #90 measured.
+    @Test func alternateScreenTapTargetTriplesTheCaretBand() {
+        let bounds = CGRect(x: 0, y: 0, width: 390, height: 720)
+        let region = TerminalKeyboardTapTarget.region(
+            caretRect: CGRect(x: 72, y: 400, width: 9, height: 20),
+            in: bounds,
+            minimumHeight: TerminalKeyboardTapTarget.alternateScreenMinimumHeight)
+
+        #expect(region == CGRect(x: 0, y: 344, width: 390, height: 132))
+    }
+
     @MainActor
     @Test func ghosttyCursorProvidesAVisibleKeyboardTapTarget() async throws {
         let terminal = TerminalScreenView.makeConfiguredTerminal()
@@ -261,28 +273,43 @@ struct TerminalAttachTests {
         let region = terminal.keyboardActivationRegion
         #expect(!region.isNull)
         #expect(terminal.bounds.contains(region))
-        // Thumb-sized, or the single entry point is unhittable in practice.
-        #expect(region.height >= TerminalKeyboardTapTarget.minimumHeight)
+        // Reaches the visible prompt above the parked caret (#90), or the
+        // single entry point is unhittable in practice.
+        #expect(region.height >= TerminalKeyboardTapTarget.alternateScreenMinimumHeight)
         // Full width: the row is the target, not the glyph the cursor sits on.
         #expect(region.width == terminal.bounds.width)
     }
 
-    /// #90: the 44 pt band sits on the caret, and an agent TUI parks its caret
-    /// below the prompt the user actually reads. Aiming at Claude Code's `>`
-    /// missed four times running in a real session, so the whole surface has to
-    /// answer once the alternate screen is up — there is no native scrollback
-    /// left to protect there.
+    /// #90 measured Claude Code's visible `>` prompt 16–40 pt above the parked
+    /// caret, so the alternate screen keeps the caret anchor but triples the
+    /// band to cover the whole bordered input box. The output area stays
+    /// inert: #92's whole-screen activation answered every output-area tap
+    /// with a keyboard nobody asked for.
     @MainActor
-    @Test func anyTapRaisesTheKeyboardOnceATUIOwnsTheScreen() {
+    @Test func aTUITapRaisesTheKeyboardOnlyAroundItsInputBox() async throws {
         let terminal = TerminalScreenView.makeConfiguredTerminal()
         terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 720)
-        let farFromTheCaret = CGPoint(x: 195, y: 120)
+        let controller = UIViewController()
+        controller.view = terminal
+        let windowScene = try #require(
+            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
+        let window = UIWindow(windowScene: windowScene)
+        window.frame = terminal.bounds
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
 
-        #expect(terminal.tapAction(at: farFromTheCaret) == .report(raisesKeyboard: false))
+        // A TUI on the alternate screen with its prompt parked on row 20.
+        terminal.receive(Data("\u{1B}[?1049h\u{1B}[20;3H> ".utf8))
+        terminal.layoutIfNeeded()
+        await Task.yield()
 
-        terminal.receive(Data("\u{1B}[?1049h".utf8))
-
-        #expect(terminal.tapAction(at: farFromTheCaret) == .report(raisesKeyboard: true))
+        let region = terminal.keyboardActivationRegion
+        let insideTheBand = CGPoint(x: 195, y: region.midY)
+        let outputArea = CGPoint(x: 195, y: 20)
+        #expect(!region.contains(outputArea))
+        #expect(terminal.tapAction(at: insideTheBand) == .report(raisesKeyboard: true))
+        #expect(terminal.tapAction(at: outputArea) == .report(raisesKeyboard: false))
     }
 
     /// The normal buffer keeps the old contract: scrollback is scrolled by

--- a/Tests/HerdrMobileTests/TerminalAttachTests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachTests.swift
@@ -143,6 +143,13 @@ struct TerminalAttachTests {
         terminal.touchesBegan([touch], with: nil)
         #expect(!terminal.resignFirstResponder())
         #expect(terminal.isFirstResponder)
+        // A short backgrounding hides the keyboard but keeps the first
+        // responder, and UIKit answers a re-assert on the current first
+        // responder without consulting canBecomeFirstResponder. The override
+        // swallows it mid-touch; the swallowed re-present itself is only
+        // observable on a device, so this pins down status and return value.
+        #expect(terminal.becomeFirstResponder())
+        #expect(terminal.isFirstResponder)
         terminal.touchesEnded([touch], with: nil)
 
         // A UIKit-style resign outside any touch still goes through, keeping

--- a/Tests/HerdrMobileTests/TerminalAttachTests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachTests.swift
@@ -121,6 +121,77 @@ struct TerminalAttachTests {
         #expect(terminal.canBecomeFirstResponder)
     }
 
+    /// Ghostty's `UITerminalView` raises the keyboard from `touchesBegan` and
+    /// takes it down from `touchesEnded` — on any body touch. Once the user
+    /// had raised the keyboard once, that turned every body tap into a
+    /// keyboard toggle, bypassing the input-row policy entirely. Responder
+    /// changes arriving mid-touch are Ghostty's and are refused; the same
+    /// requests pass again once the touch ends (UIKit's restore path).
+    @MainActor
+    @Test func bodyTouchesCannotToggleTheKeyboard() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: 874))
+        let terminal = TerminalScreenView.makeConfiguredTerminal()
+        window.addSubview(terminal)
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        terminal.requestKeyboard()
+        #expect(terminal.isFirstResponder)
+
+        // Ghostty's touchesEnded dismisses the keyboard after any body tap;
+        // that resign lands mid-touch and must be refused.
+        let touch = UITouch()
+        terminal.touchesBegan([touch], with: nil)
+        #expect(!terminal.resignFirstResponder())
+        #expect(terminal.isFirstResponder)
+        terminal.touchesEnded([touch], with: nil)
+
+        // A UIKit-style resign outside any touch still goes through, keeping
+        // sheets and backgrounding working.
+        _ = terminal.resignFirstResponder()
+        #expect(!terminal.isFirstResponder)
+
+        // Ghostty's touchesBegan re-raises the keyboard on the next body tap;
+        // with no user request driving it the surface refuses.
+        terminal.touchesBegan([touch], with: nil)
+        #expect(!terminal.becomeFirstResponder())
+        terminal.touchesEnded([touch], with: nil)
+
+        // Outside the touch, UIKit's restore-after-resign path still passes.
+        #expect(terminal.canBecomeFirstResponder)
+    }
+
+    @Test func responderGateRefusesGhosttysTouchDrivenChanges() {
+        var gate = TerminalKeyboardResponderGate()
+        gate.beginUserDrivenChange(wantsKeyboard: true)
+        gate.endUserDrivenChange()
+
+        gate.directTouchesBegan(1)
+        #expect(!gate.mayBecomeFirstResponder)
+        #expect(!gate.mayResignFirstResponder)
+
+        gate.directTouchesEnded(1)
+        #expect(gate.mayBecomeFirstResponder)
+        #expect(gate.mayResignFirstResponder)
+    }
+
+    /// The input-row tap and the accessory's dismiss button both fire while
+    /// their own touch may still be active, so user-driven changes pass the
+    /// gate mid-touch.
+    @Test func responderGatePassesUserDrivenChangesMidTouch() {
+        var gate = TerminalKeyboardResponderGate()
+        gate.directTouchesBegan(1)
+
+        gate.beginUserDrivenChange(wantsKeyboard: true)
+        #expect(gate.mayBecomeFirstResponder)
+        gate.endUserDrivenChange()
+
+        gate.beginUserDrivenChange(wantsKeyboard: false)
+        #expect(gate.mayResignFirstResponder)
+        gate.endUserDrivenChange()
+
+        #expect(!gate.mayBecomeFirstResponder)
+    }
+
     @Test func keyboardTapTargetCoversOnlyTheCurrentInputRow() {
         let bounds = CGRect(x: 0, y: 0, width: 390, height: 720)
         let region = TerminalKeyboardTapTarget.region(

--- a/Tests/HerdrMobileTests/TerminalThemeSettingsTests.swift
+++ b/Tests/HerdrMobileTests/TerminalThemeSettingsTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import Testing
 
 @testable import HerdrMobile
@@ -17,6 +18,48 @@ struct TerminalThemeSettingsTests {
         defer { cleanup() }
 
         #expect(TerminalThemeSettings(defaults: defaults).selection == .followSystem)
+    }
+
+    /// The chrome around the terminal (safe areas, transparent bar region) is
+    /// painted with the theme's own background, so the surface colour must
+    /// resolve from the catalog — not fall back to systemBackground.
+    @Test func surfaceBackgroundResolvesFromTheThemeCatalog() {
+        #expect(
+            TerminalThemeOption.tokyoNight.surfaceBackground(for: .dark)
+                == Color(hex: "1a1b26"))
+        #expect(
+            TerminalThemeOption.tokyoNight.surfaceBackground(for: .light)
+                == Color(hex: "e1e2e7"))
+        // Follow System maps to libghostty's default pair, which the catalog
+        // carries under its own names (TerminalTheme+Defaults).
+        #expect(
+            TerminalThemeOption.followSystem.surfaceBackground(for: .light)
+                == Color(hex: "f7f7f7"))
+        #expect(
+            TerminalThemeOption.followSystem.surfaceBackground(for: .dark)
+                == Color(hex: "212121"))
+    }
+
+    /// Chrome legibility follows the theme's luminance, not the system
+    /// appearance: Dracula stays dark in Light Mode, so its bar titles and
+    /// status-bar text must stay light there too.
+    @Test func chromeSchemeFollowsThemeLuminanceNotSystemAppearance() {
+        #expect(TerminalThemeOption.dracula.chromeColorScheme(for: .light) == .dark)
+        #expect(TerminalThemeOption.dracula.chromeColorScheme(for: .dark) == .dark)
+        #expect(TerminalThemeOption.solarized.chromeColorScheme(for: .light) == .light)
+        #expect(TerminalThemeOption.solarized.chromeColorScheme(for: .dark) == .dark)
+        #expect(TerminalThemeOption.followSystem.chromeColorScheme(for: .light) == .light)
+        #expect(TerminalThemeOption.followSystem.chromeColorScheme(for: .dark) == .dark)
+    }
+
+    /// Every option must yield a catalog-backed surface for both appearances;
+    /// a silent fallback to systemBackground would reintroduce the black
+    /// bands around the terminal for that theme.
+    @Test(arguments: TerminalThemeOption.allCases)
+    func everyThemeResolvesACatalogSurface(option: TerminalThemeOption) {
+        for scheme in [ColorScheme.light, .dark] {
+            #expect(option.surfaceBackground(for: scheme) != Color(uiColor: .systemBackground))
+        }
     }
 
     @Test func selectionPersistsAcrossStoreInstances() throws {

--- a/Tests/HerdrMobileTests/TerminalThemeSettingsTests.swift
+++ b/Tests/HerdrMobileTests/TerminalThemeSettingsTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GhosttyTerminal
 import SwiftUI
 import Testing
 
@@ -16,8 +17,43 @@ struct TerminalThemeSettingsTests {
     @Test func defaultsToFollowingTheSystem() throws {
         let (defaults, cleanup) = try makeDefaults()
         defer { cleanup() }
+        let settings = TerminalThemeSettings(defaults: defaults)
 
-        #expect(TerminalThemeSettings(defaults: defaults).selection == .followSystem)
+        #expect(settings.lightSelection == .followSystem)
+        #expect(settings.darkSelection == .followSystem)
+        // Both slots on the default must render exactly what pre-slot
+        // installs rendered: libghostty's built-in pair.
+        #expect(settings.theme == .default)
+    }
+
+    /// Pre-slot releases persisted one selection; it must seed both slots so
+    /// the rendered pair survives the upgrade unchanged.
+    @Test func legacySingleSelectionSeedsBothSlots() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        defaults.set("tokyo-night", forKey: "terminal-theme")
+        let settings = TerminalThemeSettings(defaults: defaults)
+
+        #expect(settings.lightSelection == .tokyoNight)
+        #expect(settings.darkSelection == .tokyoNight)
+        #expect(settings.theme == TerminalThemeOption.tokyoNight.terminalTheme)
+    }
+
+    /// The point of the two slots: the composed theme takes its light half
+    /// from the light slot and its dark half from the dark slot.
+    @Test func slotsComposeTheThemeHalfByHalf() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let settings = TerminalThemeSettings(defaults: defaults)
+
+        settings.select(.solarized, for: .light)
+        settings.select(.tokyoNight, for: .dark)
+
+        #expect(
+            settings.theme
+                == TerminalTheme(
+                    light: TerminalThemeOption.solarized.configuration(isDark: false),
+                    dark: TerminalThemeOption.tokyoNight.configuration(isDark: true)))
     }
 
     /// The chrome around the terminal (safe areas, transparent bar region) is
@@ -67,17 +103,23 @@ struct TerminalThemeSettingsTests {
         defer { cleanup() }
         let settings = TerminalThemeSettings(defaults: defaults)
 
-        settings.select(.dracula)
+        settings.select(.dracula, for: .dark)
 
-        #expect(TerminalThemeSettings(defaults: defaults).selection == .dracula)
+        let reloaded = TerminalThemeSettings(defaults: defaults)
+        #expect(reloaded.darkSelection == .dracula)
+        #expect(reloaded.lightSelection == .followSystem)
     }
 
     @Test func unknownPersistedSelectionFallsBackToTheSystem() throws {
         let (defaults, cleanup) = try makeDefaults()
         defer { cleanup() }
         defaults.set("removed-theme", forKey: "terminal-theme")
+        defaults.set("removed-theme", forKey: "terminal-theme-light")
+        defaults.set("removed-theme", forKey: "terminal-theme-dark")
+        let settings = TerminalThemeSettings(defaults: defaults)
 
-        #expect(TerminalThemeSettings(defaults: defaults).selection == .followSystem)
+        #expect(settings.lightSelection == .followSystem)
+        #expect(settings.darkSelection == .followSystem)
     }
 
     @Test func curatedCatalogEntriesExistInThePinnedPackage() {


### PR DESCRIPTION
## Keyboard: body taps must not raise the keyboard

Three stacked fixes, each verified on device against a live report:

1. **Responder gate** (`464fbbe`): Ghostty's `UITerminalView` raises the keyboard from `touchesBegan` and dismisses it from `touchesEnded` on any body touch. Once the keyboard had been raised once, the standing intent flag let those calls through, turning every body tap into a keyboard toggle that bypassed the input-row policy. `TerminalKeyboardResponderGate` now refuses responder changes arriving mid-touch unless `requestKeyboard()`/`dismissKeyboard()` drives them; UIKit's own resigns and restores (sheets, backgrounding) arrive outside touch sequences and still pass.
2. **Already-first-responder re-assert** (`760d961`): a short backgrounding hides the keyboard but keeps the first responder, and UIKit answers `becomeFirstResponder` on the current first responder without consulting `canBecomeFirstResponder`. Swallow mid-touch re-asserts too.
3. **Tap-target policy** (`05c0090`, `31f4e48`): replaces #92's whole-screen activation on the alternate screen, which answered every output-area tap with the keyboard. The caret band triples to 132 pt (covers the bordered input box #90 measured), and the bottom quarter always answers — the tool-agnostic invariant across chat TUIs (Claude Code, Codex, Amp, Droid, …) whose input boxes pin to the bottom rows while parking carets in tool-specific spots. refs #90

## Chrome: theme background owns the attach screen

The terminal representable stops at the safe-area edges, so the theme background ended there too, showing `systemBackground` as black bands above and below (the iOS 26 navigation bar itself is already transparent over non-scrolling content — pixel-verified). The SwiftUI container is now painted with the active theme's background (bleeds into all safe areas without moving the grid or affecting keyboard resize / SIGWINCH), and bar/status-bar legibility follows the theme's luminance instead of the system appearance, per Ghostty's `window-theme = auto` semantics. Matches the pattern of Termius / Blink / Prompt 3 (5 of 6 shipping iOS terminals).

## Themes: per-appearance slots and 20 more curated options

Light Mode and Dark Mode each get an independent theme slot; a paired option contributes the half matching its slot, and a single dark option in the light slot expresses "dark terminal even under a light system". The legacy persisted selection seeds both slots so upgrades render the same pair as before. The option-to-catalog-name mapping collapses to one function that rendering, swatches and chrome colours all derive from, with the catalog drift test's required-names list generated from it. Curated set grows from 10 to 30 (Rosé Pine, Ayu, One Half, Kanagawa, Everforest, GitHub, Night Owl, Iceberg, Flexoki, Selenized, Modus, Tomorrow, Melange, Zenbones, One Dark, Snazzy, Oceanic Next, Poimandres, Horizon, Zenburn), every half verified against the pinned catalog. Settings shows one picker per appearance; the Keys keyboard grid edits the slot for the appearance in force.

Also starts `CHANGELOG.md` (Keep a Changelog, Unreleased section) and records the maintenance convention in `CLAUDE.md`.

## Tests

- `TerminalAttachTests`: responder-gate unit + windowed end-to-end toggle scenario, tap-target band and bottom-quarter cases
- `TerminalThemeSettingsTests`: slot persistence and legacy migration, half-by-half theme composition, surface colour resolution, luminance-driven chrome scheme (incl. dark theme + light system), no-fallback invariant across all 30 themes
- All terminal suites green on iPhone 17 Pro simulator; keyboard, chrome and theming verified on device

## Known limitations

- `.toolbarColorScheme` flipping status-bar text is an empirically verified but undocumented behavior; worth a screenshot test if it regresses
- Terminal text scrolls under the transparent bar with no scroll edge effect (Ghostty renders via Metal, no `UIScrollView` to attach one); acceptable for now, escalation paths documented in `.claude/ui-research/terminal-chrome-blending/report.html` (local, not committed)