### PR TITLE
feat(monitor): snapshot-first agent detail with Attach escape hatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Entries reference the issue that motivated them.
 
 ### Added
 
+- Opening an Agent now lands on Monitor: a color-preserving snapshot of its
+  latest screen with an honest capture time. Attach remains available as a
+  full-screen toolbar action for realtime interaction; leaving it closes the
+  live terminal and refreshes Monitor once. Agent Notification taps land on
+  Monitor as well. (#179)
+
 - Settings > About now has Acknowledgements: every redistributed third-party
   component ships with its exact upstream licence notice, including libssh2
   and its secondary sources, OpenSSL, Ghostty and its stack, the monospaced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Entries reference the issue that motivated them.
 
 ### Added
 
+- Monitor has a control-key strip (Enter, Esc, Ctrl+C, arrows) so a Blocked
+  Agent's confirmation prompt can be answered — and work interrupted —
+  without entering Attach. Each tap is delivered through agent-level
+  `send_keys` and refreshes the snapshot once the Host accepts it. (#183)
+
 - Opening an Agent now lands on Monitor: a color-preserving snapshot of its
   latest screen with an honest capture time. Attach remains available as a
   full-screen toolbar action for realtime interaction; leaving it closes the

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00BB32665B566815194A17D5 /* AgentMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68C51ED25429F47720E29976 /* AgentMonitorView.swift */; };
 		00FB65666F7C2E065D94DF2C /* StartAgentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24EF5EA39899292A1907226 /* StartAgentStore.swift */; };
 		03970FA28B8C09C524AF435E /* NotificationPrivacyCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 943C187E6425414801A4734E /* NotificationPrivacyCopyTests.swift */; };
 		052916002C06699B9F2F1A4B /* AttachTerminalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07A0F64626D74A8EC9A1FE2 /* AttachTerminalStore.swift */; };
@@ -44,6 +45,7 @@
 		299786029A482075003F78B9 /* SkillsKeyboardPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2EF92E96C6A4905CD809C5C /* SkillsKeyboardPane.swift */; };
 		29BCAD9E51F92125461CC37F /* LicenseNoticeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0882D4EC9985979DA989F01B /* LicenseNoticeTests.swift */; };
 		2B3962C6AAC18E5692C77269 /* ImageStaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD54D5F2D15F2F318B55D4DB /* ImageStaging.swift */; };
+		2BFEB992D411C0FF7BDE4361 /* AgentMonitorStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5D29D0F34EC475220D1085 /* AgentMonitorStore.swift */; };
 		2D7A4526AD24DAC4133B25BC /* JSONValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A3266F97C243598703DB0A /* JSONValue.swift */; };
 		2D7DC2A884FB9BA311D265A6 /* SkillProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176C059114F4646026196943 /* SkillProbeTests.swift */; };
 		2E612B94231EF97A285C83D5 /* SSHSourcePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CFDDFD7A676ECD4EF29BDE /* SSHSourcePolicyTests.swift */; };
@@ -198,6 +200,7 @@
 		C9F1C6CFE1F09E58CD9B3948 /* LocalSSHTestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F172C9E024F73AD2DD96288 /* LocalSSHTestEnvironment.swift */; };
 		CADB1AE0B86B4046A331C0D7 /* ImageAttachStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A77E8F2009C150A3A07AA7C /* ImageAttachStore.swift */; };
 		CBAEF7D1E91053F0B15E2F31 /* PairingCeremonyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0763484EE05424146492C1 /* PairingCeremonyTests.swift */; };
+		CEFDE26E6526835254F14493 /* AgentMonitorStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842E5C0930772F4B79955DFC /* AgentMonitorStoreTests.swift */; };
 		D08663BD250210835FE7ED49 /* PhotosPickerImageSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A3BD235B5209892137FCAF9 /* PhotosPickerImageSelection.swift */; };
 		D20C025851965986547FAAB5 /* ClosePaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D46328CE795C513FE11AD04 /* ClosePaneStore.swift */; };
 		D2405D8443F085D4E3CD1810 /* NotificationKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6D0361E0EB15681156D5C7 /* NotificationKeyStore.swift */; };
@@ -369,6 +372,7 @@
 		67AAFD0BF81441DB59EEF7AA /* NotificationRegistrationFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRegistrationFile.swift; sourceTree = "<group>"; };
 		6803A0055A861DFCA2A67217 /* AgentCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentCardView.swift; sourceTree = "<group>"; };
 		6876069E2B641D09FF1520E6 /* NotificationRelayEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRelayEndpoint.swift; sourceTree = "<group>"; };
+		68C51ED25429F47720E29976 /* AgentMonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentMonitorView.swift; sourceTree = "<group>"; };
 		6908778391053E855ED67E36 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		696C6905D9D6EEFF77A64E2E /* FakeTransportConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeTransportConnector.swift; sourceTree = "<group>"; };
 		6A9156B9BB51E7A5AD1792D9 /* SkillsPaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsPaneStore.swift; sourceTree = "<group>"; };
@@ -388,12 +392,14 @@
 		7B0A5D6A13F3F940E50EDCFD /* DemoScreenshotMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoScreenshotMode.swift; sourceTree = "<group>"; };
 		7CCE32D8F2A1A12B183B3DA5 /* TerminalKeysKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeysKeyboardTests.swift; sourceTree = "<group>"; };
 		7CF0F9F0EDF8757DC1D275D2 /* TerminalKeyboardInset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeyboardInset.swift; sourceTree = "<group>"; };
+		7D5D29D0F34EC475220D1085 /* AgentMonitorStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentMonitorStore.swift; sourceTree = "<group>"; };
 		7FC1C5701C464ADBBAE0525D /* HostOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostOnboardingView.swift; sourceTree = "<group>"; };
 		7FCA00B5F2A05A599D74FCCE /* DeviceKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyStoreTests.swift; sourceTree = "<group>"; };
 		80D43A25D50EDEF5D1E64BEF /* SkillProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillProbe.swift; sourceTree = "<group>"; };
 		8133B7654CEFC5533DCDCC5A /* TransportError+Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransportError+Presentation.swift"; sourceTree = "<group>"; };
 		823B2239BDC425FCE456B625 /* EventsSessionKeepaliveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionKeepaliveTests.swift; sourceTree = "<group>"; };
 		8273181A2428AD3F78FCC27B /* FakePairingConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakePairingConnector.swift; sourceTree = "<group>"; };
+		842E5C0930772F4B79955DFC /* AgentMonitorStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentMonitorStoreTests.swift; sourceTree = "<group>"; };
 		847A1406F4AAEBF2F1EDFA1F /* TerminalScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalScreenView.swift; sourceTree = "<group>"; };
 		84DA8573DB6A7EBC95A57F2F /* StartAgentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStoreTests.swift; sourceTree = "<group>"; };
 		856C56B29DCF048C09AF7C1C /* TerminalStatusDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalStatusDialogTests.swift; sourceTree = "<group>"; };
@@ -539,6 +545,7 @@
 		11AC34F8912DA80C6DF2524F /* HeelerTests */ = {
 			isa = PBXGroup;
 			children = (
+				842E5C0930772F4B79955DFC /* AgentMonitorStoreTests.swift */,
 				64D3B8E2EB97A8376B333914 /* AgentNameTests.swift */,
 				0A319930B80D42FB33DC8E42 /* AgentNotificationBannerStoreTests.swift */,
 				9D5CBA3E14F186170A2EF2CA /* AgentNotificationRendererTests.swift */,
@@ -648,6 +655,8 @@
 		1E9D44A38E208A1D0329903E /* Monitor */ = {
 			isa = PBXGroup;
 			children = (
+				7D5D29D0F34EC475220D1085 /* AgentMonitorStore.swift */,
+				68C51ED25429F47720E29976 /* AgentMonitorView.swift */,
 				8C68AA831B8C9DB0ACCA4D50 /* ANSISnapshotRenderer.swift */,
 			);
 			path = Monitor;
@@ -1140,6 +1149,8 @@
 				17F313D8AE9647F8F5D4DBFD /* AgentAttachStore.swift in Sources */,
 				12B61E17D212416E86EE63ED /* AgentCardView.swift in Sources */,
 				E1C95FE0F5AC6271001DBF60 /* AgentDetailView.swift in Sources */,
+				2BFEB992D411C0FF7BDE4361 /* AgentMonitorStore.swift in Sources */,
+				00BB32665B566815194A17D5 /* AgentMonitorView.swift in Sources */,
 				8EB4F2396CC905928797A622 /* AgentName.swift in Sources */,
 				72448624659DCDD94EF81DE8 /* AgentNotificationBannerStore.swift in Sources */,
 				143A46DB20266BCCDF1206F6 /* AgentNotificationBannerView.swift in Sources */,
@@ -1277,6 +1288,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0D191EBCDBE44260BB137F1A /* ANSISnapshotRendererTests.swift in Sources */,
+				CEFDE26E6526835254F14493 /* AgentMonitorStoreTests.swift in Sources */,
 				E379C1AD65B445D4E08614CF /* AgentNameTests.swift in Sources */,
 				6CD1D3CCDB58EBFF5350AC7F /* AgentNotificationBannerStoreTests.swift in Sources */,
 				14500112C25383EFD80A7A32 /* AgentNotificationRendererTests.swift in Sources */,

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		519B9551A9C12FB14C8349FD /* HostStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0443F1688BCEC3474F278889 /* HostStoreTests.swift */; };
 		541F71DBCA922E84DCA98D5E /* AgentNotificationRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F3B82DFAD293C0EE344804 /* AgentNotificationRouting.swift */; };
 		54D3A4F4FBF8F3F6C154BACE /* AppActivityCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B72AE2059C59D8A59C9B2A /* AppActivityCoordinator.swift */; };
