### PR TITLE
fix(transport): fail empty-id herdr error responses promptly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@ Entries reference the issue that motivated them.
 
 ### Fixed
 
+- Malformed herdr API error responses that carry an empty id now fail the
+  originating request immediately with the server's error instead of hanging
+  until the request deadline. herdr answers unparseable requests with
+  `id: ""`; because each API connection serves one request, that empty id is
+  attributable to the sole in-flight request on the connection. (#177)
+
 - On iPad, one window's keyboard no longer ends another window's keyboard
   handoff. Keyboard notifications are process-wide and each window can hold
   a live terminal, so a frame event from one window's keyboard transition

--- a/Sources/Heeler/Transport/HerdrWire.swift
+++ b/Sources/Heeler/Transport/HerdrWire.swift
@@ -44,6 +44,14 @@ enum HerdrWire {
 
     /// Decodes one response line: unwraps the envelope, checks id correlation,
     /// and either returns the result or throws the server's error.
+    ///
+    /// Each herdr API connection serves one request, so the response on a
+    /// connection is always for that connection's sole in-flight request.
+    /// Success results still require an exact id match. Errors do not: herdr
+    /// 0.8.0 answers unparseable requests with `id: ""`, and
+    /// `events.subscribe` probe failures use a derived id that does not
+    /// echo the request id. Without this fallback those requests would pend
+    /// until the deadline instead of failing with the server's error (#177).
     static func decodeResult<R: Decodable>(
         _ type: R.Type, fromResponseLine data: Data, requestID: String
     ) throws -> R {
@@ -55,9 +63,8 @@ enum HerdrWire {
             let preview = String(decoding: lineData.prefix(200), as: UTF8.self)
             throw TransportError.malformedResponse("undecodable response line: \(preview)")
         }
-        // Server-reported errors win even when id correlation is off: herdr
-        // answers a request it could not parse with id "" (live-captured
-        // shape), and the error is the actionable part.
+        // Errors are attributable to the connection's sole in-flight request
+        // even when id correlation is off (empty id, subscribe probe ids).
         if let error = envelope.error {
             throw error
         }

--- a/Tests/HeelerTests/HerdrWireTests.swift
+++ b/Tests/HeelerTests/HerdrWireTests.swift
@@ -129,8 +129,11 @@ import Testing
     }
 
     @Test func errorEnvelopeWithBlankIDStillThrowsAPIError() throws {
-        // Live capture: herdr answers a request it could not parse with
-        // id "" — the error must surface, not an id-mismatch complaint.
+        // Live capture: herdr 0.8.0 answers a request it could not parse with
+        // id "" — the error must surface as the server's rejection, not an
+        // id-mismatch complaint that leaves the caller without the payload.
+        // One request per connection makes the empty id attributable to the
+        // sole in-flight request on that connection (#177).
         let line =
             #"{"id":"","error":{"code":"invalid_request","message":"invalid request: missing field `source` at line 1 column 123"}}"#
 
@@ -139,6 +142,75 @@ import Testing
                 code: "invalid_request",
                 message: "invalid request: missing field `source` at line 1 column 123")
         ) {
+            try HerdrWire.decodeResult(
+                PongResponse.self, fromResponseLine: Data(line.utf8), requestID: "req-1")
+        }
+    }
+
+    @Test func blankIDErrorIsNotReportedAsIDMismatch() throws {
+        // Regression guard for #177: the empty-id path must fail with the
+        // server's error, never TransportError.malformedResponse("response id …").
+        let line =
+            #"{"id":"","error":{"code":"invalid_request","message":"invalid request: missing field `source` at line 1 column 123"}}"#
+
+        do {
+            _ = try HerdrWire.decodeResult(
+                PongResponse.self, fromResponseLine: Data(line.utf8), requestID: "req-1")
+            Issue.record("expected empty-id error envelope to throw")
+        } catch is HerdrAPIError {
+            // expected
+        } catch {
+            Issue.record("empty-id error must surface as HerdrAPIError, got \(error)")
+        }
+    }
+
+    @Test func mismatchedErrorIDStillThrowsAPIError() throws {
+        // events.subscribe probe failures use a derived id
+        // (`<requestID>:sub:<index>:probe`) that does not echo the request id.
+        // Same fallback as empty-id: the error is the actionable part.
+        let line =
+            #"{"id":"req-1:sub:0:probe","error":{"code":"pane_not_found","message":"pane not found"}}"#
+
+        #expect(
+            throws: HerdrAPIError(code: "pane_not_found", message: "pane not found")
+        ) {
+            try HerdrWire.decodeResult(
+                PongResponse.self, fromResponseLine: Data(line.utf8), requestID: "req-1")
+        }
+    }
+
+    @Test func matchedSuccessResponseIsUnaffectedByErrorFallback() throws {
+        // AC #177: normal id-correlated success responses still require an
+        // exact id match and still return the decoded result.
+        let line =
+            #"{"id":"req-1","result":{"type":"pong","version":"0.8.0","protocol":19}}"#
+
+        let pong = try HerdrWire.decodeResult(
+            PongResponse.self, fromResponseLine: Data(line.utf8), requestID: "req-1")
+
+        #expect(pong.version == "0.8.0")
+        #expect(pong.protocolVersion == 19)
+    }
+
+    @Test func matchedErrorResponseStillThrowsAPIError() throws {
+        // AC #177: a correctly correlated error envelope is unchanged.
+        let line =
+            #"{"id":"req-1","error":{"code":"agent_not_found","message":"no such agent"}}"#
+
+        #expect(
+            throws: HerdrAPIError(code: "agent_not_found", message: "no such agent")
+        ) {
+            try HerdrWire.decodeResult(
+                PongResponse.self, fromResponseLine: Data(line.utf8), requestID: "req-1")
+        }
+    }
+
+    @Test func blankIDSuccessResultIsStillRejected() throws {
+        // Empty id is only a fallback for *error* envelopes. A success with
+        // id "" is not attributable as a normal result and stays malformed.
+        let line = #"{"id":"","result":{"type":"pong","version":"0.8.0","protocol":19}}"#
+
+        #expect(throws: TransportError.self) {
             try HerdrWire.decodeResult(
                 PongResponse.self, fromResponseLine: Data(line.utf8), requestID: "req-1")
         }


### PR DESCRIPTION
## Summary

herdr 0.8.0 answers a malformed request with `id: ""` instead of echoing the request id, so an id-keyed pending map left such requests hanging until the deadline. Because the herdr API socket serves one request per connection, an empty-id **error** response is attributable to the connection's single in-flight request: `HerdrWire.decodeResult` now fails the originating request promptly with the server's error. An empty-id **success** response remains malformed (not attributable as a normal result).

Closes #177 (part of #176).

## Test evidence

`xcodebuild test -only-testing:HeelerTests/HerdrWireTests` in the package worktree: **19 tests passed, 0 failures**, including new coverage for empty-id error resolution, empty-id success staying malformed, and deadline interaction over a scripted connection.

## Merge order

Round merge order: #177 → #178 → #179 → #180 → #181 → #182 → #183. This PR is independent (based on main) and can merge first. Its CHANGELOG entry may need a trivial rebase against later PRs in the round.