### PR TITLE
fix(console): preserve the first attach consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ Entries reference the issue that motivated them.
   already cancelled ended the working terminal's output silently, with no
   dialog at all. In both cases the live terminal now keeps running, and the
   refused surface alone shows "Another terminal is already open on this
-  Host." with Reattach. (#151, #164)
+  Host." with Reattach. (#151, #164; PR #174)
 
 - A Host that fails while you have one of its Agents open now says why on the
   session screen. It used to read "This Agent's pane is no longer reported" —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,15 @@ Entries reference the issue that motivated them.
   on this Host." and a Reattach button, so the worst case is one surface that
   has to be reopened rather than the whole app disappearing. (#137)
 
+- A turned-away duplicate terminal reader can no longer take the live
+  terminal down with it. When the refused reader was a terminal screen, its
+  cleanup ended the very session the refusal had just protected, so the
+  working terminal went down anyway; and a duplicate reader whose task was
+  already cancelled ended the working terminal's output silently, with no
+  dialog at all. In both cases the live terminal now keeps running, and the
+  refused surface alone shows "Another terminal is already open on this
+  Host." with Reattach. (#151, #164)
+
 - A Host that fails while you have one of its Agents open now says why on the
   session screen. It used to read "This Agent's pane is no longer reported" —
   blaming the Agent for the Host's problem, and pointing you at the wrong

--- a/Sources/Heeler/Console/AttachTerminalStore.swift
+++ b/Sources/Heeler/Console/AttachTerminalStore.swift
@@ -17,6 +17,26 @@ struct TerminalSessionHandler: Sendable {
     func run(_ session: TerminalAttachSession) async throws {
         try await operation(session)
     }
+
+    /// One complete session lifetime with owned teardown: runs the handler,
+    /// then ends the channel — on success and on every failure except a
+    /// `terminalChannelAlreadyOpen` refusal. That refusal means this
+    /// consumer never owned the session: another consumer holds the output,
+    /// the transport has already refused only this reader, and `end()` here
+    /// would reach through the shared channel and tear down the legitimate
+    /// consumer's live terminal (#151). The refusal itself still propagates,
+    /// so the offending surface shows it rather than swallowing it (#141).
+    func runEndingSession(_ session: TerminalAttachSession) async throws {
+        do {
+            try await run(session)
+        } catch TransportError.terminalChannelAlreadyOpen {
+            throw TransportError.terminalChannelAlreadyOpen
+        } catch {
+            await session.end()
+            throw error
+        }
+        await session.end()
+    }
 }
 
 /// The identity of one terminal pipeline, and so of the SwiftUI surface built

--- a/Sources/Heeler/Console/HostConsoleProjection.swift
+++ b/Sources/Heeler/Console/HostConsoleProjection.swift
@@ -141,13 +141,7 @@ final class HostConsoleProjection {
         return { request, handler in
             try await session.withTerminalTransport { transport in
                 let terminal = try await transport.attachTerminal(request)
-                do {
-                    try await handler.run(terminal)
-                    await terminal.end()
-                } catch {
-                    await terminal.end()
-                    throw error
-                }
+                try await handler.runEndingSession(terminal)
             }
         }
     }

--- a/Sources/Heeler/Demo/DemoScreenshotMode.swift
+++ b/Sources/Heeler/Demo/DemoScreenshotMode.swift
@@ -404,7 +404,7 @@
                     (profile.terminalOutputs[request.target] ?? DemoScreenshotFixture.terminalOutput)
                         .utf8)
             )
