### PR TITLE
feat(console): animated solving orb for working agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Changed
+
+- Working agents in the Console list now show a live "solving" orb — a
+  dotted sphere whose bands twist and click back into place (ported from
+  Jakub Antalik's MIT-licensed thinking-orbs) — instead of the static blue
+  Working capsule. Reduced-motion users get a still frame.
+
 ### Added
 
 - Attach Links silently collect web and OSC 8 targets into a memory-only list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Entries reference the issue that motivated them.
 - Working agents in the Console list now show a live "solving" orb — a
   dotted sphere whose bands twist and click back into place (ported from
   Jakub Antalik's MIT-licensed thinking-orbs) — instead of the static blue
-  Working capsule. Reduced-motion users get a still frame.
+  Working capsule. Reduced-motion users get a still frame. (PR #106)
 
 ### Added
 

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		345C7A9CB13934941D67390F /* NotificationPrivacyCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323782148B559800B45E2930 /* NotificationPrivacyCopy.swift */; };
 		350A0384BD81FAA414168A18 /* TerminalKeysKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0BE586B3BBEDFA132705C6 /* TerminalKeysKeyboard.swift */; };
 		36B674DF605ECAE382E51196 /* HostOnboardingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCAF31058B6430B514B2188 /* HostOnboardingStore.swift */; };
+		39042960B48C542434ACA532 /* SolvingOrbView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00DCBDBB970535D6E758CE4 /* SolvingOrbView.swift */; };
 		39F4A48A7BAC63BD4B458FB1 /* AgentNotificationBannerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB92C9C0B3E90920CAAA8AB3 /* AgentNotificationBannerStore.swift */; };
 		3B0FFA83C8F1751A86BD3EA5 /* FakePairingConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7448C8647569740BB956262 /* FakePairingConnector.swift */; };
 		3D70FC70FD0C9EAE47C96B06 /* TerminalStatusDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82301D476437A71BE8B9682E /* TerminalStatusDialog.swift */; };
@@ -57,6 +58,7 @@
 		3ECB4DD848A1C73AF0ED4B5F /* ConsoleAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498ECBCD631F9734C28861EA /* ConsoleAgent.swift */; };
 		3F3E89D840711FE7EA62A0E5 /* notification-payload-v1.json in Resources */ = {isa = PBXBuildFile; fileRef = 0ACA2329DD2A706A72E0754E /* notification-payload-v1.json */; };
 		41BBA40C97BAE65E56D0E3B5 /* TerminalAttach.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8007AF9894BE8BAFFA7A6372 /* TerminalAttach.swift */; };
+		46F44C4392FF4F743410DECD /* SolvingOrbRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DD6513020B3A70EFCBA3EF /* SolvingOrbRendererTests.swift */; };
 		473F834A4C680F18BA303DB9 /* ScriptedTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFE5C640586747D567E1CF1 /* ScriptedTransport.swift */; };
 		47E51B32528E78D6FC1C16B2 /* AgentNotificationRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C716FB1853560D9CFF3F1351 /* AgentNotificationRoutingTests.swift */; };
 		488EF0DD844658122800A1A7 /* StartAgentStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71CE71D20ABB90D7E94264E /* StartAgentStoreTests.swift */; };
@@ -295,6 +297,7 @@
 		45811603D8C7CF196D6EC6BF /* TerminalKeysKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeysKeyboardTests.swift; sourceTree = "<group>"; };
 		45FC4FCCE9B94EC52FD930B1 /* Base64URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64URL.swift; sourceTree = "<group>"; };
 		46B11849C0824D5679BD9289 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
+		48DD6513020B3A70EFCBA3EF /* SolvingOrbRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolvingOrbRendererTests.swift; sourceTree = "<group>"; };
 		498ECBCD631F9734C28861EA /* ConsoleAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleAgent.swift; sourceTree = "<group>"; };
 		4BEEFE71E302772A774FA4EE /* SSHJumpHostE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHJumpHostE2ETests.swift; sourceTree = "<group>"; };
 		4DBF37BC147BBEEB4549FD21 /* AppActivityCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivityCoordinator.swift; sourceTree = "<group>"; };
@@ -388,6 +391,7 @@
 		BD390F4EE653187BCF20037F /* HerdrAPITypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrAPITypes.swift; sourceTree = "<group>"; };
 		BE8796AB629EF68A90C96B3D /* TerminalAttachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAttachTests.swift; sourceTree = "<group>"; };
 		BEBCD83AC5D4AF0193B2AF9B /* NotificationPrivacyCopyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPrivacyCopyTests.swift; sourceTree = "<group>"; };
+		C00DCBDBB970535D6E758CE4 /* SolvingOrbView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolvingOrbView.swift; sourceTree = "<group>"; };
 		C14983BD8988E4AAE79DC46A /* FakeTransportConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeTransportConnector.swift; sourceTree = "<group>"; };
 		C1B1FCCEF619BD597ECD3353 /* TerminalZoomSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalZoomSettings.swift; sourceTree = "<group>"; };
 		C232163905675760F37FD7A0 /* KnownHostsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStore.swift; sourceTree = "<group>"; };
@@ -646,6 +650,7 @@
 				7F2E906A8515E1152AE2B346 /* SnippetStoreTests.swift */,
 				E8222CAA17C89C53EF9D0706 /* SnippetTests.swift */,
 				4347ECA58D4717BD40A788A4 /* SocatDiscoveryTests.swift */,