+		552A7228E4CCBDD917A28336 /* MonitorControlKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465E3717AC740808499C4B45 /* MonitorControlKey.swift */; };
 		55C7DF5052817C34AFF088C2 /* TerminalTextSelectionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19FF62E7BD9DC71E1172A472 /* TerminalTextSelectionPresenter.swift */; };
 		5B0522DF97BC46599DDE4E93 /* TransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A41E40939438986DE30402 /* TransportConnector.swift */; };
 		5B137E763FFACD1AFE5C7E30 /* AgentNotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7EC7BEC9AACD2DAF634B2C /* AgentNotificationRouter.swift */; };
@@ -142,6 +143,7 @@
 		8D9ED28E1DB5A72B471CBD45 /* AppAppearanceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEAF21DF91A1BCE4C9F79A3 /* AppAppearanceSettings.swift */; };
 		8DF7095F918DBDA5B76F24F1 /* HeelerSSH in Frameworks */ = {isa = PBXBuildFile; productRef = 13CFA5F5C15E83F411CC03BA /* HeelerSSH */; };
 		8E440AFCE2BF426ECD8E0A86 /* SecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D2BCB4E4038F510852F71C /* SecretStore.swift */; };
+		8E9395210E0D0428E4BD8BDF /* MonitorControlKeyStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B485211F81965289691333 /* MonitorControlKeyStrip.swift */; };
 		8EB4F2396CC905928797A622 /* AgentName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4692E780178FDFA1CF9537B1 /* AgentName.swift */; };
 		8F91EAC7F32AA058E7F23394 /* TerminalKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247FF74AD248F26A072EA263 /* TerminalKeyboard.swift */; };
 		91BF879F537B1B0DD0B5E78B /* HostConsoleProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E1434C9C39A6419A3A0D79 /* HostConsoleProjection.swift */; };
@@ -337,6 +339,7 @@
 		42B76BFF68DEE415DEA495C4 /* ANSISnapshotRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSISnapshotRendererTests.swift; sourceTree = "<group>"; };
 		4582B5EA42CFA9C8878E6207 /* HeelerSSH */ = {isa = PBXFileReference; lastKnownFileType = folder; name = HeelerSSH; path = Packages/HeelerSSH; sourceTree = SOURCE_ROOT; };
 		45DB60007029322902FD1AFF /* PairingScanStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScanStore.swift; sourceTree = "<group>"; };
+		465E3717AC740808499C4B45 /* MonitorControlKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorControlKey.swift; sourceTree = "<group>"; };
 		4692E780178FDFA1CF9537B1 /* AgentName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentName.swift; sourceTree = "<group>"; };
 		46F7218F35AFEB5DCDF8BAF5 /* ConsoleActivityDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleActivityDriver.swift; sourceTree = "<group>"; };
 		48B853441AF972F5F05ADA67 /* AgentStatusPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentStatusPaletteTests.swift; sourceTree = "<group>"; };
@@ -399,6 +402,7 @@
 		8133B7654CEFC5533DCDCC5A /* TransportError+Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransportError+Presentation.swift"; sourceTree = "<group>"; };
 		823B2239BDC425FCE456B625 /* EventsSessionKeepaliveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionKeepaliveTests.swift; sourceTree = "<group>"; };
 		8273181A2428AD3F78FCC27B /* FakePairingConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakePairingConnector.swift; sourceTree = "<group>"; };
+		83B485211F81965289691333 /* MonitorControlKeyStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorControlKeyStrip.swift; sourceTree = "<group>"; };
 		842E5C0930772F4B79955DFC /* AgentMonitorStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentMonitorStoreTests.swift; sourceTree = "<group>"; };
 		847A1406F4AAEBF2F1EDFA1F /* TerminalScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalScreenView.swift; sourceTree = "<group>"; };
 		84DA8573DB6A7EBC95A57F2F /* StartAgentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStoreTests.swift; sourceTree = "<group>"; };
@@ -658,6 +662,8 @@
 				7D5D29D0F34EC475220D1085 /* AgentMonitorStore.swift */,
 				68C51ED25429F47720E29976 /* AgentMonitorView.swift */,
 				8C68AA831B8C9DB0ACCA4D50 /* ANSISnapshotRenderer.swift */,
+				465E3717AC740808499C4B45 /* MonitorControlKey.swift */,
+				83B485211F81965289691333 /* MonitorControlKeyStrip.swift */,
 			);
 			path = Monitor;
 			sourceTree = "<group>";
@@ -1200,6 +1206,8 @@
 				D8742E32B3BA3A76771BC2B7 /* JSONValue.swift in Sources */,
 				A20CC86A7DC41BD651647882 /* KnownHostsStore.swift in Sources */,
 				B818BFAB2A5008CF865D3422 /* LicenseNotices.swift in Sources */,
+				552A7228E4CCBDD917A28336 /* MonitorControlKey.swift in Sources */,
+				8E9395210E0D0428E4BD8BDF /* MonitorControlKeyStrip.swift in Sources */,
 				359A3FA92C332BEC1DA1982C /* NotificationConfigFile.swift in Sources */,
 				DF88C6F619C253A98F0EC3F6 /* NotificationDisclosureView.swift in Sources */,
 				A555F2DD86EC81E37D3A9323 /* NotificationEnvelope.swift in Sources */,

--- a/Sources/Heeler/Console/AgentDetailView.swift
+++ b/Sources/Heeler/Console/AgentDetailView.swift
@@ -2,10 +2,10 @@ import PhotosUI
 import SwiftUI
 import UIKit
 
-/// The Agent detail screen: one interactive Attach terminal. Ghostty owns
+/// The full-screen interactive Attach destination. Ghostty owns
 /// rendering, scrollback, and IME; the adapter routes input-row taps and touch
 /// scrolling without adding separate terminal chrome.
-struct AgentDetailView: View {
+struct AgentAttachView: View {
     let agent: ConsoleAgent
     private let console: ConsoleStore
     private let terminal: TerminalSettings
@@ -578,7 +578,7 @@ struct AgentDetailView: View {
         return count == 1 ? "1 distinct link" : "\(count) distinct links"
     }
 
-    private static func displayTitle(for agent: ConsoleAgent) -> String {
+    static func displayTitle(for agent: ConsoleAgent) -> String {
         agent.agent.title.isEmpty ? agent.agent.displayName : agent.agent.title
     }
 }

--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -249,6 +249,15 @@ final class ConsoleStore {
         }
     }
 
+    /// Monitor's control-key strip delivery path (`agent.send_keys`). Same
+    /// live Console transport as `readAgent` so a key tap never dials a
+    /// parallel connection.
+    func sendAgentKeys(_ params: AgentSendKeysParams, on hostID: Host.ID) async throws {
+        try await projection(for: hostID).session.withTransport { transport in
+            try await transport.sendAgentKeys(params)
+        }
+    }
+
     @discardableResult
     func startAgent(
         _ request: AgentLaunchRequest,

--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -239,6 +239,16 @@ final class ConsoleStore {
         }
     }
 
+    /// Monitor's one-shot snapshot source. It borrows the Host's live Console
+    /// transport so opening a detail screen never dials a parallel connection.
+    func readAgent(_ params: AgentReadParams, on hostID: Host.ID) async throws
+        -> PaneReadResult
+    {
+        try await projection(for: hostID).session.withTransport { transport in
+            try await transport.readAgent(params)
+        }
+    }
+
     @discardableResult
     func startAgent(
         _ request: AgentLaunchRequest,

--- a/Sources/Heeler/Console/ConsoleView.swift
+++ b/Sources/Heeler/Console/ConsoleView.swift
@@ -15,7 +15,7 @@ struct ConsoleView: View {
     @Bindable var notificationRouter: AgentNotificationRouter
     /// Announces foreground Blocked/Done transitions in-app (#77).
     let bannerStore: AgentNotificationBannerStore
-    /// Scene phase widened by the background grace period; the Attach screen
+    /// Scene phase widened by the background grace period; an Attach screen
     /// pauses its work on real suspensions only.
     let activity: AppActivityCoordinator
     @State private var hostSheet: HostSheet?
@@ -125,7 +125,7 @@ struct ConsoleView: View {
             }
         }
         .animation(.snappy, value: bannerStore.banner)
-        // A notification deep link must land on the Attach even when one of
+        // A notification deep link must land on Monitor even when one of
         // the Console's sheets covers it. The only other push a sheet can
         // cause is the new-agent flow's, which dismisses itself first, so
         // clearing here is a no-op for it.
@@ -178,9 +178,9 @@ struct ConsoleView: View {
                     onSwitch: { notificationRouter.path = [$0] },
                     onClosed: { notificationRouter.path = [] }
                 )
-                // Selecting another Agent must tear down the previous Attach
-                // and build a fresh one; without the explicit identity the
-                // detail column would reuse the old view's state.
+                // Selecting another Agent must tear down the previous Monitor
+                // and build fresh snapshot state; without the explicit identity
+                // the detail column would reuse the old view's state.
                 .id(id)
             } else {
                 // The Agent is gone from the list, but not necessarily
@@ -197,7 +197,7 @@ struct ConsoleView: View {
         } else {
             ContentUnavailableView(
                 "No Agent Selected", systemImage: "rectangle.on.rectangle",
-                description: Text("Choose an Agent to open its terminal."))
+                description: Text("Choose an Agent to monitor its latest screen."))
         }
     }
 

