### PR TITLE
feat: surface Attach Links from terminal output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ Entries reference the issue that motivated them.
   ANSI styling stays transparent, and OSC 8 hyperlinks expose their real
   targets instead of their labels. New targets show a short-lived Open prompt,
   and a failed open keeps the target available with a Copy Link recovery. The
-  list survives terminal recovery and is discarded when Attach ends.
-  (#101, #102, #103)
+  list survives terminal recovery, adapts between iPhone and iPad, and remains
+  usable with Dynamic Type and VoiceOver. It is discarded when Attach ends.
+  (#101, #102, #103, #104)
 
 - An iPad-fit Console: on regular widths the Agent list becomes a sidebar
   beside the open terminal (a split view) instead of stretching edge to edge,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,10 @@ Entries reference the issue that motivated them.
 - Attach Links collect plain HTTP and HTTPS targets printed during an Attach
   into a memory-only, most-recent-first list with native opening and copying.
   ANSI styling stays transparent, and OSC 8 hyperlinks expose their real
-  targets instead of their labels. New targets show a short-lived Open prompt,
-  and a failed open keeps the target available with a Copy Link recovery. The
-  list survives terminal recovery, adapts between iPhone and iPad, and remains
-  usable with Dynamic Type and VoiceOver. It is discarded when Attach ends.
-  (#101, #102, #103, #104)
+  targets instead of their labels. A failed open keeps the target available
+  with a Copy Link recovery. The list survives terminal recovery, adapts
+  between iPhone and iPad, and remains usable with Dynamic Type and VoiceOver.
+  It is discarded when Attach ends. (#101, #102, #103, #104)
 
 - An iPad-fit Console: on regular widths the Agent list becomes a sidebar
   beside the open terminal (a split view) instead of stretching edge to edge,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,9 @@ Entries reference the issue that motivated them.
 
 ### Added
 
-- Attach Links collect plain HTTP and HTTPS targets printed during an Attach
-  into a memory-only, most-recent-first list with native opening and copying.
-  ANSI styling stays transparent, and OSC 8 hyperlinks expose their real
-  targets instead of their labels. A failed open keeps the target available
-  with a Copy Link recovery. The list survives terminal recovery, adapts
-  between iPhone and iPad, and remains usable with Dynamic Type and VoiceOver.
-  It is discarded when Attach ends. (#101, #102, #103, #104; PR #105)
+- Attach Links silently collect web and OSC 8 targets into a memory-only list
+  for opening or copying. Links survive terminal recovery and are discarded
+  when Attach ends. (#101, #102, #103, #104; PR #105)
 
 - An iPad-fit Console: on regular widths the Agent list becomes a sidebar
   beside the open terminal (a split view) instead of stretching edge to edge,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ Entries reference the issue that motivated them.
 
 - Attach Links collect plain HTTP and HTTPS targets printed during an Attach
   into a memory-only, most-recent-first list with native opening and copying.
-  The list survives terminal recovery and is discarded when Attach ends. (#101)
+  ANSI styling stays transparent, and OSC 8 hyperlinks expose their real
+  targets instead of their labels. The list survives terminal recovery and is
+  discarded when Attach ends. (#101, #102)
 
 - An iPad-fit Console: on regular widths the Agent list becomes a sidebar
   beside the open terminal (a split view) instead of stretching edge to edge,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Entries reference the issue that motivated them.
 
 ### Added
 
+- Attach Links collect plain HTTP and HTTPS targets printed during an Attach
+  into a memory-only, most-recent-first list with native opening and copying.
+  The list survives terminal recovery and is discarded when Attach ends. (#101)
+
 - An iPad-fit Console: on regular widths the Agent list becomes a sidebar
   beside the open terminal (a split view) instead of stretching edge to edge,
   and the in-app notification banner caps at a system-banner width. iPhone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Entries reference the issue that motivated them.
   targets instead of their labels. A failed open keeps the target available
   with a Copy Link recovery. The list survives terminal recovery, adapts
   between iPhone and iPad, and remains usable with Dynamic Type and VoiceOver.
-  It is discarded when Attach ends. (#101, #102, #103, #104)
+  It is discarded when Attach ends. (#101, #102, #103, #104; PR #105)
 
 - An iPad-fit Console: on regular widths the Agent list becomes a sidebar
   beside the open terminal (a split view) instead of stretching edge to edge,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ Entries reference the issue that motivated them.
 - Attach Links collect plain HTTP and HTTPS targets printed during an Attach
   into a memory-only, most-recent-first list with native opening and copying.
   ANSI styling stays transparent, and OSC 8 hyperlinks expose their real
-  targets instead of their labels. The list survives terminal recovery and is
-  discarded when Attach ends. (#101, #102)
+  targets instead of their labels. New targets show a short-lived Open prompt,
+  and a failed open keeps the target available with a Copy Link recovery. The
+  list survives terminal recovery and is discarded when Attach ends.
+  (#101, #102, #103)
 
 - An iPad-fit Console: on regular widths the Agent list becomes a sidebar
   beside the open terminal (a split view) instead of stretching edge to edge,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -83,6 +83,12 @@ quarter always answers, because chat-style TUIs pin their input box there. The
 tap that halts a flick is spent on the halt alone.
 _Avoid_: takeover (that's herdr's flag, not our surface), connect
 
+**Attach Link**:
+An ordinary web URL observed in the terminal during one Attach. It remains
+available after scrolling or reconnecting, but is forgotten when the user
+leaves Attach; a later Attach discovers whatever its terminal shows anew.
+_Avoid_: recent link, visible link, link history
+
 **Terminal Keyboard**:
 The two input modes used within Attach. Text keeps the standard iOS input method
 for composition, autocorrection, dictation, and language switching. The Keys mode

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -1212,7 +1212,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Sources/HerdrMobile/HerdrMobile.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Herdr;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -1256,7 +1256,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Sources/HerdrMobile/HerdrMobile.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Herdr;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -1364,7 +1364,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Sources/HerdrNotificationService/HerdrNotificationService.entitlements;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				INFOPLIST_FILE = Sources/HerdrNotificationService/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1441,7 +1441,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Sources/HerdrNotificationService/HerdrNotificationService.entitlements;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				INFOPLIST_FILE = Sources/HerdrNotificationService/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		718719DA8913E787FA68BD45 /* GhosttyTerminal in Frameworks */ = {isa = PBXBuildFile; productRef = 168EBAF199220582EB0C49F7 /* GhosttyTerminal */; };
 		71F4A714BC2E527F40E657B6 /* Base64URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FC4FCCE9B94EC52FD930B1 /* Base64URL.swift */; };
 		724AEEB52CDF4B28AFF8E3E5 /* HerdrWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6970DEB7C22EFDB1A26F6F9 /* HerdrWireTests.swift */; };
+		731D433F2309641163FA3B88 /* TestWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B410938C05A8D90C4A67D49E /* TestWindow.swift */; };
 		782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */; };
 		78DE951AD8EEDB9423984268 /* AgentNotificationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DD3637ABCBDDA9385F5FBD /* AgentNotificationRenderer.swift */; };
 		7C3999C38A0126986F9CCC58 /* AgentNotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC309E333009D66F9757CD13 /* AgentNotificationRouter.swift */; };
@@ -378,6 +379,7 @@
 		B36D007E7AE959F6D62B166D /* PushRegistrationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRegistrationStore.swift; sourceTree = "<group>"; };
 		B383994C2C8492694D5F3690 /* HerdrMobile.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HerdrMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E5E9501F8CC386668291C1 /* TerminalTextSafety.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTextSafety.swift; sourceTree = "<group>"; };
+		B410938C05A8D90C4A67D49E /* TestWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestWindow.swift; sourceTree = "<group>"; };
 		B66B41C393D38FA09388E3E2 /* ReconnectPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectPolicyTests.swift; sourceTree = "<group>"; };
 		B75316F4E6B80E442C365765 /* TerminalInputControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalInputControllerTests.swift; sourceTree = "<group>"; };
 		BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOFUHostKeyValidator.swift; sourceTree = "<group>"; };
@@ -805,6 +807,7 @@
 				44F4B2F424E3FC8AB7DA69FC /* NotificationVectorFile.swift */,
 				17424B6972D7D7E6271350A5 /* PairingCodeVectorFile.swift */,
 				7AFE5C640586747D567E1CF1 /* ScriptedTransport.swift */,
+				B410938C05A8D90C4A67D49E /* TestWindow.swift */,
 				FCB59377D34D0C652DF70F01 /* UnixSockets.swift */,
 			);
 			path = Support;
@@ -1188,6 +1191,7 @@
 				AA2B03CF466688D5A4862273 /* TerminalStatusDialogTests.swift in Sources */,
 				D51F828E0AC4A2F6C23A0CBE /* TerminalThemeSettingsTests.swift in Sources */,
 				ECC2A0575FFC9EB286B9F8AC /* TerminalZoomSettingsTests.swift in Sources */,
+				731D433F2309641163FA3B88 /* TestWindow.swift in Sources */,
 				E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */,
 				782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */,
 				C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */,

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		989FE5FA6D3BD73A6183B079 /* GitBranchNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66DB4D6D48C0D21C9A7B02B8 /* GitBranchNameTests.swift */; };
 		98E83E883BCC8534910D7493 /* TerminalInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E727A9081269681AD7581B /* TerminalInputController.swift */; };
 		9C1C00F36A178BF1BEE6C0A5 /* StartAgentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E14A4298DB015E6477F789 /* StartAgentStore.swift */; };
+		9E33EFFDF58051602436068F /* AttachLinkIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A077320E247C9C81F71966F /* AttachLinkIndex.swift */; };
 		9F3F748E722FD8059A59ECBD /* HostStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6434D31A79422C0BAE80993F /* HostStoreTests.swift */; };
 		9FD3129232CA2D5BBEC3A7B9 /* TerminalFontSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F683C9B399511ED2FD476FA9 /* TerminalFontSettings.swift */; };
 		A0C9B80A4139A6FA73261805 /* HerdrWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FC9B455C6266F12DA82A07 /* HerdrWire.swift */; };
@@ -280,6 +281,7 @@
 		31A3BC92C11A1D5AF39C5340 /* HerdrNotificationService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HerdrNotificationService.entitlements; sourceTree = "<group>"; };
 		323782148B559800B45E2930 /* NotificationPrivacyCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPrivacyCopy.swift; sourceTree = "<group>"; };
 		389EE12865BBCAD1E1A7494A /* TerminalThemePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemePreview.swift; sourceTree = "<group>"; };
+		3A077320E247C9C81F71966F /* AttachLinkIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachLinkIndex.swift; sourceTree = "<group>"; };
 		3C07948FE6D5E399672A9395 /* AgentAttachStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAttachStore.swift; sourceTree = "<group>"; };
 		3CCDC5144D5AA6403150431A /* ImageAttachStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachStoreTests.swift; sourceTree = "<group>"; };
 		3CE658EA3C6364BCC0D8CE14 /* SharedAsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedAsyncOperation.swift; sourceTree = "<group>"; };
@@ -732,6 +734,7 @@
 				0B3FA15CCDC83C72DDA81BEB /* AgentCardView.swift */,
 				5ADF336771A3F757F2AD441D /* AgentDetailView.swift */,
 				066E173006FDDF8FE2E93308 /* AgentName.swift */,
+				3A077320E247C9C81F71966F /* AttachLinkIndex.swift */,
 				97970F4D535CC80592333995 /* AttachTerminalStore.swift */,
 				F13921A61B4E4F17CDE47C96 /* ClosePaneStore.swift */,
 				498ECBCD631F9734C28861EA /* ConsoleAgent.swift */,
@@ -1013,6 +1016,7 @@
 				7C3999C38A0126986F9CCC58 /* AgentNotificationRouter.swift in Sources */,
 				07594B18999B4ACCD9C590F9 /* AgentNotificationRouting.swift in Sources */,
 				862121A4D41D3E1EA1E56D84 /* AppActivityCoordinator.swift in Sources */,
