### PR TITLE
build: TestFlight release plumbing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Xcode
+build/
 xcuserdata/
 *.xcuserstate
 DerivedData/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ Rediscovering these is expensive; they were verified against herdr 0.7.4 source 
 
 ## Conventions
 
+- Build, test, device installs, and TestFlight uploads all go through `make` (see `make help`). A new TestFlight build is `make bump && make testflight` — App Store Connect rejects reused build numbers.
+
 - Swift 6 strict concurrency. No force unwraps or `try!` outside tests.
 - Secrets never leave the Keychain; private keys are generated on device (CryptoKit Ed25519) where possible. Host key policy is TOFU with fingerprint confirmation.
 - Pin Citadel exactly in `Package.resolved` and review updates: Citadel 0.12.1 depends on a third-party fork of swift-nio-ssh (Wellz26), not Apple's repo.

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -1162,6 +1162,8 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Herdr;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "herdr uses the camera to scan the Pairing Code shown on your computer, so you can add that machine without typing anything.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "herdr uses the microphone to transcribe your spoken reply into the message box. Audio is processed on device and never leaves your phone.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -1204,6 +1206,8 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Herdr;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "herdr uses the camera to scan the Pairing Code shown on your computer, so you can add that machine without typing anything.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "herdr uses the microphone to transcribe your spoken reply into the message box. Audio is processed on device and never leaves your phone.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+# Task runner for HerdrMobile. Typical flows:
+#   make install                 # build Debug and run it on the connected iPhone
+#   make bump && make testflight # next TestFlight build (build number must be unique per upload)
+
+PROJECT := HerdrMobile.xcodeproj
+SCHEME  := HerdrMobile
+ARCHIVE := build/HerdrMobile.xcarchive
+DERIVED := build/DerivedData
+APP_ID  := dev.herdr.mobile.HerdrMobile
+
+# First physical device paired with devicectl; override with `make install DEVICE=<uuid>`.
+DEVICE ?= $(shell xcrun devicectl list devices 2>/dev/null | awk '/physical[a-z]* *$$/ { for (i = 1; i <= NF; i++) if ($$i ~ /^[0-9A-Fa-f-]{36}$$/) { print $$i; exit } }')
+
+.PHONY: help generate build test install archive upload testflight bump clean check-device
+
+help: ## Show available targets
+	@awk -F':.*## ' '/^[a-z]+:.*## / { printf "  make %-12s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+generate: ## Regenerate the Xcode project from project.yml (XcodeGen)
+	xcodegen generate
+
+build: generate ## Build Debug for a physical device without installing
+	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -configuration Debug \
+		-destination 'generic/platform=iOS' -derivedDataPath $(DERIVED) \
+		-allowProvisioningUpdates build
+
+test: generate ## Run the unit test suite on a simulator
+	xcodebuild -project $(PROJECT) -scheme $(SCHEME) \
+		-destination 'platform=iOS Simulator,name=iPhone 17' test
+
+check-device:
+	@test -n "$(DEVICE)" || { echo "No physical device found; pass DEVICE=<devicectl uuid>"; exit 1; }
+
+install: check-device build ## Build Debug, install on the iPhone, and relaunch it
+	xcrun devicectl device install app --device $(DEVICE) \
+		$(DERIVED)/Build/Products/Debug-iphoneos/HerdrMobile.app
+	xcrun devicectl device process launch --terminate-existing --device $(DEVICE) $(APP_ID)
+
+archive: generate ## Archive a Release build for distribution
+	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -configuration Release \
+		-destination 'generic/platform=iOS' -archivePath $(ARCHIVE) \
+		-allowProvisioningUpdates archive
+
+upload: ## Upload the existing archive to App Store Connect (TestFlight)
+	xcodebuild -exportArchive -archivePath $(ARCHIVE) \
+		-exportOptionsPlist scripts/ExportOptions.plist \
+		-exportPath build/export -allowProvisioningUpdates
+
+testflight: archive upload ## Archive and upload in one go
+
+bump: ## Increment CURRENT_PROJECT_VERSION in project.yml (app + extension stay in lockstep)
+	@CUR=$$(awk -F'"' '/CURRENT_PROJECT_VERSION/ { print $$2; exit }' project.yml); \
+	NEW=$$((CUR + 1)); \
+	sed -i '' "s/CURRENT_PROJECT_VERSION: \"$$CUR\"/CURRENT_PROJECT_VERSION: \"$$NEW\"/g" project.yml; \
+	echo "CURRENT_PROJECT_VERSION: $$CUR -> $$NEW"
+
+clean: ## Remove local build products
+	rm -rf build