--- a/Sources/Heeler/Console/TerminalStatusDialog.swift
+++ b/Sources/Heeler/Console/TerminalStatusDialog.swift
@@ -20,7 +20,7 @@ enum TerminalStatusGlyph {
     case progress
 }
 
-/// The status overlay `AgentDetailView` presents for one terminal state.
+/// The status overlay `AgentAttachView` presents for one terminal state.
 /// Keeping this mapping as a value lets hosted lifecycle tests observe the
 /// actual presentation choice without snapshotting Ghostty's live Metal tree.
 struct TerminalStatusPresentation: Equatable {

--- a/Sources/Heeler/Demo/DemoScreenshotMode.swift
+++ b/Sources/Heeler/Demo/DemoScreenshotMode.swift
@@ -362,6 +362,20 @@
                 workspaceID: agent?.workspaceID ?? "demo")
         }
 
+        func readAgent(_ params: AgentReadParams) async throws -> PaneReadResult {
+            let agent = profile.snapshot.agents.first(where: { $0.paneID == params.target })
+            return PaneReadResult(
+                format: params.format ?? .text,
+                paneID: params.target,
+                revision: 1,
+                source: params.source,
+                tabID: agent?.tabID ?? "demo:t1",
+                text: profile.terminalOutputs[params.target]
+                    ?? DemoScreenshotFixture.terminalOutput,
+                truncated: false,
+                workspaceID: agent?.workspaceID ?? "demo")
+        }
+
         func startAgent(_ request: AgentLaunchRequest) async throws -> Agent {
             guard let first = profile.snapshot.agents.first else {
                 throw TransportError.malformedResponse("Demo profile has no Agents.")

--- a/Sources/Heeler/Demo/DemoScreenshotMode.swift
+++ b/Sources/Heeler/Demo/DemoScreenshotMode.swift
@@ -376,6 +376,8 @@
                 workspaceID: agent?.workspaceID ?? "demo")
         }
 