+				48DD6513020B3A70EFCBA3EF /* SolvingOrbRendererTests.swift */,
 				6BE2EC235A2ACCB61A98881E /* SSHAuthE2ETests.swift */,
 				7CA60F860890A7CAA368B268 /* SSHChannelBudgetTests.swift */,
 				5582E1837DE62FBC4C5DDC5A /* SSHHostKeyE2ETests.swift */,
@@ -747,6 +752,7 @@
 				1B72A9326AE8FA1006B2EE18 /* RecentWorkspaceStore.swift */,
 				6B69B78F6EBB1B005C76FDA7 /* RenameSheetView.swift */,
 				EF12CB7CC9AE3E986821A896 /* RenameStore.swift */,
+				C00DCBDBB970535D6E758CE4 /* SolvingOrbView.swift */,
 				08E14A4298DB015E6477F789 /* StartAgentStore.swift */,
 				18AE2DC88A745FB457350957 /* StartAgentView.swift */,
 				82301D476437A71BE8B9682E /* TerminalStatusDialog.swift */,
@@ -1084,6 +1090,7 @@
 				AD6B71FC22B287C4158B4DA4 /* SnippetStore.swift in Sources */,
 				C74210294D0992F2315F6943 /* SnippetsKeyboardPane.swift in Sources */,
 				CEE4A4F9733B79886D294DE6 /* SnippetsManagementView.swift in Sources */,
+				39042960B48C542434ACA532 /* SolvingOrbView.swift in Sources */,
 				9C1C00F36A178BF1BEE6C0A5 /* StartAgentStore.swift in Sources */,
 				7EEB41E5CD728587D7DCEC96 /* StartAgentView.swift in Sources */,
 				1F4B065DFCAF8E6656600F1E /* TOFUHostKeyValidator.swift in Sources */,
@@ -1181,6 +1188,7 @@
 				BA09A8237E5F6F14E47B083E /* SnippetStoreTests.swift in Sources */,
 				AD28BE038C3F0BC6E72DFF1E /* SnippetTests.swift in Sources */,
 				B56DB49BC073C1F0F95365C3 /* SocatDiscoveryTests.swift in Sources */,
+				46F44C4392FF4F743410DECD /* SolvingOrbRendererTests.swift in Sources */,
 				488EF0DD844658122800A1A7 /* StartAgentStoreTests.swift in Sources */,
 				E8E50DCA9F56799E022F9252 /* TerminalAttachE2ETests.swift in Sources */,
 				0CF1AA5AF7F2357186A5E486 /* TerminalAttachTests.swift in Sources */,

--- a/Sources/HerdrMobile/Console/AgentCardView.swift
+++ b/Sources/HerdrMobile/Console/AgentCardView.swift
@@ -75,17 +75,28 @@ struct AgentCardView: View {
 }
 
 /// Status rendered as a tinted capsule; Blocked gets the loudest color