-            return TerminalAttachSession(output: output, input: input) {
+            return TerminalAttachSession(output: { output }, input: input) {
                 await self.endTerminal()
             }
         }

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -124,10 +124,18 @@ final class HeelerSSHAttachOutputGate: Sendable {
         gate: HeelerSSHAttachOutputGate
     ) {
         let gate = HeelerSSHAttachOutputGate()
-        let output = AsyncThrowingStream<Data, any Error> {
-            try await gate.next()
-        }
-        return (output, gate)
+        return (gate.makeOutput(), gate)
+    }
+
+    /// One stream view over this gate. The gate owns all buffering and the
+    /// consumer claim, so views are stateless and interchangeable for the
+    /// claimant — but they are not shareable across readers: an unfolding
+    /// stream instance keeps one produce storage for all its iterators, and
+    /// the standard library clears it from a cancellation handler that runs
+    /// before `next()` is ever invoked when the reading task is already
+    /// cancelled. Hand each potential reader its own view (#164).
+    func makeOutput() -> AsyncThrowingStream<Data, any Error> {
+        AsyncThrowingStream { try await self.next() }
     }
 
     func beginExplicitEnd() {
@@ -220,12 +228,22 @@ final class HeelerSSHAttachOutputGate: Sendable {
                 }
             }
         } onCancel: {
-            cancelConsumer()
+            cancelConsumer(reader)
         }
     }
 