+				9E33EFFDF58051602436068F /* AttachLinkIndex.swift in Sources */,
 				225ECBDC69A7785559BC4D20 /* AttachTerminalStore.swift in Sources */,
 				664FBC89396DBDD1083749E0 /* Base64URL.swift in Sources */,
 				CC20BAD2AC1A725889F82A20 /* ClosePaneStore.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ herdr-mobile is an **agent console**: a native dashboard of every coding agent r
 - **Attach** — a real terminal (libghostty, Metal-rendered) with native
   scrollback, momentum touch scrolling that also drives full-screen TUIs,
   long-press selection, and IME input.
+- **Attach Links** — silently collect web links to open or copy later.
 - **Terminal keyboard** — a Keys pad with control keys, reusable Snippets, and
   appearance controls next to the standard iOS keyboard; multiline or control
   pastes go through review before they hit the shell; on-device dictation.

--- a/Sources/HerdrMobile/Console/AgentAttachStore.swift
+++ b/Sources/HerdrMobile/Console/AgentAttachStore.swift
@@ -9,6 +9,7 @@ import Observation
 final class AgentAttachStore {
     private let target: String
     private let runTerminal: TerminalSessionRunner
+    private let linkIndex: AttachLinkIndex
 
     private(set) var terminal: AttachTerminalStore
     let input: TerminalInputController
@@ -33,8 +34,10 @@ final class AgentAttachStore {
         self.runTerminal = runTerminal
         self.transportGeneration = transportGeneration
         self.input = input
-        terminal = AttachTerminalStore(
-            target: target, input: input, runTerminal: runTerminal)
+        let linkIndex = AttachLinkIndex()
+        self.linkIndex = linkIndex
+        terminal = Self.makeTerminal(
+            target: target, input: input, runTerminal: runTerminal, linkIndex: linkIndex)
         image = ImageAttachStore(stageImage: stageImage, input: input)
         close = ClosePaneStore(paneTitle: paneTitle, close: closePane)
     }
@@ -49,6 +52,10 @@ final class AgentAttachStore {
 
     var terminalFeed: TerminalByteFeed {
         terminal.feed
+    }
+
+    var attachLinks: [AttachLink] {
+        linkIndex.links
     }
 
     var imageState: ImageAttachState {
@@ -149,10 +156,11 @@ final class AgentAttachStore {
             let previous = self.terminal
             await previous.stop()
             guard !self.hasLeft, self.transportGeneration == generation else { return }
-            self.terminal = AttachTerminalStore(
+            self.terminal = Self.makeTerminal(
                 target: self.target,
                 input: self.input,
-                runTerminal: self.runTerminal)
+                runTerminal: self.runTerminal,
+                linkIndex: self.linkIndex)
         }
     }
 
@@ -173,10 +181,12 @@ final class AgentAttachStore {
             return
         }
         hasLeft = true
+        linkIndex.clear()
         let transition = enqueueLifecycleTransition { [weak self] in
             guard let self else { return }
             await self.image.leaveAttach()
             await self.terminal.stop()
+            self.linkIndex.clear()
         }
         await transition.value
     }
@@ -199,5 +209,19 @@ final class AgentAttachStore {
             self?.lifecycleTask = nil
         }
         return task
+    }
+
+    private static func makeTerminal(
+        target: String,
+        input: TerminalInputController,
+        runTerminal: @escaping TerminalSessionRunner,
+        linkIndex: AttachLinkIndex
+    ) -> AttachTerminalStore {
+        AttachTerminalStore(
+            target: target,
+            input: input,
+            observeOutput: { data in linkIndex.receive(data) },
+            finishOutput: { linkIndex.finishOutput() },
+            runTerminal: runTerminal)
     }
 }

--- a/Sources/HerdrMobile/Console/AgentAttachStore.swift
+++ b/Sources/HerdrMobile/Console/AgentAttachStore.swift
@@ -87,6 +87,11 @@ final class AgentAttachStore {
         terminal.viewDidResize(cols: cols, rows: rows)
     }
 
+    func viewportTextDidChange(_ text: String) {
+        guard !hasLeft else { return }
+        linkIndex.receiveViewportText(text)
+    }
+
     func send(_ keystrokes: Data) {
         terminal.send(keystrokes)
     }

--- a/Sources/HerdrMobile/Console/AgentAttachStore.swift
+++ b/Sources/HerdrMobile/Console/AgentAttachStore.swift
@@ -1,6 +1,17 @@
 import Foundation
 import Observation
 
+typealias AttachLinkOpener = @MainActor @Sendable (URL) async -> Bool
+
+struct AttachLinkOpenFailure: Identifiable, Equatable {
+    let link: AttachLink
+
+    var id: String { link.id }
+    var message: String {
+        "This link couldn't be opened. You can copy it instead."
+    }
+}
+
 /// Owns the complete Agent Attach interaction: terminal lifetime, input
 /// generation and pause state, image staging, reconnect replacement, close,
 /// and deterministic leave ordering. The view only forwards UI events.
@@ -10,11 +21,13 @@ final class AgentAttachStore {
     private let target: String
     private let runTerminal: TerminalSessionRunner
     private let linkIndex: AttachLinkIndex
+    private let linkPrompt: AttachLinkPromptController
 
     private(set) var terminal: AttachTerminalStore
     let input: TerminalInputController
     let image: ImageAttachStore
     let close: ClosePaneStore
+    private(set) var attachLinkOpenFailure: AttachLinkOpenFailure?
 
     private var transportGeneration: UInt64?
     private var lifecycleTask: Task<Void, Never>?
@@ -27,14 +40,19 @@ final class AgentAttachStore {
         transportGeneration: UInt64?,
         runTerminal: @escaping TerminalSessionRunner,
         stageImage: @escaping ImageStager,
+        linkPromptClock: AttachLinkPromptClock = .continuous,
         closePane: @escaping () async throws -> Void
     ) {
         let input = TerminalInputController()
+        let linkPrompt = AttachLinkPromptController(clock: linkPromptClock)
         self.target = target
         self.runTerminal = runTerminal
         self.transportGeneration = transportGeneration
         self.input = input
-        let linkIndex = AttachLinkIndex()
+        self.linkPrompt = linkPrompt
+        let linkIndex = AttachLinkIndex { link in
+            linkPrompt.present(link)
+        }
         self.linkIndex = linkIndex
         terminal = Self.makeTerminal(
             target: target, input: input, runTerminal: runTerminal, linkIndex: linkIndex)
@@ -56,6 +74,10 @@ final class AgentAttachStore {
 
     var attachLinks: [AttachLink] {
         linkIndex.links
+    }
+
+    var attachLinkPrompt: AttachLink? {
+        linkPrompt.prompt
     }
 
     var imageState: ImageAttachState {
@@ -90,6 +112,30 @@ final class AgentAttachStore {
     func viewportTextDidChange(_ text: String) {
         guard !hasLeft else { return }
         linkIndex.receiveViewportText(text)
+    }
+
+    func viewActivityDidChange(isActive: Bool) {
+        guard !hasLeft else { return }
+        linkPrompt.setActive(isActive)
+    }
+
+    func openAttachLink(_ link: AttachLink, using open: AttachLinkOpener) async {
+        guard !hasLeft else { return }
+        linkPrompt.dismiss()
+        attachLinkOpenFailure = nil
+        let accepted = await open(link.url)
+        guard !hasLeft, !accepted else { return }
+        attachLinkOpenFailure = AttachLinkOpenFailure(link: link)
+    }
+
+    func copyFailedAttachLink(using copy: (String) -> Void) {
+        guard let failure = attachLinkOpenFailure else { return }
+        copy(failure.link.target)
+        attachLinkOpenFailure = nil
+    }
+
+    func dismissAttachLinkOpenFailure() {
+        attachLinkOpenFailure = nil
     }
 
     func send(_ keystrokes: Data) {
@@ -186,6 +232,8 @@ final class AgentAttachStore {
             return
         }
         hasLeft = true
+        linkPrompt.leave()
+        attachLinkOpenFailure = nil
         linkIndex.clear()
         let transition = enqueueLifecycleTransition { [weak self] in
             guard let self else { return }
@@ -228,5 +276,73 @@ final class AgentAttachStore {
             observeOutput: { data in linkIndex.receive(data) },
             finishOutput: { linkIndex.finishOutput() },
             runTerminal: runTerminal)
+    }
+}
+
+struct AttachLinkPromptClock: Sendable {
+    private let sleepOperation: @Sendable (Duration) async throws -> Void
+
+    static let continuous = AttachLinkPromptClock { duration in
+        try await Task.sleep(for: duration)
+    }
+
+    init(sleep: @escaping @Sendable (Duration) async throws -> Void) {
+        sleepOperation = sleep
+    }
+
+    func sleep(for duration: Duration) async throws {
+        try await sleepOperation(duration)
+    }
+}
+
+@MainActor
+@Observable
+private final class AttachLinkPromptController {
+    static let duration: Duration = .seconds(4)
+
+    private(set) var prompt: AttachLink?
+
+    @ObservationIgnored private let clock: AttachLinkPromptClock
+    @ObservationIgnored private var expiryTask: Task<Void, Never>?
+    @ObservationIgnored private var isActive = true
+
+    init(clock: AttachLinkPromptClock) {
+        self.clock = clock
+    }
+
+    func present(_ link: AttachLink) {
+        guard isActive else { return }
+        expiryTask?.cancel()
+        prompt = link
+        expiryTask = Task { [weak self, clock] in
+            do {
+                try await clock.sleep(for: Self.duration)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            self?.prompt = nil
+        }
+    }
+
+    func setActive(_ isActive: Bool) {
+        self.isActive = isActive
+        guard !isActive else { return }
+        cancelPrompt()
+    }
+
+    func dismiss() {
+        cancelPrompt()
+    }
+
+    func leave() {
+        isActive = false
+        cancelPrompt()
+    }
+
+    private func cancelPrompt() {
+        expiryTask?.cancel()
+        expiryTask = nil
+        prompt = nil
     }
 }

--- a/Sources/HerdrMobile/Console/AgentAttachStore.swift
+++ b/Sources/HerdrMobile/Console/AgentAttachStore.swift
@@ -21,7 +21,6 @@ final class AgentAttachStore {
     private let target: String
     private let runTerminal: TerminalSessionRunner
     private let linkIndex: AttachLinkIndex
-    private let linkPrompt: AttachLinkPromptController
 
     private(set) var terminal: AttachTerminalStore
     let input: TerminalInputController
@@ -42,19 +41,14 @@ final class AgentAttachStore {
         transportGeneration: UInt64?,
         runTerminal: @escaping TerminalSessionRunner,
         stageImage: @escaping ImageStager,
-        linkPromptClock: AttachLinkPromptClock = .continuous,
         closePane: @escaping () async throws -> Void
     ) {
         let input = TerminalInputController()
-        let linkPrompt = AttachLinkPromptController(clock: linkPromptClock)
         self.target = target
         self.runTerminal = runTerminal
         self.transportGeneration = transportGeneration
         self.input = input
-        self.linkPrompt = linkPrompt
-        let linkIndex = AttachLinkIndex { link in
-            linkPrompt.present(link)
-        }
+        let linkIndex = AttachLinkIndex()
         self.linkIndex = linkIndex
         terminal = Self.makeTerminal(
             target: target, input: input, runTerminal: runTerminal, linkIndex: linkIndex)
@@ -76,10 +70,6 @@ final class AgentAttachStore {
 
     var attachLinks: [AttachLink] {
         linkIndex.links
-    }
-
-    var attachLinkPrompt: AttachLink? {
-        linkPrompt.prompt
     }
 
     var imageState: ImageAttachState {
@@ -116,14 +106,8 @@ final class AgentAttachStore {
         linkIndex.receiveViewportText(text)
     }
 
-    func viewActivityDidChange(isActive: Bool) {
-        guard !hasLeft else { return }
-        linkPrompt.setActive(isActive)
-    }
-
     func openAttachLink(_ link: AttachLink, using open: @escaping AttachLinkOpener) {
         guard !hasLeft else { return }
-        linkPrompt.dismiss()
         attachLinkOpenFailure = nil
         invalidateAttachLinkOpen()
         let openID = attachLinkOpenID
@@ -248,7 +232,6 @@ final class AgentAttachStore {
         }
         hasLeft = true
         invalidateAttachLinkOpen()
-        linkPrompt.leave()
         attachLinkOpenFailure = nil
         linkIndex.clear()
         let transition = enqueueLifecycleTransition { [weak self] in
@@ -298,82 +281,5 @@ final class AgentAttachStore {
             observeOutput: { data in linkIndex.receive(data) },
             finishOutput: { linkIndex.finishOutput() },
             runTerminal: runTerminal)
-    }
-}
-
-struct AttachLinkPromptClock: Sendable {
-    private let sleepOperation: @Sendable (Duration) async throws -> Void
-
-    static let continuous = AttachLinkPromptClock { duration in
-        try await Task.sleep(for: duration)
-    }
-
-    init(sleep: @escaping @Sendable (Duration) async throws -> Void) {
-        sleepOperation = sleep
-    }
-
-    func sleep(for duration: Duration) async throws {
-        try await sleepOperation(duration)
-    }
-}
-
-@MainActor
-@Observable
-private final class AttachLinkPromptController {
-    static let duration: Duration = .seconds(4)
-
-    private(set) var prompt: AttachLink?
-
-    @ObservationIgnored private let clock: AttachLinkPromptClock
-    @ObservationIgnored private var expiryTask: Task<Void, Never>?
-    @ObservationIgnored private var expiryID: UInt64 = 0
-    @ObservationIgnored private var isActive = true
-
-    init(clock: AttachLinkPromptClock) {
-        self.clock = clock
-    }
-
-    func present(_ link: AttachLink) {
-        guard isActive else { return }
-        invalidateExpiry()
-        prompt = link
-        let id = expiryID
-        expiryTask = Task { [weak self, clock] in
-            do {
-                try await clock.sleep(for: Self.duration)
-            } catch {
-                return
-            }
-            guard !Task.isCancelled else { return }
-            guard let self, self.expiryID == id else { return }
-            self.expiryTask = nil
-            self.prompt = nil
-        }
-    }
-
-    func setActive(_ isActive: Bool) {
-        self.isActive = isActive
-        guard !isActive else { return }
-        cancelPrompt()
-    }
-
-    func dismiss() {
-        cancelPrompt()
-    }
-
-    func leave() {
-        isActive = false
-        cancelPrompt()
-    }
-
-    private func cancelPrompt() {
-        invalidateExpiry()
-        prompt = nil
-    }
-
-    private func invalidateExpiry() {
-        expiryID &+= 1
-        expiryTask?.cancel()
-        expiryTask = nil
     }
 }

--- a/Sources/HerdrMobile/Console/AgentAttachStore.swift
+++ b/Sources/HerdrMobile/Console/AgentAttachStore.swift
@@ -8,7 +8,7 @@ struct AttachLinkOpenFailure: Identifiable, Equatable {
 
     var id: String { link.id }
     var message: String {
-        "This link couldn't be opened. You can copy it instead."
+        "The link to \(link.host) couldn't be opened. You can copy it instead."
     }
 }
 

--- a/Sources/HerdrMobile/Console/AgentAttachStore.swift
+++ b/Sources/HerdrMobile/Console/AgentAttachStore.swift
@@ -32,6 +32,8 @@ final class AgentAttachStore {
     private var transportGeneration: UInt64?
     private var lifecycleTask: Task<Void, Never>?
     private var lifecycleID: UInt64 = 0
+    private var attachLinkOpenTask: Task<Void, Never>?
+    private var attachLinkOpenID: UInt64 = 0
     private var hasLeft = false
 
     init(
@@ -119,13 +121,26 @@ final class AgentAttachStore {
         linkPrompt.setActive(isActive)
     }
 
-    func openAttachLink(_ link: AttachLink, using open: AttachLinkOpener) async {
+    func openAttachLink(_ link: AttachLink, using open: @escaping AttachLinkOpener) {
         guard !hasLeft else { return }
         linkPrompt.dismiss()
         attachLinkOpenFailure = nil
-        let accepted = await open(link.url)
-        guard !hasLeft, !accepted else { return }
-        attachLinkOpenFailure = AttachLinkOpenFailure(link: link)
+        invalidateAttachLinkOpen()
+        let openID = attachLinkOpenID
+        attachLinkOpenTask = Task { @MainActor [weak self] in
+            let accepted = await open(link.url)
+            guard
+                let self,
+                !Task.isCancelled,
+                !self.hasLeft,
+                self.attachLinkOpenID == openID
+            else {
+                return
+            }
+            self.attachLinkOpenTask = nil
+            guard !accepted else { return }
+            self.attachLinkOpenFailure = AttachLinkOpenFailure(link: link)
+        }
     }
 
     func copyFailedAttachLink(using copy: (String) -> Void) {
@@ -232,6 +247,7 @@ final class AgentAttachStore {
             return
         }
         hasLeft = true
+        invalidateAttachLinkOpen()
         linkPrompt.leave()
         attachLinkOpenFailure = nil
         linkIndex.clear()
@@ -262,6 +278,12 @@ final class AgentAttachStore {
             self?.lifecycleTask = nil
         }
         return task
+    }
+
+    private func invalidateAttachLinkOpen() {
+        attachLinkOpenID &+= 1
+        attachLinkOpenTask?.cancel()
+        attachLinkOpenTask = nil
     }
 
     private static func makeTerminal(
@@ -304,6 +326,7 @@ private final class AttachLinkPromptController {
 
     @ObservationIgnored private let clock: AttachLinkPromptClock
     @ObservationIgnored private var expiryTask: Task<Void, Never>?
+    @ObservationIgnored private var expiryID: UInt64 = 0
     @ObservationIgnored private var isActive = true
 
     init(clock: AttachLinkPromptClock) {
@@ -312,8 +335,9 @@ private final class AttachLinkPromptController {
 
     func present(_ link: AttachLink) {
         guard isActive else { return }
-        expiryTask?.cancel()
+        invalidateExpiry()
         prompt = link
+        let id = expiryID
         expiryTask = Task { [weak self, clock] in
             do {
                 try await clock.sleep(for: Self.duration)
@@ -321,7 +345,9 @@ private final class AttachLinkPromptController {
                 return
             }
             guard !Task.isCancelled else { return }
-            self?.prompt = nil
+            guard let self, self.expiryID == id else { return }
+            self.expiryTask = nil
+            self.prompt = nil
         }
     }
 
@@ -341,8 +367,13 @@ private final class AttachLinkPromptController {
     }
 
     private func cancelPrompt() {
+        invalidateExpiry()
+        prompt = nil
+    }
+
+    private func invalidateExpiry() {
+        expiryID &+= 1
         expiryTask?.cancel()
         expiryTask = nil
-        prompt = nil
     }
 }

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -29,6 +29,7 @@ struct AgentDetailView: View {
     @State private var closeErrorMessage: String?
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.openURL) private var openURL
+    @Environment(\.scenePhase) private var scenePhase
 
     init(
         agent: ConsoleAgent,
@@ -87,76 +88,13 @@ struct AgentDetailView: View {
     }
 
     var body: some View {
-        terminalScreen
-            .id(attach.terminalID)
-        .overlay { statusOverlay }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            imageAttachStatus
-        }
-        // background(_:ignoresSafeAreaEdges:) defaults to .all: the theme
-        // colour reaches under the transparent navigation bar and into the
-        // home-indicator area without moving the terminal grid or touching
-        // keyboard resize. Must stay outside the safeAreaInset above.
-        .background(
-            terminal.themes.selection(for: colorScheme)
-                .surfaceBackground(for: colorScheme))
-        .toolbarColorScheme(
-            terminal.themes.selection(for: colorScheme)
-                .chromeColorScheme(for: colorScheme),
-            for: .navigationBar)
-        .navigationTitle(title)
-        .navigationBarTitleDisplayMode(.inline)
+        lifecycleSurface
+    }
+
+    private var presentedSurface: some View {
+        terminalSurface
         .toolbar {
-            if !attach.attachLinks.isEmpty {
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        isShowingAttachLinks = true
-                    } label: {
-                        HStack(spacing: 3) {
-                            Image(systemName: "link")
-                            Text("\(attach.attachLinks.count)")
-                                .monospacedDigit()
-                        }
-                    }
-                    .accessibilityLabel("Attach Links")
-                    .accessibilityValue("\(attach.attachLinks.count)")
-                    .popover(isPresented: $isShowingAttachLinks) {
-                        AttachLinksView(
-                            links: attach.attachLinks,
-                            open: { link in openURL(link.url) },
-                            copy: { link in UIPasteboard.general.string = link.target })
-                        .presentationCompactAdaptation(.sheet)
-                    }
-                }
-            }
-            ToolbarItem(placement: .primaryAction) {
-                PhotosPicker(selection: $selectedPhoto, matching: .images) {
-                    Label("Attach Image", systemImage: "photo.badge.plus")
-                }
-                .disabled(!attach.canSelectImage)
-                .accessibilityLabel("Attach Image")
-            }
-            ToolbarItem(placement: .primaryAction) {
-                Menu {
-                    Button("Settings", systemImage: "gearshape") {
-                        isShowingSettings = true
-                    }
-                    Button("Snippets", systemImage: "quote.bubble") {
-                        isManagingSnippets = true
-                    }
-                    Button("Rename Agent", systemImage: "pencil") {
-                        isRenamingAgent = true
-                    }
-                    Button("Rename Workspace", systemImage: "pencil.line") {
-                        isRenamingWorkspace = true
-                    }
-                    Button("Close Agent", systemImage: "trash", role: .destructive) {
-                        isConfirmingClose = true
-                    }
-                } label: {
-                    Label("More", systemImage: "ellipsis.circle")
-                }
-            }
+            toolbarContent
         }
         .sheet(isPresented: $isShowingSettings) {
             SettingsView(
@@ -210,6 +148,10 @@ struct AgentDetailView: View {
                 "This closes the pane on the Host and removes the agent everywhere. "
                     + "This can't be undone.")
         }
+    }
+
+    private var alertSurface: some View {
+        presentedSurface
         .alert(
             "Couldn't Close Agent",
             isPresented: Binding(
@@ -232,10 +174,42 @@ struct AgentDetailView: View {
         } message: {
             Text(attach.pasteErrorMessage ?? "")
         }
+        .alert(
+            "Couldn't Open Link",
+            isPresented: Binding(
+                get: { attach.attachLinkOpenFailure != nil },
+                set: { if !$0 { attach.dismissAttachLinkOpenFailure() } })
+        ) {
+            Button("Copy Link") {
+                attach.copyFailedAttachLink {
+                    UIPasteboard.general.string = $0
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                attach.dismissAttachLinkOpenFailure()
+            }
+        } message: {
+            Text(
+                attach.attachLinkOpenFailure?.message
+                    ?? "This link couldn't be opened.")
+        }
+    }
+
+    private var lifecycleSurface: some View {
+        alertSurface
         .onChange(of: selectedPhoto) { _, item in
             guard let item else { return }
             selectedPhoto = nil
             attach.selectImage(PhotosPickerImageSelection(item: item))
+        }
+        .onAppear {
+            attach.viewActivityDidChange(isActive: scenePhase == .active)
+        }
+        // Prompt visibility follows the raw scene phase, not the background
+        // connection grace period. Output can keep collecting while the app
+        // is out of sight, but it must not schedule UI for later.
+        .onChange(of: scenePhase) { _, phase in
+            attach.viewActivityDidChange(isActive: phase == .active)
         }
         // Follows the grace period, not the raw scene phase: an image upload
         // is exactly the work worth finishing while the app is briefly out of
@@ -252,7 +226,109 @@ struct AgentDetailView: View {
             attach.transportGenerationDidChange(generation)
         }
         .onDisappear {
+            attach.viewActivityDidChange(isActive: false)
             Task { await attach.leave() }
+        }
+    }
+
+    private var terminalSurface: some View {
+        terminalScreen
+            .id(attach.terminalID)
+        .overlay { statusOverlay }
+        // The prompt is an overlay, not an inset: it must never change the
+        // terminal's measured rows or the remote PTY geometry.
+        .overlay(alignment: .bottom) {
+            if let link = attach.attachLinkPrompt {
+                AttachLinkPromptView(link: link) {
+                    openAttachLink(link)
+                }
+                .padding(12)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .animation(.snappy, value: attach.attachLinkPrompt)
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            imageAttachStatus
+        }
+        // background(_:ignoresSafeAreaEdges:) defaults to .all: the theme
+        // colour reaches under the transparent navigation bar and into the
+        // home-indicator area without moving the terminal grid or touching
+        // keyboard resize. Must stay outside the safeAreaInset above.
+        .background(
+            terminal.themes.selection(for: colorScheme)
+                .surfaceBackground(for: colorScheme))
+        .toolbarColorScheme(
+            terminal.themes.selection(for: colorScheme)
+                .chromeColorScheme(for: colorScheme),
+            for: .navigationBar)
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        if !attach.attachLinks.isEmpty {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    isShowingAttachLinks = true
+                } label: {
+                    HStack(spacing: 3) {
+                        Image(systemName: "link")
+                        Text("\(attach.attachLinks.count)")
+                            .monospacedDigit()
+                    }
+                }
+                .accessibilityLabel("Attach Links")
+                .accessibilityValue("\(attach.attachLinks.count)")
+                .popover(isPresented: $isShowingAttachLinks) {
+                    AttachLinksView(
+                        links: attach.attachLinks,
+                        open: { link in openAttachLink(link) },
+                        copy: { link in UIPasteboard.general.string = link.target })
+                    .presentationCompactAdaptation(.sheet)
+                }
+            }
+        }
+        ToolbarItem(placement: .primaryAction) {
+            PhotosPicker(selection: $selectedPhoto, matching: .images) {
+                Label("Attach Image", systemImage: "photo.badge.plus")
+            }
+            .disabled(!attach.canSelectImage)
+            .accessibilityLabel("Attach Image")
+        }
+        ToolbarItem(placement: .primaryAction) {
+            Menu {
+                Button("Settings", systemImage: "gearshape") {
+                    isShowingSettings = true
+                }
+                Button("Snippets", systemImage: "quote.bubble") {
+                    isManagingSnippets = true
+                }
+                Button("Rename Agent", systemImage: "pencil") {
+                    isRenamingAgent = true
+                }
+                Button("Rename Workspace", systemImage: "pencil.line") {
+                    isRenamingWorkspace = true
+                }
+                Button("Close Agent", systemImage: "trash", role: .destructive) {
+                    isConfirmingClose = true
+                }
+            } label: {
+                Label("More", systemImage: "ellipsis.circle")
+            }
+        }
+    }
+
+    private func openAttachLink(_ link: AttachLink) {
+        let openURL = openURL
+        Task {
+            await attach.openAttachLink(link) { url in
+                await withCheckedContinuation { continuation in
+                    openURL(url) { accepted in
+                        continuation.resume(returning: accepted)
+                    }
+                }
+            }
         }
     }
 
@@ -415,6 +491,39 @@ private struct AttachLinksView: View {
             .navigationBarTitleDisplayMode(.inline)
         }
         .frame(idealWidth: 460, idealHeight: 520)
+    }
+}
+
+private struct AttachLinkPromptView: View {
+    let link: AttachLink
+    let open: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "link")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(link.host)
+                    .font(.headline)
+                    .lineLimit(1)
+                Text(link.target)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            Button("Open", systemImage: "arrow.up.right.square", action: open)
+                .labelStyle(.titleAndIcon)
+                .buttonStyle(.borderedProminent)
+                .accessibilityLabel("Open Attach Link")
+                .accessibilityValue(link.target)
+        }
+        .padding(12)
+        .background(.regularMaterial, in: .rect(cornerRadius: 14))
+        .shadow(color: .black.opacity(0.15), radius: 12, y: 4)
+        .accessibilityElement(children: .contain)
     }
 }
 

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -65,6 +65,9 @@ struct AgentDetailView: View {
         screen.onSizeChanged = { cols, rows in
             attach.viewDidResize(cols: cols, rows: rows)
         }
+        screen.onViewportTextChanged = { text in
+            attach.viewportTextDidChange(text)
+        }
         screen.onSend = { keystrokes in attach.send(keystrokes) }
         screen.onPaste = { text, bracketed in
             attach.requestPaste(text, bracketedPaste: bracketed)

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -1,5 +1,6 @@
 import PhotosUI
 import SwiftUI
+import UIKit
 
 /// The Agent detail screen: one interactive Attach terminal. Ghostty owns
 /// rendering, scrollback, and IME; the adapter routes input-row taps and touch
@@ -24,8 +25,10 @@ struct AgentDetailView: View {
     @State private var isManagingSnippets = false
     @State private var isRenamingAgent = false
     @State private var isRenamingWorkspace = false
+    @State private var isShowingAttachLinks = false
     @State private var closeErrorMessage: String?
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.openURL) private var openURL
 
     init(
         agent: ConsoleAgent,
@@ -101,6 +104,28 @@ struct AgentDetailView: View {
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            if !attach.attachLinks.isEmpty {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        isShowingAttachLinks = true
+                    } label: {
+                        HStack(spacing: 3) {
+                            Image(systemName: "link")
+                            Text("\(attach.attachLinks.count)")
+                                .monospacedDigit()
+                        }
+                    }
+                    .accessibilityLabel("Attach Links")
+                    .accessibilityValue("\(attach.attachLinks.count)")
+                    .popover(isPresented: $isShowingAttachLinks) {
+                        AttachLinksView(
+                            links: attach.attachLinks,
+                            open: { link in openURL(link.url) },
+                            copy: { link in UIPasteboard.general.string = link.target })
+                        .presentationCompactAdaptation(.sheet)
+                    }
+                }
+            }
             ToolbarItem(placement: .primaryAction) {
                 PhotosPicker(selection: $selectedPhoto, matching: .images) {
                     Label("Attach Image", systemImage: "photo.badge.plus")
@@ -349,6 +374,44 @@ struct AgentDetailView: View {
 
     private static func displayTitle(for agent: ConsoleAgent) -> String {
         agent.agent.title.isEmpty ? agent.agent.displayName : agent.agent.title
+    }
+}
+
+private struct AttachLinksView: View {
+    let links: [AttachLink]
+    let open: (AttachLink) -> Void
+    let copy: (AttachLink) -> Void
+
+    var body: some View {
+        NavigationStack {
+            List(links) { link in
+                Button {
+                    open(link)
+                } label: {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(link.host)
+                            .font(.headline)
+                            .foregroundStyle(.primary)
+                        Text(link.target)
+                            .font(.footnote.monospaced())
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(.rect)
+                }
+                .buttonStyle(.plain)
+                .contextMenu {
+                    Button("Copy Link", systemImage: "doc.on.doc") {
+                        copy(link)
+                    }
+                }
+            }
+            .navigationTitle("Attach Links")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .frame(idealWidth: 460, idealHeight: 520)
     }
 }
 

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -321,13 +321,21 @@ struct AgentDetailView: View {
 
     private func openAttachLink(_ link: AttachLink) {
         let openURL = openURL
-        Task {
-            await attach.openAttachLink(link) { url in
-                await withCheckedContinuation { continuation in
-                    openURL(url) { accepted in
-                        continuation.resume(returning: accepted)
-                    }
+        attach.openAttachLink(link) { url in
+            guard !Task.isCancelled else { return false }
+            let (results, continuation) = AsyncStream<Bool>.makeStream(
+                bufferingPolicy: .bufferingNewest(1))
+            openURL(url) { accepted in
+                continuation.yield(accepted)
+                continuation.finish()
+            }
+            return await withTaskCancellationHandler {
+                for await accepted in results {
+                    return accepted
                 }
+                return false
+            } onCancel: {
+                continuation.finish()
             }
         }
     }

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -279,7 +279,7 @@ struct AgentDetailView: View {
                     }
                 }
                 .accessibilityLabel("Attach Links")
-                .accessibilityValue("\(attach.attachLinks.count)")
+                .accessibilityValue(attachLinkCountDescription)
                 .popover(isPresented: $isShowingAttachLinks) {
                     AttachLinksView(
                         links: attach.attachLinks,
@@ -459,6 +459,11 @@ struct AgentDetailView: View {
         Self.displayTitle(for: agent)
     }
 
+    private var attachLinkCountDescription: String {
+        let count = attach.attachLinks.count
+        return count == 1 ? "1 distinct link" : "\(count) distinct links"
+    }
+
     private static func displayTitle(for agent: ConsoleAgent) -> String {
         agent.agent.title.isEmpty ? agent.agent.displayName : agent.agent.title
     }
@@ -489,6 +494,12 @@ private struct AttachLinksView: View {
                     .contentShape(.rect)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(link.host)
+                .accessibilityValue(link.target)
+                .accessibilityHint("Opens in your default browser")
+                .accessibilityAction(named: "Copy Link") {
+                    copy(link)
+                }
                 .contextMenu {
                     Button("Copy Link", systemImage: "doc.on.doc") {
                         copy(link)
@@ -505,33 +516,63 @@ private struct AttachLinksView: View {
 private struct AttachLinkPromptView: View {
     let link: AttachLink
     let open: () -> Void
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     var body: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "link")
-                .foregroundStyle(.secondary)
-                .accessibilityHidden(true)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(link.host)
-                    .font(.headline)
-                    .lineLimit(1)
-                Text(link.target)
-                    .font(.caption.monospaced())
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack(alignment: .top, spacing: 12) {
+                        linkIcon
+                        destination
+                    }
+                    openButton
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+            } else {
+                HStack(spacing: 12) {
+                    linkIcon
+                    destination
+                    openButton
+                }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            Button("Open", systemImage: "arrow.up.right.square", action: open)
-                .labelStyle(.titleAndIcon)
-                .buttonStyle(.borderedProminent)
-                .accessibilityLabel("Open Attach Link")
-                .accessibilityValue(link.target)
         }
         .padding(12)
         .background(.regularMaterial, in: .rect(cornerRadius: 14))
         .shadow(color: .black.opacity(0.15), radius: 12, y: 4)
         .accessibilityElement(children: .contain)
+    }
+
+    private var linkIcon: some View {
+        Image(systemName: "link")
+            .foregroundStyle(.secondary)
+            .accessibilityHidden(true)
+    }
+
+    private var destination: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(link.host)
+                .font(.headline)
+                .lineLimit(1)
+            Text(link.target)
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 3 : 1)
+                .truncationMode(.middle)
+                .fixedSize(horizontal: false, vertical: dynamicTypeSize.isAccessibilitySize)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Attach Link from \(link.host)")
+        .accessibilityValue(link.target)
+    }
+
+    private var openButton: some View {
+        Button("Open", systemImage: "arrow.up.right.square", action: open)
+            .labelStyle(.titleAndIcon)
+            .buttonStyle(.borderedProminent)
+            .accessibilityLabel("Open Attach Link")
+            .accessibilityValue(link.target)
     }
 }
 

--- a/Sources/HerdrMobile/Console/AgentDetailView.swift
+++ b/Sources/HerdrMobile/Console/AgentDetailView.swift
@@ -29,7 +29,6 @@ struct AgentDetailView: View {
     @State private var closeErrorMessage: String?
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.openURL) private var openURL
-    @Environment(\.scenePhase) private var scenePhase
 
     init(
         agent: ConsoleAgent,
@@ -202,15 +201,6 @@ struct AgentDetailView: View {
             selectedPhoto = nil
             attach.selectImage(PhotosPickerImageSelection(item: item))
         }
-        .onAppear {
-            attach.viewActivityDidChange(isActive: scenePhase == .active)
-        }
-        // Prompt visibility follows the raw scene phase, not the background
-        // connection grace period. Output can keep collecting while the app
-        // is out of sight, but it must not schedule UI for later.
-        .onChange(of: scenePhase) { _, phase in
-            attach.viewActivityDidChange(isActive: phase == .active)
-        }
         // Follows the grace period, not the raw scene phase: an image upload
         // is exactly the work worth finishing while the app is briefly out of
         // sight, and it is cancelled only once the app really suspends.
@@ -226,7 +216,6 @@ struct AgentDetailView: View {
             attach.transportGenerationDidChange(generation)
         }
         .onDisappear {
-            attach.viewActivityDidChange(isActive: false)
             Task { await attach.leave() }
         }
     }
@@ -235,18 +224,6 @@ struct AgentDetailView: View {
         terminalScreen
             .id(attach.terminalID)
         .overlay { statusOverlay }
-        // The prompt is an overlay, not an inset: it must never change the
-        // terminal's measured rows or the remote PTY geometry.
-        .overlay(alignment: .bottom) {
-            if let link = attach.attachLinkPrompt {
-                AttachLinkPromptView(link: link) {
-                    openAttachLink(link)
-                }
-                .padding(12)
-                .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
-        }
-        .animation(.snappy, value: attach.attachLinkPrompt)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             imageAttachStatus
         }
@@ -510,69 +487,6 @@ private struct AttachLinksView: View {
             .navigationBarTitleDisplayMode(.inline)
         }
         .frame(idealWidth: 460, idealHeight: 520)
-    }
-}
-
-private struct AttachLinkPromptView: View {
-    let link: AttachLink
-    let open: () -> Void
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-
-    var body: some View {
-        Group {
-            if dynamicTypeSize.isAccessibilitySize {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack(alignment: .top, spacing: 12) {
-                        linkIcon
-                        destination
-                    }
-                    openButton
-                        .frame(maxWidth: .infinity, alignment: .trailing)
-                }
-            } else {
-                HStack(spacing: 12) {
-                    linkIcon
-                    destination
-                    openButton
-                }
-            }
-        }
-        .padding(12)
-        .background(.regularMaterial, in: .rect(cornerRadius: 14))
-        .shadow(color: .black.opacity(0.15), radius: 12, y: 4)
-        .accessibilityElement(children: .contain)
-    }
-
-    private var linkIcon: some View {
-        Image(systemName: "link")
-            .foregroundStyle(.secondary)
-            .accessibilityHidden(true)
-    }
-
-    private var destination: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(link.host)
-                .font(.headline)
-                .lineLimit(1)
-            Text(link.target)
-                .font(.caption.monospaced())
-                .foregroundStyle(.secondary)
-                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 3 : 1)
-                .truncationMode(.middle)
-                .fixedSize(horizontal: false, vertical: dynamicTypeSize.isAccessibilitySize)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Attach Link from \(link.host)")
-        .accessibilityValue(link.target)
-    }
-
-    private var openButton: some View {
-        Button("Open", systemImage: "arrow.up.right.square", action: open)
-            .labelStyle(.titleAndIcon)
-            .buttonStyle(.borderedProminent)
-            .accessibilityLabel("Open Attach Link")
-            .accessibilityValue(link.target)
     }
 }
 

--- a/Sources/HerdrMobile/Console/AttachLinkIndex.swift
+++ b/Sources/HerdrMobile/Console/AttachLinkIndex.swift
@@ -20,7 +20,7 @@ final class AttachLinkIndex {
 
     private(set) var links: [AttachLink] = []
 
-    private var scanner = PlainAttachLinkScanner()
+    private var scanner = AttachLinkScanner()
 
     func receive(_ data: Data) {
         var scanner = scanner
@@ -30,19 +30,37 @@ final class AttachLinkIndex {
         self.scanner = scanner
     }
 
-    func finishOutput() {
-        if let target = scanner.finishOutput() {
-            record(target)
+    /// Supplements stream discovery from Ghostty's current visible text.
+    /// Every snapshot is independent: its newlines remain hard boundaries
+    /// because the embedding API does not identify visual soft wraps.
+    func receiveViewportText(_ text: String) {
+        var viewportScanner = AttachLinkScanner()
+        viewportScanner.receive(Data(text.utf8)) { target in
+            record(target, moveExistingToFront: false)
+        }
+        viewportScanner.finishOutput { target in
+            record(target, moveExistingToFront: false)
         }
     }
 
+    func finishOutput() {
+        var scanner = scanner
+        scanner.finishOutput { target in
+            record(target)
+        }
+        self.scanner = scanner
+    }
+
     func clear() {
-        scanner = PlainAttachLinkScanner()
+        scanner = AttachLinkScanner()
         links.removeAll(keepingCapacity: false)
     }
 
-    private func record(_ target: String) {
+    private func record(_ target: String, moveExistingToFront: Bool = true) {
         guard let url = TerminalLinkPolicy.url(for: target) else { return }
+        if !moveExistingToFront, links.contains(where: { $0.target == target }) {
+            return
+        }
         let link = AttachLink(target: target, url: url)
         links.removeAll { $0.target == link.target }
         links.insert(link, at: 0)
@@ -52,9 +70,247 @@ final class AttachLinkIndex {
     }
 }
 
-/// Recognizes plain web targets directly from the PTY byte stream. Network
-/// chunk boundaries are invisible here; actual control and whitespace bytes
-/// terminate candidates. Both state buffers have hard upper bounds.
+/// Removes terminal control content while preserving stream state across
+/// arbitrary PTY chunks. SGR styling is transparent to visible URLs; other
+/// controls end plain candidates. OSC 8 targets are collected explicitly so
+/// their labels cannot hide or replace the real destination.
+private struct AttachLinkScanner {
+    private enum State: Equatable {
+        case text
+        case escape
+        case escapeSequence
+        case csi
+        case osc
+        case oscEscape
+        case stringControl
+        case stringControlEscape
+    }
+
+    private var state = State.text
+    private var plain = PlainAttachLinkScanner()
+    private var osc = OSC8Accumulator()
+    private var isOSC8LabelActive = false
+
+    mutating func receive(_ data: Data, record: (String) -> Void) {
+        for byte in data {
+            receive(byte, record: record)
+        }
+    }
+
+    mutating func finishOutput(record: (String) -> Void) {
+        if state != .text {
+            finishPlainCandidate(record: record)
+        } else if !isOSC8LabelActive, let target = plain.finishOutput() {
+            record(target)
+        }
+        state = .text
+        osc.reset()
+        isOSC8LabelActive = false
+    }
+
+    private mutating func receive(_ byte: UInt8, record: (String) -> Void) {
+        switch state {
+        case .text:
+            receiveText(byte, record: record)
+
+        case .escape:
+            receiveAfterEscape(byte, record: record)
+
+        case .escapeSequence:
+            if (0x30...0x7E).contains(byte) {
+                state = .text
+            } else if byte == 0x1B {
+                state = .escape
+            }
+
+        case .csi:
+            if (0x40...0x7E).contains(byte) {
+                if byte != 0x6D {
+                    finishPlainCandidate(record: record)
+                }
+                state = .text
+            } else if byte == 0x1B {
+                finishPlainCandidate(record: record)
+                state = .escape
+            }
+
+        case .osc:
+            if byte == 0x07 || byte == 0x9C {
+                finishOSC(record: record)
+            } else if byte == 0x1B {
+                state = .oscEscape
+            } else {
+                osc.receive(byte)
+            }
+
+        case .oscEscape:
+            if byte == 0x5C {
+                finishOSC(record: record)
+            } else {
+                osc.invalidate()
+                state = byte == 0x1B ? .oscEscape : .osc
+            }
+
+        case .stringControl:
+            if byte == 0x9C {
+                state = .text
+            } else if byte == 0x1B {
+                state = .stringControlEscape
+            }
+
+        case .stringControlEscape:
+            state = byte == 0x5C ? .text : .stringControl
+        }
+    }
+
+    private mutating func receiveText(_ byte: UInt8, record: (String) -> Void) {
+        switch byte {
+        case 0x1B:
+            state = .escape
+        case 0x9B:
+            state = .csi
+        case 0x9D:
+            osc.reset()
+            state = .osc
+        case 0x90, 0x98, 0x9E, 0x9F:
+            finishPlainCandidate(record: record)
+            state = .stringControl
+        default:
+            guard !isOSC8LabelActive else { return }
+            plain.receive(byte, record: record)
+        }
+    }
+
+    private mutating func receiveAfterEscape(
+        _ byte: UInt8,
+        record: (String) -> Void
+    ) {
+        switch byte {
+        case 0x5B:
+            state = .csi
+        case 0x5D:
+            osc.reset()
+            state = .osc
+        case 0x50, 0x58, 0x5E, 0x5F:
+            finishPlainCandidate(record: record)
+            state = .stringControl
+        case 0x20...0x2F:
+            finishPlainCandidate(record: record)
+            state = .escapeSequence
+        default:
+            finishPlainCandidate(record: record)
+            state = .text
+        }
+    }
+
+    private mutating func finishOSC(record: (String) -> Void) {
+        defer {
+            osc.reset()
+            state = .text
+        }
+        guard let hyperlink = osc.hyperlink else {
+            finishPlainCandidate(record: record)
+            return
+        }
+
+        finishPlainCandidate(record: record)
+        switch hyperlink {
+        case .close:
+            isOSC8LabelActive = false
+        case .open(let target):
+            isOSC8LabelActive = true
+            if let target {
+                record(target)
+            }
+        }
+    }
+
+    private mutating func finishPlainCandidate(record: (String) -> Void) {
+        guard !isOSC8LabelActive, let target = plain.finishOutput() else { return }
+        record(target)
+    }
+}
+
+private struct OSC8Accumulator {
+    enum Hyperlink {
+        case open(String?)
+        case close
+    }
+
+    private enum Field: Equatable {
+        case command
+        case parameters
+        case target
+        case ignored
+    }
+
+    private static let maximumTargetBytes = 32 * 1024
+    private static let maximumCommandBytes = 16
+
+    private var field = Field.command
+    private var command = Data()
+    private var target = Data()
+    private var isTargetOversized = false
+
+    var hyperlink: Hyperlink? {
+        guard field == .target else { return nil }
+        guard !target.isEmpty else { return .close }
+        guard !isTargetOversized,
+            let target = String(data: target, encoding: .utf8)
+        else {
+            return .open(nil)
+        }
+        return .open(target)
+    }
+
+    mutating func receive(_ byte: UInt8) {
+        switch field {
+        case .command:
+            if byte == 0x3B {
+                field = command == Data("8".utf8) ? .parameters : .ignored
+            } else if command.count < Self.maximumCommandBytes {
+                command.append(byte)
+            } else {
+                field = .ignored
+            }
+
+        case .parameters:
+            if byte == 0x3B {
+                field = .target
+            }
+
+        case .target:
+            guard !isTargetOversized else { return }
+            guard target.count < Self.maximumTargetBytes else {
+                target.removeAll(keepingCapacity: false)
+                isTargetOversized = true
+                return
+            }
+            target.append(byte)
+
+        case .ignored:
+            break
+        }
+    }
+
+    mutating func invalidate() {
+        field = .ignored
+        command.removeAll(keepingCapacity: false)
+        target.removeAll(keepingCapacity: false)
+        isTargetOversized = false
+    }
+
+    mutating func reset() {
+        field = .command
+        command.removeAll(keepingCapacity: true)
+        target.removeAll(keepingCapacity: true)
+        isTargetOversized = false
+    }
+}
+
+/// Recognizes plain web targets from printable terminal text. Network chunk
+/// boundaries are invisible here; actual whitespace terminates candidates.
+/// Both state buffers have hard upper bounds.
 private struct PlainAttachLinkScanner {
     private static let maximumTargetBytes = 32 * 1024
     private static let longestSchemeBytes = Array("https://".utf8)
@@ -70,28 +326,32 @@ private struct PlainAttachLinkScanner {
 
     mutating func receive(_ data: Data, record: (String) -> Void) {
         for byte in data {
-            if Self.isBoundary(byte) {
-                if let target = finishCandidate() {
-                    record(target)
-                }
-                recent.removeAll(keepingCapacity: true)
-                continue
-            }
-
-            if !candidate.isEmpty || isOversized {
-                appendToCandidate(byte)
-                continue
-            }
-
-            recent.append(byte)
-            if recent.count > Self.longestSchemeBytes.count {
-                recent.removeFirst(recent.count - Self.longestSchemeBytes.count)
-            }
-            guard let scheme = Self.webSchemes.first(where: { recentEnds(with: $0) })
-            else { continue }
-            candidate = Data(recent.suffix(scheme.count))
-            recent.removeAll(keepingCapacity: true)
+            receive(byte, record: record)
         }
+    }
+
+    mutating func receive(_ byte: UInt8, record: (String) -> Void) {
+        if Self.isBoundary(byte) {
+            if let target = finishCandidate() {
+                record(target)
+            }
+            recent.removeAll(keepingCapacity: true)
+            return
+        }
+
+        if !candidate.isEmpty || isOversized {
+            appendToCandidate(byte)
+            return
+        }
+
+        recent.append(byte)
+        if recent.count > Self.longestSchemeBytes.count {
+            recent.removeFirst(recent.count - Self.longestSchemeBytes.count)
+        }
+        guard let scheme = Self.webSchemes.first(where: { recentEnds(with: $0) })
+        else { return }
+        candidate = Data(recent.suffix(scheme.count))
+        recent.removeAll(keepingCapacity: true)
     }
 
     mutating func finishOutput() -> String? {

--- a/Sources/HerdrMobile/Console/AttachLinkIndex.swift
+++ b/Sources/HerdrMobile/Console/AttachLinkIndex.swift
@@ -331,8 +331,8 @@ private struct PlainAttachLinkScanner {
     ]
     private static let trailingSentencePunctuation = CharacterSet(charactersIn: ".,;:!")
 
-    private var recent = Data()
-    private var candidate = Data()
+    private var recent: [UInt8] = []
+    private var candidate: [UInt8] = []
     private var isOversized = false
 
     mutating func receive(_ data: Data, record: (String) -> Void) {
@@ -361,7 +361,7 @@ private struct PlainAttachLinkScanner {
         }
         guard let scheme = Self.webSchemes.first(where: { recentEnds(with: $0) })
         else { return }
-        candidate = Data(recent.suffix(scheme.count))
+        candidate = Array(recent.suffix(scheme.count))
         recent.removeAll(keepingCapacity: true)
     }
 
@@ -385,7 +385,7 @@ private struct PlainAttachLinkScanner {
             candidate.removeAll(keepingCapacity: true)
             isOversized = false
         }
-        guard !isOversized, let text = String(data: candidate, encoding: .utf8) else {
+        guard !isOversized, let text = String(bytes: candidate, encoding: .utf8) else {
             return nil
         }
         let target = Self.removingSurroundingPunctuation(from: text)

--- a/Sources/HerdrMobile/Console/AttachLinkIndex.swift
+++ b/Sources/HerdrMobile/Console/AttachLinkIndex.swift
@@ -22,6 +22,8 @@ final class AttachLinkIndex {
 
     @ObservationIgnored private let onDistinctLink: (AttachLink) -> Void
     private var scanner = AttachLinkScanner()
+    private var streamObservedTargets: Set<String> = []
+    private var viewportOnlyTargets: Set<String> = []
 
     init(onDistinctLink: @escaping (AttachLink) -> Void) {
         self.onDistinctLink = onDistinctLink
@@ -30,42 +32,83 @@ final class AttachLinkIndex {
     func receive(_ data: Data) {
         var scanner = scanner
         scanner.receive(data) { target in
-            record(target)
+            recordStreamTarget(target)
         }
         self.scanner = scanner
     }
 
     /// Supplements stream discovery from Ghostty's current visible text.
     /// Every snapshot is independent: its newlines remain hard boundaries
-    /// because the embedding API does not identify visual soft wraps.
+    /// because the embedding API does not identify visual soft wraps. Viewport
+    /// candidates are provisional: only the longest member of an ambiguous
+    /// prefix family is kept unless the stream observed the shorter target.
     func receiveViewportText(_ text: String) {
         var viewportScanner = AttachLinkScanner()
         viewportScanner.receive(Data(text.utf8)) { target in
-            record(target, moveExistingToFront: false)
+            recordViewportTarget(target)
         }
         viewportScanner.finishOutput { target in
-            record(target, moveExistingToFront: false)
+            recordViewportTarget(target)
         }
     }
 
     func finishOutput() {
         var scanner = scanner
         scanner.finishOutput { target in
-            record(target)
+            recordStreamTarget(target)
         }
         self.scanner = scanner
     }
 
     func clear() {
         scanner = AttachLinkScanner()
+        streamObservedTargets.removeAll(keepingCapacity: false)
+        viewportOnlyTargets.removeAll(keepingCapacity: false)
         links.removeAll(keepingCapacity: false)
     }
 
-    private func record(_ target: String, moveExistingToFront: Bool = true) {
-        guard let url = TerminalLinkPolicy.url(for: target) else { return }
+    private func recordStreamTarget(_ target: String) {
+        guard TerminalLinkPolicy.url(for: target) != nil else { return }
+        removeViewportOnlyPrefixes(of: target)
+        guard record(target) else { return }
+        streamObservedTargets.insert(target)
+        viewportOnlyTargets.remove(target)
+    }
+
+    private func recordViewportTarget(_ target: String) {
+        guard TerminalLinkPolicy.url(for: target) != nil else { return }
+        guard
+            !links.contains(where: {
+                $0.target != target && $0.target.hasPrefix(target)
+            })
+        else {
+            return
+        }
+        removeViewportOnlyPrefixes(of: target)
+        guard record(target, moveExistingToFront: false) else { return }
+        if !streamObservedTargets.contains(target) {
+            viewportOnlyTargets.insert(target)
+        }
+    }
+
+    private func removeViewportOnlyPrefixes(of target: String) {
+        let prefixes = viewportOnlyTargets.filter {
+            $0 != target && target.hasPrefix($0)
+        }
+        guard !prefixes.isEmpty else { return }
+        links.removeAll { prefixes.contains($0.target) }
+        viewportOnlyTargets.subtract(prefixes)
+    }
+
+    @discardableResult
+    private func record(
+        _ target: String,
+        moveExistingToFront: Bool = true
+    ) -> Bool {
+        guard let url = TerminalLinkPolicy.url(for: target) else { return false }
         let isDistinct = !links.contains(where: { $0.target == target })
         if !moveExistingToFront, !isDistinct {
-            return
+            return true
         }
         let link = AttachLink(target: target, url: url)
         links.removeAll { $0.target == link.target }
@@ -73,9 +116,13 @@ final class AttachLinkIndex {
         if links.count > Self.maximumLinkCount {
             links.removeLast(links.count - Self.maximumLinkCount)
         }
+        let retainedTargets = Set(links.map(\.target))
+        streamObservedTargets.formIntersection(retainedTargets)
+        viewportOnlyTargets.formIntersection(retainedTargets)
         if isDistinct {
             onDistinctLink(link)
         }
+        return true
     }
 }
 

--- a/Sources/HerdrMobile/Console/AttachLinkIndex.swift
+++ b/Sources/HerdrMobile/Console/AttachLinkIndex.swift
@@ -23,9 +23,11 @@ final class AttachLinkIndex {
     private var scanner = PlainAttachLinkScanner()
 
     func receive(_ data: Data) {
-        for target in scanner.receive(data) {
+        var scanner = scanner
+        scanner.receive(data) { target in
             record(target)
         }
+        self.scanner = scanner
     }
 
     func finishOutput() {
@@ -66,12 +68,11 @@ private struct PlainAttachLinkScanner {
     private var candidate = Data()
     private var isOversized = false
 
-    mutating func receive(_ data: Data) -> [String] {
-        var targets: [String] = []
+    mutating func receive(_ data: Data, record: (String) -> Void) {
         for byte in data {
             if Self.isBoundary(byte) {
                 if let target = finishCandidate() {
-                    targets.append(target)
+                    record(target)
                 }
                 recent.removeAll(keepingCapacity: true)
                 continue
@@ -91,7 +92,6 @@ private struct PlainAttachLinkScanner {
             candidate = Data(recent.suffix(scheme.count))
             recent.removeAll(keepingCapacity: true)
         }
-        return targets
     }
 
     mutating func finishOutput() -> String? {

--- a/Sources/HerdrMobile/Console/AttachLinkIndex.swift
+++ b/Sources/HerdrMobile/Console/AttachLinkIndex.swift
@@ -20,14 +20,9 @@ final class AttachLinkIndex {
 
     private(set) var links: [AttachLink] = []
 
-    @ObservationIgnored private let onDistinctLink: (AttachLink) -> Void
     private var scanner = AttachLinkScanner()
     private var streamObservedTargets: Set<String> = []
     private var viewportOnlyTargets: Set<String> = []
-
-    init(onDistinctLink: @escaping (AttachLink) -> Void) {
-        self.onDistinctLink = onDistinctLink
-    }
 
     func receive(_ data: Data) {
         var scanner = scanner
@@ -119,9 +114,6 @@ final class AttachLinkIndex {
         let retainedTargets = Set(links.map(\.target))
         streamObservedTargets.formIntersection(retainedTargets)
         viewportOnlyTargets.formIntersection(retainedTargets)
-        if isDistinct {
-            onDistinctLink(link)
-        }
         return true
     }
 }

--- a/Sources/HerdrMobile/Console/AttachLinkIndex.swift
+++ b/Sources/HerdrMobile/Console/AttachLinkIndex.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Observation
+
+/// One exact HTTP(S) target observed during the current Attach.
+struct AttachLink: Identifiable, Equatable {
+    let target: String
+    let url: URL
+
+    var id: String { target }
+    var host: String { url.host ?? "" }
+}
+
+/// Owns the bounded, memory-only Attach Link collection and incremental
+/// discovery state. A terminal pipeline may be replaced without replacing
+/// this index; the enclosing `AgentAttachStore` clears it on leave.
+@MainActor
+@Observable
+final class AttachLinkIndex {
+    private static let maximumLinkCount = 20
+
+    private(set) var links: [AttachLink] = []
+
+    private var scanner = PlainAttachLinkScanner()
+
+    func receive(_ data: Data) {
+        for target in scanner.receive(data) {
+            record(target)
+        }
+    }
+
+    func finishOutput() {
+        if let target = scanner.finishOutput() {
+            record(target)
+        }
+    }
+
+    func clear() {
+        scanner = PlainAttachLinkScanner()
+        links.removeAll(keepingCapacity: false)
+    }
+
+    private func record(_ target: String) {
+        guard let url = TerminalLinkPolicy.url(for: target) else { return }
+        let link = AttachLink(target: target, url: url)
+        links.removeAll { $0.target == link.target }
+        links.insert(link, at: 0)
+        if links.count > Self.maximumLinkCount {
+            links.removeLast(links.count - Self.maximumLinkCount)
+        }
+    }
+}
+
+/// Recognizes plain web targets directly from the PTY byte stream. Network
+/// chunk boundaries are invisible here; actual control and whitespace bytes
+/// terminate candidates. Both state buffers have hard upper bounds.
+private struct PlainAttachLinkScanner {
+    private static let maximumTargetBytes = 32 * 1024
+    private static let longestSchemeBytes = Array("https://".utf8)
+    private static let webSchemes = [
+        Array("http://".utf8),
+        Array("https://".utf8),
+    ]
+    private static let trailingSentencePunctuation = CharacterSet(charactersIn: ".,;:!")
+
+    private var recent = Data()
+    private var candidate = Data()
+    private var isOversized = false
+
+    mutating func receive(_ data: Data) -> [String] {
+        var targets: [String] = []
+        for byte in data {
+            if Self.isBoundary(byte) {
+                if let target = finishCandidate() {
+                    targets.append(target)
+                }
+                recent.removeAll(keepingCapacity: true)
+                continue
+            }
+
+            if !candidate.isEmpty || isOversized {
+                appendToCandidate(byte)
+                continue
+            }
+
+            recent.append(byte)
+            if recent.count > Self.longestSchemeBytes.count {
+                recent.removeFirst(recent.count - Self.longestSchemeBytes.count)
+            }
+            guard let scheme = Self.webSchemes.first(where: { recentEnds(with: $0) })
+            else { continue }
+            candidate = Data(recent.suffix(scheme.count))
+            recent.removeAll(keepingCapacity: true)
+        }
+        return targets
+    }
+
+    mutating func finishOutput() -> String? {
+        defer { recent.removeAll(keepingCapacity: true) }
+        return finishCandidate()
+    }
+
+    private mutating func appendToCandidate(_ byte: UInt8) {
+        guard !isOversized else { return }
+        guard candidate.count < Self.maximumTargetBytes else {
+            candidate.removeAll(keepingCapacity: false)
+            isOversized = true
+            return
+        }
+        candidate.append(byte)
+    }
+
+    private mutating func finishCandidate() -> String? {
+        defer {
+            candidate.removeAll(keepingCapacity: true)
+            isOversized = false
+        }
+        guard !isOversized, let text = String(data: candidate, encoding: .utf8) else {
+            return nil
+        }
+        let target = Self.removingSurroundingPunctuation(from: text)
+        return target.isEmpty ? nil : target
+    }
+
+    private func recentEnds(with suffix: [UInt8]) -> Bool {
+        guard recent.count >= suffix.count else { return false }
+        return zip(recent.suffix(suffix.count), suffix).allSatisfy {
+            Self.lowercasedASCII($0.0) == $0.1
+        }
+    }
+
+    private static func lowercasedASCII(_ byte: UInt8) -> UInt8 {
+        (0x41...0x5A).contains(byte) ? byte + 0x20 : byte
+    }
+
+    private static func removingSurroundingPunctuation(from text: String) -> String {
+        var target = text
+        var removedCharacter = true
+        while removedCharacter, let last = target.last {
+            removedCharacter = false
+            if last.unicodeScalars.allSatisfy(trailingSentencePunctuation.contains) {
+                target.removeLast()
+                removedCharacter = true
+                continue
+            }
+            for (opening, closing) in [("(", ")"), ("[", "]"), ("{", "}")] {
+                guard last == Character(closing) else { continue }
+                let openingCount = target.reduce(into: 0) {
+                    if $1 == Character(opening) { $0 += 1 }
+                }
+                let closingCount = target.reduce(into: 0) {
+                    if $1 == Character(closing) { $0 += 1 }
+                }
+                if closingCount > openingCount {
+                    target.removeLast()
+                    removedCharacter = true
+                }
+                break
+            }
+        }
+        return target
+    }
+
+    private static func isBoundary(_ byte: UInt8) -> Bool {
+        byte <= 0x20 || byte == 0x7F
+            || byte == 0x22 || byte == 0x27
+            || byte == 0x3C || byte == 0x3E
+    }
+}

--- a/Sources/HerdrMobile/Console/AttachLinkIndex.swift
+++ b/Sources/HerdrMobile/Console/AttachLinkIndex.swift
@@ -175,6 +175,8 @@ private struct AttachLinkScanner {
         case 0x90, 0x98, 0x9E, 0x9F:
             finishPlainCandidate(record: record)
             state = .stringControl
+        case 0x80...0x9F:
+            finishPlainCandidate(record: record)
         default:
             guard !isOSC8LabelActive else { return }
             plain.receive(byte, record: record)

--- a/Sources/HerdrMobile/Console/AttachLinkIndex.swift
+++ b/Sources/HerdrMobile/Console/AttachLinkIndex.swift
@@ -20,7 +20,12 @@ final class AttachLinkIndex {
 
     private(set) var links: [AttachLink] = []
 
+    @ObservationIgnored private let onDistinctLink: (AttachLink) -> Void
     private var scanner = AttachLinkScanner()
+
+    init(onDistinctLink: @escaping (AttachLink) -> Void) {
+        self.onDistinctLink = onDistinctLink
+    }
 
     func receive(_ data: Data) {
         var scanner = scanner
@@ -58,7 +63,8 @@ final class AttachLinkIndex {
 
     private func record(_ target: String, moveExistingToFront: Bool = true) {
         guard let url = TerminalLinkPolicy.url(for: target) else { return }
-        if !moveExistingToFront, links.contains(where: { $0.target == target }) {
+        let isDistinct = !links.contains(where: { $0.target == target })
+        if !moveExistingToFront, !isDistinct {
             return
         }
         let link = AttachLink(target: target, url: url)
@@ -66,6 +72,9 @@ final class AttachLinkIndex {
         links.insert(link, at: 0)
         if links.count > Self.maximumLinkCount {
             links.removeLast(links.count - Self.maximumLinkCount)
+        }
+        if isDistinct {
+            onDistinctLink(link)
         }
     }
 }

--- a/Sources/HerdrMobile/Console/AttachTerminalStore.swift
+++ b/Sources/HerdrMobile/Console/AttachTerminalStore.swift
@@ -53,6 +53,8 @@ final class AttachTerminalStore {
     private let target: String
     private let takeover: Bool
     private let input: TerminalInputController
+    private let observeOutput: @MainActor @Sendable (Data) -> Void
+    private let finishOutput: @MainActor @Sendable () -> Void
     /// Opens and owns exclusive Host terminal access for one complete run,
     /// including explicit channel teardown.
     private let runTerminal: TerminalSessionRunner
@@ -67,11 +69,15 @@ final class AttachTerminalStore {
     init(
         target: String, takeover: Bool = false,
         input: TerminalInputController = TerminalInputController(),
+        observeOutput: @escaping @MainActor @Sendable (Data) -> Void = { _ in },
+        finishOutput: @escaping @MainActor @Sendable () -> Void = {},
         runTerminal: @escaping TerminalSessionRunner
     ) {
         self.target = target
         self.takeover = takeover
         self.input = input
+        self.observeOutput = observeOutput
+        self.finishOutput = finishOutput
         self.runTerminal = runTerminal
     }
 
@@ -154,6 +160,7 @@ final class AttachTerminalStore {
         initialCols: Int,
         initialRows: Int
     ) async throws {
+        defer { finishOutput() }
         if stopRequested {
             await session.end()
             return
@@ -174,6 +181,7 @@ final class AttachTerminalStore {
 
         do {
             for try await bytes in session.output {
+                observeOutput(bytes)
                 feed.write(bytes)
             }
         } catch {

--- a/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
+++ b/Sources/HerdrMobile/Terminal/TerminalScreenView.swift
@@ -19,6 +19,7 @@ enum TerminalLinkPolicy {
 struct TerminalScreenView: UIViewRepresentable {
     let feed: TerminalByteFeed
     var onSizeChanged: ((_ cols: Int, _ rows: Int) -> Void)?
+    var onViewportTextChanged: ((String) -> Void)?
     var onSend: ((Data) -> Void)?
     var onPaste: ((_ text: String, _ bracketed: Bool) -> Void)?
     var onSnippet: ((_ text: String, _ bracketed: Bool) -> Void)?
@@ -37,6 +38,7 @@ struct TerminalScreenView: UIViewRepresentable {
     func makeUIView(context: Context) -> HerdrTerminalView {
         let view = Self.makeConfiguredTerminal(
             onSizeChanged: onSizeChanged,
+            onViewportTextChanged: onViewportTextChanged,
             onSend: onSend,
             onPaste: onPaste,
             onSnippet: onSnippet,
@@ -55,6 +57,7 @@ struct TerminalScreenView: UIViewRepresentable {
     @MainActor
     static func makeConfiguredTerminal(
         onSizeChanged: ((_ cols: Int, _ rows: Int) -> Void)? = nil,
+        onViewportTextChanged: ((String) -> Void)? = nil,
         onSend: ((Data) -> Void)? = nil,
         onPaste: ((_ text: String, _ bracketed: Bool) -> Void)? = nil,
         onSnippet: ((_ text: String, _ bracketed: Bool) -> Void)? = nil,
@@ -66,6 +69,7 @@ struct TerminalScreenView: UIViewRepresentable {
         let view = HerdrTerminalView(
             frame: .zero,
             onSizeChanged: onSizeChanged,
+            onViewportTextChanged: onViewportTextChanged,
             onSend: onSend,
             onPaste: onPaste,
             onSnippet: onSnippet,
@@ -80,6 +84,7 @@ struct TerminalScreenView: UIViewRepresentable {
     func updateUIView(_ view: HerdrTerminalView, context: Context) {
         view.updateCallbacks(
             onSizeChanged: onSizeChanged,
+            onViewportTextChanged: onViewportTextChanged,
             onSend: onSend,
             onPaste: onPaste,
             onSnippet: onSnippet)
@@ -89,6 +94,7 @@ struct TerminalScreenView: UIViewRepresentable {
         view.applyFontSize(fontSize)
         view.applyFontFamily(fontFamily)
         view.onFontSizeChanged = onFontSizeChanged
+        view.reportViewportText()
         context.coordinator.onOpenLink = { url in openURL(url) }
     }
 
@@ -124,6 +130,7 @@ struct TerminalScreenView: UIViewRepresentable {
 @MainActor
 private final class TerminalSessionCallbackBridge {
     var onSizeChanged: ((Int, Int) -> Void)?
+    var onViewportTextChanged: ((String) -> Void)?
     var onSend: ((Data) -> Void)?
     var onPaste: ((String, Bool) -> Void)?
     var onSnippet: ((String, Bool) -> Void)?
@@ -131,11 +138,13 @@ private final class TerminalSessionCallbackBridge {
 
     init(
         onSizeChanged: ((Int, Int) -> Void)?,
+        onViewportTextChanged: ((String) -> Void)?,
         onSend: ((Data) -> Void)?,
         onPaste: ((String, Bool) -> Void)?,
         onSnippet: ((String, Bool) -> Void)?
     ) {
         self.onSizeChanged = onSizeChanged
+        self.onViewportTextChanged = onViewportTextChanged
         self.onSend = onSend
         self.onPaste = onPaste
         self.onSnippet = onSnippet
@@ -161,6 +170,10 @@ private final class TerminalSessionCallbackBridge {
     func snippet(_ text: String, bracketed: Bool) {
         onSnippet?(text, bracketed)
     }
+
+    func viewportTextDidChange(_ text: String) {
+        onViewportTextChanged?(text)
+    }
 }
 
 /// The app-owned seam around libghostty-spm. It keeps keyboard policy and the
@@ -181,6 +194,7 @@ final class HerdrTerminalView: UITerminalView {
     private var modeTracker = TerminalModeTracker()
     private var lastInputWindowSize: CGSize?
     private var responderGate = TerminalKeyboardResponderGate()
+    private var viewportSnapshotTask: Task<Void, Never>?
     private(set) var isLocalInputEnabled = true
     private var terminalGridSize = (columns: 80, rows: 24)
     private var terminalCellSize = CGSize(width: 8, height: 16)
@@ -261,6 +275,7 @@ final class HerdrTerminalView: UITerminalView {
     init(
         frame: CGRect,
         onSizeChanged: ((Int, Int) -> Void)?,
+        onViewportTextChanged: ((String) -> Void)?,
         onSend: ((Data) -> Void)?,
         onPaste: ((String, Bool) -> Void)?,
         onSnippet: ((String, Bool) -> Void)?,
@@ -272,6 +287,7 @@ final class HerdrTerminalView: UITerminalView {
         self.keysContext = keysContext
         let callbackBridge = TerminalSessionCallbackBridge(
             onSizeChanged: onSizeChanged,
+            onViewportTextChanged: onViewportTextChanged,
             onSend: onSend,
             onPaste: onPaste,
             onSnippet: onSnippet)
@@ -313,11 +329,13 @@ final class HerdrTerminalView: UITerminalView {
 
     func updateCallbacks(
         onSizeChanged: ((Int, Int) -> Void)?,
+        onViewportTextChanged: ((String) -> Void)?,
         onSend: ((Data) -> Void)?,
         onPaste: ((String, Bool) -> Void)?,
         onSnippet: ((String, Bool) -> Void)?
     ) {
         callbackBridge.onSizeChanged = onSizeChanged
+        callbackBridge.onViewportTextChanged = onViewportTextChanged
         callbackBridge.onSend = onSend
         callbackBridge.onPaste = onPaste
         callbackBridge.onSnippet = onSnippet
@@ -382,6 +400,24 @@ final class HerdrTerminalView: UITerminalView {
     func receive(_ data: Data) {
         modeTracker.receive(data)
         terminalSession.receive(data)
+        scheduleViewportSnapshot()
+    }
+
+    /// Viewport reads are supplemental to raw-stream discovery. Ghostty
+    /// parses host output off-main, so coalescing briefly lets redraw bursts
+    /// settle without making terminal rendering wait on link collection.
+    func reportViewportText() {
+        guard let text = terminalSession.readViewportText() else { return }
+        callbackBridge.viewportTextDidChange(text)
+    }
+
+    private func scheduleViewportSnapshot() {
+        viewportSnapshotTask?.cancel()
+        viewportSnapshotTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(50))
+            guard !Task.isCancelled else { return }
+            self?.reportViewportText()
+        }
     }
 
     /// Raises the keyboard, and records that the user wants it up.

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -338,6 +338,226 @@ struct AttachTerminalStoreTests {
 @MainActor
 @Suite("Agent Attach store")
 struct AgentAttachStoreTests {
+    @Test func plainWebURLsBecomeAttachLinksInMostRecentOrder() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        await transport.emitAttachOutput(
+            Data(
+                """
+                Preview: https://example.com/build/42?mode=full#result
+                Local: http://localhost:3000/health
+
+                """.utf8))
+        try await waitUntil("both links should become observable") {
+            store.attachLinks.map(\.target) == [
+                "http://localhost:3000/health",
+                "https://example.com/build/42?mode=full#result",
+            ]
+        }
+
+        await store.leave()
+    }
+
+    @Test func exactRepeatsMoveToFrontAndTheLeastRecentLinkIsEvicted() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        for index in 0..<21 {
+            await transport.emitAttachOutput(
+                Data("https://example.com/item?index=\(index)#detail\n".utf8))
+        }
+        await transport.emitAttachOutput(
+            Data("https://example.com/item?index=1#detail\n".utf8))
+
+        try await waitUntil("the bounded collection should settle") {
+            store.attachLinks.count == 20
+                && store.attachLinks.first?.target
+                    == "https://example.com/item?index=1#detail"
+        }
+        #expect(
+            !store.attachLinks.contains {
+                $0.target == "https://example.com/item?index=0#detail"
+            })
+        #expect(
+            store.attachLinks.contains {
+                $0.target == "https://example.com/item?index=20#detail"
+            })
+
+        await store.leave()
+    }
+
+    @Test func targetAtTheByteLimitIsAcceptedAndAnOversizedTargetIsIgnoredWhole()
+        async throws
+    {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+        let prefix = "https://example.com/"
+        let maximumTarget =
+            prefix
+            + String(
+                repeating: "a",
+                count: 32 * 1024 - prefix.utf8.count)
+        let oversizedTarget = maximumTarget + "b"
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        await transport.emitAttachOutput(Data((maximumTarget + "\n").utf8))
+        await transport.emitAttachOutput(Data((oversizedTarget + "\n").utf8))
+        await transport.emitAttachOutput(Data("https://example.com/sentinel\n".utf8))
+
+        try await waitUntil("the output after the oversized target should be observed") {
+            store.attachLinks.first?.target == "https://example.com/sentinel"
+        }
+        #expect(
+            store.attachLinks.map(\.target) == [
+                "https://example.com/sentinel",
+                maximumTarget,
+            ])
+
+        await store.leave()
+    }
+
+    @Test func balancedURLPunctuationIsRetainedWhileSurroundingPunctuationIsExcluded()
+        async throws
+    {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        await transport.emitAttachOutput(
+            Data(
+                """
+                Docs: (https://example.com/wiki/Function_(mathematics)).
+
+                """.utf8))
+        try await waitUntil("the literal target should be observed") {
+            !store.attachLinks.isEmpty
+        }
+        #expect(
+            store.attachLinks.map(\.target) == [
+                "https://example.com/wiki/Function_(mathematics)"
+            ])
+
+        await store.leave()
+    }
+
+    @Test func arbitraryOutputChunksJoinButRealLineBreaksDoNot() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        await transport.emitAttachOutput(Data("Preview https://exa".utf8))
+        await transport.emitAttachOutput(Data("mple.com/a/visually-".utf8))
+        await transport.emitAttachOutput(Data("wrapped?q=1#result ".utf8))
+        await transport.emitAttachOutput(Data("https://\nexample.com\n".utf8))
+
+        try await waitUntil("the complete chunked target should be observed") {
+            store.attachLinks.map(\.target) == [
+                "https://example.com/a/visually-wrapped?q=1#result"
+            ]
+        }
+
+        await store.leave()
+    }
+
+    @Test func webPolicyRejectsUnsafeTargetsAndKeepsPrivateTargetsLiteral() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        await transport.emitAttachOutput(
+            Data(
+                """
+                file:///tmp/result https:///missing-host
+                echo http://127.0.0.1:8443/path?q=x#fragment
+                http://192.168.1.9:3000/private
+
+                """.utf8))
+        try await waitUntil("both literal private targets should be observed") {
+            store.attachLinks.count == 2
+        }
+        #expect(
+            store.attachLinks.map(\.target) == [
+                "http://192.168.1.9:3000/private",
+                "http://127.0.0.1:8443/path?q=x#fragment",
+            ])
+
+        await store.leave()
+    }
+
+    @Test func linksSurviveTerminalRecoveryButLeavingAttachClearsThem() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+        await transport.emitAttachOutput(Data("https://before.example/retry\n".utf8))
+        try await waitUntil("the first link should be observed") {
+            store.attachLinks.count == 1
+        }
+
+        await transport.endAttachFromRemote()
+        try await waitUntil("the terminal end should surface") {
+            if case .ended = store.terminalStatus { return true }
+            return false
+        }
+        store.retryTerminal()
+        try await waitUntil("the terminal should retry") {
+            store.terminalStatus == .live
+        }
+        #expect(store.attachLinks.map(\.target) == ["https://before.example/retry"])
+
+        await transport.emitAttachOutput(Data("https://after.example/retry\n".utf8))
+        try await waitUntil("the retry output should be observed") {
+            store.attachLinks.count == 2
+        }
+        let terminalID = store.terminalID
+        store.transportGenerationDidChange(1)
+        try await waitUntil("the Transport replacement should land") {
+            store.terminalID != terminalID
+        }
+        #expect(
+            store.attachLinks.map(\.target) == [
+                "https://after.example/retry",
+                "https://before.example/retry",
+            ])
+
+        await store.leave()
+        #expect(store.attachLinks.isEmpty)
+
+        let laterAttach = makeStore(transport: transport, generation: 1)
+        #expect(laterAttach.attachLinks.isEmpty)
+        await laterAttach.leave()
+    }
+
     @Test func transportReplacementStopsTheOldTerminalBeforeReattaching() async throws {
         let transport = ScriptedTransport()
         let store = makeStore(transport: transport, generation: 0)

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -380,6 +380,7 @@ struct AgentAttachStoreTests {
             store.attachLinkPrompt?.target
                 == "https://example.com/new?signature=exact#result"
         }
+        #expect(await transport.attachInputs.isEmpty)
 
         await store.leave()
     }
@@ -557,6 +558,7 @@ struct AgentAttachStoreTests {
         try await waitUntil("the failed open should offer copy recovery") {
             store.attachLinkOpenFailure?.link == link
         }
+        #expect(store.attachLinkOpenFailure?.message.contains(link.host) == true)
 
         var copiedTarget: String?
         store.copyFailedAttachLink { copiedTarget = $0 }

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -548,19 +548,134 @@ struct AgentAttachStoreTests {
         }
         let link = try #require(store.attachLinks.first)
 
-        await store.openAttachLink(link) { url in
+        store.openAttachLink(link) { url in
             #expect(url.absoluteString == exactTarget)
             return false
         }
 
         #expect(store.attachLinks.map(\.target) == [exactTarget])
-        #expect(store.attachLinkOpenFailure?.link == link)
+        try await waitUntil("the failed open should offer copy recovery") {
+            store.attachLinkOpenFailure?.link == link
+        }
 
         var copiedTarget: String?
         store.copyFailedAttachLink { copiedTarget = $0 }
         #expect(copiedTarget == exactTarget)
         #expect(store.attachLinks.map(\.target) == [exactTarget])
         #expect(store.attachLinkOpenFailure == nil)
+
+        await store.leave()
+    }
+
+    @Test func anOlderFailedOpenCannotReplaceTheLatestSuccessfulOpen() async throws {
+        let transport = ScriptedTransport()
+        let opener = DeferredAttachLinkOpener()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+        await transport.emitAttachOutput(
+            Data(
+                """
+                https://example.com/first
+                https://example.com/latest
+
+                """.utf8))
+        try await waitUntil("both links should be collected") {
+            store.attachLinks.count == 2
+        }
+        let first = try #require(
+            store.attachLinks.first { $0.target == "https://example.com/first" })
+        let latest = try #require(
+            store.attachLinks.first { $0.target == "https://example.com/latest" })
+
+        store.openAttachLink(first, using: opener.open)
+        try await waitUntil("the first system open should be pending") {
+            opener.pendingTargets == [first.target]
+        }
+        store.openAttachLink(latest, using: opener.open)
+        try await waitUntil("both system opens should be pending") {
+            Set(opener.pendingTargets) == Set([first.target, latest.target])
+        }
+
+        opener.complete(latest.target, accepted: true)
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+        #expect(store.attachLinkOpenFailure == nil)
+
+        opener.complete(first.target, accepted: false)
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+        #expect(store.attachLinkOpenFailure == nil)
+        #expect(store.attachLinks.count == 2)
+
+        await store.leave()
+    }
+
+    @Test func leavingAttachCancelsAPendingSystemOpenWithoutLaterMutation() async throws {
+        let transport = ScriptedTransport()
+        let opener = CancellationAwareAttachLinkOpener()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+        await transport.emitAttachOutput(Data("https://example.com/leaving-open\n".utf8))
+        try await waitUntil("the link should be collected") {
+            store.attachLinks.count == 1
+        }
+        let link = try #require(store.attachLinks.first)
+
+        store.openAttachLink(link, using: opener.open)
+        try await waitUntil("the system open should be pending") {
+            opener.pendingTarget == link.target
+        }
+
+        await store.leave()
+        try await waitUntil("leaving Attach should cancel the system open") {
+            opener.cancelledTargets == [link.target]
+        }
+
+        #expect(store.attachLinks.isEmpty)
+        #expect(store.attachLinkOpenFailure == nil)
+    }
+
+    @Test func anOlderPromptExpiryCannotClearItsReplacement() async throws {
+        let transport = ScriptedTransport()
+        let clock = DeferredPromptClock()
+        let store = makeStore(
+            transport: transport,
+            generation: 0,
+            promptClock: AttachLinkPromptClock(sleep: clock.sleep))
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+        await transport.emitAttachOutput(Data("https://example.com/first-prompt\n".utf8))
+        try await waitUntil("the first prompt expiry should be pending") {
+            store.attachLinkPrompt?.target == "https://example.com/first-prompt"
+                && clock.pendingSleepCount == 1
+        }
+
+        await transport.emitAttachOutput(Data("https://example.com/latest-prompt\n".utf8))
+        try await waitUntil("the replacement prompt expiry should be pending") {
+            store.attachLinkPrompt?.target == "https://example.com/latest-prompt"
+                && clock.pendingSleepCount == 2
+        }
+
+        clock.resumeSleep(at: 0)
+        await Task.yield()
+        #expect(store.attachLinkPrompt?.target == "https://example.com/latest-prompt")
+
+        clock.resumeSleep(at: 0)
+        await yieldUntil { store.attachLinkPrompt == nil }
+        #expect(store.attachLinkPrompt == nil)
 
         await store.leave()
     }
@@ -1238,5 +1353,76 @@ private actor ControllablePromptClock {
     private func cancel(_ id: UUID) {
         guard let waiter = waiters.removeValue(forKey: id) else { return }
         waiter.continuation.resume(throwing: CancellationError())
+    }
+}
+
+@MainActor
+private final class DeferredAttachLinkOpener {
+    private var continuations: [String: CheckedContinuation<Bool, Never>] = [:]
+
+    var pendingTargets: [String] {
+        continuations.keys.sorted()
+    }
+
+    func open(_ url: URL) async -> Bool {
+        await withCheckedContinuation { continuation in
+            continuations[url.absoluteString] = continuation
+        }
+    }
+
+    func complete(_ target: String, accepted: Bool) {
+        continuations.removeValue(forKey: target)?.resume(returning: accepted)
+    }
+}
+
+@MainActor
+private final class CancellationAwareAttachLinkOpener {
+    private var continuation: CheckedContinuation<Bool, Never>?
+    private(set) var pendingTarget: String?
+    private(set) var cancelledTargets: [String] = []
+
+    func open(_ url: URL) async -> Bool {
+        let target = url.absoluteString
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                pendingTarget = target
+                self.continuation = continuation
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancel(target)
+            }
+        }
+    }
+
+    private func cancel(_ target: String) {
+        guard pendingTarget == target else { return }
+        pendingTarget = nil
+        cancelledTargets.append(target)
+        continuation?.resume(returning: false)
+        continuation = nil
+    }
+}
+
+@MainActor
+private final class DeferredPromptClock {
+    private var continuations: [CheckedContinuation<Void, any Error>] = []
+
+    var pendingSleepCount: Int {
+        continuations.count
+    }
+
+    func sleep(for _: Duration) async throws {
+        try await withCheckedThrowingContinuation {
+            continuations.append($0)
+        }
+    }
+
+    func resumeSleep(at index: Int) {
+        continuations.remove(at: index).resume()
     }
 }

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -364,6 +364,207 @@ struct AgentAttachStoreTests {
         await store.leave()
     }
 
+    @Test func aNewDistinctLinkPresentsAnOpenPrompt() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        await transport.emitAttachOutput(
+            Data("https://example.com/new?signature=exact#result\n".utf8))
+
+        try await waitUntil("the new distinct link should present a prompt") {
+            store.attachLinkPrompt?.target
+                == "https://example.com/new?signature=exact#result"
+        }
+
+        await store.leave()
+    }
+
+    @Test func anOpenPromptExpiresAfterFourSecondsOnTheInjectedClock() async throws {
+        let transport = ScriptedTransport()
+        let clock = ControllablePromptClock()
+        let store = makeStore(
+            transport: transport,
+            generation: 0,
+            promptClock: AttachLinkPromptClock(sleep: clock.sleep))
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+        await transport.emitAttachOutput(Data("https://example.com/expiring\n".utf8))
+        try await waitUntil("the new link should present a prompt") {
+            store.attachLinkPrompt != nil
+        }
+        await clock.waitUntilSleeping()
+
+        await clock.advance(by: .seconds(3))
+        #expect(store.attachLinkPrompt?.target == "https://example.com/expiring")
+
+        await clock.advance(by: .seconds(1))
+        await yieldUntil { store.attachLinkPrompt == nil }
+        #expect(store.attachLinkPrompt == nil)
+
+        await store.leave()
+    }
+
+    @Test func anExactRepeatReordersWithoutReplacingOrExtendingThePrompt() async throws {
+        let transport = ScriptedTransport()
+        let clock = ControllablePromptClock()
+        let store = makeStore(
+            transport: transport,
+            generation: 0,
+            promptClock: AttachLinkPromptClock(sleep: clock.sleep))
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+        await transport.emitAttachOutput(Data("https://example.com/first\n".utf8))
+        await transport.emitAttachOutput(Data("https://example.com/second\n".utf8))
+        try await waitUntil("the latest distinct link should own the prompt") {
+            store.attachLinkPrompt?.target == "https://example.com/second"
+        }
+        await clock.waitUntilSleeping()
+
+        await clock.advance(by: .seconds(3))
+        await transport.emitAttachOutput(Data("https://example.com/first\n".utf8))
+        try await waitUntil("the repeat should only reorder the collection") {
+            store.attachLinks.first?.target == "https://example.com/first"
+        }
+        #expect(store.attachLinkPrompt?.target == "https://example.com/second")
+
+        await clock.advance(by: .seconds(1))
+        await yieldUntil { store.attachLinkPrompt == nil }
+        #expect(store.attachLinkPrompt == nil)
+
+        await store.leave()
+    }
+
+    @Test func aBurstReplacesThePromptWithoutQueueingOlderLinks() async throws {
+        let transport = ScriptedTransport()
+        let clock = ControllablePromptClock()
+        let store = makeStore(
+            transport: transport,
+            generation: 0,
+            promptClock: AttachLinkPromptClock(sleep: clock.sleep))
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+        await transport.emitAttachOutput(
+            Data(
+                """
+                https://example.com/first
+                https://example.com/latest
+
+                """.utf8))
+        try await waitUntil("the latest burst link should replace the prompt") {
+            store.attachLinkPrompt?.target == "https://example.com/latest"
+        }
+        await clock.waitUntilSleeping()
+
+        await clock.advance(by: .seconds(4))
+        await yieldUntil { store.attachLinkPrompt == nil }
+        #expect(store.attachLinkPrompt == nil)
+
+        await store.leave()
+    }
+
+    @Test func leavingAttachCancelsPromptExpiryAndClearsThePrompt() async throws {
+        let transport = ScriptedTransport()
+        let clock = ControllablePromptClock()
+        let store = makeStore(
+            transport: transport,
+            generation: 0,
+            promptClock: AttachLinkPromptClock(sleep: clock.sleep))
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+        await transport.emitAttachOutput(Data("https://example.com/leaving\n".utf8))
+        try await waitUntil("the link should present a prompt") {
+            store.attachLinkPrompt != nil
+        }
+        await clock.waitUntilSleeping()
+
+        await store.leave()
+        #expect(store.attachLinkPrompt == nil)
+
+        await clock.advance(by: .seconds(4))
+        await Task.yield()
+        #expect(store.attachLinkPrompt == nil)
+    }
+
+    @Test func inactiveOutputCollectsSilentlyAndDoesNotPromptOnReturn() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+        await transport.emitAttachOutput(Data("https://example.com/visible\n".utf8))
+        try await waitUntil("the active link should present a prompt") {
+            store.attachLinkPrompt != nil
+        }
+
+        store.viewActivityDidChange(isActive: false)
+        #expect(store.attachLinkPrompt == nil)
+        await transport.emitAttachOutput(Data("https://example.com/background\n".utf8))
+        try await waitUntil("background output should still update the collection") {
+            store.attachLinks.first?.target == "https://example.com/background"
+        }
+        #expect(store.attachLinkPrompt == nil)
+
+        store.viewActivityDidChange(isActive: true)
+        #expect(store.attachLinkPrompt == nil)
+        await transport.emitAttachOutput(Data("https://example.com/foreground\n".utf8))
+        try await waitUntil("later foreground output should prompt normally") {
+            store.attachLinkPrompt?.target == "https://example.com/foreground"
+        }
+
+        await store.leave()
+    }
+
+    @Test func failedOpenKeepsTheLinkAndOffersExactCopyRecovery() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+        let exactTarget = "https://example.com/signed?q=a%2Fb#Exact"
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+        await transport.emitAttachOutput(Data((exactTarget + "\n").utf8))
+        try await waitUntil("the exact link should be collected") {
+            store.attachLinks.first?.target == exactTarget
+        }
+        let link = try #require(store.attachLinks.first)
+
+        await store.openAttachLink(link) { url in
+            #expect(url.absoluteString == exactTarget)
+            return false
+        }
+
+        #expect(store.attachLinks.map(\.target) == [exactTarget])
+        #expect(store.attachLinkOpenFailure?.link == link)
+
+        var copiedTarget: String?
+        store.copyFailedAttachLink { copiedTarget = $0 }
+        #expect(copiedTarget == exactTarget)
+        #expect(store.attachLinks.map(\.target) == [exactTarget])
+        #expect(store.attachLinkOpenFailure == nil)
+
+        await store.leave()
+    }
+
     @Test func styledTextAndOSC8HyperlinksExposeTheirRealTargets() async throws {
         let transport = ScriptedTransport()
         let store = makeStore(transport: transport, generation: 0)
@@ -926,6 +1127,7 @@ struct AgentAttachStoreTests {
     private func makeStore(
         transport: ScriptedTransport,
         generation: UInt64?,
+        promptClock: AttachLinkPromptClock = .continuous,
         close: @escaping () async throws -> Void = {}
     ) -> AgentAttachStore {
         AgentAttachStore(
@@ -945,6 +1147,7 @@ struct AgentAttachStoreTests {
             stageImage: { _, _ in
                 throw ImageStagingError.transferFailed
             },
+            linkPromptClock: promptClock,
             closePane: close)
     }
 
@@ -971,6 +1174,12 @@ struct AgentAttachStoreTests {
         }
         #expect(await condition(), comment)
     }
+
+    private func yieldUntil(condition: () -> Bool) async {
+        for _ in 0..<100 where !condition() {
+            await Task.yield()
+        }
+    }
 }
 
 private actor CloseCallRecorder {
@@ -978,5 +1187,56 @@ private actor CloseCallRecorder {
 
     func record() {
         count += 1
+    }
+}
+
+private actor ControllablePromptClock {
+    private struct Waiter {
+        let deadline: Duration
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private var now: Duration = .zero
+    private var waiters: [UUID: Waiter] = [:]
+    private var sleepObservers: [CheckedContinuation<Void, Never>] = []
+
+    func sleep(for duration: Duration) async throws {
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                waiters[id] = Waiter(
+                    deadline: now + duration,
+                    continuation: continuation)
+                let observers = sleepObservers
+                sleepObservers.removeAll()
+                observers.forEach { $0.resume() }
+            }
+        } onCancel: {
+            Task { await self.cancel(id) }
+        }
+    }
+
+    func waitUntilSleeping() async {
+        guard waiters.isEmpty else { return }
+        await withCheckedContinuation { sleepObservers.append($0) }
+    }
+
+    func advance(by duration: Duration) {
+        now += duration
+        let ready = waiters.filter { $0.value.deadline <= now }
+        for (id, waiter) in ready {
+            waiters[id] = nil
+            waiter.continuation.resume()
+        }
+    }
+
+    private func cancel(_ id: UUID) {
+        guard let waiter = waiters.removeValue(forKey: id) else { return }
+        waiter.continuation.resume(throwing: CancellationError())
     }
 }

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -503,6 +503,34 @@ struct AgentAttachStoreTests {
         await store.leave()
     }
 
+    @Test func c1ControlsSeparateAdjacentVisibleURLs() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+        var output = Data("https://before-nel.example/result".utf8)
+        output.append(0x85)
+        output.append(Data("https://after-nel.example/result\n".utf8))
+        output.append(Data("https://before-st.example/result".utf8))
+        output.append(0x9C)
+        output.append(Data("https://after-st.example/result\n".utf8))
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+        await transport.emitAttachOutput(output)
+
+        try await waitUntil("C1 controls should separate visible targets") {
+            store.attachLinks.map(\.target) == [
+                "https://after-st.example/result",
+                "https://before-st.example/result",
+                "https://after-nel.example/result",
+                "https://before-nel.example/result",
+            ]
+        }
+
+        await store.leave()
+    }
+
     @Test func osc8TargetsReuseWebValidationAndCollectionBounds() async throws {
         let transport = ScriptedTransport()
         let store = makeStore(transport: transport, generation: 0)

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -364,7 +364,7 @@ struct AgentAttachStoreTests {
         await store.leave()
     }
 
-    @Test func aNewDistinctLinkPresentsAnOpenPrompt() async throws {
+    @Test func aNewDistinctLinkIsIndexedWithoutSendingTerminalInput() async throws {
         let transport = ScriptedTransport()
         let store = makeStore(transport: transport, generation: 0)
 
@@ -376,160 +376,11 @@ struct AgentAttachStoreTests {
         await transport.emitAttachOutput(
             Data("https://example.com/new?signature=exact#result\n".utf8))
 
-        try await waitUntil("the new distinct link should present a prompt") {
-            store.attachLinkPrompt?.target
+        try await waitUntil("the new distinct link should be indexed") {
+            store.attachLinks.first?.target
                 == "https://example.com/new?signature=exact#result"
         }
         #expect(await transport.attachInputs.isEmpty)
-
-        await store.leave()
-    }
-
-    @Test func anOpenPromptExpiresAfterFourSecondsOnTheInjectedClock() async throws {
-        let transport = ScriptedTransport()
-        let clock = ControllablePromptClock()
-        let store = makeStore(
-            transport: transport,
-            generation: 0,
-            promptClock: AttachLinkPromptClock(sleep: clock.sleep))
-
-        store.viewDidResize(cols: 80, rows: 24)
-        try await waitUntil("the terminal should go live") {
-            store.terminalStatus == .live
-        }
-        await transport.emitAttachOutput(Data("https://example.com/expiring\n".utf8))
-        try await waitUntil("the new link should present a prompt") {
-            store.attachLinkPrompt != nil
-        }
-        await clock.waitUntilSleeping()
-
-        await clock.advance(by: .seconds(3))
-        #expect(store.attachLinkPrompt?.target == "https://example.com/expiring")
-
-        await clock.advance(by: .seconds(1))
-        await yieldUntil { store.attachLinkPrompt == nil }
-        #expect(store.attachLinkPrompt == nil)
-
-        await store.leave()
-    }
-
-    @Test func anExactRepeatReordersWithoutReplacingOrExtendingThePrompt() async throws {
-        let transport = ScriptedTransport()
-        let clock = ControllablePromptClock()
-        let store = makeStore(
-            transport: transport,
-            generation: 0,
-            promptClock: AttachLinkPromptClock(sleep: clock.sleep))
-
-        store.viewDidResize(cols: 80, rows: 24)
-        try await waitUntil("the terminal should go live") {
-            store.terminalStatus == .live
-        }
-        await transport.emitAttachOutput(Data("https://example.com/first\n".utf8))
-        await transport.emitAttachOutput(Data("https://example.com/second\n".utf8))
-        try await waitUntil("the latest distinct link should own the prompt") {
-            store.attachLinkPrompt?.target == "https://example.com/second"
-        }
-        await clock.waitUntilSleeping()
-
-        await clock.advance(by: .seconds(3))
-        await transport.emitAttachOutput(Data("https://example.com/first\n".utf8))
-        try await waitUntil("the repeat should only reorder the collection") {
-            store.attachLinks.first?.target == "https://example.com/first"
-        }
-        #expect(store.attachLinkPrompt?.target == "https://example.com/second")
-
-        await clock.advance(by: .seconds(1))
-        await yieldUntil { store.attachLinkPrompt == nil }
-        #expect(store.attachLinkPrompt == nil)
-
-        await store.leave()
-    }
-
-    @Test func aBurstReplacesThePromptWithoutQueueingOlderLinks() async throws {
-        let transport = ScriptedTransport()
-        let clock = ControllablePromptClock()
-        let store = makeStore(
-            transport: transport,
-            generation: 0,
-            promptClock: AttachLinkPromptClock(sleep: clock.sleep))
-
-        store.viewDidResize(cols: 80, rows: 24)
-        try await waitUntil("the terminal should go live") {
-            store.terminalStatus == .live
-        }
-        await transport.emitAttachOutput(
-            Data(
-                """
-                https://example.com/first
-                https://example.com/latest
-
-                """.utf8))
-        try await waitUntil("the latest burst link should replace the prompt") {
-            store.attachLinkPrompt?.target == "https://example.com/latest"
-        }
-        await clock.waitUntilSleeping()
-
-        await clock.advance(by: .seconds(4))
-        await yieldUntil { store.attachLinkPrompt == nil }
-        #expect(store.attachLinkPrompt == nil)
-
-        await store.leave()
-    }
-
-    @Test func leavingAttachCancelsPromptExpiryAndClearsThePrompt() async throws {
-        let transport = ScriptedTransport()
-        let clock = ControllablePromptClock()
-        let store = makeStore(
-            transport: transport,
-            generation: 0,
-            promptClock: AttachLinkPromptClock(sleep: clock.sleep))
-
-        store.viewDidResize(cols: 80, rows: 24)
-        try await waitUntil("the terminal should go live") {
-            store.terminalStatus == .live
-        }
-        await transport.emitAttachOutput(Data("https://example.com/leaving\n".utf8))
-        try await waitUntil("the link should present a prompt") {
-            store.attachLinkPrompt != nil
-        }
-        await clock.waitUntilSleeping()
-
-        await store.leave()
-        #expect(store.attachLinkPrompt == nil)
-
-        await clock.advance(by: .seconds(4))
-        await Task.yield()
-        #expect(store.attachLinkPrompt == nil)
-    }
-
-    @Test func inactiveOutputCollectsSilentlyAndDoesNotPromptOnReturn() async throws {
-        let transport = ScriptedTransport()
-        let store = makeStore(transport: transport, generation: 0)
-
-        store.viewDidResize(cols: 80, rows: 24)
-        try await waitUntil("the terminal should go live") {
-            store.terminalStatus == .live
-        }
-        await transport.emitAttachOutput(Data("https://example.com/visible\n".utf8))
-        try await waitUntil("the active link should present a prompt") {
-            store.attachLinkPrompt != nil
-        }
-
-        store.viewActivityDidChange(isActive: false)
-        #expect(store.attachLinkPrompt == nil)
-        await transport.emitAttachOutput(Data("https://example.com/background\n".utf8))
-        try await waitUntil("background output should still update the collection") {
-            store.attachLinks.first?.target == "https://example.com/background"
-        }
-        #expect(store.attachLinkPrompt == nil)
-
-        store.viewActivityDidChange(isActive: true)
-        #expect(store.attachLinkPrompt == nil)
-        await transport.emitAttachOutput(Data("https://example.com/foreground\n".utf8))
-        try await waitUntil("later foreground output should prompt normally") {
-            store.attachLinkPrompt?.target == "https://example.com/foreground"
-        }
 
         await store.leave()
     }
@@ -645,41 +496,6 @@ struct AgentAttachStoreTests {
 
         #expect(store.attachLinks.isEmpty)
         #expect(store.attachLinkOpenFailure == nil)
-    }
-
-    @Test func anOlderPromptExpiryCannotClearItsReplacement() async throws {
-        let transport = ScriptedTransport()
-        let clock = DeferredPromptClock()
-        let store = makeStore(
-            transport: transport,
-            generation: 0,
-            promptClock: AttachLinkPromptClock(sleep: clock.sleep))
-
-        store.viewDidResize(cols: 80, rows: 24)
-        try await waitUntil("the terminal should go live") {
-            store.terminalStatus == .live
-        }
-        await transport.emitAttachOutput(Data("https://example.com/first-prompt\n".utf8))
-        try await waitUntil("the first prompt expiry should be pending") {
-            store.attachLinkPrompt?.target == "https://example.com/first-prompt"
-                && clock.pendingSleepCount == 1
-        }
-
-        await transport.emitAttachOutput(Data("https://example.com/latest-prompt\n".utf8))
-        try await waitUntil("the replacement prompt expiry should be pending") {
-            store.attachLinkPrompt?.target == "https://example.com/latest-prompt"
-                && clock.pendingSleepCount == 2
-        }
-
-        clock.resumeSleep(at: 0)
-        await Task.yield()
-        #expect(store.attachLinkPrompt?.target == "https://example.com/latest-prompt")
-
-        clock.resumeSleep(at: 0)
-        await yieldUntil { store.attachLinkPrompt == nil }
-        #expect(store.attachLinkPrompt == nil)
-
-        await store.leave()
     }
 
     @Test func styledTextAndOSC8HyperlinksExposeTheirRealTargets() async throws {
@@ -1292,7 +1108,6 @@ struct AgentAttachStoreTests {
     private func makeStore(
         transport: ScriptedTransport,
         generation: UInt64?,
-        promptClock: AttachLinkPromptClock = .continuous,
         close: @escaping () async throws -> Void = {}
     ) -> AgentAttachStore {
         AgentAttachStore(
@@ -1312,7 +1127,6 @@ struct AgentAttachStoreTests {
             stageImage: { _, _ in
                 throw ImageStagingError.transferFailed
             },
-            linkPromptClock: promptClock,
             closePane: close)
     }
 
@@ -1340,11 +1154,6 @@ struct AgentAttachStoreTests {
         #expect(await condition(), comment)
     }
 
-    private func yieldUntil(condition: () -> Bool) async {
-        for _ in 0..<100 where !condition() {
-            await Task.yield()
-        }
-    }
 }
 
 private actor CloseCallRecorder {
@@ -1352,57 +1161,6 @@ private actor CloseCallRecorder {
 
     func record() {
         count += 1
-    }
-}
-
-private actor ControllablePromptClock {
-    private struct Waiter {
-        let deadline: Duration
-        let continuation: CheckedContinuation<Void, any Error>
-    }
-
-    private var now: Duration = .zero
-    private var waiters: [UUID: Waiter] = [:]
-    private var sleepObservers: [CheckedContinuation<Void, Never>] = []
-
-    func sleep(for duration: Duration) async throws {
-        let id = UUID()
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation {
-                (continuation: CheckedContinuation<Void, any Error>) in
-                guard !Task.isCancelled else {
-                    continuation.resume(throwing: CancellationError())
-                    return
-                }
-                waiters[id] = Waiter(
-                    deadline: now + duration,
-                    continuation: continuation)
-                let observers = sleepObservers
-                sleepObservers.removeAll()
-                observers.forEach { $0.resume() }
-            }
-        } onCancel: {
-            Task { await self.cancel(id) }
-        }
-    }
-
-    func waitUntilSleeping() async {
-        guard waiters.isEmpty else { return }
-        await withCheckedContinuation { sleepObservers.append($0) }
-    }
-
-    func advance(by duration: Duration) {
-        now += duration
-        let ready = waiters.filter { $0.value.deadline <= now }
-        for (id, waiter) in ready {
-            waiters[id] = nil
-            waiter.continuation.resume()
-        }
-    }
-
-    private func cancel(_ id: UUID) {
-        guard let waiter = waiters.removeValue(forKey: id) else { return }
-        waiter.continuation.resume(throwing: CancellationError())
     }
 }
 
@@ -1455,24 +1213,5 @@ private final class CancellationAwareAttachLinkOpener {
         cancelledTargets.append(target)
         continuation?.resume(returning: false)
         continuation = nil
-    }
-}
-
-@MainActor
-private final class DeferredPromptClock {
-    private var continuations: [CheckedContinuation<Void, any Error>] = []
-
-    var pendingSleepCount: Int {
-        continuations.count
-    }
-
-    func sleep(for _: Duration) async throws {
-        try await withCheckedThrowingContinuation {
-            continuations.append($0)
-        }
-    }
-
-    func resumeSleep(at index: Int) {
-        continuations.remove(at: index).resume()
     }
 }

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -364,6 +364,191 @@ struct AgentAttachStoreTests {
         await store.leave()
     }
 
+    @Test func styledTextAndOSC8HyperlinksExposeTheirRealTargets() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        await transport.emitAttachOutput(
+            Data(
+                "\u{001B}Phttps://hidden-control.example\u{001B}\\"
+                    .utf8))
+        await transport.emitAttachOutput(
+            Data(
+                "\u{001B}]0;https://hidden-title.example\u{0007}"
+                    .utf8))
+        await transport.emitAttachOutput(
+            Data("See (\u{001B}[31mhttps://styled.exa".utf8))
+        await transport.emitAttachOutput(
+            Data("mple/path\u{001B}[0m),\n".utf8))
+        await transport.emitAttachOutput(
+            Data(
+                "\u{001B}]8;;https://actual.example/build/42?mode=full#result\u{0007}"
+                    .utf8))
+        await transport.emitAttachOutput(
+            Data("https://misleading.example\u{001B}]8;;\u{0007}\n".utf8))
+        await transport.emitAttachOutput(
+            Data("\u{001B}]8;id=docs;https://docs.example/guide\u{001B}".utf8))
+        await transport.emitAttachOutput(
+            Data("\\Documentation\u{001B}]8;;\u{001B}\\\n".utf8))
+
+        try await waitUntil("styled and explicit hyperlink targets should settle") {
+            store.attachLinks.map(\.target) == [
+                "https://docs.example/guide",
+                "https://actual.example/build/42?mode=full#result",
+                "https://styled.example/path",
+            ]
+        }
+
+        await store.leave()
+    }
+
+    @Test func redrawnViewportTextSupplementsOutputWithoutJoiningRows() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        await transport.emitAttachOutput(
+            Data("https://\nredrawn.example/result\n".utf8))
+        store.viewportTextDidChange(
+            """
+            Result: (https://redrawn.example/result).
+            https://
+            split.example/path
+            """)
+
+        try await waitUntil("the complete redrawn target should be observed") {
+            store.attachLinks.map(\.target) == [
+                "https://redrawn.example/result"
+            ]
+        }
+
+        await store.leave()
+    }
+
+    @Test func repeatedViewportSnapshotsDoNotRewriteStreamRecency() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+        await transport.emitAttachOutput(
+            Data(
+                """
+                https://older.example/result
+                https://newer.example/result
+
+                """.utf8))
+        try await waitUntil("stream order should settle") {
+            store.attachLinks.map(\.target) == [
+                "https://newer.example/result",
+                "https://older.example/result",
+            ]
+        }
+
+        store.viewportTextDidChange("https://older.example/result")
+
+        #expect(
+            store.attachLinks.map(\.target) == [
+                "https://newer.example/result",
+                "https://older.example/result",
+            ])
+
+        await store.leave()
+    }
+
+    @Test func osc8AcceptsC1IntroducerAndStringTerminatorForms() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+        var output = Data([0x1B, 0x5D])
+        output.append(Data("8;;https://c1-st.example/result".utf8))
+        output.append(0x9C)
+        output.append(Data("Result".utf8))
+        output.append(contentsOf: [0x1B, 0x5D])
+        output.append(Data("8;;".utf8))
+        output.append(0x9C)
+        output.append(0x0A)
+        output.append(0x9D)
+        output.append(Data("8;;https://c1-osc.example/docs".utf8))
+        output.append(0x07)
+        output.append(Data("Docs".utf8))
+        output.append(0x9D)
+        output.append(Data("8;;".utf8))
+        output.append(0x07)
+        output.append(0x0A)
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+        await transport.emitAttachOutput(output)
+
+        try await waitUntil("both C1 forms should expose their targets") {
+            store.attachLinks.map(\.target) == [
+                "https://c1-osc.example/docs",
+                "https://c1-st.example/result",
+            ]
+        }
+
+        await store.leave()
+    }
+
+    @Test func osc8TargetsReuseWebValidationAndCollectionBounds() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+        let prefix = "https://bounded.example/"
+        let maximumTarget =
+            prefix
+            + String(
+                repeating: "a",
+                count: 32 * 1024 - prefix.utf8.count)
+        let oversizedTarget = maximumTarget + "b"
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        await emitOSC8(
+            maximumTarget, label: "maximum", transport: transport)
+        await emitOSC8(
+            oversizedTarget, label: "oversized", transport: transport)
+        await emitOSC8(
+            "file:///tmp/result", label: "unsafe", transport: transport)
+        await emitOSC8(
+            "https:///missing-host", label: "missing", transport: transport)
+
+        try await waitUntil("only the maximum valid target should be observed") {
+            store.attachLinks.map(\.target) == [maximumTarget]
+        }
+
+        for index in 0..<21 {
+            await emitOSC8(
+                "https://example.com/item/\(index)",
+                label: "item \(index)",
+                transport: transport)
+        }
+
+        try await waitUntil("OSC targets should use the same bounded collection") {
+            store.attachLinks.count == 20
+                && store.attachLinks.first?.target == "https://example.com/item/20"
+        }
+        #expect(store.attachLinks.last?.target == "https://example.com/item/1")
+        #expect(!store.attachLinks.contains { $0.target == maximumTarget })
+
+        await store.leave()
+    }
+
     @Test func exactRepeatsMoveToFrontAndTheLeastRecentLinkIsEvicted() async throws {
         let transport = ScriptedTransport()
         let store = makeStore(transport: transport, generation: 0)
@@ -733,6 +918,17 @@ struct AgentAttachStoreTests {
                 throw ImageStagingError.transferFailed
             },
             closePane: close)
+    }
+
+    private func emitOSC8(
+        _ target: String,
+        label: String,
+        transport: ScriptedTransport
+    ) async {
+        await transport.emitAttachOutput(
+            Data(
+                "\u{001B}]8;;\(target)\u{0007}\(label)\u{001B}]8;;\u{0007}\n"
+                    .utf8))
     }
 
     private func waitUntil(

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -397,6 +397,33 @@ struct AgentAttachStoreTests {
         await store.leave()
     }
 
+    @Test func oneOutputChunkKeepsTheLatestLinksBeyondCollectionCapacity() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+        let output = (0..<25)
+            .map { "https://example.com/item/\($0)" }
+            .joined(separator: "\n") + "\n"
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        await transport.emitAttachOutput(Data(output.utf8))
+
+        try await waitUntil("the complete output chunk should be observed") {
+            store.attachLinks.count == 20
+                && store.attachLinks.first?.target == "https://example.com/item/24"
+        }
+        #expect(store.attachLinks.last?.target == "https://example.com/item/5")
+        #expect(
+            !store.attachLinks.contains {
+                $0.target == "https://example.com/item/4"
+            })
+
+        await store.leave()
+    }
+
     @Test func targetAtTheByteLimitIsAcceptedAndAnOversizedTargetIsIgnoredWhole()
         async throws
     {

--- a/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
+++ b/Tests/HerdrMobileTests/AttachTerminalStoreTests.swift
@@ -752,6 +752,54 @@ struct AgentAttachStoreTests {
         await store.leave()
     }
 
+    @Test func softWrappedViewportDoesNotAddPrefixesOfStreamTargets() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+        let target = "https://127.0.0.1:8443/private?token=literal#frag"
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        await transport.emitAttachOutput(Data("\(target)\n".utf8))
+        try await waitUntil("the complete stream target should be observed") {
+            store.attachLinks.map(\.target) == [target]
+        }
+
+        store.viewportTextDidChange(
+            "https://127.0.0                  \n"
+                + ".1:8443/private?to             \n"
+                + "ken=literal#frag               ")
+
+        #expect(store.attachLinks.map(\.target) == [target])
+
+        await store.leave()
+    }
+
+    @Test func repeatedViewportLayoutsKeepTheLongestAmbiguousTarget() async throws {
+        let transport = ScriptedTransport()
+        let store = makeStore(transport: transport, generation: 0)
+        let target =
+            "https://softwrap.example/this/is/a/very/long/path?token=literal#finish"
+
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the terminal should go live") {
+            store.terminalStatus == .live
+        }
+
+        store.viewportTextDidChange(target)
+        #expect(store.attachLinks.map(\.target) == [target])
+
+        store.viewportTextDidChange(
+            "https://softwrap.example/this/is/a/very")
+        store.viewportTextDidChange("https://softwrap")
+
+        #expect(store.attachLinks.map(\.target) == [target])
+
+        await store.leave()
+    }
+
     @Test func repeatedViewportSnapshotsDoNotRewriteStreamRecency() async throws {
         let transport = ScriptedTransport()
         let store = makeStore(transport: transport, generation: 0)

--- a/Tests/HerdrMobileTests/Support/TestWindow.swift
+++ b/Tests/HerdrMobileTests/Support/TestWindow.swift
@@ -1,0 +1,29 @@
+import Testing
+import UIKit
+
+@MainActor
+func makeTestWindow(
+    frame: CGRect,
+    rootViewController: UIViewController,
+    timeout: Duration = .seconds(2)
+) async throws -> UIWindow {
+    let deadline = ContinuousClock.now + timeout
+    var windowScene: UIWindowScene?
+    while windowScene == nil, ContinuousClock.now < deadline {
+        windowScene = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first
+        if windowScene == nil {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    let window = UIWindow(
+        windowScene: try #require(
+            windowScene,
+            "the test host should connect a window scene"))
+    window.frame = frame
+    window.rootViewController = rootViewController
+    window.makeKeyAndVisible()
+    return window
+}

--- a/Tests/HerdrMobileTests/TerminalAttachTests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachTests.swift
@@ -275,6 +275,39 @@ struct TerminalAttachTests {
         #expect(terminal.bounds.contains(terminal.keyboardActivationRegion))
     }
 
+    @MainActor
+    @Test func renderedOutputReportsViewportTextToTheHost() async throws {
+        var snapshots: [String] = []
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            onViewportTextChanged: { snapshots.append($0) })
+        terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 720)
+        let controller = UIViewController()
+        controller.view = terminal
+        let windowScene = try #require(
+            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
+        let window = UIWindow(windowScene: windowScene)
+        window.frame = terminal.bounds
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        terminal.receive(
+            Data("\u{001B}[2J\u{001B}[Hhttps://viewport.example/result\n".utf8))
+        terminal.layoutIfNeeded()
+
+        let deadline = ContinuousClock.now + .seconds(2)
+        while !snapshots.contains(where: { $0.contains("https://viewport.example/result") }),
+            ContinuousClock.now < deadline
+        {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(
+            snapshots.contains {
+                $0.contains("https://viewport.example/result")
+            })
+    }
+
     /// The shell above is not what Attach actually shows: every agent is a
     /// full-screen TUI that takes the alternate screen and grabs the mouse, and
     /// the keyboard has exactly one entry point. If the cursor stopped yielding

--- a/Tests/HerdrMobileTests/TerminalAttachTests.swift
+++ b/Tests/HerdrMobileTests/TerminalAttachTests.swift
@@ -259,12 +259,9 @@ struct TerminalAttachTests {
         terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 720)
         let controller = UIViewController()
         controller.view = terminal
-        let windowScene = try #require(
-            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
-        let window = UIWindow(windowScene: windowScene)
-        window.frame = terminal.bounds
-        window.rootViewController = controller
-        window.makeKeyAndVisible()
+        let window = try await makeTestWindow(
+            frame: terminal.bounds,
+            rootViewController: controller)
         defer { window.isHidden = true }
 
         terminal.receive(Data("$ ".utf8))
@@ -283,12 +280,9 @@ struct TerminalAttachTests {
         terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 720)
         let controller = UIViewController()
         controller.view = terminal
-        let windowScene = try #require(
-            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
-        let window = UIWindow(windowScene: windowScene)
-        window.frame = terminal.bounds
-        window.rootViewController = controller
-        window.makeKeyAndVisible()
+        let window = try await makeTestWindow(
+            frame: terminal.bounds,
+            rootViewController: controller)
         defer { window.isHidden = true }
 
         terminal.receive(
@@ -319,12 +313,9 @@ struct TerminalAttachTests {
         terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 720)
         let controller = UIViewController()
         controller.view = terminal
-        let windowScene = try #require(
-            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
-        let window = UIWindow(windowScene: windowScene)
-        window.frame = terminal.bounds
-        window.rootViewController = controller
-        window.makeKeyAndVisible()
+        let window = try await makeTestWindow(
+            frame: terminal.bounds,
+            rootViewController: controller)
         defer { window.isHidden = true }
 
         // Alternate screen + SGR mouse tracking, then a prompt parked on a low
@@ -355,12 +346,9 @@ struct TerminalAttachTests {
         terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 720)
         let controller = UIViewController()
         controller.view = terminal
-        let windowScene = try #require(
-            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
-        let window = UIWindow(windowScene: windowScene)
-        window.frame = terminal.bounds
-        window.rootViewController = controller
-        window.makeKeyAndVisible()
+        let window = try await makeTestWindow(
+            frame: terminal.bounds,
+            rootViewController: controller)
         defer { window.isHidden = true }
 
         // A TUI on the alternate screen with its prompt parked on row 20.

--- a/Tests/HerdrMobileTests/TerminalMouseReportingTests.swift
+++ b/Tests/HerdrMobileTests/TerminalMouseReportingTests.swift
@@ -117,12 +117,9 @@ struct TerminalMouseReportingTests {
         terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 720)
         let controller = UIViewController()
         controller.view = terminal
-        let windowScene = try #require(
-            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
-        let window = UIWindow(windowScene: windowScene)
-        window.frame = terminal.bounds
-        window.rootViewController = controller
-        window.makeKeyAndVisible()
+        let window = try await makeTestWindow(
+            frame: terminal.bounds,
+            rootViewController: controller)
         defer { window.isHidden = true }
 
         terminal.receive(Data("\u{1B}[?1049h\u{1B}[?1000;1006h".utf8))

--- a/Tests/HerdrMobileTests/TerminalStatusDialogTests.swift
+++ b/Tests/HerdrMobileTests/TerminalStatusDialogTests.swift
@@ -12,8 +12,8 @@ import UIKit
 @MainActor
 @Suite("Terminal status dialog")
 struct TerminalStatusDialogTests {
-    @Test func theDialogCoversWhateverTheTerminalWasShowing() throws {
-        let image = try Self.render(
+    @Test func theDialogCoversWhateverTheTerminalWasShowing() async throws {
+        let image = try await Self.render(
             TerminalStatusDialog(
                 glyph: .symbol("cable.connector.slash"),
                 title: "Session Ended",
@@ -27,14 +27,14 @@ struct TerminalStatusDialogTests {
         #expect(behind != Self.backdrop, "the dialog let the terminal through")
     }
 
-    @Test func theDimOnlyAppliesWhereItIsAskedFor() throws {
+    @Test func theDimOnlyAppliesWhereItIsAskedFor() async throws {
         // A corner is outside the card but inside the scrim.
         let corner = CGPoint(x: 0.03, y: 0.06)
 
-        let dimmed = try Self.render(
+        let dimmed = try await Self.render(
             TerminalStatusDialog(
                 glyph: .symbol("cable.connector.slash"), title: "Session Ended"))
-        let undimmed = try Self.render(
+        let undimmed = try await Self.render(
             TerminalStatusDialog(glyph: .progress, title: "Connecting…", dimsBackground: false))
 
         #expect(try #require(Self.color(in: dimmed, atUnit: corner)) != Self.backdrop)
@@ -46,7 +46,7 @@ struct TerminalStatusDialogTests {
     /// Pure red, so anything drawn over it is unmistakable.
     private static let backdrop: UInt32 = 0xFF00_0000 >> 8
 
-    private static func render(_ dialog: some View) throws -> UIImage {
+    private static func render(_ dialog: some View) async throws -> UIImage {
         let bounds = CGRect(x: 0, y: 0, width: 390, height: 720)
         let controller = UIHostingController(
             rootView: ZStack {
@@ -55,12 +55,9 @@ struct TerminalStatusDialogTests {
             })
         controller.view.frame = bounds
 
-        let windowScene = try #require(
-            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
-        let window = UIWindow(windowScene: windowScene)
-        window.frame = bounds
-        window.rootViewController = controller
-        window.makeKeyAndVisible()
+        let window = try await makeTestWindow(
+            frame: bounds,
+            rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
 

--- a/docs/adr/0010-index-attach-links-from-terminal-output.md
+++ b/docs/adr/0010-index-attach-links-from-terminal-output.md
@@ -38,8 +38,8 @@ terminal parser to map touch coordinates back to wrapped text.
   backgrounding while the Attach remains alive. Leaving Attach or terminating
   the app clears it. Nothing is written to persistent storage.
 - A toolbar item appears only when the index is non-empty and opens the list.
-  New distinct links produce one replaceable, short-lived open prompt. Rows
-  expose the real Host and full URL, open through the system default browser,
-  and support explicit copying. Failed opens retain the link and offer copying.
+  Discovery is silent; rows expose the real Host and full URL, open through the
+  system default browser, and support explicit copying. Failed opens retain the
+  link and offer copying.
 - There is no terminal-text tap handling, manual deletion, clear action,
   feature setting, timestamp display, or background notification.

--- a/docs/adr/0010-index-attach-links-from-terminal-output.md
+++ b/docs/adr/0010-index-attach-links-from-terminal-output.md
@@ -1,0 +1,45 @@
+# Index Attach Links from terminal output
+
+HerdrMobile will not make terminal text directly tappable while libghostty lacks
+a public iOS point-to-link query. Each Attach instead owns a bounded,
+memory-only index of web links observed in its terminal output and presents that
+index through native UI. This avoids waiting on a long libghostty development
+cycle, synthesizing modifier-clicks into mouse-aware TUIs, or duplicating a
+terminal parser to map touch coordinates back to wrapped text.
+
+## Considered Options
+
+- **Add a point-to-link API to libghostty** — the clean long-term solution, but
+  rejected for this feature because its delivery is outside the app's control.
+- **Probe or activate links through synthetic mouse input** — rejected because
+  it depends on undocumented hover behavior and can interfere with TUIs that
+  capture the mouse.
+- **Parse only the current viewport** — rejected because the exposed viewport
+  text does not distinguish a visual soft wrap from a real line break.
+- **Index links from terminal output** — chosen. Incremental output preserves a
+  complete URL across network chunks, ANSI styling, and terminal soft wrapping;
+  viewport text may supplement discovery but is not treated as an exact
+  terminal-cell model.
+
+## Consequences
+
+- An Attach Link is an absolute `http` or `https` target found as visible text
+  or as an OSC 8 target. Real line breaks are never guessed away. Complex
+  cursor movement and overwrite sequences that assemble a URL on screen are
+  explicitly best-effort.
+- User input echoed by the remote terminal is indistinguishable from other PTY
+  output and therefore participates in discovery. Loopback and private-network
+  targets are retained literally; the app never rewrites them to a Host
+  address.
+- One Attach keeps at most 20 distinct targets, ordered by most recent
+  occurrence. Exact repeats move to the front. A target larger than 32 KiB is
+  ignored rather than truncated.
+- The index survives terminal retries, Transport reconnection, and ordinary
+  backgrounding while the Attach remains alive. Leaving Attach or terminating
+  the app clears it. Nothing is written to persistent storage.
+- A toolbar item appears only when the index is non-empty and opens the list.
+  New distinct links produce one replaceable, short-lived open prompt. Rows
+  expose the real Host and full URL, open through the system default browser,
+  and support explicit copying. Failed opens retain the link and offer copying.
+- There is no terminal-text tap handling, manual deletion, clear action,
+  feature setting, timestamp display, or background notification.

--- a/project.yml
+++ b/project.yml
@@ -53,7 +53,7 @@ targets:
         # Home-screen name; the App Store listing is "Herdr Console".
         INFOPLIST_KEY_CFBundleDisplayName: Herdr
         MARKETING_VERSION: "0.1.0"
-        CURRENT_PROJECT_VERSION: "3"
+        CURRENT_PROJECT_VERSION: "4"
         # Dictation captures the microphone to transcribe on device (#36). No
         # speech-recognition usage key is set: the iOS 26 SpeechAnalyzer stack
         # is on-device and needs no legacy SFSpeechRecognizer authorization.
@@ -117,7 +117,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: dev.herdr.mobile.HerdrMobile.NotificationService
         MARKETING_VERSION: "0.1.0"
-        CURRENT_PROJECT_VERSION: "3"
+        CURRENT_PROJECT_VERSION: "4"
 
   HerdrMobileTests:
     type: bundle.unit-test


### PR DESCRIPTION
Closes #100
Closes #104

References #101, #102, and #103.

## Summary

- collect bounded, memory-only HTTP and HTTPS Attach Links from terminal output and viewport redraws, including chunked URLs, ANSI-styled text, and OSC 8 targets
- preserve the most recent 20 distinct links across terminal retry and Transport replacement, then clear them when Attach ends
- expose a conditional native toolbar list with exact targets, system-browser opening, copying, open-failure recovery, VoiceOver labels, Dynamic Type support, and adaptive iPhone/iPad presentation
- keep terminal touch behavior and PTY geometry unchanged, with bounded scanning and strict HTTP(S)-with-Host validation

## Product adjustment

The original spec included a transient Open prompt for every new distinct link. Physical-device feedback found that bottom toast too noisy, so discovery is now intentionally silent. Links still update the toolbar count and remain available in Attach Links; all prompt UI, timers, foreground state, and prompt-only tests were removed.

## Verification

- `xcodebuild test -quiet -project HerdrMobile.xcodeproj -scheme HerdrMobile -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:HerdrMobileTests/AgentAttachStoreTests`
  - 25 tests passed, 0 failed, 0 skipped on iOS 27 Simulator
- `env DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer make install DEVICE=33D77AEA-83E1-59FD-AAF0-BA52564500B1`
  - Debug build, signing, installation, launch, and live-process verification passed on a physical iPhone 17 Pro Max

## Manual acceptance boundary

Opening through a non-Safari default browser remains a manual device check; this PR does not claim that case as completed.