### PR TITLE
test: run HeelerSSH package suite from make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,10 @@ build: generate ## Build Debug for a physical device without installing
 		-destination 'generic/platform=iOS' -derivedDataPath $(DERIVED) \
 		-allowProvisioningUpdates build
 
-test: generate ## Run the unit test suite on a simulator
+test: generate ## Run the app and HeelerSSH unit test suites on a simulator
 	xcodebuild -project $(PROJECT) -scheme $(SCHEME) \
 		-destination 'platform=iOS Simulator,name=iPhone 17' test
+	scripts/run-heelerssh-package-tests.sh 'platform=iOS Simulator,name=iPhone 17'
 
 check-device:
 	@test -n "$(DEVICE)" || { echo "No physical device found; pass DEVICE=<devicectl uuid>"; exit 1; }

--- a/scripts/run-heelerssh-package-tests.sh
+++ b/scripts/run-heelerssh-package-tests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+destination=${1:-platform=iOS Simulator,name=iPhone 17}
+test_log=$(mktemp -t heeler-ssh-tests.XXXXXX)
+
+cleanup() {
+    rm -f "$test_log"
+}
+trap cleanup EXIT
+
+(
+    cd "$repo_root/Packages/HeelerSSH"
+    xcodebuild test \
+        -scheme HeelerSSH \
+        -destination "$destination" \
+        -derivedDataPath "$repo_root/build/HeelerSSHDerivedData" \
+        -collect-test-diagnostics never
+) 2>&1 | tee "$test_log"
+
+total=$(sed -n \
+    's/^.*Test run with \([0-9][0-9]*\) tests in .* passed after .*$/\1/p' \
+    "$test_log" | tail -n 1)
+if [[ -z "$total" ]]; then
+    echo "The HeelerSSH package suite printed no passing run summary" >&2
+    exit 1
+fi
+
+skips=$(grep -c 'Test .* skipped:' "$test_log" || true)
+executed=$((total - skips))
+if ((executed <= 0)); then
+    echo "The HeelerSSH package suite executed no tests ($total registered, $skips skipped)" >&2
+    exit 1
+fi
+
+echo "HeelerSSH package suite executed $executed of $total tests ($skips skipped)."


### PR DESCRIPTION
## Summary

- run the repository-local HeelerSSH package suite from `make test`
- keep package DerivedData scoped to the repository build directory
- fail when Swift Testing reports no tests actually executed, accounting for fixture-gated skips

## Validation

- `make test` (919 app tests; 26 registered HeelerSSH tests, 9 executed and 17 fixture-gated skips)
- zero-test mutation exits non-zero with the package guard's diagnostic
- `bash -n scripts/run-heelerssh-package-tests.sh`
- `shellcheck scripts/run-heelerssh-package-tests.sh`
- `git diff --check origin/main...HEAD`

Closes #132