-    private func cancelConsumer() {
+    /// Ends delivery because a consumer's task was cancelled.
+    ///
+    /// The cancellation handler is installed by every reader before the
+    /// claim check in `next()` can refuse it, and it can fire at any point
+    /// after installation. Without the ownership guard, a refused second
+    /// consumer whose task is cancelled around its read would clear the
+    /// buffer and resume the claimant's waiter with nil — silently ending a
+    /// terminal it never owned (#164). Only the claimant, or a first reader
+    /// still racing its own claim, may cancel delivery.
+    private func cancelConsumer(_ reader: TaskIdentity) {
         state.withLock { state in
+            guard state.consumer == nil || state.consumer == reader else { return }
             guard !state.isConsumerCancelled else { return }
             state.isConsumerCancelled = true
             state.buffered.removeAll(keepingCapacity: false)
@@ -1874,7 +1892,7 @@ actor HeelerSSHTransport: Transport {
                 throw await mapOperationError(error)
             }
 
-            let outputSource = HeelerSSHAttachOutputGate.makeStream()
+            let outputGate = HeelerSSHAttachOutputGate()
             let input = TerminalAttachInputQueue()
             nextTerminalReaderID &+= 1
             let readerID = nextTerminalReaderID
@@ -1885,12 +1903,12 @@ actor HeelerSSHTransport: Transport {
                     channel: channel,
                     admissionLease: lease,
                     input: input,
-                    output: outputSource.gate)
+                    output: outputGate)
             }
             return TerminalAttachSession(
-                output: outputSource.output,
+                output: outputGate.makeOutput,
                 input: input,
-                onEndStarted: outputSource.gate.beginExplicitEnd
+                onEndStarted: outputGate.beginExplicitEnd
             ) {
                 input.finish()
                 readerTask.cancel()

--- a/Sources/Heeler/Transport/TerminalAttach.swift
+++ b/Sources/Heeler/Transport/TerminalAttach.swift
@@ -276,18 +276,29 @@ final class TerminalAttachSession: Sendable {
     /// Raw PTY output in arrival order. Finishes without error when the
     /// remote attach exits cleanly (the user detached inside the TUI) or
     /// after `end()`; finishes throwing if the channel dies.
-    let output: AsyncThrowingStream<Data, any Error>
+    ///
+    /// Each access returns its own stream over the shared source. An
+    /// unfolding stream keeps one produce storage per stream *instance*,
+    /// shared by every iterator, and its own cancellation handler clears
+    /// that storage for a reader whose task is already cancelled — before
+    /// the source underneath can refuse the read. Through a single shared
+    /// instance, such a reader silently terminates the legitimate consumer's
+    /// iteration (#164). A per-access stream confines the damage to the
+    /// offending reader; who may consume at all is still decided underneath,
+    /// where the first reading task claims the output (#153).
+    var output: AsyncThrowingStream<Data, any Error> { makeOutput() }
+    private let makeOutput: @Sendable () -> AsyncThrowingStream<Data, any Error>
     private let input: TerminalAttachInputQueue
     private let onEndStarted: @Sendable () -> Void
     private let ender: @Sendable () async -> Void
 
     init(
-        output: AsyncThrowingStream<Data, any Error>,
+        output makeOutput: @escaping @Sendable () -> AsyncThrowingStream<Data, any Error>,
         input: TerminalAttachInputQueue,
         onEndStarted: @escaping @Sendable () -> Void = {},
         ender: @escaping @Sendable () async -> Void
     ) {
-        self.output = output
+        self.makeOutput = makeOutput
         self.input = input
         self.onEndStarted = onEndStarted
         self.ender = ender

--- a/Tests/HeelerTests/AgentSurfaceReplacementTests.swift
+++ b/Tests/HeelerTests/AgentSurfaceReplacementTests.swift
@@ -665,13 +665,7 @@ struct AgentSurfaceReplacementTests {
             isOnStage: { true },
             runTerminal: { request, handler in
                 let session = try await transport.attachTerminal(request)
-                do {
-                    try await handler.run(session)
-                    await session.end()
-                } catch {
-                    await session.end()
-                    throw error
-                }
+                try await handler.runEndingSession(session)
             },
             stageImage: { _, _ in throw TransportError.cancelled },
             closePane: {})

--- a/Tests/HeelerTests/AttachTerminalStoreTests.swift
+++ b/Tests/HeelerTests/AttachTerminalStoreTests.swift
@@ -326,13 +326,15 @@ struct AttachTerminalStoreTests {
         }
     }
 
-    /// #151: when this store is the refused second consumer, the refusal
-    /// must end only this store's run. The transport's gate leaves the
-    /// legitimate consumer running; an unconditional `end()` in the runner's
-    /// catch would reach through the shared session and tear down the very
+    /// #151: when a store is the refused second consumer, the refusal must
+    /// end only that store's run. The transport's gate leaves the legitimate
+    /// consumer running; an unconditional `end()` in the runner's catch
+    /// would reach through the shared session and tear down the very
     /// terminal the gate just protected — so the runner's owned teardown
     /// (`runEndingSession`, which `HostConsoleProjection.terminalRunner`
-    /// uses) skips exactly that error, and the refusal stays visible here.
+    /// uses) skips exactly that error, and the refusal stays visible on the
+    /// offending store. Both consumers are real stores: the proof is the
+    /// first app terminal staying live and its screen still receiving.
     @Test(.timeLimit(.minutes(1)))
     func aRefusedSecondConsumerStoreLeavesTheFirstTerminalRunning() async throws {
         let gate = HeelerSSHAttachOutputGate()
@@ -341,38 +343,42 @@ struct AttachTerminalStoreTests {
             input: TerminalAttachInputQueue(),
             onEndStarted: gate.beginExplicitEnd
         ) {}
-
-        let first = Task { () -> [Data] in
-            var seen: [Data] = []
-            do {
-                for try await bytes in shared.output { seen.append(bytes) }
-            } catch {}
-            return seen
-        }
-        try await waitUntil("the first consumer should park on the gate") {
-            gate.hasParkedConsumerForTesting
-        }
-
-        let store = AttachTerminalStore(target: "w1:p1") { _, handler in
+        let runSharedSession: TerminalSessionRunner = { _, handler in
             try await handler.runEndingSession(shared)
         }
-        store.viewDidResize(cols: 80, rows: 24)
+
+        let first = AttachTerminalStore(target: "w1:p1", runTerminal: runSharedSession)
+        let firstScreen = Captured()
+        first.feed.attach(firstScreen)
+        first.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the first store should claim the gate") {
+            gate.hasParkedConsumerForTesting
+        }
+        gate.yield(Self.firstPaint)
+        try await waitUntil("the first store should go live") { first.status == .live }
+
+        let second = AttachTerminalStore(target: "w1:p1", runTerminal: runSharedSession)
+        second.viewDidResize(cols: 80, rows: 24)
         try await waitUntil("the refusal should surface on the offending store") {
-            store.status == .ended("Another terminal is already open on this Host.")
+            second.status == .ended("Another terminal is already open on this Host.")
         }
 
         // The refused store must not have ended the shared session: the
-        // first consumer is still parked and still receives output. Two
-        // chunks, so silent early termination cannot pass for survival.
-        #expect(
-            gate.hasParkedConsumerForTesting,
-            "the refused store ended the first consumer's registration")
-        let afterRefusal = Data("after-the-refusal".utf8)
-        let stillFlowing = Data("still-flowing".utf8)
-        gate.yield(afterRefusal)
-        gate.yield(stillFlowing)
-        gate.finish()
-        #expect(await first.value == [afterRefusal, stillFlowing])
+        // first terminal is still live, still registered on the gate, and
+        // its screen still receives output. Two chunks, so silent early
+        // termination cannot pass for survival.
+        #expect(first.status == .live, "the refusal ended the first store's session")
+        try await waitUntil("the first store should stay parked on the gate") {
+            gate.hasParkedConsumerForTesting
+        }
+        gate.yield(Data("after-the-refusal".utf8))
+        gate.yield(Data("still-flowing".utf8))
+        try await waitUntil("the first terminal should keep receiving output") {
+            firstScreen.text == "\u{1B}[2J" + "after-the-refusal" + "still-flowing"
+        }
+        #expect(first.status == .live, "later output must reach a still-live first terminal")
+
+        await first.stop()
     }
 
     @Test func stopEndsTheSessionAndIsTerminal() async throws {

--- a/Tests/HeelerTests/AttachTerminalStoreTests.swift
+++ b/Tests/HeelerTests/AttachTerminalStoreTests.swift
@@ -21,13 +21,7 @@ struct AttachTerminalStoreTests {
                 throw TransportError.sshUnreachable(detail: "The Host is not connected.")
             }
             let session = try await transport.attachTerminal(request)
-            do {
-                try await handler.run(session)
-                await session.end()
-            } catch {
-                await session.end()
-                throw error
-            }
+            try await handler.runEndingSession(session)
         }
         let captured = Captured()
         store.feed.attach(captured)
@@ -330,6 +324,55 @@ struct AttachTerminalStoreTests {
         try await waitUntil("the store should surface the missing transport") {
             store.status == .ended("The Host is not connected.")
         }
+    }
+
+    /// #151: when this store is the refused second consumer, the refusal
+    /// must end only this store's run. The transport's gate leaves the
+    /// legitimate consumer running; an unconditional `end()` in the runner's
+    /// catch would reach through the shared session and tear down the very
+    /// terminal the gate just protected — so the runner's owned teardown
+    /// (`runEndingSession`, which `HostConsoleProjection.terminalRunner`
+    /// uses) skips exactly that error, and the refusal stays visible here.
+    @Test(.timeLimit(.minutes(1)))
+    func aRefusedSecondConsumerStoreLeavesTheFirstTerminalRunning() async throws {
+        let gate = HeelerSSHAttachOutputGate()
+        let shared = TerminalAttachSession(
+            output: gate.makeOutput,
+            input: TerminalAttachInputQueue(),
+            onEndStarted: gate.beginExplicitEnd
+        ) {}
+
+        let first = Task { () -> [Data] in
+            var seen: [Data] = []
+            do {
+                for try await bytes in shared.output { seen.append(bytes) }
+            } catch {}
+            return seen
+        }
+        try await waitUntil("the first consumer should park on the gate") {
+            gate.hasParkedConsumerForTesting
+        }
+
+        let store = AttachTerminalStore(target: "w1:p1") { _, handler in
+            try await handler.runEndingSession(shared)
+        }
+        store.viewDidResize(cols: 80, rows: 24)
+        try await waitUntil("the refusal should surface on the offending store") {
+            store.status == .ended("Another terminal is already open on this Host.")
+        }
+
+        // The refused store must not have ended the shared session: the
+        // first consumer is still parked and still receives output. Two
+        // chunks, so silent early termination cannot pass for survival.
+        #expect(
+            gate.hasParkedConsumerForTesting,
+            "the refused store ended the first consumer's registration")
+        let afterRefusal = Data("after-the-refusal".utf8)
+        let stillFlowing = Data("still-flowing".utf8)
+        gate.yield(afterRefusal)
+        gate.yield(stillFlowing)
+        gate.finish()
+        #expect(await first.value == [afterRefusal, stillFlowing])
     }
 
     @Test func stopEndsTheSessionAndIsTerminal() async throws {
@@ -2119,13 +2162,7 @@ struct AgentAttachStoreTests {
             isOnStage: isOnStage,
             runTerminal: runTerminal ?? { request, handler in
                 let session = try await transport.attachTerminal(request)
-                do {
-                    try await handler.run(session)
-                    await session.end()
-                } catch {
-                    await session.end()
-                    throw error
-                }
+                try await handler.runEndingSession(session)
             },
             stageImage: stageImage ?? { _, _ in throw ImageStagingError.transferFailed },
             closePane: close)
@@ -2195,13 +2232,7 @@ struct AgentAttachStoreTests {
             try await permit.acquire()
             do {
                 let session = try await transport.attachTerminal(request)
-                do {
-                    try await handler.run(session)
-                    await session.end()
-                } catch {
-                    await session.end()
-                    throw error
-                }
+                try await handler.runEndingSession(session)
             } catch {
                 await permit.release()
                 throw error
@@ -2384,13 +2415,7 @@ struct AgentAttachStoreForegroundTests {
             isOnStage: isOnStage,
             runTerminal: { request, handler in
                 let session = try await transport.attachTerminal(request)
-                do {
-                    try await handler.run(session)
-                    await session.end()
-                } catch {
-                    await session.end()
-                    throw error
-                }
+                try await handler.runEndingSession(session)
             },
             stageImage: { _, _ in throw TransportError.cancelled },
             closePane: {})

--- a/Tests/HeelerTests/Support/ScriptedTransport.swift
+++ b/Tests/HeelerTests/Support/ScriptedTransport.swift
@@ -383,7 +383,7 @@ final actor ScriptedTransport: Transport {
                 self.recordAttachInput(item)
             }
         }
-        return TerminalAttachSession(output: output, input: input) {
+        return TerminalAttachSession(output: { output }, input: input) {
             await endGate?.waitUntilOpen()
             await self.endAttach(id: attachID)
         }

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -248,6 +248,108 @@ struct TerminalAttachTests {
             """)
     }
 
+    /// A second consumer whose task is already cancelled reaches for the
+    /// stream through cancellation handlers that run before any claim check
+    /// can refuse it (#164): the unfolding stream's own handler clears the
+    /// produce storage its iterators share, and the gate's handler is
+    /// installed by every reader ahead of `next()`'s body. Neither door may
+    /// end the legitimate consumer: sessions hand each reader its own
+    /// stream, and the gate only honours a cancellation from its claimant.
+    @Test(.timeLimit(.minutes(1)))
+    func anAlreadyCancelledSecondConsumerCannotEndTheFirst() async throws {
+        let gate = HeelerSSHAttachOutputGate()
+        let session = TerminalAttachSession(
+            output: gate.makeOutput,
+            input: TerminalAttachInputQueue()
+        ) {}
+
+        let first = Task { () -> AttachConsumerOutcome in
+            var seen: [Data] = []
+            do {
+                for try await bytes in session.output { seen.append(bytes) }
+                return .drained(seen)
+            } catch {
+                return .failed(String(describing: error))
+            }
+        }
+        let parked = await Self.waitForParkedConsumer(gate)
+        #expect(parked, "the first consumer never parked on the gate")
+
+        let second = Task { () -> AttachConsumerOutcome in
+            // Reads only once its own task is already cancelled, so every
+            // cancellation handler fires ahead of the read instead of
+            // racing it.
+            while !Task.isCancelled { await Task.yield() }
+            var iterator = session.output.makeAsyncIterator()
+            do {
+                guard let bytes = try await iterator.next() else { return .drained([]) }
+                return .drained([bytes])
+            } catch {
+                return .failed(String(describing: error))
+            }
+        }
+        second.cancel()
+        let refusal = await Self.outcome(of: second)
+        #expect(
+            refusal == .drained([]),
+            """
+            an already-cancelled extra consumer must end quietly with nil, \
+            never with output: \(String(describing: refusal))
+            """)
+
+        // Its cancellation must not have reached the first consumer: the
+        // waiter is still parked, and later output still arrives. Two
+        // chunks, deliberately: a poisoned shared stream still hands over
+        // the one read already in flight and only then ends, so a single
+        // chunk cannot tell survival from silent early termination.
+        #expect(
+            gate.hasParkedConsumerForTesting,
+            "the cancelled extra consumer cleared the first consumer's waiter")
+        let afterCancellation = Data("after-the-cancellation".utf8)
+        let stillFlowing = Data("still-flowing".utf8)
+        gate.yield(afterCancellation)
+        gate.yield(stillFlowing)
+        gate.finish()
+        let served = await Self.outcome(of: first)
+        #expect(
+            served == .drained([afterCancellation, stillFlowing]),
+            """
+            the first consumer must keep receiving output unaffected: \
+            \(String(describing: served))
+            """)
+    }
+
+    /// The ownership guard on the gate's cancellation path must not cost the
+    /// claimant its own cancellation: cancelling the task that reads the
+    /// stream still ends its iteration promptly.
+    @Test(.timeLimit(.minutes(1)))
+    func cancellingTheClaimantsTaskStillEndsItsIteration() async throws {
+        let source = HeelerSSHAttachOutputGate.makeStream()
+        let gate = source.gate
+        let stream = source.output
+
+        let claimant = Task { () -> AttachConsumerOutcome in
+            var seen: [Data] = []
+            do {
+                for try await bytes in stream { seen.append(bytes) }
+                return .drained(seen)
+            } catch {
+                return .failed(String(describing: error))
+            }
+        }
+        let parked = await Self.waitForParkedConsumer(gate)
+        #expect(parked, "the claimant never parked on the gate")
+
+        claimant.cancel()
+        let ending = await Self.outcome(of: claimant)
+        #expect(
+            ending == .drained([]),
+            """
+            cancelling the claimant must end its own iteration without \
+            error: \(String(describing: ending))
+            """)
+    }
+
     /// Polls until a consumer is registered on the gate, so the test enters
     /// the double-consumer window deterministically rather than by sleeping.
     private static func waitForParkedConsumer(
@@ -302,7 +404,7 @@ struct TerminalAttachTests {
         let (output, outputContinuation) = AsyncThrowingStream<Data, any Error>.makeStream()
         let input = TerminalAttachInputQueue()
         let session = TerminalAttachSession(
-            output: output,
+            output: { output },
             input: input,
             ender: { outputContinuation.finish() })
         let inputController = TerminalInputController()


### PR DESCRIPTION
## Summary

- keep a refused second app consumer from ending the first terminal session
- isolate per-reader output views so a cancelled impostor cannot poison the legitimate stream
- preserve claimant cancellation while keeping refusal errors visible
- cover both consumers through real app stores and verify continued output

## Validation

- `xcodebuild test -project Heeler.xcodeproj -scheme Heeler -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:HeelerTests/AttachTerminalStoreTests -only-testing:HeelerTests/TerminalAttachTests`
- 85 tests in 2 suites passed

Closes #151
Closes #164