-/// because it is the one asking for the user.
+/// because it is the one asking for the user. Working trades the capsule
+/// for a live solving orb — motion is the signal, so it needs no tint.
 struct AgentStatusBadge: View {
     let status: AgentStatus
 
     var body: some View {
-        Text(status.rawValue.capitalized)
-            .font(.caption2.weight(.semibold))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(color.opacity(0.15), in: Capsule())
-            .foregroundStyle(color)
+        if status == .working {
+            HStack(spacing: 4) {
+                SolvingOrbView(size: 16)
+                    .accessibilityHidden(true)
+                Text("Working")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+        } else {
+            Text(status.rawValue.capitalized)
+                .font(.caption2.weight(.semibold))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(color.opacity(0.15), in: Capsule())
+                .foregroundStyle(color)
+        }
     }
 
     private var color: Color {

--- a/Sources/HerdrMobile/Console/AgentCardView.swift
+++ b/Sources/HerdrMobile/Console/AgentCardView.swift
@@ -13,11 +13,8 @@ struct AgentCardView: View {
                 Text(headline)
                     .font(.headline)
                     .lineLimit(1)
-                AgentStatusBadge(status: agent.agent.status)
                 Spacer(minLength: 8)
-                Text(agent.hostName)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                AgentStatusBadge(status: agent.agent.status)
             }
             if !agent.agent.title.isEmpty {
                 Text(agent.agent.title)
@@ -41,6 +38,10 @@ struct AgentCardView: View {
                 Text(agent.agent.paneID)
                     .font(.caption2.monospaced())
                     .foregroundStyle(.tertiary)
+                Spacer(minLength: 8)
+                Text(agent.hostName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .padding(.vertical, 4)

--- a/Sources/HerdrMobile/Console/SolvingOrbView.swift
+++ b/Sources/HerdrMobile/Console/SolvingOrbView.swift
@@ -1,0 +1,224 @@
+import SwiftUI
+
+/// The "solving" thought-orb: a dotted sphere whose bands twist in eased
+/// quarter turns — rapid moves scramble, then replay in reverse so every
+/// band clicks back to solved, rest, repeat. Depth is carried by dot size
+/// and ink weight alone; on dark substrates the ink is mirrored so near
+/// dots read bright.
+///
+/// Algorithm ported from thinking-orbs by Jakub Antalik (MIT,
+/// https://github.com/Jakubantalik/thinking-orbs), "solving" state, with
+/// the library's count/size multipliers pre-resolved into plain numbers.
+struct SolvingOrbRenderer: Sendable {
+    struct Dot: Equatable, Sendable {
+        var x: Double
+        var y: Double
+        var z: Double
+        var radius: Double
+        /// Ink value: 0 = darkest ink on paper. Mirrored on dark themes.
+        var white: Double
+    }
+
+    /// One shipped tuning (the library ships 64pt and 20pt variants).
+    struct Preset: Sendable {
+        /// Multiplier on wall-clock seconds; all motion terms consume the
+        /// scaled time.
+        let speed: Double
+        let latRings: Int
+        let lonDensity: Double
+        let dotBase: Double
+        let dotDepth: Double
+        let dotActive: Double
+    }
+
+    static let large = Preset(
+        speed: 1.82, latRings: 9, lonDensity: 24,
+        dotBase: 0.63, dotDepth: 1.785, dotActive: 0.315)
+    static let small = Preset(
+        speed: 1.95, latRings: 4, lonDensity: 12,
+        dotBase: 1.14, dotDepth: 3.23, dotActive: 0.57)
+
+    /// A quarter-turn of one band of the sphere: every lattice point whose
+    /// `axis` coordinate falls in [lo, lo + 0.5) rotates by `angle`.
+    struct Move: Sendable {
+        let axis: Int
+        let lo: Double
+        let angle: Double
+    }
+
+    static let moveCount = 14
+    static let slotDuration = 0.42
+    static let restDuration = 1.2
+
+    /// The fixed scramble, derived from a deterministic hash so every orb
+    /// plays the same choreography.
+    static let moves: [Move] = (0..<moveCount).map { i in
+        let index = Double(i)
+        let axis = min(2, Int(hash(index, 2.3) * 3))
+        let lo = -1.0 + 0.5 * Double(min(3, Int(hash(index, 5.9) * 4)))
+        let direction: Double = hash(index, 7.7) < 0.5 ? 1 : -1
+        return Move(axis: axis, lo: lo, angle: direction * .pi / 2)
+    }
+
+    let size: Double
+    let preset: Preset
+
+    init(size: Double) {
+        self.size = size
+        self.preset = size <= 40 ? Self.small : Self.large
+    }
+
+    /// Deterministic hash in [0, 1).
+    private static func hash(_ a: Double, _ b: Double) -> Double {
+        let h = sin(a * 12.9898 + b * 78.233) * 43758.5453
+        return h - h.rounded(.down)
+    }
+
+    /// The solver heartbeat: eased moves scramble for `count` slots, then
+    /// replay in reverse (palindrome), rest, repeat. Returns how far each
+    /// move has turned (0...1) and which one is mid-turn.
+    static func solveCycle(at time: Double) -> (amounts: [Double], active: Int) {
+        let count = moveCount
+        let cycle = 2 * Double(count) * slotDuration + restDuration
+        let tc = time.truncatingRemainder(dividingBy: cycle)
+        var amounts = [Double](repeating: 0, count: count)
+        var active = -1
+        if tc < 2 * Double(count) * slotDuration {
+            let slot = Int(tc / slotDuration)
+            let p = (tc - Double(slot) * slotDuration) / slotDuration
+            let clamped = min(1, p / 0.7)
+            let eased = 1 - pow(1 - clamped, 3)
+            if slot < count {
+                for i in 0..<slot { amounts[i] = 1 }
+                amounts[slot] = eased
+                active = slot
+            } else {
+                let unwinding = 2 * count - 1 - slot
+                for i in 0..<unwinding { amounts[i] = 1 }
+                amounts[unwinding] = 1 - eased
+                active = unwinding
+            }
+        }
+        return (amounts, active)
+    }
+
+    private static func applyMoves(
+        _ point: (x: Double, y: Double, z: Double),
+        amounts: [Double],
+        active: Int
+    ) -> (x: Double, y: Double, z: Double, inActive: Bool) {
+        var (x, y, z) = point
+        var inActive = false
+        for i in 0..<moves.count where amounts[i] > 0 {
+            let move = moves[i]
+            let coordinate = move.axis == 0 ? x : move.axis == 1 ? y : z
+            guard coordinate >= move.lo, coordinate < move.lo + 0.5 else { continue }
+            if i == active { inActive = true }
+            let a = move.angle * amounts[i]
+            let ca = cos(a)
+            let sa = sin(a)
+            switch move.axis {
+            case 0:
+                (y, z) = (y * ca - z * sa, y * sa + z * ca)
+            case 1:
+                (x, z) = (x * ca + z * sa, -x * sa + z * ca)
+            default:
+                (x, y) = (x * ca - y * sa, x * sa + y * ca)
+            }
+        }
+        return (x, y, z, inActive)
+    }
+
+    /// One frame of the orb at scaled time `t`, z-sorted far → near.
+    func dots(at t: Double) -> [Dot] {
+        let center = size / 2
+        let radius = size / 2 * 0.82
+        let yaw = t * 0.55
+        let tilt = 0.35 + 0.1 * sin(t * 0.9)
+        let (sy, cy) = (sin(yaw), cos(yaw))
+        let (st, ct) = (sin(tilt), cos(tilt))
+        // Dot radii were tuned for a 300pt frame; sub-linear scaling keeps
+        // small orbs legible.
+        let radiusScale = pow(size / 300, 0.6)
+        let (amounts, active) = Self.solveCycle(at: t)
+
+        var dots: [Dot] = []
+        for ring in 0...preset.latRings {
+            let lat = -Double.pi / 2 + Double(ring) / Double(preset.latRings) * .pi
+            let cosLat = cos(lat)
+            let sinLat = sin(lat)
+            let lonCount = max(1, Int((abs(cosLat) * preset.lonDensity).rounded()))
+            for step in 0..<lonCount {
+                let lon = Double(step) / Double(lonCount) * 2 * .pi
+                let moved = Self.applyMoves(
+                    (cosLat * cos(lon), sinLat, cosLat * sin(lon)),
+                    amounts: amounts, active: active)
+                // Spin + tilt + orthographic projection.
+                let x1 = moved.x * cy + moved.z * sy
+                let z1 = -moved.x * sy + moved.z * cy
+                let y1 = moved.y * ct - z1 * st
+                let z2 = moved.y * st + z1 * ct
+                let depth = (z2 + 1) / 2
+                dots.append(Dot(
+                    x: center + x1 * radius,
+                    y: center - y1 * radius,
+                    z: z2,
+                    radius: (preset.dotBase + preset.dotDepth * depth
+                        + (moved.inActive ? preset.dotActive : 0)) * radiusScale,
+                    // the band being turned inks a touch darker — the "hand"
+                    white: 0.62 - 0.54 * depth - (moved.inActive ? 0.14 : 0)))
+            }
+        }
+        dots.sort { $0.z < $1.z }
+        return dots
+    }
+}
+
+/// The animated orb view. All mounted orbs share the wall clock, so they
+/// stay in phase; reduced-motion users get a static representative frame.
+struct SolvingOrbView: View {
+    var size: CGFloat = 16
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        let renderer = SolvingOrbRenderer(size: Double(size))
+        Group {
+            if reduceMotion {
+                frame(renderer, at: 0.6)
+            } else {
+                TimelineView(.animation) { timeline in
+                    frame(
+                        renderer,
+                        at: timeline.date.timeIntervalSinceReferenceDate * renderer.preset.speed)
+                }
+            }
+        }
+        .frame(width: size, height: size)
+    }
+
+    private func frame(_ renderer: SolvingOrbRenderer, at t: Double) -> some View {
+        let dark = colorScheme == .dark
+        return Canvas { context, _ in
+            for dot in renderer.dots(at: t) {
+                let ink = min(1, max(0, dot.white))
+                let radius = max(0.3, dot.radius)
+                context.fill(
+                    Path(ellipseIn: CGRect(
+                        x: dot.x - radius, y: dot.y - radius,
+                        width: radius * 2, height: radius * 2)),
+                    with: .color(Color(white: dark ? 1 - ink : ink)))
+            }
+        }
+    }
+}
+
+#Preview {
+    HStack(spacing: 32) {
+        SolvingOrbView(size: 64)
+        SolvingOrbView(size: 20)
+        SolvingOrbView(size: 16)
+    }
+    .padding()
+}

--- a/Sources/HerdrMobile/Console/SolvingOrbView.swift
+++ b/Sources/HerdrMobile/Console/SolvingOrbView.swift
@@ -34,9 +34,13 @@ struct SolvingOrbRenderer: Sendable {
     static let large = Preset(
         speed: 1.82, latRings: 9, lonDensity: 24,
         dotBase: 0.63, dotDepth: 1.785, dotActive: 0.315)
+    /// Deviates from the library's 20px tuning (4 rings, ~30 fat dots):
+    /// at badge size that read as loose scatter, not a sphere. Small orbs
+    /// keep the dense lattice and only take the faster clock; the painter's
+    /// minimum dot radius keeps the finer dots legible on Retina.
     static let small = Preset(
-        speed: 1.95, latRings: 4, lonDensity: 12,
-        dotBase: 1.14, dotDepth: 3.23, dotActive: 0.57)
+        speed: 1.95, latRings: 9, lonDensity: 24,
+        dotBase: 0.63, dotDepth: 1.785, dotActive: 0.315)
 
     /// A quarter-turn of one band of the sphere: every lattice point whose
     /// `axis` coordinate falls in [lo, lo + 0.5) rotates by `angle`.

--- a/Tests/HerdrMobileTests/SolvingOrbRendererTests.swift
+++ b/Tests/HerdrMobileTests/SolvingOrbRendererTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+
+@testable import HerdrMobile
+
+/// The solving orb behind the Working badge: a deterministic dotted
+/// sphere whose bands scramble and then replay in reverse. The renderer
+/// is pure, so the choreography is testable without rendering a frame.
+@Suite("Solving orb renderer")
+struct SolvingOrbRendererTests {
+    @Test func presetFollowsTheRenderedSize() {
+        #expect(SolvingOrbRenderer(size: 16).preset.latRings == SolvingOrbRenderer.small.latRings)
+        #expect(SolvingOrbRenderer(size: 64).preset.latRings == SolvingOrbRenderer.large.latRings)
+    }
+
+    @Test func scrambleIsDeterministic() {
+        let renderer = SolvingOrbRenderer(size: 16)
+        #expect(renderer.dots(at: 3.7) == renderer.dots(at: 3.7))
+        for move in SolvingOrbRenderer.moves {
+            #expect((0...2).contains(move.axis))
+            #expect(move.lo >= -1.0 && move.lo <= 0.5)
+            #expect(abs(move.angle) == .pi / 2)
+        }
+    }
+
+    @Test(arguments: [16.0, 64.0])
+    func dotsStayInsideTheFrame(size: Double) {
+        let renderer = SolvingOrbRenderer(size: size)
+        for t in stride(from: 0.0, through: 13.0, by: 0.5) {
+            let dots = renderer.dots(at: t)
+            #expect(!dots.isEmpty)
+            for dot in dots {
+                #expect(dot.x - dot.radius >= 0 && dot.x + dot.radius <= size)
+                #expect(dot.y - dot.radius >= 0 && dot.y + dot.radius <= size)
+            }
+        }
+    }
+
+    @Test func dotsArePaintedFarToNear() {
+        let dots = SolvingOrbRenderer(size: 64).dots(at: 1.3)
+        for (far, near) in zip(dots, dots.dropFirst()) {
+            #expect(far.z <= near.z)
+        }
+    }
+
+    /// The heartbeat is a palindrome: after `moveCount` forward slots the
+    /// same moves unwind, and the rest window holds every band at zero —
+    /// solved — until the next cycle.
+    @Test func solveCycleScramblesThenUnwindsToSolved() {
+        let count = SolvingOrbRenderer.moveCount
+        let slot = SolvingOrbRenderer.slotDuration
+
+        // Mid-scramble: earlier moves are locked in, one is mid-turn.
+        let scrambling = SolvingOrbRenderer.solveCycle(at: 3.5 * slot)
+        #expect(scrambling.active == 3)
+        #expect(scrambling.amounts[0..<3].allSatisfy { $0 == 1 })
+        #expect(scrambling.amounts[3] > 0 && scrambling.amounts[3] < 1)
+
+        // Mid-unwind: the mirror slot turns the same move back.
+        let unwinding = SolvingOrbRenderer.solveCycle(at: (2 * Double(count) - 3.5) * slot)
+        #expect(unwinding.active == 3)
+        #expect(unwinding.amounts[3] > 0 && unwinding.amounts[3] < 1)
+
+        // Rest: everything has clicked back to solved.
+        let resting = SolvingOrbRenderer.solveCycle(at: 2 * Double(count) * slot + 0.1)
+        #expect(resting.active == -1)
+        #expect(resting.amounts.allSatisfy { $0 == 0 })
+    }
+
+    /// The rest pose recurs every cycle at the same phase, so the orb
+    /// returns to solved rather than accumulating twist over time.
+    @Test func solvedPoseRecursEveryCycle() {
+        let cycle = 2 * Double(SolvingOrbRenderer.moveCount) * SolvingOrbRenderer.slotDuration
+            + SolvingOrbRenderer.restDuration
+        for lap in 0..<5 {
+            let resting = SolvingOrbRenderer.solveCycle(at: Double(lap) * cycle + cycle - 0.5)
+            #expect(resting.active == -1)
+            #expect(resting.amounts.allSatisfy { $0 == 0 })
+        }
+    }
+}

--- a/Tests/HerdrMobileTests/SolvingOrbRendererTests.swift
+++ b/Tests/HerdrMobileTests/SolvingOrbRendererTests.swift
@@ -9,8 +9,8 @@ import Testing
 @Suite("Solving orb renderer")
 struct SolvingOrbRendererTests {
     @Test func presetFollowsTheRenderedSize() {
-        #expect(SolvingOrbRenderer(size: 16).preset.latRings == SolvingOrbRenderer.small.latRings)
-        #expect(SolvingOrbRenderer(size: 64).preset.latRings == SolvingOrbRenderer.large.latRings)
+        #expect(SolvingOrbRenderer(size: 16).preset.speed == SolvingOrbRenderer.small.speed)
+        #expect(SolvingOrbRenderer(size: 64).preset.speed == SolvingOrbRenderer.large.speed)
     }
 
     @Test func scrambleIsDeterministic() {


### PR DESCRIPTION
## Summary

- Replace the static blue **Working** capsule on Console cards with a live "solving" thought-orb: a dotted sphere whose bands twist in eased quarter turns — scramble, then replay in reverse so everything clicks back to solved, rest, repeat. Ported from Jakub Antalik's MIT-licensed [thinking-orbs](https://github.com/Jakubantalik/thinking-orbs) (`solving` state) to a pure `SolvingOrbRenderer` driven by `TimelineView(.animation)` + `Canvas`.
- The port was verified numerically against the original engine (8 sampled frames, worst position delta 7e-15, ink identical after quantization). Small badge-size orbs deviate from the library's sparse 20px tuning on purpose: at 16pt that read as loose scatter, so they keep the dense 64pt lattice and only take the faster clock.
- Reduced-motion users get a static representative frame; dark mode mirrors the ink so near dots read bright. All mounted orbs share the wall clock and stay in phase.
- Card layout: status moved to the headline row's trailing edge, Host name to the foot row's trailing edge.

## Testing

- `SolvingOrbRendererTests` (6 tests): preset selection, deterministic scramble, dots stay inside the frame across the cycle, far-to-near paint order, palindromic scramble/unwind, solved pose recurring every cycle.
- Installed and eyeballed on device.