+        func sendAgentKeys(_ params: AgentSendKeysParams) async throws {}
+
         func startAgent(_ request: AgentLaunchRequest) async throws -> Agent {
             guard let first = profile.snapshot.agents.first else {
                 throw TransportError.malformedResponse("Demo profile has no Agents.")

--- a/Sources/Heeler/Monitor/AgentMonitorStore.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorStore.swift
@@ -51,7 +51,7 @@ final class AgentMonitorStore {
     }
 
     /// Refreshes once after Attach closes, then consumes the pending marker.
-    func refreshAfterAttach() async {
+    func refreshOnReturn() async {
         guard needsRefreshAfterAttach else { return }
         needsRefreshAfterAttach = false
         await waitForCurrentFetch()
@@ -87,6 +87,8 @@ final class AgentMonitorStore {
                 hasOpened = false
             }
         } catch {
+            // #181 owns special `agent_not_idle` handling for history
+            // backfill; this visible-screen cut surfaces every error honestly.
             state = .failed(Self.message(for: error))
         }
     }

--- a/Sources/Heeler/Monitor/AgentMonitorStore.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorStore.swift
@@ -1,9 +1,11 @@
 import Foundation
 import Observation
 
-/// Owns the first Monitor cut: one ANSI snapshot on open and one refresh
-/// after an Attach round trip. It deliberately has no event subscription or
-/// polling; later Monitor packages add those behaviors from ADR 0012.
+/// Owns the first Monitor cut: one ANSI snapshot on open, one refresh after
+/// an Attach round trip, and control-key delivery with a one-shot refresh
+/// after each successful send (#183). It deliberately has no event
+/// subscription or polling; later Monitor packages add those behaviors from
+/// ADR 0012.
 @MainActor
 @Observable
 final class AgentMonitorStore {
@@ -17,10 +19,16 @@ final class AgentMonitorStore {
     private(set) var state: State = .idle
     private(set) var snapshot: AttributedString?
     private(set) var capturedAt: Date?
+    /// User-facing message from the last failed control-key send; cleared on
+    /// the next successful send. Independent of snapshot `state` so a key
+    /// failure never pretends the screen is missing.
+    private(set) var sendError: String?
+    private(set) var isSendingKey = false
 
     private let target: String
     private let now: @Sendable () -> Date
     private let read: @Sendable (AgentReadParams) async throws -> PaneReadResult
+    private let sendKeys: @Sendable (AgentSendKeysParams) async throws -> Void
     @ObservationIgnored private var hasOpened = false
     @ObservationIgnored private var needsRefreshAfterAttach = false
     @ObservationIgnored private var isFetching = false
@@ -29,11 +37,13 @@ final class AgentMonitorStore {
     init(
         target: String,
         now: @escaping @Sendable () -> Date = { Date() },
-        read: @escaping @Sendable (AgentReadParams) async throws -> PaneReadResult
+        read: @escaping @Sendable (AgentReadParams) async throws -> PaneReadResult,
+        sendKeys: @escaping @Sendable (AgentSendKeysParams) async throws -> Void = { _ in }
     ) {
         self.target = target
         self.now = now
         self.read = read
+        self.sendKeys = sendKeys
     }
 
     /// Fetches exactly once for this Monitor instance. SwiftUI may re-run its
@@ -59,6 +69,27 @@ final class AgentMonitorStore {
     }
 
     func retry() async {
+        await waitForCurrentFetch()
+        await fetch()
+    }
+
+    /// Delivers one control-key sequence via `agent.send_keys`, then refreshes
+    /// the snapshot so the strip's effect is visible without Attach (#183).
+    /// Concurrent taps are ignored while a send is in flight.
+    func send(_ key: MonitorControlKey) async {
+        guard !isSendingKey else { return }
+        isSendingKey = true
+        defer { isSendingKey = false }
+
+        do {
+            try await sendKeys(
+                AgentSendKeysParams(keys: key.keys, target: target))
+            sendError = nil
+        } catch {
+            sendError = Self.sendMessage(for: error)
+            return
+        }
+
         await waitForCurrentFetch()
         await fetch()
     }
@@ -121,6 +152,21 @@ final class AgentMonitorStore {
             error.connectionGuidance
         default:
             "Loading the latest screen failed: \(error)"
+        }
+    }
+
+    private static func sendMessage(for error: any Error) -> String {
+        switch error {
+        case TransportError.sshUnreachable:
+            "The Host is not connected."
+        case TransportError.timedOut:
+            "The Host did not answer in time."
+        case let error as HerdrAPIError:
+            "herdr rejected the key: \(error.message)"
+        case let error as TransportError:
+            error.connectionGuidance
+        default:
+            "Sending the key failed: \(error)"
         }
     }
 }

--- a/Sources/Heeler/Monitor/AgentMonitorStore.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorStore.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Observation
+
+/// Owns the first Monitor cut: one ANSI snapshot on open and one refresh
+/// after an Attach round trip. It deliberately has no event subscription or
+/// polling; later Monitor packages add those behaviors from ADR 0012.
+@MainActor
+@Observable
+final class AgentMonitorStore {
+    enum State: Equatable {
+        case idle
+        case loading
+        case loaded
+        case failed(String)
+    }
+
+    private(set) var state: State = .idle
+    private(set) var snapshot: AttributedString?
+    private(set) var capturedAt: Date?
+
+    private let target: String
+    private let now: @Sendable () -> Date
+    private let read: @Sendable (AgentReadParams) async throws -> PaneReadResult
+    @ObservationIgnored private var hasOpened = false
+    @ObservationIgnored private var needsRefreshAfterAttach = false
+    @ObservationIgnored private var isFetching = false
+    @ObservationIgnored private var fetchWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(
+        target: String,
+        now: @escaping @Sendable () -> Date = { Date() },
+        read: @escaping @Sendable (AgentReadParams) async throws -> PaneReadResult
+    ) {
+        self.target = target
+        self.now = now
+        self.read = read
+    }
+
+    /// Fetches exactly once for this Monitor instance. SwiftUI may re-run its
+    /// task when Attach pops, so the return refresh has its own explicit path.
+    func open() async {
+        guard !hasOpened else { return }
+        hasOpened = true
+        await fetch()
+    }
+
+    /// Records a user-initiated Attach push. Repeated destination lifecycle
+    /// callbacks still collapse to one refresh when navigation returns.
+    func attachDidOpen() {
+        needsRefreshAfterAttach = true
+    }
+
+    /// Refreshes once after Attach closes, then consumes the pending marker.
+    func refreshAfterAttach() async {
+        guard needsRefreshAfterAttach else { return }
+        needsRefreshAfterAttach = false
+        await waitForCurrentFetch()
+        await fetch()
+    }
+
+    func retry() async {
+        await waitForCurrentFetch()
+        await fetch()
+    }
+
+    private func fetch() async {
+        guard !isFetching else { return }
+        isFetching = true
+        if snapshot == nil {
+            state = .loading
+        }
+        defer { finishFetch() }
+
+        do {
+            let result = try await read(
+                AgentReadParams(
+                    source: .visible,
+                    target: target,
+                    format: .ansi,
+                    stripANSI: false))
+            snapshot = ANSISnapshotRenderer.render(result.text)
+            capturedAt = now()
+            state = .loaded
+        } catch is CancellationError {
+            state = snapshot == nil ? .idle : .loaded
+            if snapshot == nil {
+                hasOpened = false
+            }
+        } catch {
+            state = .failed(Self.message(for: error))
+        }
+    }
+
+    private func waitForCurrentFetch() async {
+        guard isFetching else { return }
+        await withCheckedContinuation { continuation in
+            fetchWaiters.append(continuation)
+        }
+    }
+
+    private func finishFetch() {
+        isFetching = false
+        let waiters = fetchWaiters
+        fetchWaiters.removeAll(keepingCapacity: false)
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private static func message(for error: any Error) -> String {
+        switch error {
+        case TransportError.sshUnreachable:
+            "The Host is not connected."
+        case TransportError.timedOut:
+            "The Host did not answer in time."
+        case let error as HerdrAPIError:
+            "herdr rejected the snapshot: \(error.message)"
+        case let error as TransportError:
+            error.connectionGuidance
+        default:
+            "Loading the latest screen failed: \(error)"
+        }
+    }
+}

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+
+/// The default Agent detail surface (ADR 0012). It reads one local-rendered
+/// snapshot and pushes the existing live terminal only when the user chooses
+/// Attach.
+struct AgentDetailView: View {
+    let agent: ConsoleAgent
+    private let console: ConsoleStore
+    private let terminal: TerminalSettings
+    private let hosts: [Host]
+    private let activity: AppActivityCoordinator
+    private let keyboardHandoff: TerminalKeyboardHandoff
+    private let keyboardInset: TerminalKeyboardInset
+    private let isOnStage: () -> Bool
+    private let onSwitch: (ConsoleAgent.ID) -> Void
+    private let onClosed: () -> Void
+    @State private var monitor: AgentMonitorStore
+    @State private var attach: AgentAttachStore
+    @State private var isShowingAttach = false
+
+    init(
+        agent: ConsoleAgent,
+        console: ConsoleStore,
+        terminal: TerminalSettings,
+        hosts: [Host],
+        activity: AppActivityCoordinator,
+        keyboardHandoff: TerminalKeyboardHandoff,
+        keyboardInset: TerminalKeyboardInset,
+        isOnStage: @escaping () -> Bool,
+        onSwitch: @escaping (ConsoleAgent.ID) -> Void,
+        onClosed: @escaping () -> Void,
+        monitorStore: AgentMonitorStore? = nil,
+        attachStore: AgentAttachStore? = nil
+    ) {
+        self.agent = agent
+        self.console = console
+        self.terminal = terminal
+        self.hosts = hosts
+        self.activity = activity
+        self.keyboardHandoff = keyboardHandoff
+        self.keyboardInset = keyboardInset
+        self.isOnStage = isOnStage
+        self.onSwitch = onSwitch
+        self.onClosed = onClosed
+        _monitor = State(
+            initialValue: monitorStore ?? AgentMonitorStore(target: agent.agent.paneID) {
+                [console, agent] params in
+                try await console.readAgent(params, on: agent.hostID)
+            })
+        _attach = State(
+            initialValue: attachStore ?? AgentAttachStore(
+                target: agent.agent.paneID,
+                paneTitle: AgentAttachView.displayTitle(for: agent),
+                transportGeneration: console.hostConnectionGenerations[agent.hostID],
+                isOnStage: isOnStage,
+                runTerminal: console.terminalRunner(for: agent.hostID),
+                stageImage: console.imageStager(for: agent.hostID)
+            ) {
+                try await console.closePane(agent.agent.paneID, on: agent.hostID)
+            })
+    }
+
+    var body: some View {
+        monitorSurface
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Attach", systemImage: "terminal") {
+                        monitor.attachDidOpen()
+                        isShowingAttach = true
+                    }
+                }
+            }
+            .navigationDestination(isPresented: $isShowingAttach) {
+                AgentAttachView(
+                    agent: agent,
+                    console: console,
+                    terminal: terminal,
+                    hosts: hosts,
+                    activity: activity,
+                    keyboardHandoff: keyboardHandoff,
+                    keyboardInset: keyboardInset,
+                    isOnStage: isOnStage,
+                    onSwitch: onSwitch,
+                    onClosed: onClosed,
+                    attachStore: attach)
+            }
+            .onChange(of: isShowingAttach) { wasShowing, isShowing in
+                guard wasShowing, !isShowing else { return }
+                Task {
+                    await attach.leave().value
+                    await monitor.refreshAfterAttach()
+                }
+            }
+            .task { await monitor.open() }
+    }
+
+    @ViewBuilder
+    private var monitorSurface: some View {
+        if let snapshot = monitor.snapshot {
+            VStack(spacing: 0) {
+                statusHeader
+                Divider()
+                if snapshot.characters.isEmpty {
+                    ContentUnavailableView(
+                        "No Output", systemImage: "rectangle.dashed",
+                        description: Text("The Agent's latest screen is empty."))
+                } else {
+                    ScrollView([.horizontal, .vertical]) {
+                        Text(snapshot)
+                            .font(.system(.body, design: .monospaced))
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .topLeading)
+                            .padding()
+                    }
+                }
+            }
+        } else {
+            switch monitor.state {
+            case .failed(let message):
+                ContentUnavailableView {
+                    Label("Couldn't Load Screen", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(message)
+                } actions: {
+                    Button("Retry") { Task { await monitor.retry() } }
+                        .buttonStyle(.borderedProminent)
+                }
+            case .idle, .loading, .loaded:
+                ProgressView("Loading latest screen…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+    }
+
+    private var statusHeader: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let capturedAt = monitor.capturedAt {
+                Label(
+                    "Updated \(capturedAt.formatted(date: .omitted, time: .standard))",
+                    systemImage: "clock")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            if case .failed(let message) = monitor.state {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Label(message, systemImage: "exclamationmark.triangle")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 8)
+                    Button("Retry") { Task { await monitor.retry() } }
+                        .font(.footnote)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal)
+        .padding(.vertical, 10)
+    }
+
+    private var title: String {
+        AgentAttachView.displayTitle(for: agent)
+    }
+}

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -90,7 +90,7 @@ struct AgentDetailView: View {
                 guard wasShowing, !isShowing else { return }
                 Task {
                     await attach.leave().value
-                    await monitor.refreshAfterAttach()
+                    await monitor.refreshOnReturn()
                 }
             }
             .task { await monitor.open() }

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -43,10 +43,15 @@ struct AgentDetailView: View {
         self.onSwitch = onSwitch
         self.onClosed = onClosed
         _monitor = State(
-            initialValue: monitorStore ?? AgentMonitorStore(target: agent.agent.paneID) {
-                [console, agent] params in
-                try await console.readAgent(params, on: agent.hostID)
-            })
+            initialValue: monitorStore
+                ?? AgentMonitorStore(
+                    target: agent.agent.paneID,
+                    read: { [console, agent] params in
+                        try await console.readAgent(params, on: agent.hostID)
+                    },
+                    sendKeys: { [console, agent] params in
+                        try await console.sendAgentKeys(params, on: agent.hostID)
+                    }))
         _attach = State(
             initialValue: attachStore ?? AgentAttachStore(
                 target: agent.agent.paneID,
@@ -114,6 +119,19 @@ struct AgentDetailView: View {
                             .frame(maxWidth: .infinity, alignment: .topLeading)
                             .padding()
                     }
+                }
+                if let sendError = monitor.sendError {
+                    Text(sendError)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal)
+                        .padding(.top, 8)
+                }
+                // Additive attachment for #183; keep minimal so parallel
+                // Monitor packages (#180) can rebase cleanly.
+                MonitorControlKeyStrip(isEnabled: !monitor.isSendingKey) { key in
+                    Task { await monitor.send(key) }
                 }
             }
         } else {

--- a/Sources/Heeler/Monitor/MonitorControlKey.swift
+++ b/Sources/Heeler/Monitor/MonitorControlKey.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// A control key on Monitor's strip (#183): a labeled shortcut mapped to the
+/// exact `agent.send_keys` spelling herdr expects. The set covers answering a
+/// Blocked Agent's confirmation prompt and interrupting work without Attach —
+/// Enter, Esc, Ctrl+C, and the four arrows.
+///
+/// Spellings are load-bearing, not cosmetic. Verified live against herdr
+/// 0.8.0 (shared with `pane.send_keys` / `pane.send_input`): `enter`, `esc`,
+/// `ctrl+c` / `C-c` accepted case-insensitively; the near-miss `ctrl-c` is
+/// rejected with `invalid_key`. Arrows are `up`/`down`/`left`/`right`.
+enum MonitorControlKey: String, CaseIterable, Identifiable, Sendable {
+    case enter
+    case escape
+    case interrupt
+    case up
+    case down
+    case left
+    case right
+
+    var id: String { rawValue }
+
+    /// The herdr `agent.send_keys` key sequence this shortcut sends.
+    var keys: [String] {
+        switch self {
+        case .enter: ["enter"]
+        case .escape: ["esc"]
+        case .interrupt: ["ctrl+c"]
+        case .up: ["up"]
+        case .down: ["down"]
+        case .left: ["left"]
+        case .right: ["right"]
+        }
+    }
+
+    /// Short label for the button; nil when an SF Symbol carries it instead.
+    var label: String? {
+        switch self {
+        case .enter: "Enter"
+        case .escape: "Esc"
+        case .interrupt: "Ctrl+C"
+        case .up, .down, .left, .right: nil
+        }
+    }
+
+    /// SF Symbol for the arrow keys; nil when a text label carries it.
+    var systemImage: String? {
+        switch self {
+        case .up: "arrow.up"
+        case .down: "arrow.down"
+        case .left: "arrow.left"
+        case .right: "arrow.right"
+        default: nil
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch self {
+        case .enter: "Enter"
+        case .escape: "Escape"
+        case .interrupt: "Control C"
+        case .up: "Up Arrow"
+        case .down: "Down Arrow"
+        case .left: "Left Arrow"
+        case .right: "Right Arrow"
+        }
+    }
+}

--- a/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
+++ b/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+/// Monitor's horizontal control-key strip (#183): Enter, Esc, Ctrl+C, and
+/// the four arrows. Self-contained so package #180 can attach elsewhere
+/// without reshaping the rest of the Monitor surface. Spellings live on
+/// ``MonitorControlKey``; this view only presents the buttons.
+struct MonitorControlKeyStrip: View {
+    let isEnabled: Bool
+    let onTap: (MonitorControlKey) -> Void
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(MonitorControlKey.allCases) { key in
+                    Button {
+                        onTap(key)
+                    } label: {
+                        keyLabel(key)
+                            .font(.callout.weight(.medium))
+                            .frame(minWidth: 44, minHeight: 36)
+                            .padding(.horizontal, 4)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(!isEnabled)
+                    .accessibilityLabel(key.accessibilityLabel)
+                }
+            }
+            .padding(.horizontal, 1)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(.bar)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Control keys")
+    }
+
+    @ViewBuilder
+    private func keyLabel(_ key: MonitorControlKey) -> some View {
+        if let systemImage = key.systemImage {
+            Image(systemName: systemImage)
+        } else if let label = key.label {
+            Text(label)
+        }
+    }
+}

--- a/Sources/Heeler/Notifications/AgentNotificationRouter.swift
+++ b/Sources/Heeler/Notifications/AgentNotificationRouter.swift
@@ -2,8 +2,8 @@ import Foundation
 import Observation
 
 /// Owns the Console's navigation path and lands Agent Notification taps on
-/// the right Attach surface (#74). A tap can arrive before the tapped pane
-/// is known — a killed-state launch routes only once the Host's first sync
+/// the right Monitor surface (#74, #179). A tap can arrive before the tapped
+/// pane is known — a killed-state launch routes only once the Host's first sync
 /// delivers the pane — so an unresolved target waits as pending until the
 /// pane appears, the user navigates somewhere themselves, or a grace window
 /// elapses. Falling back always means the Console, quietly: never an alert.
@@ -28,7 +28,7 @@ final class AgentNotificationRouter {
         self.pendingGrace = pendingGrace
     }
 
-    /// Routes a tapped notification. A known pane opens its Attach at once;
+    /// Routes a tapped notification. A known pane opens its Monitor at once;
     /// an unknown one parks the user on the Console and follows up if the
     /// pane arrives within the grace window (killed-state launches); no
     /// target at all (unknown key id, undecryptable envelope) is the Console

--- a/Sources/Heeler/Transport/Generated/HerdrAPITypes.swift
+++ b/Sources/Heeler/Transport/Generated/HerdrAPITypes.swift
@@ -179,6 +179,17 @@ struct AgentRenameParams: Codable, Equatable, Sendable {
     }
 }
 
+/// herdr schema `$defs/AgentSendKeysParams`.
+struct AgentSendKeysParams: Codable, Equatable, Sendable {
+    let keys: [String]
+    let target: String
+
+    init(keys: [String], target: String) {
+        self.keys = keys
+        self.target = target
+    }
+}
+
 /// herdr schema `$defs/AgentSessionInfo`.
 struct AgentSessionInfo: Codable, Equatable, Sendable {
     let agent: String

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -612,6 +612,11 @@ actor HeelerSSHTransport: Transport {
             .read
     }
 
+    func readAgent(_ params: AgentReadParams) async throws -> PaneReadResult {
+        try await request(method: "agent.read", params: params, decoding: PaneReadResponse.self)
+            .read
+    }
+
     func startAgent(_ launch: AgentLaunchRequest) async throws -> Agent {
         let created = try await request(
             method: "tab.create",

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -617,6 +617,13 @@ actor HeelerSSHTransport: Transport {
             .read
     }
 
+    func sendAgentKeys(_ params: AgentSendKeysParams) async throws {
+        _ = try await request(
+            method: "agent.send_keys",
+            params: params,
+            decoding: OkResponse.self)
+    }
+
     func startAgent(_ launch: AgentLaunchRequest) async throws -> Agent {
         let created = try await request(
             method: "tab.create",

--- a/Sources/Heeler/Transport/Transport.swift
+++ b/Sources/Heeler/Transport/Transport.swift
@@ -37,6 +37,14 @@ protocol Transport: Sendable {
     /// snapshot and requests ANSI output for local rendering (ADR 0012).
     func readAgent(_ params: AgentReadParams) async throws -> PaneReadResult
 
+    /// Sends control keys to an Agent (`agent.send_keys`): Monitor's
+    /// control-key strip (#183). Key names are herdr's own spellings —
+    /// verified live against herdr 0.8.0 and shared with `pane.send_keys` /
+    /// `pane.send_input`: `enter`, `esc`, `ctrl+c` / `C-c` accepted
+    /// case-insensitively; `ctrl-c` is rejected with `invalid_key`. Arrows
+    /// are `up`/`down`/`left`/`right`.
+    func sendAgentKeys(_ params: AgentSendKeysParams) async throws
+
     /// Starts a new Agent: the new-agent flow (#12, User Story 8 — dispatch
     /// work from the road). Creates a fresh herdr tab in the chosen workspace,
     /// starts the requested agent in its root pane, and returns the Agent once

--- a/Sources/Heeler/Transport/Transport.swift
+++ b/Sources/Heeler/Transport/Transport.swift
@@ -30,6 +30,13 @@ protocol Transport: Sendable {
     /// Reads a Pane's recent terminal output for the Console card snippet.
     func readPane(_ params: PaneReadParams) async throws -> PaneReadResult
 
+    /// Reads an Agent's terminal output. Unlike `pane.read`, this preserves
+    /// history semantics for alternate-screen Agents: history-capable sources
+    /// fail honestly while the Agent is working instead of silently degrading
+    /// to the visible screen. Monitor uses `.visible` for its always-available
+    /// snapshot and requests ANSI output for local rendering (ADR 0012).
+    func readAgent(_ params: AgentReadParams) async throws -> PaneReadResult
+
     /// Starts a new Agent: the new-agent flow (#12, User Story 8 — dispatch
     /// work from the road). Creates a fresh herdr tab in the chosen workspace,
     /// starts the requested agent in its root pane, and returns the Agent once

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -41,8 +41,8 @@ struct AgentMonitorStoreTests {
 
         await transport.setAgentText("after", target: "w1:p1")
         store.attachDidOpen()
-        await store.refreshAfterAttach()
-        await store.refreshAfterAttach()
+        await store.refreshOnReturn()
+        await store.refreshOnReturn()
 
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "after")
@@ -64,7 +64,7 @@ struct AgentMonitorStoreTests {
         }
         await transport.setAgentText("after Attach", target: "w1:p1")
         store.attachDidOpen()
-        let returning = Task { await store.refreshAfterAttach() }
+        let returning = Task { await store.refreshOnReturn() }
 
         await gate.open()
         await opening.value
@@ -109,7 +109,7 @@ struct AgentMonitorStoreTests {
 
         await transport.setAgentReadFailure(TransportError.timedOut)
         store.attachDidOpen()
-        await store.refreshAfterAttach()
+        await store.refreshOnReturn()
 
         #expect(store.state == .failed("The Host did not answer in time."))
         #expect(store.capturedAt == capturedAt)

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -117,6 +117,99 @@ struct AgentMonitorStoreTests {
         #expect(String(snapshot.characters) == "known screen")
     }
 
+    @Test func sendDeliversControlKeysAndRefreshesTheSnapshot() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("before", target: "w1:p1")
+        let store = makeStore(transport: transport)
+        await store.open()
+
+        await transport.setAgentText("after ctrl+c", target: "w1:p1")
+        await store.send(.interrupt)
+
+        #expect(store.sendError == nil)
+        #expect(store.isSendingKey == false)
+        let snapshot = try #require(store.snapshot)
+        #expect(String(snapshot.characters) == "after ctrl+c")
+        #expect(
+            await transport.agentSendKeysParams == [
+                AgentSendKeysParams(keys: ["ctrl+c"], target: "w1:p1")
+            ])
+        #expect(await transport.agentReadParams.count == 2)
+    }
+
+    @Test func sendFailureSurfacesWithoutRefreshing() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("known screen", target: "w1:p1")
+        let store = makeStore(transport: transport)
+        await store.open()
+
+        await transport.setAgentSendKeysFailure(
+            HerdrAPIError(code: "invalid_key", message: "unsupported key foo"))
+        await store.send(.enter)
+
+        #expect(store.sendError == "herdr rejected the key: unsupported key foo")
+        let snapshot = try #require(store.snapshot)
+        #expect(String(snapshot.characters) == "known screen")
+        #expect(await transport.agentSendKeysParams.isEmpty)
+        #expect(await transport.agentReadParams.count == 1)
+    }
+
+    @Test func successfulSendClearsAPriorSendError() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("screen", target: "w1:p1")
+        let store = makeStore(transport: transport)
+        await store.open()
+
+        await transport.setAgentSendKeysFailure(TransportError.timedOut)
+        await store.send(.escape)
+        #expect(store.sendError == "The Host did not answer in time.")
+
+        await transport.setAgentSendKeysFailure(nil)
+        await transport.setAgentText("dismissed", target: "w1:p1")
+        await store.send(.escape)
+
+        #expect(store.sendError == nil)
+        let snapshot = try #require(store.snapshot)
+        #expect(String(snapshot.characters) == "dismissed")
+        #expect(
+            await transport.agentSendKeysParams == [
+                AgentSendKeysParams(keys: ["esc"], target: "w1:p1")
+            ])
+    }
+
+    @Test func controlKeySpellingsMatchHerdrContract() {
+        // Load-bearing spellings verified live on herdr 0.8.0 (CLAUDE.md):
+        // enter/esc/ctrl+c accepted; ctrl-c rejected with invalid_key.
+        #expect(MonitorControlKey.enter.keys == ["enter"])
+        #expect(MonitorControlKey.escape.keys == ["esc"])
+        #expect(MonitorControlKey.interrupt.keys == ["ctrl+c"])
+        #expect(MonitorControlKey.interrupt.keys != ["ctrl-c"])
+        #expect(MonitorControlKey.up.keys == ["up"])
+        #expect(MonitorControlKey.down.keys == ["down"])
+        #expect(MonitorControlKey.left.keys == ["left"])
+        #expect(MonitorControlKey.right.keys == ["right"])
+
+        for key in MonitorControlKey.allCases {
+            #expect(!key.keys.isEmpty)
+            #expect(key.keys.allSatisfy { !$0.isEmpty })
+            #expect(key.label != nil || key.systemImage != nil)
+            // Never ship the rejected near-miss form.
+            #expect(!key.keys.contains("ctrl-c"))
+        }
+    }
+
+    private func makeStore(
+        transport: ScriptedTransport,
+        target: String = "w1:p1",
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) -> AgentMonitorStore {
+        AgentMonitorStore(
+            target: target,
+            now: now,
+            read: { params in try await transport.readAgent(params) },
+            sendKeys: { params in try await transport.sendAgentKeys(params) })
+    }
+
     private func waitUntil(
         _ comment: Comment,
         timeout: Duration = .seconds(2),

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -193,8 +193,15 @@ struct AgentMonitorStoreTests {
             #expect(!key.keys.isEmpty)
             #expect(key.keys.allSatisfy { !$0.isEmpty })
             #expect(key.label != nil || key.systemImage != nil)
-            // Never ship the rejected near-miss form.
-            #expect(!key.keys.contains("ctrl-c"))
+            // Negative contract: herdr rejects hyphenated `ctrl-…` spellings
+            // with `invalid_key` (verified live on 0.8.0); only `ctrl+c` /
+            // `C-c` are accepted. Pin the whole prefix so a future key
+            // (⌃D, ⌃Z, …) cannot regress into the trap.
+            for spelling in key.keys {
+                #expect(
+                    !spelling.lowercased().hasPrefix("ctrl-"),
+                    "\(key.rawValue) must not use hyphenated ctrl- form \(spelling)")
+            }
         }
     }
 

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@MainActor
+@Suite("Agent Monitor store")
+struct AgentMonitorStoreTests {
+    @Test func openingFetchesOneVisibleANSISnapshot() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("plain \u{1B}[31mred\u{1B}[0m", target: "w1:p1")
+        let capturedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let store = AgentMonitorStore(target: "w1:p1", now: { capturedAt }) { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+        await store.open()
+
+        #expect(store.state == .loaded)
+        #expect(store.capturedAt == capturedAt)
+        let snapshot = try #require(store.snapshot)
+        #expect(String(snapshot.characters) == "plain red")
+        #expect(
+            await transport.agentReadParams == [
+                AgentReadParams(
+                    source: .visible,
+                    target: "w1:p1",
+                    format: .ansi,
+                    stripANSI: false)
+            ])
+    }
+
+    @Test func returningFromAttachRefreshesExactlyOnce() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("before", target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+
+        await transport.setAgentText("after", target: "w1:p1")
+        store.attachDidOpen()
+        await store.refreshAfterAttach()
+        await store.refreshAfterAttach()
+
+        let snapshot = try #require(store.snapshot)
+        #expect(String(snapshot.characters) == "after")
+        #expect(await transport.agentReadParams.count == 2)
+    }
+
+    @Test func returningWhileOpenIsLoadingStillPerformsTheRefresh() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("opening", target: "w1:p1")
+        let gate = ScriptedTransportCallGate()
+        await transport.gateNextAgentRead(using: gate)
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        let opening = Task { await store.open() }
+        try await waitUntil("the opening read should be in flight") {
+            await gate.entryCount == 1
+        }
+        await transport.setAgentText("after Attach", target: "w1:p1")
+        store.attachDidOpen()
+        let returning = Task { await store.refreshAfterAttach() }
+
+        await gate.open()
+        await opening.value
+        await returning.value
+
+        let snapshot = try #require(store.snapshot)
+        #expect(String(snapshot.characters) == "after Attach")
+        #expect(await transport.agentReadParams.count == 2)
+    }
+
+    @Test func failedOpenSurfacesTheServerErrorAndRetryRecovers() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentReadFailure(
+            HerdrAPIError(code: "agent_not_idle", message: "agent is working"))
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        #expect(store.state == .failed("herdr rejected the snapshot: agent is working"))
+        #expect(store.snapshot == nil)
+
+        await transport.setAgentReadFailure(nil)
+        await transport.setAgentText("recovered", target: "w1:p1")
+        await store.retry()
+
+        #expect(store.state == .loaded)
+        let snapshot = try #require(store.snapshot)
+        #expect(String(snapshot.characters) == "recovered")
+        #expect(await transport.agentReadParams.count == 2)
+    }
+
+    @Test func failedReturnKeepsTheLastSnapshotAndItsFreshness() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("known screen", target: "w1:p1")
+        let capturedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let store = AgentMonitorStore(target: "w1:p1", now: { capturedAt }) { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+
+        await transport.setAgentReadFailure(TransportError.timedOut)
+        store.attachDidOpen()
+        await store.refreshAfterAttach()
+
+        #expect(store.state == .failed("The Host did not answer in time."))
+        #expect(store.capturedAt == capturedAt)
+        let snapshot = try #require(store.snapshot)
+        #expect(String(snapshot.characters) == "known screen")
+    }
+
+    private func waitUntil(
+        _ comment: Comment,
+        timeout: Duration = .seconds(2),
+        condition: () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await condition(), comment)
+    }
+}

