### PR TITLE
Add explicit Host reconnect controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ Entries reference the issue that motivated them.
 
 ### Fixed
 
+- Failed Host notices stay compact in the Agent list and open the affected
+  Host directly, where an explicit reconnect action is now available.
+
 - Arguments typed on the New Agent form survive the iOS keyboard's smart
   punctuation: `--yolo` no longer reaches the Host as an em-dash garbage
   argument, and curly quotes normalize back to the straight quotes the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Entries reference the issue that motivated them.
 ### Fixed
 
 - Failed Host notices stay compact in the Agent list and open the affected
-  Host directly, where an explicit reconnect action is now available.
+  Host directly, where an explicit reconnect action is always available.
 
 - Arguments typed on the New Agent form survive the iOS keyboard's smart
   punctuation: `--yolo` no longer reaches the Host as an em-dash garbage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Entries reference the issue that motivated them.
 
 - Failed Host notices stay compact in the Agent list and open the affected
   Host directly, where an explicit reconnect action stays visible, animates
-  while restarting, and leaves the latest connection error below it.
+  while restarting, and leaves the latest connection error below it. (PR #107)
 
 - Arguments typed on the New Agent form survive the iOS keyboard's smart
   punctuation: `--yolo` no longer reaches the Host as an em-dash garbage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,8 @@ Entries reference the issue that motivated them.
 ### Fixed
 
 - Failed Host notices stay compact in the Agent list and open the affected
-  Host directly, where an explicit reconnect action is always available.
+  Host directly, where an explicit reconnect action stays visible, animates
+  while restarting, and leaves the latest connection error below it.
 
 - Arguments typed on the New Agent form survive the iOS keyboard's smart
   punctuation: `--yolo` no longer reaches the Host as an em-dash garbage

--- a/HerdrMobile.xcodeproj/project.pbxproj
+++ b/HerdrMobile.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		033E8DCA2F64ABE6CA898758 /* EventsSessionSubscriptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA5E9DDE1AB0F68F6EC56EB /* EventsSessionSubscriptionsTests.swift */; };
 		0513EE0829F55B1D68943E77 /* IBMPlexMono-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3F06DA8EA035AE18A632802A /* IBMPlexMono-Bold.ttf */; };
 		05A6F31F9CAC1CA1C57D7C71 /* DeviceKeyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8323C68B13826B7388800B1F /* DeviceKeyStoreTests.swift */; };
+		06F2D25907DF19984C88ACA2 /* TransportErrorPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FA707A0438836868F79770 /* TransportErrorPresentationTests.swift */; };
 		0700F97FBF6A714C5D9EA5CD /* ColdStartE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646861C32DDA14D63389C518 /* ColdStartE2ETests.swift */; };
 		073427C275CFEDBD5D3176DC /* SSHTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1C4EC65B71F33394E7DA9F /* SSHTransport.swift */; };
 		07594B18999B4ACCD9C590F9 /* AgentNotificationRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26E32987E7CE7EF970DB7B0 /* AgentNotificationRouting.swift */; };
@@ -193,6 +194,7 @@
 		E39009FA2165293772189094 /* JetBrainsMono-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E63AA097AC0843D1BB51461F /* JetBrainsMono-Bold.ttf */; };
 		E4CC508EF3C28A14A4EE2901 /* SSHTransportE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62C94D6B84C468B0A4D991C /* SSHTransportE2ETests.swift */; };
 		E5950D24C4F647368C03853F /* ImageAttachStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4847B965ACCAC480398065 /* ImageAttachStore.swift */; };
+		E837DFB8795251F7556809F5 /* TransportError+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8089AC82EFA9095EAA866E0C /* TransportError+Presentation.swift */; };
 		E8E50DCA9F56799E022F9252 /* TerminalAttachE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83F34B22988623AD8E2093C /* TerminalAttachE2ETests.swift */; };
 		E908289DF03C6732F7D91328 /* HerdrEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A696EC4D243B31D1B22C13F0 /* HerdrEventsTests.swift */; };
 		EAA349947E6AF58625E35481 /* HerdrNotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 0C40CAB15B8223BC58AB39F1 /* HerdrNotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -342,6 +344,7 @@
 		7F2E906A8515E1152AE2B346 /* SnippetStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetStoreTests.swift; sourceTree = "<group>"; };
 		8007AF9894BE8BAFFA7A6372 /* TerminalAttach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAttach.swift; sourceTree = "<group>"; };
 		806A90DBCA99FD02E76D68C6 /* Host.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Host.swift; sourceTree = "<group>"; };
+		8089AC82EFA9095EAA866E0C /* TransportError+Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransportError+Presentation.swift"; sourceTree = "<group>"; };
 		80E727A9081269681AD7581B /* TerminalInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalInputController.swift; sourceTree = "<group>"; };
 		82301D476437A71BE8B9682E /* TerminalStatusDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalStatusDialog.swift; sourceTree = "<group>"; };
 		8323C68B13826B7388800B1F /* DeviceKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyStoreTests.swift; sourceTree = "<group>"; };
@@ -407,6 +410,7 @@
 		CADA0E8C1DC6D30FCC6CEDC2 /* HostKeyPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostKeyPolicy.swift; sourceTree = "<group>"; };
 		CC309E333009D66F9757CD13 /* AgentNotificationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationRouter.swift; sourceTree = "<group>"; };
 		D04EAA030D8329A1716714A8 /* DeviceKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyStore.swift; sourceTree = "<group>"; };
+		D4FA707A0438836868F79770 /* TransportErrorPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportErrorPresentationTests.swift; sourceTree = "<group>"; };
 		D6FCFE74BB45C0D8B600FFD3 /* SkeletonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonTests.swift; sourceTree = "<group>"; };
 		D7ABA4C994F50578849374F1 /* TerminalAppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAppearancePane.swift; sourceTree = "<group>"; };
 		D83F34B22988623AD8E2093C /* TerminalAttachE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAttachE2ETests.swift; sourceTree = "<group>"; };
@@ -533,6 +537,7 @@
 				8007AF9894BE8BAFFA7A6372 /* TerminalAttach.swift */,
 				BC1CA00EE3CB38A822FEA4B2 /* TOFUHostKeyValidator.swift */,
 				259E51D58B1094AC5B389EDA /* Transport.swift */,