--- a/Sources/HerdrNotificationService/Info.plist
+++ b/Sources/HerdrNotificationService/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Herdr Notification Service</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/project.yml
+++ b/project.yml
@@ -50,6 +50,8 @@ targets:
       base:
         GENERATE_INFOPLIST_FILE: YES
         PRODUCT_BUNDLE_IDENTIFIER: dev.herdr.mobile.HerdrMobile
+        # Home-screen name; the App Store listing is "Herdr Console".
+        INFOPLIST_KEY_CFBundleDisplayName: Herdr
         MARKETING_VERSION: "0.1.0"
         CURRENT_PROJECT_VERSION: "1"
         # Dictation captures the microphone to transcribe on device (#36). No
@@ -105,6 +107,9 @@ targets:
         # so both bundles stay in lockstep.
         CFBundleShortVersionString: $(MARKETING_VERSION)
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        # App Store validation (code 90360) requires a display name on
+        # every embedded appex; never user-visible for this extension.
+        CFBundleDisplayName: Herdr Notification Service
         NSExtension:
           NSExtensionPointIdentifier: com.apple.usernotifications.service
           NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).NotificationService

--- a/project.yml
+++ b/project.yml
@@ -58,6 +58,10 @@ targets:
         INFOPLIST_KEY_NSMicrophoneUsageDescription: "herdr uses the microphone to transcribe your spoken reply into the message box. Audio is processed on device and never leaves your phone."
         # Scan to Pair (#62) reads the Pairing Code QR from the computer screen.
         INFOPLIST_KEY_NSCameraUsageDescription: "herdr uses the camera to scan the Pairing Code shown on your computer, so you can add that machine without typing anything."
+        # Only exempt encryption is used (standard SSH algorithms via Citadel,
+        # OS-provided CryptoKit); declaring it here keeps every TestFlight
+        # upload from stalling on the Missing Compliance prompt.
+        INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: NO
         # iPhone + iPad.
         TARGETED_DEVICE_FAMILY: "1,2"
         INFOPLIST_KEY_UILaunchScreen_Generation: YES

--- a/scripts/ExportOptions.plist
+++ b/scripts/ExportOptions.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>destination</key>
+	<string>upload</string>
+	<key>teamID</key>
+	<string>9VM4RM39R3</string>
+	<key>uploadSymbols</key>
+	<true/>
+	<key>manageAppVersionAndBuildNumber</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Everything needed to ship the first TestFlight build (0.1.0 (1), uploaded and processing on App Store Connect):

- Declare exempt-only encryption (`ITSAppUsesNonExemptEncryption: NO`) so uploads don't stall on the Missing Compliance prompt. The app only uses standard SSH algorithms (Citadel) and OS-provided CryptoKit.
- Add `CFBundleDisplayName` to the notification service extension — App Store validation rejects the bundle without it (code 90360) — and set the app's home-screen name to "Herdr".
- Add a `Makefile` covering the day-to-day flows: `make install` (Debug build + `devicectl` install to the paired iPhone), `make bump && make testflight` (increment build number, archive, upload), plus `generate`/`build`/`test`/`clean`. `ExportOptions.plist` lives in `scripts/`.
- Ignore local archive output under `build/`; document the make-based workflow in `CLAUDE.md`.

## Test plan

- Archived and uploaded with these exact settings; App Store Connect accepted the build (previous upload was rejected with validation code 90360).
- `make help` / `make install` device discovery / `make bump` version rewrite verified locally; `make install` fails fast when no device is paired.