### PR TITLE
fix(terminal): isolate keyboard handoff notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ Entries reference the issue that motivated them.
 
 ### Fixed
 
+- On iPad, one window's keyboard no longer ends another window's keyboard
+  handoff. Keyboard notifications are process-wide and each window can hold
+  a live terminal, so a frame event from one window's keyboard transition
+  could unfreeze the other terminal's grid before the keyboard had settled
+  for it. A terminal now heeds a transition only for its own keyboard: it
+  must be first responder, and a frame event must leave the keyboard
+  covering its own window. (#157)
+
 - Attach again withholds generic remote startup and SSH rc chatter until the
   attach command begins. The attach exec prints a short handshake marker
   immediately before `herdr agent attach`, and the client drops everything

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,8 @@ Entries reference the issue that motivated them.
   could unfreeze the other terminal's grid before the keyboard had settled
   for it. A terminal now heeds a transition only for its own keyboard: it
   must be first responder, and a frame event must leave the keyboard
-  covering its own window. (#157)
+  covering its own window. Process-wide show/hide broadcasts no longer end a
+  handoff. (#157)
 
 - Attach again withholds generic remote startup and SSH rc chatter until the
   attach command begins. The attach exec prints a short handshake marker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ Entries reference the issue that motivated them.
   for it. A terminal now heeds a transition only for its own keyboard: it
   must be first responder, and a frame event must leave the keyboard
   covering its own window. Process-wide show/hide broadcasts no longer end a
-  handoff. (#157)
+  handoff. (#157; PR #175)
 
 - Attach again withholds generic remote startup and SSH rc chatter until the
   attach command begins. The attach exec prints a short handshake marker

--- a/Sources/Heeler/Terminal/TerminalKeyboard.swift
+++ b/Sources/Heeler/Terminal/TerminalKeyboard.swift
@@ -516,16 +516,17 @@ extension HeelerTerminalView {
     /// Hooks the terminal into the keyboard's lifecycle, observed through
     /// `notificationCenter`.
     ///
-    /// Production keeps the default. The Console's detail column stages one
-    /// Attach at a time — keyed by Agent, with a switch replacing the whole
-    /// navigation path — the generated scene manifest enables no extra
-    /// windows, and iOS posts keyboard notifications per process. So no
-    /// keyboard event belonging to another live terminal exists to end a
-    /// handoff here; that half of #157 is not reachable in the shipped app.
-    /// Tests pass a center of their own, the same seam `TerminalKeyboardInset`
-    /// takes, so a keyboard settling in a neighbouring test cannot end this
-    /// terminal's handoff. There is nothing to balance: the center drops an
-    /// observer that deallocates.
+    /// Production observes the process-wide default: UIKit posts keyboard
+    /// notifications there, and there is no per-window center to move to.
+    /// What keeps one window's keyboard from ending another window's handoff
+    /// is the receiving end — a terminal heeds a transition event only for
+    /// its own keyboard (see `keyboardTransitionDidFinish` and
+    /// `textKeyboardFrameDidChange`) — because on iPad two of the app's
+    /// windows can each hold a live terminal (#157). Tests pass a center of
+    /// their own, the same seam `TerminalKeyboardInset` takes, so a keyboard
+    /// settling in a neighbouring test cannot reach this terminal at all.
+    /// There is nothing to balance: the center drops an observer that
+    /// deallocates.
     func installKeyboardSwitcher(notificationCenter: NotificationCenter = .default) {
         inputAssistantItem.leadingBarButtonGroups = []
         inputAssistantItem.trailingBarButtonGroups = []
@@ -618,7 +619,9 @@ extension HeelerTerminalView {
     }
 
     @objc private func textKeyboardFrameDidChange(_ notification: Notification) {
-        keyboardFrameDidSettle()
+        if notificationSettlesOwnKeyboard(notification) {
+            keyboardFrameDidSettle()
+        }
         guard keyboardMode == .text, isFirstResponder, let window,
               let endFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey]
                 as? CGRect
@@ -631,5 +634,24 @@ extension HeelerTerminalView {
             TerminalKeyboardAccessory.preferredHeight)
         recordTextKeyboardHeight(
             totalHeight: totalHeight, accessoryHeight: accessoryHeight)
+    }
+
+    /// Whether a keyboard frame event is this terminal's own settle signal.
+    /// Keyboard notifications are process-wide, and on iPad a second window
+    /// of the app can hold a live terminal of its own (#157): the event
+    /// belongs to this terminal's keyboard only while this terminal is first
+    /// responder, and only when the reported end frame leaves the keyboard
+    /// covering this terminal's window. A frame on its way out belongs to a
+    /// different transition — the other window's, say — and must not end
+    /// this terminal's handoff. A post carrying no frame cannot be judged
+    /// and is let through: UIKit always sends one, so only a test posts
+    /// without.
+    private func notificationSettlesOwnKeyboard(_ notification: Notification) -> Bool {
+        guard isFirstResponder, let window else { return false }
+        guard let endFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey]
+            as? CGRect
+        else { return true }
+        let frameInWindow = window.convert(endFrame, from: window.screen.coordinateSpace)
+        return window.bounds.intersection(frameInWindow).height > 0
     }
 }

--- a/Sources/Heeler/Terminal/TerminalKeyboard.swift
+++ b/Sources/Heeler/Terminal/TerminalKeyboard.swift
@@ -513,25 +513,38 @@ extension HeelerTerminalView {
         inputView as? TerminalKeysKeyboardView
     }
 
-    func installKeyboardSwitcher() {
+    /// Hooks the terminal into the keyboard's lifecycle, observed through
+    /// `notificationCenter`.
+    ///
+    /// Production keeps the default. The Console's detail column stages one
+    /// Attach at a time — keyed by Agent, with a switch replacing the whole
+    /// navigation path — the generated scene manifest enables no extra
+    /// windows, and iOS posts keyboard notifications per process. So no
+    /// keyboard event belonging to another live terminal exists to end a
+    /// handoff here; that half of #157 is not reachable in the shipped app.
+    /// Tests pass a center of their own, the same seam `TerminalKeyboardInset`
+    /// takes, so a keyboard settling in a neighbouring test cannot end this
+    /// terminal's handoff. There is nothing to balance: the center drops an
+    /// observer that deallocates.
+    func installKeyboardSwitcher(notificationCenter: NotificationCenter = .default) {
         inputAssistantItem.leadingBarButtonGroups = []
         inputAssistantItem.trailingBarButtonGroups = []
         _ = inputAccessoryView
-        NotificationCenter.default.addObserver(
+        notificationCenter.addObserver(
             self, selector: #selector(textKeyboardFrameDidChange(_:)),
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil)
-        NotificationCenter.default.addObserver(
+        notificationCenter.addObserver(
             self, selector: #selector(keyboardDismissalWillBegin(_:)),
             name: UIResponder.keyboardWillHideNotification, object: nil)
-        NotificationCenter.default.addObserver(
+        notificationCenter.addObserver(
             self, selector: #selector(keyboardPresentationWillBegin(_:)),
             name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(
+        notificationCenter.addObserver(
             self, selector: #selector(keyboardTransitionDidFinish(_:)),
             name: UIResponder.keyboardDidHideNotification, object: nil)
         // The other end of a transition: a terminal that inherited the
         // keyboard keeps its grid frozen until the keyboard has settled.
-        NotificationCenter.default.addObserver(
+        notificationCenter.addObserver(
             self, selector: #selector(keyboardTransitionDidFinish(_:)),
             name: UIResponder.keyboardDidShowNotification, object: nil)
     }

--- a/Sources/Heeler/Terminal/TerminalKeyboard.swift
+++ b/Sources/Heeler/Terminal/TerminalKeyboard.swift
@@ -520,11 +520,11 @@ extension HeelerTerminalView {
     /// notifications there, and there is no per-window center to move to.
     /// What keeps one window's keyboard from ending another window's handoff
     /// is the receiving end — a terminal heeds a transition event only for
-    /// its own keyboard (see `keyboardTransitionDidFinish` and
-    /// `textKeyboardFrameDidChange`) — because on iPad two of the app's
-    /// windows can each hold a live terminal (#157). Tests pass a center of
-    /// their own, the same seam `TerminalKeyboardInset` takes, so a keyboard
-    /// settling in a neighbouring test cannot reach this terminal at all.
+    /// its own keyboard (see `textKeyboardFrameDidChange`) — because on iPad
+    /// two of the app's windows can each hold a live terminal (#157). Tests
+    /// pass a center of their own, the same seam `TerminalKeyboardInset`
+    /// takes, so a keyboard settling in a neighbouring test cannot reach this
+    /// terminal at all.
     /// There is nothing to balance: the center drops an observer that
     /// deallocates.
     func installKeyboardSwitcher(notificationCenter: NotificationCenter = .default) {
@@ -540,14 +540,6 @@ extension HeelerTerminalView {
         notificationCenter.addObserver(
             self, selector: #selector(keyboardPresentationWillBegin(_:)),
             name: UIResponder.keyboardWillShowNotification, object: nil)
-        notificationCenter.addObserver(
-            self, selector: #selector(keyboardTransitionDidFinish(_:)),
-            name: UIResponder.keyboardDidHideNotification, object: nil)
-        // The other end of a transition: a terminal that inherited the
-        // keyboard keeps its grid frozen until the keyboard has settled.
-        notificationCenter.addObserver(
-            self, selector: #selector(keyboardTransitionDidFinish(_:)),
-            name: UIResponder.keyboardDidShowNotification, object: nil)
     }
 
     func setKeyboardMode(_ mode: TerminalKeyboardMode) {
@@ -643,14 +635,13 @@ extension HeelerTerminalView {
     /// responder, and only when the reported end frame leaves the keyboard
     /// covering this terminal's window. A frame on its way out belongs to a
     /// different transition — the other window's, say — and must not end
-    /// this terminal's handoff. A post carrying no frame cannot be judged
-    /// and is let through: UIKit always sends one, so only a test posts
-    /// without.
+    /// this terminal's handoff. A post carrying no frame cannot establish
+    /// ownership and is ignored.
     private func notificationSettlesOwnKeyboard(_ notification: Notification) -> Bool {
         guard isFirstResponder, let window else { return false }
         guard let endFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey]
             as? CGRect
-        else { return true }
+        else { return false }
         let frameInWindow = window.convert(endFrame, from: window.screen.coordinateSpace)
         return window.bounds.intersection(frameInWindow).height > 0
     }

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -107,7 +107,11 @@ struct TerminalScreenView: UIViewRepresentable {
         keysContext: TerminalKeysContext? = nil,
         theme: TerminalTheme = .default,
         fontSize: Float = TerminalZoomSettings.defaultFontSize,
-        fontFamily: String? = nil
+        fontFamily: String? = nil,
+        /// The center the terminal observes the keyboard through. Tests pass
+        /// their own so one test's keyboard cannot end another test's
+        /// handoff (#157); production keeps the default.
+        notificationCenter: NotificationCenter = .default
     ) -> HeelerTerminalView {
         let view = HeelerTerminalView(
             frame: .zero,
@@ -121,7 +125,7 @@ struct TerminalScreenView: UIViewRepresentable {
             theme: theme,
             fontSize: fontSize,
             fontFamily: fontFamily)
-        view.installKeyboardSwitcher()
+        view.installKeyboardSwitcher(notificationCenter: notificationCenter)
         return view
     }
 

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -981,12 +981,19 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     }
 
     @objc func keyboardTransitionDidFinish(_: Notification) {
+        // Keyboard notifications are process-wide, and on iPad a second
+        // window of the app can hold a live terminal of its own (#157): a
+        // did-show or did-hide is this terminal's own transition only while
+        // this terminal owns a keyboard at all — is first responder.
+        guard isFirstResponder else { return }
         finishKeyboardTransitionLayout()
     }
 
     /// The keyboard reached its end frame. An inherited keyboard never leaves,
     /// so this is the only settled signal it gets — there is no did-show to
-    /// wait for.
+    /// wait for. Whose keyboard it is, the caller answers: frame events are
+    /// process-wide, and only one that leaves the keyboard covering this
+    /// terminal's own window may thaw the freeze (#157).
     func keyboardFrameDidSettle() {
         guard keyboardTransitionEndsOnFrameChange else { return }
         finishKeyboardTransitionLayout()

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -980,20 +980,13 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         }
     }
 
-    @objc func keyboardTransitionDidFinish(_: Notification) {
-        // Keyboard notifications are process-wide, and on iPad a second
-        // window of the app can hold a live terminal of its own (#157): a
-        // did-show or did-hide is this terminal's own transition only while
-        // this terminal owns a keyboard at all — is first responder.
-        guard isFirstResponder else { return }
-        finishKeyboardTransitionLayout()
-    }
-
     /// The keyboard reached its end frame. An inherited keyboard never leaves,
     /// so this is the only settled signal it gets — there is no did-show to
-    /// wait for. Whose keyboard it is, the caller answers: frame events are
-    /// process-wide, and only one that leaves the keyboard covering this
-    /// terminal's own window may thaw the freeze (#157).
+    /// wait for. Show/hide notifications are process-wide and carry no scene
+    /// ownership, so they cannot safely end a handoff. Whose keyboard it is,
+    /// the caller answers from the end frame: only one that leaves the
+    /// keyboard covering this terminal's own window may thaw the freeze
+    /// (#157).
     func keyboardFrameDidSettle() {
         guard keyboardTransitionEndsOnFrameChange else { return }
         finishKeyboardTransitionLayout()

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -421,10 +421,15 @@ struct TerminalAgentSwitcherTests {
     @MainActor
     @Test func aClaimedHandoffFreezesTheGridUntilTheKeyboardSettles() async throws {
         var reportedGrids: [TerminalGrid] = []
+        // The terminal's own center, so a keyboard settling anywhere else in
+        // the process — another test's terminal, say — cannot end this
+        // handoff (#157).
+        let center = NotificationCenter()
         let terminal = TerminalScreenView.makeConfiguredTerminal(
             onSizeChanged: { columns, rows in
                 reportedGrids.append(TerminalGrid(columns: columns, rows: rows))
-            })
+            },
+            notificationCenter: center)
         let host = UIViewController()
         let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 390, height: 700),
@@ -439,6 +444,13 @@ struct TerminalAgentSwitcherTests {
         host.view.addSubview(terminal)
         window.layoutIfNeeded()
 
+        // A foreign settle, posted to the process-wide center inside the
+        // handoff window. Before the isolation above, exactly this thawed the
+        // freeze early — that was #145's second failure — so the window below
+        // doubles as the proof that it no longer can.
+        NotificationCenter.default.post(
+            name: UIResponder.keyboardDidChangeFrameNotification, object: nil)
+
         // The keyboard is arriving: every bounds UIKit animates through here
         // is a half-built grid Ghostty must not be measured against.
         for height: CGFloat in [520, 440, 360] {
@@ -450,8 +462,9 @@ struct TerminalAgentSwitcherTests {
         #expect(reportedGrids.isEmpty)
 
         // The keyboard settled. A keyboard that never left reports no
-        // did-show, so its end frame is what thaws the grid.
-        NotificationCenter.default.post(
+        // did-show, so its end frame is what thaws the grid — delivered on
+        // the terminal's own center, the only one it observes.
+        center.post(
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil)
         try await Self.waitForGridReportsToStop { reportedGrids }
         let escaped = reportedGrids
@@ -495,23 +508,31 @@ struct TerminalAgentSwitcherTests {
             rootViewController: host)
         defer { window.isHidden = true }
 
-        let inherited = TerminalScreenView.makeConfiguredTerminal()
+        // Both terminals observe the test's own center: with every terminal
+        // in the process on the shared one, any keyboard settling anywhere
+        // could end the handoff before the explicit call below (#157).
+        let center = NotificationCenter()
+        let inherited = TerminalScreenView.makeConfiguredTerminal(
+            notificationCenter: center)
         inherited.raisesKeyboardWhenReady = true
         inherited.frame = CGRect(x: 0, y: 0, width: 390, height: 400)
         host.view.addSubview(inherited)
-        // Every terminal in the process listens for the keyboard's frame, so
-        // any keyboard settling anywhere can be what ends this handoff. This
-        // call is then as likely to find the handoff already over as to be what
-        // ends it — but either way it is over once the call returns. Counting
-        // the rebuilds around the call would only catch the republish in the
-        // second case, which is scheduling rather than behaviour.
+        // A foreign settle inside the handoff window must leave the handoff
+        // standing, so the call below is necessarily what ends it — and the
+        // republish lands exactly there, not whenever a neighbour's keyboard
+        // happened to settle.
+        NotificationCenter.default.post(
+            name: UIResponder.keyboardDidChangeFrameNotification, object: nil)
+        let rebuildsBeforeHandoffEnds = inherited.inputViewRebuildCount
         inherited.finishKeyboardTransitionLayout()
+        #expect(inherited.inputViewRebuildCount > rebuildsBeforeHandoffEnds)
 
         // A terminal that raised its own keyboard has no outgoing accessory to
         // account for, so the same call must leave its input views alone. That
         // makes it the yardstick as well: same surface, same window, same
         // keyboard, differing only in having no handoff to pay for.
-        let dismissing = TerminalScreenView.makeConfiguredTerminal()
+        let dismissing = TerminalScreenView.makeConfiguredTerminal(
+            notificationCenter: center)
         dismissing.frame = CGRect(x: 0, y: 0, width: 390, height: 400)
         host.view.addSubview(dismissing)
         dismissing.requestKeyboard()

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -359,18 +359,21 @@ struct TerminalAgentSwitcherTests {
     /// takes first responder in the same pass it reaches the window.
     @MainActor
     @Test func aClaimedHandoffTakesTheKeyboardOverWithoutLettingItDrop() async throws {
+        let center = NotificationCenter()
         let host = UIViewController()
         let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 390, height: 700),
             rootViewController: host)
         defer { window.isHidden = true }
 
-        let plain = TerminalScreenView.makeConfiguredTerminal()
+        let plain = TerminalScreenView.makeConfiguredTerminal(
+            notificationCenter: center)
         plain.frame = CGRect(x: 0, y: 0, width: 390, height: 400)
         host.view.addSubview(plain)
         #expect(!plain.isFirstResponder)
 
-        let claimed = TerminalScreenView.makeConfiguredTerminal()
+        let claimed = TerminalScreenView.makeConfiguredTerminal(
+            notificationCenter: center)
         claimed.raisesKeyboardWhenReady = true
         claimed.frame = CGRect(x: 0, y: 0, width: 390, height: 400)
         host.view.addSubview(claimed)
@@ -465,7 +468,9 @@ struct TerminalAgentSwitcherTests {
         // did-show, so its end frame is what thaws the grid — delivered on
         // the terminal's own center, the only one it observes.
         center.post(
-            name: UIResponder.keyboardDidChangeFrameNotification, object: nil)
+            name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                x: 0, y: 400, width: 390, height: 300)])
         try await Self.waitForGridReportsToStop { reportedGrids }
         let escaped = reportedGrids
         #expect(!escaped.isEmpty, "the settled grid never made it past the freeze")
@@ -550,13 +555,13 @@ struct TerminalAgentSwitcherTests {
 
     /// Keyboard notifications are process-wide, and on iPad two of the app's
     /// windows can each hold a live terminal (#157). Both of these terminals
-    /// observe the default center exactly as production builds them: a frame
-    /// event belonging to the other window's transition — the keyboard on
-    /// its way out there — must leave this terminal's handoff alone, and
-    /// only the frame that leaves the keyboard covering this terminal's own
+    /// observe the default center exactly as production builds them. Generic
+    /// show/hide events, a frame without ownership evidence, and a frame
+    /// leaving the other window must all leave this terminal's handoff alone.
+    /// Only a frame that leaves the keyboard covering this terminal's own
     /// window may thaw it.
     @MainActor
-    @Test func anotherWindowsKeyboardFrameDoesNotEndTheHandoff() async throws {
+    @Test func anotherWindowsKeyboardEventsDoNotEndTheHandoff() async throws {
         var reportedGrids: [TerminalGrid] = []
         let foreign = TerminalScreenView.makeConfiguredTerminal()
         let terminal = TerminalScreenView.makeConfiguredTerminal(
@@ -589,12 +594,21 @@ struct TerminalAgentSwitcherTests {
         window.layoutIfNeeded()
         #expect(terminal.isFirstResponder)
 
-        // The other window's keyboard on its way out: its end frame leaves
-        // nothing covering this terminal's window. A thaw rebuilds the input
-        // views on the spot, so an unchanged rebuild count is the proof the
-        // freeze survived — synchronous, with no window for a neighbouring
-        // test's real keyboard to slip through.
+        // The other window's keyboard notifications provide no usable scene
+        // identity. Its end frame leaves nothing covering this terminal's
+        // window. A thaw rebuilds the input views on the spot, so an unchanged
+        // rebuild count proves the freeze survived synchronously.
         let rebuildsBeforeForeignEvent = terminal.inputViewRebuildCount
+        NotificationCenter.default.post(
+            name: UIResponder.keyboardDidShowNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                x: 0, y: 400, width: 390, height: 300)])
+        NotificationCenter.default.post(
+            name: UIResponder.keyboardDidHideNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                x: 0, y: 700, width: 390, height: 300)])
+        NotificationCenter.default.post(
+            name: UIResponder.keyboardDidChangeFrameNotification, object: nil)
         NotificationCenter.default.post(
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -547,4 +547,78 @@ struct TerminalAgentSwitcherTests {
             the dismissal \(dismissing.inputViewRebuildCount)
             """)
     }
+
+    /// Keyboard notifications are process-wide, and on iPad two of the app's
+    /// windows can each hold a live terminal (#157). Both of these terminals
+    /// observe the default center exactly as production builds them: a frame
+    /// event belonging to the other window's transition — the keyboard on
+    /// its way out there — must leave this terminal's handoff alone, and
+    /// only the frame that leaves the keyboard covering this terminal's own
+    /// window may thaw it.
+    @MainActor
+    @Test func anotherWindowsKeyboardFrameDoesNotEndTheHandoff() async throws {
+        var reportedGrids: [TerminalGrid] = []
+        let foreign = TerminalScreenView.makeConfiguredTerminal()
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            onSizeChanged: { columns, rows in
+                reportedGrids.append(TerminalGrid(columns: columns, rows: rows))
+            })
+        let foreignHost = UIViewController()
+        let foreignWindow = try await makeTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 390, height: 700),
+            rootViewController: foreignHost)
+        let host = UIViewController()
+        let window = try await makeTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 390, height: 700),
+            rootViewController: host)
+        defer {
+            terminal.removeFromSuperview()
+            foreign.removeFromSuperview()
+            window.isHidden = true
+            foreignWindow.isHidden = true
+        }
+
+        foreign.frame = CGRect(x: 0, y: 0, width: 390, height: 400)
+        foreignHost.view.addSubview(foreign)
+
+        // The handoff itself: the terminal claims the keyboard as it reaches
+        // its window and freezes its grid until that keyboard settles.
+        terminal.raisesKeyboardWhenReady = true
+        terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 600)
+        host.view.addSubview(terminal)
+        window.layoutIfNeeded()
+        #expect(terminal.isFirstResponder)
+
+        // The other window's keyboard on its way out: its end frame leaves
+        // nothing covering this terminal's window. A thaw rebuilds the input
+        // views on the spot, so an unchanged rebuild count is the proof the
+        // freeze survived — synchronous, with no window for a neighbouring
+        // test's real keyboard to slip through.
+        let rebuildsBeforeForeignEvent = terminal.inputViewRebuildCount
+        NotificationCenter.default.post(
+            name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                x: 0, y: 700, width: 390, height: 300)])
+        #expect(terminal.inputViewRebuildCount == rebuildsBeforeForeignEvent)
+
+        for height: CGFloat in [520, 440, 360] {
+            terminal.frame.size.height = height
+            terminal.setNeedsLayout()
+            terminal.layoutIfNeeded()
+        }
+        #expect(terminal.inputViewRebuildCount == rebuildsBeforeForeignEvent)
+        #expect(reportedGrids.isEmpty)
+
+        // This terminal's own settle: the keyboard ends its move covering
+        // the terminal's window, and the freeze thaws.
+        NotificationCenter.default.post(
+            name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                x: 0, y: 400, width: 390, height: 300)])
+        #expect(terminal.inputViewRebuildCount > rebuildsBeforeForeignEvent)
+        try await Self.waitForGridReportsToStop { reportedGrids }
+        #expect(
+            !reportedGrids.isEmpty,
+            "the terminal's own settle never made it past the freeze")
+    }
 }

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -935,14 +935,18 @@ struct TerminalAttachTests {
     @MainActor
     @Test func theKeyboardRowLeavesInSyncWithTheKeyboard() throws {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: 874))
-        let terminal = TerminalScreenView.makeConfiguredTerminal()
+        // The terminal's own center: a test's keyboard events must not reach
+        // another test's terminal, this one's included (#157).
+        let center = NotificationCenter()
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            notificationCenter: center)
         window.addSubview(terminal)
         window.makeKeyAndVisible()
         terminal.requestKeyboard()
         let accessory = try #require(
             terminal.inputAccessoryView as? TerminalKeyboardAccessory)
 
-        NotificationCenter.default.post(
+        center.post(
             name: UIResponder.keyboardWillHideNotification, object: nil,
             userInfo: [UIResponder.keyboardAnimationDurationUserInfoKey: NSNumber(value: 0.0)])
 
@@ -1032,10 +1036,14 @@ struct TerminalAttachTests {
     @MainActor
     @Test func aKeyboardHandoffCoalescesItsTransientGridsIntoOneResize() async throws {
         var reportedGrids: [(columns: Int, rows: Int)] = []
+        // The terminal's own center, so a keyboard settling in a neighbouring
+        // test cannot end the handoff inside the freeze window below (#157).
+        let center = NotificationCenter()
         let terminal = TerminalScreenView.makeConfiguredTerminal(
             onSizeChanged: { columns, rows in
                 reportedGrids.append((columns, rows))
-            })
+            },
+            notificationCenter: center)
         let host = UIViewController()
         let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 390, height: 700),
@@ -1100,7 +1108,11 @@ struct TerminalAttachTests {
     /// wearing a fully transparent toolbar until will-show restored it.
     @MainActor
     @Test func aRepresentedKeyboardRestoresItsDismissedAccessory() throws {
-        let terminal = TerminalScreenView.makeConfiguredTerminal()
+        // The terminal's own center: a test's keyboard events must not reach
+        // another test's terminal, this one's included (#157).
+        let center = NotificationCenter()
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            notificationCenter: center)
         let accessory = try #require(
             terminal.inputAccessoryView as? TerminalKeyboardAccessory)
 
@@ -1109,7 +1121,7 @@ struct TerminalAttachTests {
         accessory.animateDismissal(duration: 0)
         #expect(accessory.toolbarContentView.alpha == 0)
 
-        NotificationCenter.default.post(
+        center.post(
             name: UIResponder.keyboardWillShowNotification, object: nil,
             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
                 x: 0, y: 554, width: 440, height: 436)])


### PR DESCRIPTION
## Summary

- inject the keyboard notification center so each handoff test can use an isolated observer domain
- end inherited keyboard handoffs only from a frame change that belongs to the first-responder terminal and covers its window
- ignore process-wide show/hide broadcasts and frame changes without ownership evidence
- cover two production-configured windows and preserve the strict #145 settled-grid assertions

## Validation

- RED: `TerminalAgentSwitcherTests.anotherWindowsKeyboardEventsDoNotEndTheHandoff` failed because foreign show/hide notifications rebuilt the inherited terminal early
- `xcodebuild test -project Heeler.xcodeproj -scheme Heeler -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:HeelerTests/TerminalAgentSwitcherTests` (16 tests passed)
- `xcodebuild test -project Heeler.xcodeproj -scheme Heeler -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:HeelerTests/TerminalAttachTests` (63 tests passed)

Closes #157