+				8089AC82EFA9095EAA866E0C /* TransportError+Presentation.swift */,
 				1E109F809AACADFF5FCB7385 /* Generated */,
 			);
 			path = Transport;
@@ -667,6 +672,7 @@
 				EE72A47A2C1C9F9B4BFFB16F /* TerminalThemeSettingsTests.swift */,
 				099B4DEE5E08C6246009D0EB /* TerminalZoomSettingsTests.swift */,
 				A9EC4F17AFC933FBA45CCA09 /* TransportConcurrencyE2ETests.swift */,
+				D4FA707A0438836868F79770 /* TransportErrorPresentationTests.swift */,
 				02807C329084D58137461EF8 /* TransportFailureModesE2ETests.swift */,
 				CB45F25667AE3C5C2EFD76CB /* Support */,
 			);
@@ -1115,6 +1121,7 @@
 				8381585C97479412A40A4FC8 /* TerminalZoomSettings.swift in Sources */,
 				49CDAC5FE4566D912F72FFCA /* Transport.swift in Sources */,
 				B31E16D56EE1F19A3802625B /* TransportConnector.swift in Sources */,
+				E837DFB8795251F7556809F5 /* TransportError+Presentation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1201,6 +1208,7 @@
 				ECC2A0575FFC9EB286B9F8AC /* TerminalZoomSettingsTests.swift in Sources */,
 				731D433F2309641163FA3B88 /* TestWindow.swift in Sources */,
 				E23937EC4DC9148C2A7F8D18 /* TransportConcurrencyE2ETests.swift in Sources */,
+				06F2D25907DF19984C88ACA2 /* TransportErrorPresentationTests.swift in Sources */,
 				782980ECE8E7005A672D25A3 /* TransportFailureModesE2ETests.swift in Sources */,
 				C174C223DBE1F1DD4085A2F8 /* UnixSockets.swift in Sources */,
 			);

--- a/Sources/HerdrMobile/Console/ConsoleStore.swift
+++ b/Sources/HerdrMobile/Console/ConsoleStore.swift
@@ -91,6 +91,12 @@ final class ConsoleStore {
         }
     }
 
+    /// Restarts one failed Host without disturbing other Hosts that may be
+    /// connected, reconnecting, or waiting for their own repair.
+    func retryHost(_ id: Host.ID) async {
+        await projections[id]?.retry()
+    }
+
     /// The returned runner resolves the Host's live projection on every
     /// call: editing a Host replaces its projection (and session), and a
     /// runner captured by a long-lived Attach screen must follow it there

--- a/Sources/HerdrMobile/Console/ConsoleStore.swift
+++ b/Sources/HerdrMobile/Console/ConsoleStore.swift
@@ -91,8 +91,8 @@ final class ConsoleStore {
         }
     }
 
-    /// Restarts one failed Host without disturbing other Hosts that may be
-    /// connected, reconnecting, or waiting for their own repair.
+    /// Restarts one Host without disturbing other Hosts that may be connected,
+    /// reconnecting, or waiting for their own repair.
     func retryHost(_ id: Host.ID) async {
         await projections[id]?.retry()
     }