--- a/Tests/HeelerTests/AgentNotificationRouterTests.swift
+++ b/Tests/HeelerTests/AgentNotificationRouterTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Heeler
 
-/// The navigation half of #74: taps land on the right Agent Attach through
+/// The navigation half of #74: taps land on the right Agent Monitor through
 /// the Console's navigation path, a killed-state tap waits for the pane to
 /// arrive with the Host's first sync, and stale or unresolvable pushes fall
 /// back to the Console with no alarming copy.
@@ -30,7 +30,7 @@ struct AgentNotificationRouterTests {
         #expect(condition(), comment)
     }
 
-    @Test func tapOnAKnownAgentOpensItsAttach() {
+    @Test func tapOnAKnownAgentOpensItsMonitor() {
         let router = AgentNotificationRouter()
         let hostID = UUID()
         router.agentsDidChange([consoleAgent(hostID: hostID, paneID: "%5")])

--- a/Tests/HeelerTests/AgentSurfaceReplacementTests.swift
+++ b/Tests/HeelerTests/AgentSurfaceReplacementTests.swift
@@ -7,7 +7,7 @@ import UIKit
 /// What happens when SwiftUI replaces a terminal surface (#152).
 ///
 /// Whole-screen replacement is the one path #143 could not disprove:
-/// `AgentDetailView` holds `@State private var attach`, so an Agent switch
+/// `AgentAttachView` holds `@State private var attach`, so an Agent switch
 /// releases one store and constructs another, in an order that is SwiftUI's
 /// and unspecified. These tests drive that replacement through the real view
 /// and observe what the feed does across it.
@@ -16,7 +16,7 @@ import UIKit
 /// `NavigationSplitView` builds its columns, separators and navigation bar but
 /// never the SwiftUI content inside them, so nothing below it can be observed
 /// (measured: 72 views, all chrome, identical with and without a selection).
-/// `AgentDetailView` is not subject to that — it is a plain view and its
+/// `AgentAttachView` is not subject to that — it is a plain view and its
 /// terminal surface really is built.
 @MainActor
 @Suite("Agent surface replacement")
@@ -41,7 +41,7 @@ struct AgentSurfaceReplacementTests {
         let controller = UIHostingController(rootView: Harness(feed: feed, surface: 1))
         // This seam needs a UIKit hierarchy, not a connected app scene. A
         // scene is absent in some headless test-host launches, which made the
-        // otherwise deterministic loop fail before it reached AgentDetailView.
+        // otherwise deterministic loop fail before it reached AgentAttachView.
         let window = Self.makeLocalTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
@@ -102,7 +102,7 @@ struct AgentSurfaceReplacementTests {
     func anAgentSwitchBuildsASurfaceForTheNewStore() async throws {
         struct Harness: View {
             let agent: ConsoleAgent
-            let make: (ConsoleAgent) -> AgentDetailView
+            let make: (ConsoleAgent) -> AgentAttachView
 
             var body: some View {
                 // Mirrors what `ConsoleView` puts on its detail column: the
@@ -358,7 +358,7 @@ struct AgentSurfaceReplacementTests {
         async throws
     {
         struct Harness: View {
-            let detail: AgentDetailView
+            let detail: AgentAttachView
             let mounts: [Int]
 
             var body: some View {
@@ -589,7 +589,7 @@ struct AgentSurfaceReplacementTests {
     ///
     /// The stores are built once and shared across switches because that is
     /// what the Console does — only the Agent changes.
-    static func detailViewFactory() -> (ConsoleAgent) -> AgentDetailView {
+    static func detailViewFactory() -> (ConsoleAgent) -> AgentAttachView {
         let defaults = UserDefaults(suiteName: "agent-surface-\(UUID())") ?? .standard
         let console = ConsoleStore(snapshotRetryDelay: .seconds(30)) { _, subscriptions in
             EventsSession(
@@ -611,7 +611,7 @@ struct AgentSurfaceReplacementTests {
         let inset = TerminalKeyboardInset()
         let activity = AppActivityCoordinator()
         return { agent in
-            AgentDetailView(
+            AgentAttachView(
                 agent: agent,
                 console: console,
                 terminal: terminal,
@@ -629,7 +629,7 @@ struct AgentSurfaceReplacementTests {
         agent: ConsoleAgent,
         activity: AppActivityCoordinator,
         attachStore: AgentAttachStore
-    ) -> AgentDetailView {
+    ) -> AgentAttachView {
         let defaults = UserDefaults(suiteName: "attach-recovery-\(UUID())") ?? .standard
         let console = ConsoleStore(snapshotRetryDelay: .seconds(30)) { _, subscriptions in
             EventsSession(
@@ -643,7 +643,7 @@ struct AgentSurfaceReplacementTests {
             zoom: TerminalZoomSettings(defaults: defaults),
             fonts: TerminalFontSettings(defaults: defaults),
             snippets: SnippetStore(defaults: defaults))
-        return AgentDetailView(
+        return AgentAttachView(
             agent: agent,
             console: console,
             terminal: terminal,

--- a/Tests/HeelerTests/GeneratedWireTypesTests.swift
+++ b/Tests/HeelerTests/GeneratedWireTypesTests.swift
@@ -200,6 +200,20 @@ import Testing
         #expect(fields["source"] as? String == "visible")
     }
 
+    @Test func agentSendKeysParamsRoundTrip() throws {
+        let params = AgentSendKeysParams(keys: ["ctrl+c", "enter"], target: "w1:p1")
+
+        let data = try JSONEncoder().encode(params)
+        let decoded = try JSONDecoder().decode(AgentSendKeysParams.self, from: data)
+
+        #expect(decoded == params)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let fields = try #require(object)
+        #expect(fields.keys.sorted() == ["keys", "target"])
+        #expect(fields["target"] as? String == "w1:p1")
+        #expect(fields["keys"] as? [String] == ["ctrl+c", "enter"])
+    }
+
     @Test func agentStartParamsRoundTrip() throws {
         let params = AgentStartParams(
             kind: "claude", name: "reviewer", paneID: "w1:p1",

--- a/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
@@ -551,6 +551,8 @@ struct HeelerSSHTransportBehaviorE2ETests {
         #expect(agentRead.text == "\u{1B}[31mfixture agent output\u{1B}[0m")
         #expect(agentRead.source == .visible)
         #expect(agentRead.format == .ansi)
+        try await transport.sendAgentKeys(
+            AgentSendKeysParams(keys: ["ctrl+c", "enter"], target: "pane-1"))
         try await transport.closePane(PaneTarget(paneID: "pane-1"))
         try await transport.renameAgent(AgentRenameParams(target: "pane-1", name: "fixture"))
         try await transport.renameWorkspace(

--- a/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
@@ -544,6 +544,13 @@ struct HeelerSSHTransportBehaviorE2ETests {
         #expect(
             try await transport.readPane(PaneReadParams(paneID: "pane-1", source: .recent)).text
                 == "fixture output")
+        let agentRead = try await transport.readAgent(
+            AgentReadParams(
+                source: .visible, target: "pane-1", format: .ansi,
+                stripANSI: false))
+        #expect(agentRead.text == "\u{1B}[31mfixture agent output\u{1B}[0m")
+        #expect(agentRead.source == .visible)
+        #expect(agentRead.format == .ansi)
         try await transport.closePane(PaneTarget(paneID: "pane-1"))
         try await transport.renameAgent(AgentRenameParams(target: "pane-1", name: "fixture"))
         try await transport.renameWorkspace(

--- a/Tests/HeelerTests/Support/FakeTransportConnector.swift
+++ b/Tests/HeelerTests/Support/FakeTransportConnector.swift
@@ -39,6 +39,10 @@ final actor FakeTransport: Transport {
         throw TransportError.channelFailed(detail: "FakeTransport does not script Agent reads")
     }
 
+    func sendAgentKeys(_ params: AgentSendKeysParams) async throws {
+        throw TransportError.channelFailed(detail: "FakeTransport does not script Agent send-keys")
+    }
+
     func subscribeToEvents(_ subscriptions: [EventSubscription]) async throws -> HerdrEventStream {
         throw TransportError.channelFailed(detail: "FakeTransport does not script events")
     }

--- a/Tests/HeelerTests/Support/FakeTransportConnector.swift
+++ b/Tests/HeelerTests/Support/FakeTransportConnector.swift
@@ -35,6 +35,10 @@ final actor FakeTransport: Transport {
         throw TransportError.channelFailed(detail: "FakeTransport does not script pane reads")
     }
 
+    func readAgent(_ params: AgentReadParams) async throws -> PaneReadResult {
+        throw TransportError.channelFailed(detail: "FakeTransport does not script Agent reads")
+    }
+
     func subscribeToEvents(_ subscriptions: [EventSubscription]) async throws -> HerdrEventStream {
         throw TransportError.channelFailed(detail: "FakeTransport does not script events")
     }

--- a/Tests/HeelerTests/Support/ScriptedTransport.swift
+++ b/Tests/HeelerTests/Support/ScriptedTransport.swift
@@ -12,6 +12,10 @@ final actor ScriptedTransport: Transport {
     private(set) var capturedSubscriptions: [[EventSubscription]] = []
     private(set) var paneReadParams: [PaneReadParams] = []
     private(set) var agentReadParams: [AgentReadParams] = []
+    /// Every `agent.send_keys` received, in order; Monitor's control-key
+    /// strip (#183) asserts on the spellings and target it forwarded.
+    private(set) var agentSendKeysParams: [AgentSendKeysParams] = []
+    private var agentSendKeysFailure: (any Error)?
     /// Every `agent.start` received, in order; the new-agent flow (#12)
     /// asserts on the params it forwarded.
     private(set) var agentStarts: [AgentLaunchRequest] = []
@@ -140,6 +144,11 @@ final actor ScriptedTransport: Transport {
     /// Pauses the next Agent read after capturing its response.
     func gateNextAgentRead(using gate: ScriptedTransportCallGate) {
         nextAgentReadGate = gate
+    }
+
+    /// Makes every subsequent `sendAgentKeys` throw `failure`.
+    func setAgentSendKeysFailure(_ failure: (any Error)?) {
+        agentSendKeysFailure = failure
     }
 
     /// Scripts the `AgentInfo` `startAgent` returns; without it the fake
@@ -336,6 +345,11 @@ final actor ScriptedTransport: Transport {
             format: params.format ?? .text, paneID: params.target, revision: 0,
             source: params.source, tabID: "t", text: responseText,
             truncated: false, workspaceID: "w")
+    }
+
+    func sendAgentKeys(_ params: AgentSendKeysParams) async throws {
+        if let agentSendKeysFailure { throw agentSendKeysFailure }
+        agentSendKeysParams.append(params)
     }
 
     func startAgent(_ request: AgentLaunchRequest) async throws -> Agent {

--- a/Tests/HeelerTests/Support/ScriptedTransport.swift
+++ b/Tests/HeelerTests/Support/ScriptedTransport.swift
@@ -11,6 +11,7 @@ final actor ScriptedTransport: Transport {
     /// resubscribe-on-membership-change behavior asserts on this.
     private(set) var capturedSubscriptions: [[EventSubscription]] = []
     private(set) var paneReadParams: [PaneReadParams] = []
+    private(set) var agentReadParams: [AgentReadParams] = []
     /// Every `agent.start` received, in order; the new-agent flow (#12)
     /// asserts on the params it forwarded.
     private(set) var agentStarts: [AgentLaunchRequest] = []
@@ -54,6 +55,9 @@ final actor ScriptedTransport: Transport {
     private var paneTexts: [String: String] = [:]
     private var paneReadFailure: TransportError?
     private var nextPaneReadGate: ScriptedTransportCallGate?
+    private var agentTexts: [String: String] = [:]
+    private var agentReadFailure: (any Error)?
+    private var nextAgentReadGate: ScriptedTransportCallGate?
     private var missingPaneIDs: Set<String> = []
     private var nextStreamID: UInt64 = 0
     private var liveStreamID: UInt64?
@@ -121,6 +125,21 @@ final actor ScriptedTransport: Transport {
     /// Pauses the next pane read after capturing its response.
     func gateNextPaneRead(using gate: ScriptedTransportCallGate) {
         nextPaneReadGate = gate
+    }
+
+    /// Scripts the text `readAgent` returns for `target`.
+    func setAgentText(_ text: String, target: String) {
+        agentTexts[target] = text
+    }
+
+    /// Makes every subsequent `readAgent` throw `failure`.
+    func setAgentReadFailure(_ failure: (any Error)?) {
+        agentReadFailure = failure
+    }
+
+    /// Pauses the next Agent read after capturing its response.
+    func gateNextAgentRead(using gate: ScriptedTransportCallGate) {
+        nextAgentReadGate = gate
     }
 
     /// Scripts the `AgentInfo` `startAgent` returns; without it the fake
@@ -301,6 +320,20 @@ final actor ScriptedTransport: Transport {
         if let failure { throw failure }
         return PaneReadResult(
             format: .text, paneID: params.paneID, revision: 0,
+            source: params.source, tabID: "t", text: responseText,
+            truncated: false, workspaceID: "w")
+    }
+
+    func readAgent(_ params: AgentReadParams) async throws -> PaneReadResult {
+        agentReadParams.append(params)
+        let responseText = agentTexts[params.target] ?? ""
+        let failure = agentReadFailure
+        let gate = nextAgentReadGate
+        nextAgentReadGate = nil
+        await gate?.waitUntilOpen()
+        if let failure { throw failure }
+        return PaneReadResult(
+            format: params.format ?? .text, paneID: params.target, revision: 0,
             source: params.source, tabID: "t", text: responseText,
             truncated: false, workspaceID: "w")
     }

--- a/scripts/fixtures/fake-herdr-streamlocal.py
+++ b/scripts/fixtures/fake-herdr-streamlocal.py
@@ -271,6 +271,20 @@ class Server:
         if method == "pane.read":
             pane_id = params.get("pane_id", "pane-1") if isinstance(params, dict) else "pane-1"
             return self._pane_read_result(pane_id, "fixture output")
+        if method == "agent.read":
+            request = params if isinstance(params, dict) else {}
+            target = request.get("target", "pane-1")
+            source = request.get("source", "recent")
+            output_format = request.get("format", "text")
+            text = "fixture agent output"
+            if output_format == "ansi" and request.get("strip_ansi") is False:
+                text = "\x1b[31mfixture agent output\x1b[0m"
+            return self._pane_read_result(
+                target,
+                text,
+                source=source,
+                output_format=output_format,
+            )
         if method == "pane.close":
             return {"type": "ok"}
         if method == "tab.create":
@@ -315,15 +329,20 @@ class Server:
         return {"type": "ok"}
 
     @staticmethod
-    def _pane_read_result(pane_id: str, text: str) -> object:
+    def _pane_read_result(
+        pane_id: str,
+        text: str,
+        source: str = "recent",
+        output_format: str = "text",
+    ) -> object:
         return {
             "type": "pane_read",
             "read": {
                 "pane_id": pane_id,
                 "workspace_id": "workspace-1",
                 "tab_id": "tab-1",
-                "source": "recent",
-                "format": "text",
+                "source": source,
+                "format": output_format,
                 "text": text,
                 "revision": 1,
                 "truncated": False,

--- a/scripts/fixtures/fake-herdr-streamlocal.py
+++ b/scripts/fixtures/fake-herdr-streamlocal.py
@@ -285,6 +285,10 @@ class Server:
                 source=source,
                 output_format=output_format,
             )
+        if method == "agent.send_keys":
+            # Thin ok-envelope RPC; key-spelling contract is asserted in unit
+            # tests against the spellings Monitor ships (enter/esc/ctrl+c/…).
+            return {"type": "ok"}
         if method == "pane.close":
             return {"type": "ok"}
         if method == "tab.create":

--- a/scripts/generate-wire-types.py
+++ b/scripts/generate-wire-types.py
@@ -53,6 +53,7 @@ METHODS = [
     "agent.list",
     "agent.read",
     "agent.rename",
+    "agent.send_keys",
     "agent.start",
     "events.subscribe",
     "tab.create",


### PR DESCRIPTION
## Summary

The Agent detail screen becomes the Monitor (ADR 0012): opening an Agent fetches one ANSI-rendered snapshot of its pane (agent-level read, visible source, rendered via `ANSISnapshotRenderer`) with a freshness caption. Attach is demoted to a toolbar escape hatch pushed full screen — its connection opens on entry, closes on exit, and returning to Monitor triggers exactly one refresh. Agent Notification deep links now land on the Monitor.

Transport gains `readAgent` on the seam; wire types regenerated from the committed schema snapshot; the real-SSH E2E seam test and the fake-herdr fixture cover the new method.

Closes #179 (part of #176).

## Test evidence

Full CI mirror (`scripts/run-ci-ios-tests.sh`) in the package worktree: **exit 0, TEST SUCCEEDED, 840 of 935 tests executed, 95 skipped and proven elsewhere** — including `HeelerSSHTransportBehaviorE2ETests` at its pinned count of 31 with the new agent-read assertions.

## Merge order

Stacked on #185 (feat/178-ansi-renderer). Round merge order: #177 → #178 → #179 → #180 → #181 → #182 → #183.