--- a/Sources/HerdrMobile/Console/ConsoleView.swift
+++ b/Sources/HerdrMobile/Console/ConsoleView.swift
@@ -76,7 +76,6 @@ struct ConsoleView: View {
                     HostListView(
                         store: hosts,
                         initialHostID: destination.hostID,
-                        connectionStatuses: console.hostStatuses,
                         retryConnection: { await console.retryHost($0) })
                 }
                 .sheet(isPresented: $isStartingAgent) {

--- a/Sources/HerdrMobile/Console/ConsoleView.swift
+++ b/Sources/HerdrMobile/Console/ConsoleView.swift
@@ -17,7 +17,7 @@ struct ConsoleView: View {
     /// Scene phase widened by the background grace period; the Attach screen
     /// pauses its work on real suspensions only.
     let activity: AppActivityCoordinator
-    @State private var isManagingHosts = false
+    @State private var hostSheet: HostSheet?
     @State private var isStartingAgent = false
     @State private var isShowingSettings = false
     /// Narrows the flat list to one Host; nil shows every Host. The list
@@ -55,7 +55,7 @@ struct ConsoleView: View {
                     }
                     ToolbarItem(placement: .primaryAction) {
                         Button("Hosts", systemImage: "server.rack") {
-                            isManagingHosts = true
+                            presentHosts()
                         }
                     }
                     ToolbarItem(placement: .primaryAction) {
@@ -71,12 +71,13 @@ struct ConsoleView: View {
                         }
                     }
                 }
-                .sheet(
-                    isPresented: $isManagingHosts,
-                    onDismiss: { Task { await console.retryFailedHosts() } }
-                ) {
+                .sheet(item: $hostSheet) { destination in
                     // HostListView brings its own NavigationStack.
-                    HostListView(store: hosts)
+                    HostListView(
+                        store: hosts,
+                        initialHostID: destination.hostID,
+                        connectionStatuses: console.hostStatuses,
+                        retryConnection: { await console.retryHost($0) })
                 }
                 .sheet(isPresented: $isStartingAgent) {
                     // StartAgentView brings its own NavigationStack.
@@ -109,7 +110,7 @@ struct ConsoleView: View {
         // while a sheet is up, so this only acts on notification taps.
         .onChange(of: notificationRouter.path) { _, path in
             guard !path.isEmpty else { return }
-            isManagingHosts = false
+            hostSheet = nil
             isStartingAgent = false
             isShowingSettings = false
         }
@@ -173,7 +174,7 @@ struct ConsoleView: View {
             } description: {
                 Text("Add a machine that runs herdr to see its Agents here.")
             } actions: {
-                Button("Add Host") { isManagingHosts = true }
+                Button("Add Host") { presentHosts() }
                     .buttonStyle(.borderedProminent)
             }
         } else if console.agents.isEmpty {
@@ -182,8 +183,11 @@ struct ConsoleView: View {
             } description: {
                 Text(emptyDescription)
             } actions: {
-                if !hostIssues.isEmpty {
-                    Button("Manage Hosts") { isManagingHosts = true }
+                if let issue = hostIssues.first, hostIssues.count == 1 {
+                    Button("Open \(issue.hostName)") { presentHosts(issue.id) }
+                        .buttonStyle(.borderedProminent)
+                } else if !hostIssues.isEmpty {
+                    Button("Manage Hosts") { presentHosts() }
                         .buttonStyle(.borderedProminent)
                 }
             }
@@ -197,18 +201,30 @@ struct ConsoleView: View {
                     Text(visibleHostIssues.map(\.message).joined(separator: "\n"))
                 }
             } actions: {
+                if let issue = visibleHostIssues.first {
+                    Button("Host Settings") { presentHosts(issue.id) }
+                }
                 Button("Show All Hosts") { hostFilter = nil }
-                    .buttonStyle(.borderedProminent)
             }
         } else {
             List(selection: selectedAgent) {
                 ForEach(visibleHostIssues, id: \.id) { issue in
-                    Button { isManagingHosts = true } label: {
-                        Label(issue.message, systemImage: issue.systemImage)
-                            .font(.footnote)
-                            .foregroundStyle(issue.isCritical ? Color.red : Color.secondary)
+                    Button { presentHosts(issue.id) } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: issue.systemImage)
+                                .foregroundStyle(issue.isCritical ? Color.red : Color.orange)
+                            Text(issue.message)
+                                .font(.footnote)
+                                .foregroundStyle(issue.isCritical ? Color.red : Color.secondary)
+                                .lineLimit(1)
+                            Spacer(minLength: 0)
+                            Image(systemName: "chevron.right")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.tertiary)
+                        }
                     }
                     .buttonStyle(.plain)
+                    .accessibilityHint("Opens this Host's settings.")
                 }
                 ForEach(filteredAgents) { agent in
                     NavigationLink(value: agent.id) {
@@ -245,9 +261,15 @@ struct ConsoleView: View {
 
     private struct HostIssue {
         let id: Host.ID
+        let hostName: String
         let message: String
         let systemImage: String
         let isCritical: Bool
+    }
+
+    private struct HostSheet: Identifiable {
+        let id = UUID()
+        let hostID: Host.ID?
     }
 
     /// One actionable status per Host. A disconnected session takes priority;
@@ -258,12 +280,14 @@ struct ConsoleView: View {
             case .reconnecting(_, _, let failure):
                 return HostIssue(
                     id: host.id,
+                    hostName: host.displayName,
                     message: "Reconnecting to \(host.displayName): \(summary(for: failure))",
                     systemImage: "wifi.exclamationmark",
                     isCritical: false)
             case .failed(let failure):
                 return HostIssue(
                     id: host.id,
+                    hostName: host.displayName,
                     message: "\(host.displayName): \(guidance(for: failure))",
                     systemImage: failure.isHostKeySecurityFailure
                         ? "exclamationmark.shield.fill" : "exclamationmark.triangle.fill",
@@ -274,6 +298,7 @@ struct ConsoleView: View {
             if let message = console.hostSyncErrors[host.id] {
                 return HostIssue(
                     id: host.id,
+                    hostName: host.displayName,
                     message: "\(host.displayName): \(message)",
                     systemImage: "arrow.trianglehead.2.clockwise",
                     isCritical: false)
@@ -318,6 +343,10 @@ struct ConsoleView: View {
         default:
             "Connection failed. Check this Host, then retry."
         }
+    }
+
+    private func presentHosts(_ id: Host.ID? = nil) {
+        hostSheet = HostSheet(hostID: id)
     }
 }
 

--- a/Sources/HerdrMobile/Console/ConsoleView.swift
+++ b/Sources/HerdrMobile/Console/ConsoleView.swift
@@ -20,6 +20,7 @@ struct ConsoleView: View {
     @State private var hostSheet: HostSheet?
     @State private var isStartingAgent = false
     @State private var isShowingSettings = false
+    @State private var reconnectingHostIDs: Set<Host.ID> = []
     /// Narrows the flat list to one Host; nil shows every Host. The list
     /// stays flat either way — this is a filter, not a grouping level.
     @State private var hostFilter: Host.ID?
@@ -76,7 +77,9 @@ struct ConsoleView: View {
                     HostListView(
                         store: hosts,
                         initialHostID: destination.hostID,
-                        retryConnection: { await console.retryHost($0) })
+                        connectionStatuses: console.hostStatuses,
+                        reconnectingHostIDs: reconnectingHostIDs,
+                        retryConnection: { await reconnectHost($0) })
                 }
                 .sheet(isPresented: $isStartingAgent) {
                     // StartAgentView brings its own NavigationStack.
@@ -287,7 +290,7 @@ struct ConsoleView: View {
                 return HostIssue(
                     id: host.id,
                     hostName: host.displayName,
-                    message: "\(host.displayName): \(guidance(for: failure))",
+                    message: "\(host.displayName): \(failure.connectionGuidance)",
                     systemImage: failure.isHostKeySecurityFailure
                         ? "exclamationmark.shield.fill" : "exclamationmark.triangle.fill",
                     isCritical: failure.isHostKeySecurityFailure)
@@ -317,35 +320,15 @@ struct ConsoleView: View {
         }
     }
 
-    private func guidance(for failure: TransportError) -> String {
-        switch failure {
-        case .authenticationFailed:
-            "Authentication failed. Update the credentials in Hosts."
-        case .deviceKeyCorrupt:
-            "The Device Key is corrupted. Edit this Host, replace the Device Key, then install its new public key on every Device Key Host."
-        case .hostKeyRejected:
-            "The host key is not trusted. Verify it in Hosts."
-        case .hostKeyMismatch:
-            "Host key changed. Verify the machine before updating trust in Hosts."
-        case .protocolVersionMismatch(let server, let supported):
-            "herdr protocol \(server) is incompatible with app protocol \(supported). Update herdr or the app."
-        case .socketNotFound:
-            "The herdr socket was not found. Check the session in Hosts."
-        case .socatMissing:
-            "socat was not found on the Host. Install it or set its path in Hosts."
-        case .homeDirectoryUnresolvable:
-            "The remote home directory could not be resolved. Check the Host login shell."
-        case .malformedResponse:
-            "herdr returned an invalid response. Check its version, then retry."
-        case .eventsChannelAlreadyOpen, .terminalChannelAlreadyOpen:
-            "The connection is busy. Close the other terminal, then retry."
-        default:
-            "Connection failed. Check this Host, then retry."
-        }
-    }
-
     private func presentHosts(_ id: Host.ID? = nil) {
         hostSheet = HostSheet(hostID: id)
+    }
+
+    private func reconnectHost(_ id: Host.ID) async {
+        guard reconnectingHostIDs.insert(id).inserted else { return }
+        await console.retryHost(id)
+        try? await Task.sleep(for: .milliseconds(1_200))
+        reconnectingHostIDs.remove(id)
     }
 }
 

--- a/Sources/HerdrMobile/Console/HostConsoleProjection.swift
+++ b/Sources/HerdrMobile/Console/HostConsoleProjection.swift
@@ -63,7 +63,6 @@ final class HostConsoleProjection {
     }
 
     func retry() async {
-        guard case .failed = status else { return }
         await session.retry()
     }
 

--- a/Sources/HerdrMobile/Hosts/HostListView.swift
+++ b/Sources/HerdrMobile/Hosts/HostListView.swift
@@ -65,14 +65,25 @@ final class HostRemovalStore {
 /// row leading into that Host's onboarding checklist.
 struct HostListView: View {
     let store: HostStore
+    private let initialHostID: Host.ID?
+    private let connectionStatuses: [Host.ID: EventsSessionStatus]
+    private let retryConnection: (@MainActor @Sendable (Host.ID) async -> Void)?
     @State private var removal: HostRemovalStore
     @State private var isAddingHost = false
     @State private var isScanningToPair = false
     @State private var manualFallbackRequested = false
     @State private var path: [Host.ID] = []
 
-    init(store: HostStore) {
+    init(
+        store: HostStore,
+        initialHostID: Host.ID? = nil,
+        connectionStatuses: [Host.ID: EventsSessionStatus] = [:],
+        retryConnection: (@MainActor @Sendable (Host.ID) async -> Void)? = nil
+    ) {
         self.store = store
+        self.initialHostID = initialHostID
+        self.connectionStatuses = connectionStatuses
+        self.retryConnection = retryConnection
         _removal = State(initialValue: HostRemovalStore(store: store))
     }
 
@@ -129,7 +140,11 @@ struct HostListView: View {
                 if let host = store.hosts.first(where: { $0.id == id }) {
                     // Keyed by the Host value: editing recreates the
                     // onboarding store so checks run against fresh settings.
-                    HostOnboardingView(host: host, catalog: store)
+                    HostOnboardingView(
+                        host: host,
+                        catalog: store,
+                        connectionStatus: connectionStatuses[id],
+                        retryConnection: retryAction(for: id))
                         .id(host)
                 } else {
                     ContentUnavailableView("Host removed", systemImage: "server.rack")
@@ -191,6 +206,14 @@ struct HostListView: View {
             } message: {
                 Text(removal.errorMessage ?? "")
             }
+            .task(id: initialHostID) {
+                guard
+                    path.isEmpty,
+                    let initialHostID,
+                    store.hosts.contains(where: { $0.id == initialHostID })
+                else { return }
+                path.append(initialHostID)
+            }
         }
     }
 
@@ -202,6 +225,13 @@ struct HostListView: View {
 
     private func removeHosts(at offsets: IndexSet) {
         removal.requestRemoval(offsets.map { store.hosts[$0].id })
+    }
+
+    private func retryAction(
+        for id: Host.ID
+    ) -> (@MainActor @Sendable () async -> Void)? {
+        guard let retryConnection else { return nil }
+        return { await retryConnection(id) }
     }
 }
 

--- a/Sources/HerdrMobile/Hosts/HostListView.swift
+++ b/Sources/HerdrMobile/Hosts/HostListView.swift
@@ -66,7 +66,6 @@ final class HostRemovalStore {
 struct HostListView: View {
     let store: HostStore
     private let initialHostID: Host.ID?
-    private let connectionStatuses: [Host.ID: EventsSessionStatus]
     private let retryConnection: (@MainActor @Sendable (Host.ID) async -> Void)?
     @State private var removal: HostRemovalStore
     @State private var isAddingHost = false
@@ -77,12 +76,10 @@ struct HostListView: View {
     init(
         store: HostStore,
         initialHostID: Host.ID? = nil,
-        connectionStatuses: [Host.ID: EventsSessionStatus] = [:],
         retryConnection: (@MainActor @Sendable (Host.ID) async -> Void)? = nil
     ) {
         self.store = store
         self.initialHostID = initialHostID
-        self.connectionStatuses = connectionStatuses
         self.retryConnection = retryConnection
         _removal = State(initialValue: HostRemovalStore(store: store))
     }
@@ -143,7 +140,6 @@ struct HostListView: View {
                     HostOnboardingView(
                         host: host,
                         catalog: store,
-                        connectionStatus: connectionStatuses[id],
                         retryConnection: retryAction(for: id))
                         .id(host)
                 } else {

--- a/Sources/HerdrMobile/Hosts/HostListView.swift
+++ b/Sources/HerdrMobile/Hosts/HostListView.swift
@@ -66,6 +66,8 @@ final class HostRemovalStore {
 struct HostListView: View {
     let store: HostStore
     private let initialHostID: Host.ID?
+    private let connectionStatuses: [Host.ID: EventsSessionStatus]
+    private let reconnectingHostIDs: Set<Host.ID>
     private let retryConnection: (@MainActor @Sendable (Host.ID) async -> Void)?
     @State private var removal: HostRemovalStore
     @State private var isAddingHost = false
@@ -76,10 +78,14 @@ struct HostListView: View {
     init(
         store: HostStore,
         initialHostID: Host.ID? = nil,
+        connectionStatuses: [Host.ID: EventsSessionStatus] = [:],
+        reconnectingHostIDs: Set<Host.ID> = [],
         retryConnection: (@MainActor @Sendable (Host.ID) async -> Void)? = nil
     ) {
         self.store = store
         self.initialHostID = initialHostID
+        self.connectionStatuses = connectionStatuses
+        self.reconnectingHostIDs = reconnectingHostIDs
         self.retryConnection = retryConnection
         _removal = State(initialValue: HostRemovalStore(store: store))
     }
@@ -140,6 +146,8 @@ struct HostListView: View {
                     HostOnboardingView(
                         host: host,
                         catalog: store,
+                        connectionStatus: connectionStatuses[id],
+                        isReconnecting: reconnectingHostIDs.contains(id),
                         retryConnection: retryAction(for: id))
                         .id(host)
                 } else {

--- a/Sources/HerdrMobile/Hosts/HostOnboardingView.swift
+++ b/Sources/HerdrMobile/Hosts/HostOnboardingView.swift
@@ -6,13 +6,23 @@ import SwiftUI
 struct HostOnboardingView: View {
     /// The Host catalog, for the Edit sheet.
     let catalog: HostStore
+    let connectionStatus: EventsSessionStatus?
+    let retryConnection: (@MainActor @Sendable () async -> Void)?
     @State private var store: HostOnboardingStore
     @State private var isEditing = false
+    @State private var isRetryingConnection = false
     @State private var isConfirmingHostKeyReplacement = false
     @State private var sessionSelectionError: String?
 
-    init(host: Host, catalog: HostStore) {
+    init(
+        host: Host,
+        catalog: HostStore,
+        connectionStatus: EventsSessionStatus? = nil,
+        retryConnection: (@MainActor @Sendable () async -> Void)? = nil
+    ) {
         self.catalog = catalog
+        self.connectionStatus = connectionStatus
+        self.retryConnection = retryConnection
         _store = State(initialValue: HostOnboardingStore(host: host))
     }
 
@@ -24,6 +34,27 @@ struct HostOnboardingView: View {
                 LabeledContent(
                     "Auth",
                     value: store.host.authMethod == .deviceKey ? "Device Key" : "Password")
+            }
+
+            if canRetryConnection, retryConnection != nil {
+                Section {
+                    Button {
+                        retry()
+                    } label: {
+                        if isRetryingConnection {
+                            Label {
+                                Text("Connecting…")
+                            } icon: {
+                                ProgressView()
+                            }
+                        } else {
+                            Label("Retry Connection", systemImage: "arrow.clockwise")
+                        }
+                    }
+                    .disabled(isRetryingConnection)
+                } footer: {
+                    Text("Starts a new connection attempt using this Host's current settings.")
+                }
             }
 
             Section {
@@ -141,6 +172,20 @@ struct HostOnboardingView: View {
             return name
         }
         return "default"
+    }
+
+    private var canRetryConnection: Bool {
+        guard case .failed = connectionStatus else { return false }
+        return true
+    }
+
+    private func retry() {
+        guard !isRetryingConnection, let retryConnection else { return }
+        isRetryingConnection = true
+        Task { @MainActor in
+            await retryConnection()
+            isRetryingConnection = false
+        }
     }
 
     private func status(for check: PreflightCheck) -> PreflightCheckStatus? {

--- a/Sources/HerdrMobile/Hosts/HostOnboardingView.swift
+++ b/Sources/HerdrMobile/Hosts/HostOnboardingView.swift
@@ -6,19 +6,24 @@ import SwiftUI
 struct HostOnboardingView: View {
     /// The Host catalog, for the Edit sheet.
     let catalog: HostStore
+    let connectionStatus: EventsSessionStatus?
+    let isReconnecting: Bool
     let retryConnection: (@MainActor @Sendable () async -> Void)?
     @State private var store: HostOnboardingStore
     @State private var isEditing = false
-    @State private var isRetryingConnection = false
     @State private var isConfirmingHostKeyReplacement = false
     @State private var sessionSelectionError: String?
 
     init(
         host: Host,
         catalog: HostStore,
+        connectionStatus: EventsSessionStatus? = nil,
+        isReconnecting: Bool = false,
         retryConnection: (@MainActor @Sendable () async -> Void)? = nil
     ) {
         self.catalog = catalog
+        self.connectionStatus = connectionStatus
+        self.isReconnecting = isReconnecting
         self.retryConnection = retryConnection
         _store = State(initialValue: HostOnboardingStore(host: host))
     }
@@ -38,20 +43,27 @@ struct HostOnboardingView: View {
                     Button {
                         retry()
                     } label: {
-                        if isRetryingConnection {
-                            Label {
-                                Text("Connecting…")
-                            } icon: {
-                                ProgressView()
-                            }
-                        } else {
+                        ZStack(alignment: .leading) {
                             Label("Reconnect", systemImage: "arrow.clockwise")
+                                .opacity(isReconnecting ? 0 : 1)
+                            HStack {
+                                ProgressView()
+                                Text("Connecting…")
+                            }
+                            .opacity(isReconnecting ? 1 : 0)
                         }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .animation(.smooth(duration: 0.25), value: isReconnecting)
                     }
-                    .disabled(isRetryingConnection)
+                    .disabled(isReconnecting)
                 } footer: {
-                    Text("Restarts the Console connection using this Host's current settings.")
+                    if !isReconnecting, let connectionErrorMessage {
+                        Text(connectionErrorMessage)
+                            .foregroundStyle(.red)
+                            .transition(.opacity.combined(with: .move(edge: .top)))
+                    }
                 }
+                .animation(.smooth(duration: 0.25), value: connectionErrorMessage)
             }
 
             Section {
@@ -172,11 +184,18 @@ struct HostOnboardingView: View {
     }
 
     private func retry() {
-        guard !isRetryingConnection, let retryConnection else { return }
-        isRetryingConnection = true
+        guard !isReconnecting, let retryConnection else { return }
         Task { @MainActor in
             await retryConnection()
-            isRetryingConnection = false
+        }
+    }
+
+    private var connectionErrorMessage: String? {
+        switch connectionStatus {
+        case .reconnecting(_, _, let failure), .failed(let failure):
+            failure.connectionGuidance
+        case .connected, .suspended, .ended, nil:
+            nil
         }
     }
 

--- a/Sources/HerdrMobile/Hosts/HostOnboardingView.swift
+++ b/Sources/HerdrMobile/Hosts/HostOnboardingView.swift
@@ -6,7 +6,6 @@ import SwiftUI
 struct HostOnboardingView: View {
     /// The Host catalog, for the Edit sheet.
     let catalog: HostStore
-    let connectionStatus: EventsSessionStatus?
     let retryConnection: (@MainActor @Sendable () async -> Void)?
     @State private var store: HostOnboardingStore
     @State private var isEditing = false
@@ -17,11 +16,9 @@ struct HostOnboardingView: View {
     init(
         host: Host,
         catalog: HostStore,
-        connectionStatus: EventsSessionStatus? = nil,
         retryConnection: (@MainActor @Sendable () async -> Void)? = nil
     ) {
         self.catalog = catalog
-        self.connectionStatus = connectionStatus
         self.retryConnection = retryConnection
         _store = State(initialValue: HostOnboardingStore(host: host))
     }
@@ -36,7 +33,7 @@ struct HostOnboardingView: View {
                     value: store.host.authMethod == .deviceKey ? "Device Key" : "Password")
             }
 
-            if canRetryConnection, retryConnection != nil {
+            if retryConnection != nil {
                 Section {
                     Button {
                         retry()
@@ -48,12 +45,12 @@ struct HostOnboardingView: View {
                                 ProgressView()
                             }
                         } else {
-                            Label("Retry Connection", systemImage: "arrow.clockwise")
+                            Label("Reconnect", systemImage: "arrow.clockwise")
                         }
                     }
                     .disabled(isRetryingConnection)
                 } footer: {
-                    Text("Starts a new connection attempt using this Host's current settings.")
+                    Text("Restarts the Console connection using this Host's current settings.")
                 }
             }
 
@@ -172,11 +169,6 @@ struct HostOnboardingView: View {
             return name
         }
         return "default"
-    }
-
-    private var canRetryConnection: Bool {
-        guard case .failed = connectionStatus else { return false }
-        return true
     }
 
     private func retry() {

--- a/Sources/HerdrMobile/Transport/TransportError+Presentation.swift
+++ b/Sources/HerdrMobile/Transport/TransportError+Presentation.swift
@@ -1,0 +1,38 @@
+extension TransportError {
+    var connectionGuidance: String {
+        switch self {
+        case .sshUnreachable(let detail):
+            "SSH unavailable: \(detail)"
+        case .jumpHostFailed(let underlying):
+            "Jump Host: \(underlying.connectionGuidance)"
+        case .authenticationFailed:
+            "Authentication failed. Update this Host's credentials or authorized key."
+        case .deviceKeyCorrupt:
+            "The Device Key is corrupted. Replace it and install the new public key on the Host."
+        case .hostKeyRejected:
+            "The host key is not trusted. Verify it before reconnecting."
+        case .hostKeyMismatch:
+            "The host key changed. Verify the machine before updating trust."
+        case .socketNotFound:
+            "The herdr socket was not found. Check this Host's session."
+        case .serverNotRunning:
+            "herdr is not answering on this Host."
+        case .socatMissing:
+            "socat was not found. Install it or update this Host's socat path."
+        case .protocolVersionMismatch(let server, let supported):
+            "herdr protocol \(server) is incompatible with app protocol \(supported)."
+        case .homeDirectoryUnresolvable:
+            "The remote home directory could not be resolved."
+        case .eventsChannelAlreadyOpen, .terminalChannelAlreadyOpen:
+            "The connection is busy. Close the other terminal before reconnecting."
+        case .timedOut:
+            "The connection timed out."
+        case .cancelled:
+            "The connection was cancelled."
+        case .malformedResponse:
+            "herdr returned an invalid response. Check its version."
+        case .channelFailed(let detail):
+            "The connection failed: \(detail)"
+        }
+    }
+}

--- a/Tests/HerdrMobileTests/ConsoleStoreTests.swift
+++ b/Tests/HerdrMobileTests/ConsoleStoreTests.swift
@@ -1027,6 +1027,49 @@ struct ConsoleStoreTests {
         store.setHosts([])
     }
 
+    @Test func retryHostRestartsOnlyTheRequestedConnectedHost() async throws {
+        let hostA = Host.fixture(name: "alpha", address: "a.example")
+        let hostB = Host.fixture(name: "beta", address: "b.example")
+        let queues = [
+            hostA.id: ConnectionAttemptQueue([
+                .success(ScriptedTransport(snapshot: .fixture())),
+                .success(ScriptedTransport(snapshot: .fixture())),
+            ]),
+            hostB.id: ConnectionAttemptQueue([
+                .success(ScriptedTransport(snapshot: .fixture())),
+            ]),
+        ]
+        let store = ConsoleStore(snapshotRetryDelay: .milliseconds(10)) {
+            host, subscriptions in
+            EventsSession(
+                subscriptions: subscriptions,
+                connect: {
+                    guard let queue = queues[host.id] else {
+                        throw TransportError.sshUnreachable(detail: "unscripted host")
+                    }
+                    return try await queue.next()
+                },
+                reconnectPolicy: Self.fastPolicy,
+                keepalive: nil)
+        }
+
+        store.setHosts([hostA, hostB])
+        await store.resume()
+        try await waitUntil("both Hosts should connect") {
+            store.hostStatuses[hostA.id] == .connected
+                && store.hostStatuses[hostB.id] == .connected
+        }
+
+        await store.retryHost(hostA.id)
+        try await waitUntil("the requested Host should start a new connection") {
+            await queues[hostA.id]?.attemptCount == 2
+        }
+
+        #expect(await queues[hostB.id]?.attemptCount == 1)
+
+        store.setHosts([])
+    }
+
     @Test func eventChannelReconnectReusesHostConnectionGeneration() async throws {
         let host = Host.fixture()
         let transport = ScriptedTransport(

--- a/Tests/HerdrMobileTests/ConsoleStoreTests.swift
+++ b/Tests/HerdrMobileTests/ConsoleStoreTests.swift
@@ -978,6 +978,55 @@ struct ConsoleStoreTests {
         store.setHosts([])
     }
 
+    @Test func retryHostReconnectsOnlyTheRequestedFailedHost() async throws {
+        let hostA = Host.fixture(name: "alpha", address: "a.example")
+        let hostB = Host.fixture(name: "beta", address: "b.example")
+        let transportA = ScriptedTransport(snapshot: .fixture())
+        let transportB = ScriptedTransport(snapshot: .fixture())
+        let queues = [
+            hostA.id: ConnectionAttemptQueue([
+                .failure(.authenticationFailed),
+                .success(transportA),
+            ]),
+            hostB.id: ConnectionAttemptQueue([
+                .failure(.authenticationFailed),
+                .success(transportB),
+            ]),
+        ]
+        let store = ConsoleStore(snapshotRetryDelay: .milliseconds(10)) {
+            host, subscriptions in
+            EventsSession(
+                subscriptions: subscriptions,
+                connect: {
+                    guard let queue = queues[host.id] else {
+                        throw TransportError.sshUnreachable(detail: "unscripted host")
+                    }
+                    return try await queue.next()
+                },
+                reconnectPolicy: Self.fastPolicy,
+                keepalive: nil)
+        }
+
+        store.setHosts([hostA, hostB])
+        await store.resume()
+        try await waitUntil("both Hosts should stop on authentication failure") {
+            store.hostStatuses[hostA.id] == .failed(.authenticationFailed)
+                && store.hostStatuses[hostB.id] == .failed(.authenticationFailed)
+        }
+
+        await store.retryHost(hostA.id)
+        try await waitUntil("only the requested Host should reconnect") {
+            store.hostStatuses[hostA.id] == .connected
+        }
+
+        #expect(store.hostStatuses[hostB.id] == .failed(.authenticationFailed))
+        #expect(await queues[hostA.id]?.attemptCount == 2)
+        #expect(await queues[hostB.id]?.attemptCount == 1)
+        #expect(await transportB.capturedSubscriptions.isEmpty)
+
+        store.setHosts([])
+    }
+
     @Test func eventChannelReconnectReusesHostConnectionGeneration() async throws {
         let host = Host.fixture()
         let transport = ScriptedTransport(
@@ -1152,6 +1201,25 @@ private actor TransportQueue {
             throw TransportError.sshUnreachable(detail: "transport queue exhausted")
         }
         return remaining.removeFirst()
+    }
+}
+
+/// Scripts both failed and successful connection attempts for manual retry
+/// tests while recording exactly which Host was retried.
+private actor ConnectionAttemptQueue {
+    private var remaining: [Result<ScriptedTransport, TransportError>]
+    private(set) var attemptCount = 0
+
+    init(_ attempts: [Result<ScriptedTransport, TransportError>]) {
+        remaining = attempts
+    }
+
+    func next() throws -> ScriptedTransport {
+        attemptCount += 1
+        guard !remaining.isEmpty else {
+            throw TransportError.sshUnreachable(detail: "connection queue exhausted")
+        }
+        return try remaining.removeFirst().get()
     }
 }
 

--- a/Tests/HerdrMobileTests/TransportErrorPresentationTests.swift
+++ b/Tests/HerdrMobileTests/TransportErrorPresentationTests.swift
@@ -1,0 +1,23 @@
+import Testing
+
+@testable import HerdrMobile
+
+struct TransportErrorPresentationTests {
+    @Test func authenticationFailureExplainsTheRequiredRepair() {
+        #expect(
+            TransportError.authenticationFailed.connectionGuidance
+                == "Authentication failed. Update this Host's credentials or authorized key.")
+    }
+
+    @Test func jumpHostFailurePreservesTheUnderlyingCause() {
+        #expect(
+            TransportError.jumpHostFailed(.timedOut).connectionGuidance
+                == "Jump Host: The connection timed out.")
+    }
+
+    @Test func channelFailureIncludesItsDiagnosticDetail() {
+        #expect(
+            TransportError.channelFailed(detail: "connection reset").connectionGuidance
+                == "The connection failed: connection reset")
+    }
+}


### PR DESCRIPTION
## Summary

- keep failed Host notices compact and route them directly to the affected Host
- add an always-available Reconnect action with persistent Connecting feedback
- show actionable transport errors below the reconnect control
- restart only the selected Host connection without disturbing other Hosts

## Testing

- `xcodebuild test -quiet -project HerdrMobile.xcodeproj -scheme HerdrMobile -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:HerdrMobileTests/ConsoleStoreTests -only-testing:HerdrMobileTests/TransportErrorPresentationTests` (42 passed)\n- verified the reconnect transition and authentication error presentation on an iPhone 17 simulator\n- built, signed, installed, and launched the Debug app on a physical iPhone with `make install`