### PR TITLE
feat(monitor): control-key strip via agent-level send-keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Entries reference the issue that motivated them.
 
 ### Added
 
+- Monitor has a control-key strip (Enter, Esc, Ctrl+C, arrows) so a Blocked
+  Agent's confirmation prompt can be answered — and work interrupted —
+  without entering Attach. Each tap is delivered through agent-level
+  `send_keys` and refreshes the snapshot once the Host accepts it. (#183)
+
 - Opening an Agent now lands on Monitor: a color-preserving snapshot of its
   latest screen with an honest capture time. Attach remains available as a
   full-screen toolbar action for realtime interaction; leaving it closes the

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		519B9551A9C12FB14C8349FD /* HostStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0443F1688BCEC3474F278889 /* HostStoreTests.swift */; };
 		541F71DBCA922E84DCA98D5E /* AgentNotificationRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F3B82DFAD293C0EE344804 /* AgentNotificationRouting.swift */; };
 		54D3A4F4FBF8F3F6C154BACE /* AppActivityCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B72AE2059C59D8A59C9B2A /* AppActivityCoordinator.swift */; };
+		552A7228E4CCBDD917A28336 /* MonitorControlKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465E3717AC740808499C4B45 /* MonitorControlKey.swift */; };
 		55C7DF5052817C34AFF088C2 /* TerminalTextSelectionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19FF62E7BD9DC71E1172A472 /* TerminalTextSelectionPresenter.swift */; };
 		5B0522DF97BC46599DDE4E93 /* TransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A41E40939438986DE30402 /* TransportConnector.swift */; };
 		5B137E763FFACD1AFE5C7E30 /* AgentNotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7EC7BEC9AACD2DAF634B2C /* AgentNotificationRouter.swift */; };
@@ -142,6 +143,7 @@
 		8D9ED28E1DB5A72B471CBD45 /* AppAppearanceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEAF21DF91A1BCE4C9F79A3 /* AppAppearanceSettings.swift */; };
 		8DF7095F918DBDA5B76F24F1 /* HeelerSSH in Frameworks */ = {isa = PBXBuildFile; productRef = 13CFA5F5C15E83F411CC03BA /* HeelerSSH */; };
 		8E440AFCE2BF426ECD8E0A86 /* SecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D2BCB4E4038F510852F71C /* SecretStore.swift */; };
+		8E9395210E0D0428E4BD8BDF /* MonitorControlKeyStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B485211F81965289691333 /* MonitorControlKeyStrip.swift */; };
 		8EB4F2396CC905928797A622 /* AgentName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4692E780178FDFA1CF9537B1 /* AgentName.swift */; };
 		8F91EAC7F32AA058E7F23394 /* TerminalKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247FF74AD248F26A072EA263 /* TerminalKeyboard.swift */; };
 		91BF879F537B1B0DD0B5E78B /* HostConsoleProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E1434C9C39A6419A3A0D79 /* HostConsoleProjection.swift */; };
@@ -337,6 +339,7 @@
 		42B76BFF68DEE415DEA495C4 /* ANSISnapshotRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSISnapshotRendererTests.swift; sourceTree = "<group>"; };
 		4582B5EA42CFA9C8878E6207 /* HeelerSSH */ = {isa = PBXFileReference; lastKnownFileType = folder; name = HeelerSSH; path = Packages/HeelerSSH; sourceTree = SOURCE_ROOT; };
 		45DB60007029322902FD1AFF /* PairingScanStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScanStore.swift; sourceTree = "<group>"; };
+		465E3717AC740808499C4B45 /* MonitorControlKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorControlKey.swift; sourceTree = "<group>"; };
 		4692E780178FDFA1CF9537B1 /* AgentName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentName.swift; sourceTree = "<group>"; };
 		46F7218F35AFEB5DCDF8BAF5 /* ConsoleActivityDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleActivityDriver.swift; sourceTree = "<group>"; };
 		48B853441AF972F5F05ADA67 /* AgentStatusPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentStatusPaletteTests.swift; sourceTree = "<group>"; };
@@ -399,6 +402,7 @@
 		8133B7654CEFC5533DCDCC5A /* TransportError+Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransportError+Presentation.swift"; sourceTree = "<group>"; };
 		823B2239BDC425FCE456B625 /* EventsSessionKeepaliveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionKeepaliveTests.swift; sourceTree = "<group>"; };
 		8273181A2428AD3F78FCC27B /* FakePairingConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakePairingConnector.swift; sourceTree = "<group>"; };
+		83B485211F81965289691333 /* MonitorControlKeyStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorControlKeyStrip.swift; sourceTree = "<group>"; };
 		842E5C0930772F4B79955DFC /* AgentMonitorStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentMonitorStoreTests.swift; sourceTree = "<group>"; };
 		847A1406F4AAEBF2F1EDFA1F /* TerminalScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalScreenView.swift; sourceTree = "<group>"; };
 		84DA8573DB6A7EBC95A57F2F /* StartAgentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStoreTests.swift; sourceTree = "<group>"; };
@@ -658,6 +662,8 @@
 				7D5D29D0F34EC475220D1085 /* AgentMonitorStore.swift */,
 				68C51ED25429F47720E29976 /* AgentMonitorView.swift */,
 				8C68AA831B8C9DB0ACCA4D50 /* ANSISnapshotRenderer.swift */,
+				465E3717AC740808499C4B45 /* MonitorControlKey.swift */,
+				83B485211F81965289691333 /* MonitorControlKeyStrip.swift */,
 			);
 			path = Monitor;
 			sourceTree = "<group>";
@@ -1200,6 +1206,8 @@
 				D8742E32B3BA3A76771BC2B7 /* JSONValue.swift in Sources */,
 				A20CC86A7DC41BD651647882 /* KnownHostsStore.swift in Sources */,
 				B818BFAB2A5008CF865D3422 /* LicenseNotices.swift in Sources */,
+				552A7228E4CCBDD917A28336 /* MonitorControlKey.swift in Sources */,
+				8E9395210E0D0428E4BD8BDF /* MonitorControlKeyStrip.swift in Sources */,
 				359A3FA92C332BEC1DA1982C /* NotificationConfigFile.swift in Sources */,
 				DF88C6F619C253A98F0EC3F6 /* NotificationDisclosureView.swift in Sources */,
 				A555F2DD86EC81E37D3A9323 /* NotificationEnvelope.swift in Sources */,

--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -249,6 +249,15 @@ final class ConsoleStore {
         }
     }
 
+    /// Monitor's control-key strip delivery path (`agent.send_keys`). Same
+    /// live Console transport as `readAgent` so a key tap never dials a
+    /// parallel connection.
+    func sendAgentKeys(_ params: AgentSendKeysParams, on hostID: Host.ID) async throws {
+        try await projection(for: hostID).session.withTransport { transport in
+            try await transport.sendAgentKeys(params)
+        }
+    }
+
     @discardableResult
     func startAgent(
         _ request: AgentLaunchRequest,

--- a/Sources/Heeler/Demo/DemoScreenshotMode.swift
+++ b/Sources/Heeler/Demo/DemoScreenshotMode.swift
@@ -376,6 +376,8 @@
                 workspaceID: agent?.workspaceID ?? "demo")
         }
 
+        func sendAgentKeys(_ params: AgentSendKeysParams) async throws {}
+
         func startAgent(_ request: AgentLaunchRequest) async throws -> Agent {
             guard let first = profile.snapshot.agents.first else {
                 throw TransportError.malformedResponse("Demo profile has no Agents.")

--- a/Sources/Heeler/Monitor/AgentMonitorStore.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorStore.swift
@@ -1,9 +1,11 @@
 import Foundation
 import Observation
 
-/// Owns the first Monitor cut: one ANSI snapshot on open and one refresh
-/// after an Attach round trip. It deliberately has no event subscription or
-/// polling; later Monitor packages add those behaviors from ADR 0012.
+/// Owns the first Monitor cut: one ANSI snapshot on open, one refresh after
+/// an Attach round trip, and control-key delivery with a one-shot refresh
+/// after each successful send (#183). It deliberately has no event
+/// subscription or polling; later Monitor packages add those behaviors from
+/// ADR 0012.
 @MainActor
 @Observable
 final class AgentMonitorStore {
@@ -17,10 +19,16 @@ final class AgentMonitorStore {
     private(set) var state: State = .idle
     private(set) var snapshot: AttributedString?
     private(set) var capturedAt: Date?
+    /// User-facing message from the last failed control-key send; cleared on
+    /// the next successful send. Independent of snapshot `state` so a key
+    /// failure never pretends the screen is missing.
+    private(set) var sendError: String?
+    private(set) var isSendingKey = false
 
     private let target: String
     private let now: @Sendable () -> Date
     private let read: @Sendable (AgentReadParams) async throws -> PaneReadResult
+    private let sendKeys: @Sendable (AgentSendKeysParams) async throws -> Void
     @ObservationIgnored private var hasOpened = false
     @ObservationIgnored private var needsRefreshAfterAttach = false
     @ObservationIgnored private var isFetching = false
@@ -29,11 +37,13 @@ final class AgentMonitorStore {
     init(
         target: String,
         now: @escaping @Sendable () -> Date = { Date() },
-        read: @escaping @Sendable (AgentReadParams) async throws -> PaneReadResult
+        read: @escaping @Sendable (AgentReadParams) async throws -> PaneReadResult,
+        sendKeys: @escaping @Sendable (AgentSendKeysParams) async throws -> Void = { _ in }
     ) {
         self.target = target
         self.now = now
         self.read = read
+        self.sendKeys = sendKeys
     }
 
     /// Fetches exactly once for this Monitor instance. SwiftUI may re-run its
@@ -59,6 +69,27 @@ final class AgentMonitorStore {
     }
 
     func retry() async {
+        await waitForCurrentFetch()
+        await fetch()
+    }
+
+    /// Delivers one control-key sequence via `agent.send_keys`, then refreshes
+    /// the snapshot so the strip's effect is visible without Attach (#183).
+    /// Concurrent taps are ignored while a send is in flight.
+    func send(_ key: MonitorControlKey) async {
+        guard !isSendingKey else { return }
+        isSendingKey = true
+        defer { isSendingKey = false }
+
+        do {
+            try await sendKeys(
+                AgentSendKeysParams(keys: key.keys, target: target))
+            sendError = nil
+        } catch {
+            sendError = Self.sendMessage(for: error)
+            return
+        }
+
         await waitForCurrentFetch()
         await fetch()
     }
@@ -121,6 +152,21 @@ final class AgentMonitorStore {
             error.connectionGuidance
         default:
             "Loading the latest screen failed: \(error)"
+        }
+    }
+
+    private static func sendMessage(for error: any Error) -> String {
+        switch error {
+        case TransportError.sshUnreachable:
+            "The Host is not connected."
+        case TransportError.timedOut:
+            "The Host did not answer in time."
+        case let error as HerdrAPIError:
+            "herdr rejected the key: \(error.message)"
+        case let error as TransportError:
+            error.connectionGuidance
+        default:
+            "Sending the key failed: \(error)"
         }
     }
 }

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -43,10 +43,15 @@ struct AgentDetailView: View {
         self.onSwitch = onSwitch
         self.onClosed = onClosed
         _monitor = State(
-            initialValue: monitorStore ?? AgentMonitorStore(target: agent.agent.paneID) {
-                [console, agent] params in
-                try await console.readAgent(params, on: agent.hostID)
-            })
+            initialValue: monitorStore
+                ?? AgentMonitorStore(
+                    target: agent.agent.paneID,
+                    read: { [console, agent] params in
+                        try await console.readAgent(params, on: agent.hostID)
+                    },
+                    sendKeys: { [console, agent] params in
+                        try await console.sendAgentKeys(params, on: agent.hostID)
+                    }))
         _attach = State(
             initialValue: attachStore ?? AgentAttachStore(
                 target: agent.agent.paneID,
@@ -114,6 +119,19 @@ struct AgentDetailView: View {
                             .frame(maxWidth: .infinity, alignment: .topLeading)
                             .padding()
                     }
+                }
+                if let sendError = monitor.sendError {
+                    Text(sendError)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal)
+                        .padding(.top, 8)
+                }
+                // Additive attachment for #183; keep minimal so parallel
+                // Monitor packages (#180) can rebase cleanly.
+                MonitorControlKeyStrip(isEnabled: !monitor.isSendingKey) { key in
+                    Task { await monitor.send(key) }
                 }
             }
         } else {

--- a/Sources/Heeler/Monitor/MonitorControlKey.swift
+++ b/Sources/Heeler/Monitor/MonitorControlKey.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// A control key on Monitor's strip (#183): a labeled shortcut mapped to the
+/// exact `agent.send_keys` spelling herdr expects. The set covers answering a
+/// Blocked Agent's confirmation prompt and interrupting work without Attach —
+/// Enter, Esc, Ctrl+C, and the four arrows.
+///
+/// Spellings are load-bearing, not cosmetic. Verified live against herdr
+/// 0.8.0 (shared with `pane.send_keys` / `pane.send_input`): `enter`, `esc`,
+/// `ctrl+c` / `C-c` accepted case-insensitively; the near-miss `ctrl-c` is
+/// rejected with `invalid_key`. Arrows are `up`/`down`/`left`/`right`.
+enum MonitorControlKey: String, CaseIterable, Identifiable, Sendable {
+    case enter
+    case escape
+    case interrupt
+    case up
+    case down
+    case left
+    case right
+
+    var id: String { rawValue }
+
+    /// The herdr `agent.send_keys` key sequence this shortcut sends.
+    var keys: [String] {
+        switch self {
+        case .enter: ["enter"]
+        case .escape: ["esc"]
+        case .interrupt: ["ctrl+c"]
+        case .up: ["up"]
+        case .down: ["down"]
+        case .left: ["left"]
+        case .right: ["right"]
+        }
+    }
+
+    /// Short label for the button; nil when an SF Symbol carries it instead.
+    var label: String? {
+        switch self {
+        case .enter: "Enter"
+        case .escape: "Esc"
+        case .interrupt: "Ctrl+C"
+        case .up, .down, .left, .right: nil
+        }
+    }
+
+    /// SF Symbol for the arrow keys; nil when a text label carries it.
+    var systemImage: String? {
+        switch self {
+        case .up: "arrow.up"
+        case .down: "arrow.down"
+        case .left: "arrow.left"
+        case .right: "arrow.right"
+        default: nil
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch self {
+        case .enter: "Enter"
+        case .escape: "Escape"
+        case .interrupt: "Control C"
+        case .up: "Up Arrow"
+        case .down: "Down Arrow"
+        case .left: "Left Arrow"
+        case .right: "Right Arrow"
+        }
+    }
+}

--- a/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
+++ b/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+/// Monitor's horizontal control-key strip (#183): Enter, Esc, Ctrl+C, and
+/// the four arrows. Self-contained so package #180 can attach elsewhere
+/// without reshaping the rest of the Monitor surface. Spellings live on
+/// ``MonitorControlKey``; this view only presents the buttons.
+struct MonitorControlKeyStrip: View {
+    let isEnabled: Bool
+    let onTap: (MonitorControlKey) -> Void
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(MonitorControlKey.allCases) { key in
+                    Button {
+                        onTap(key)
+                    } label: {
+                        keyLabel(key)
+                            .font(.callout.weight(.medium))
+                            .frame(minWidth: 44, minHeight: 36)
+                            .padding(.horizontal, 4)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(!isEnabled)
+                    .accessibilityLabel(key.accessibilityLabel)
+                }
+            }
+            .padding(.horizontal, 1)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(.bar)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Control keys")
+    }
+
+    @ViewBuilder
+    private func keyLabel(_ key: MonitorControlKey) -> some View {
+        if let systemImage = key.systemImage {
+            Image(systemName: systemImage)
+        } else if let label = key.label {
+            Text(label)
+        }
+    }
+}

--- a/Sources/Heeler/Transport/Generated/HerdrAPITypes.swift
+++ b/Sources/Heeler/Transport/Generated/HerdrAPITypes.swift
@@ -179,6 +179,17 @@ struct AgentRenameParams: Codable, Equatable, Sendable {
     }
 }
 
+/// herdr schema `$defs/AgentSendKeysParams`.
+struct AgentSendKeysParams: Codable, Equatable, Sendable {
+    let keys: [String]
+    let target: String
+
+    init(keys: [String], target: String) {
+        self.keys = keys
+        self.target = target
+    }
+}
+
 /// herdr schema `$defs/AgentSessionInfo`.
 struct AgentSessionInfo: Codable, Equatable, Sendable {
     let agent: String

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -617,6 +617,13 @@ actor HeelerSSHTransport: Transport {
             .read
     }
 
+    func sendAgentKeys(_ params: AgentSendKeysParams) async throws {
+        _ = try await request(
+            method: "agent.send_keys",
+            params: params,
+            decoding: OkResponse.self)
+    }
+
     func startAgent(_ launch: AgentLaunchRequest) async throws -> Agent {
         let created = try await request(
             method: "tab.create",

--- a/Sources/Heeler/Transport/Transport.swift
+++ b/Sources/Heeler/Transport/Transport.swift
@@ -37,6 +37,14 @@ protocol Transport: Sendable {
     /// snapshot and requests ANSI output for local rendering (ADR 0012).
     func readAgent(_ params: AgentReadParams) async throws -> PaneReadResult
 
+    /// Sends control keys to an Agent (`agent.send_keys`): Monitor's
+    /// control-key strip (#183). Key names are herdr's own spellings —
+    /// verified live against herdr 0.8.0 and shared with `pane.send_keys` /
+    /// `pane.send_input`: `enter`, `esc`, `ctrl+c` / `C-c` accepted
+    /// case-insensitively; `ctrl-c` is rejected with `invalid_key`. Arrows
+    /// are `up`/`down`/`left`/`right`.
+    func sendAgentKeys(_ params: AgentSendKeysParams) async throws
+
     /// Starts a new Agent: the new-agent flow (#12, User Story 8 — dispatch
     /// work from the road). Creates a fresh herdr tab in the chosen workspace,
     /// starts the requested agent in its root pane, and returns the Agent once

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -117,6 +117,99 @@ struct AgentMonitorStoreTests {
         #expect(String(snapshot.characters) == "known screen")
     }
 
+    @Test func sendDeliversControlKeysAndRefreshesTheSnapshot() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("before", target: "w1:p1")
+        let store = makeStore(transport: transport)
+        await store.open()
+
+        await transport.setAgentText("after ctrl+c", target: "w1:p1")
+        await store.send(.interrupt)
+
+        #expect(store.sendError == nil)
+        #expect(store.isSendingKey == false)
+        let snapshot = try #require(store.snapshot)
+        #expect(String(snapshot.characters) == "after ctrl+c")
+        #expect(
+            await transport.agentSendKeysParams == [
+                AgentSendKeysParams(keys: ["ctrl+c"], target: "w1:p1")
+            ])
+        #expect(await transport.agentReadParams.count == 2)
+    }
+
+    @Test func sendFailureSurfacesWithoutRefreshing() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("known screen", target: "w1:p1")
+        let store = makeStore(transport: transport)
+        await store.open()
+
+        await transport.setAgentSendKeysFailure(
+            HerdrAPIError(code: "invalid_key", message: "unsupported key foo"))
+        await store.send(.enter)
+
+        #expect(store.sendError == "herdr rejected the key: unsupported key foo")
+        let snapshot = try #require(store.snapshot)
+        #expect(String(snapshot.characters) == "known screen")
+        #expect(await transport.agentSendKeysParams.isEmpty)
+        #expect(await transport.agentReadParams.count == 1)
+    }
+
+    @Test func successfulSendClearsAPriorSendError() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("screen", target: "w1:p1")
+        let store = makeStore(transport: transport)
+        await store.open()
+
+        await transport.setAgentSendKeysFailure(TransportError.timedOut)
+        await store.send(.escape)
+        #expect(store.sendError == "The Host did not answer in time.")
+
+        await transport.setAgentSendKeysFailure(nil)
+        await transport.setAgentText("dismissed", target: "w1:p1")
+        await store.send(.escape)
+
+        #expect(store.sendError == nil)
+        let snapshot = try #require(store.snapshot)
+        #expect(String(snapshot.characters) == "dismissed")
+        #expect(
+            await transport.agentSendKeysParams == [
+                AgentSendKeysParams(keys: ["esc"], target: "w1:p1")
+            ])
+    }
+
+    @Test func controlKeySpellingsMatchHerdrContract() {
+        // Load-bearing spellings verified live on herdr 0.8.0 (CLAUDE.md):
+        // enter/esc/ctrl+c accepted; ctrl-c rejected with invalid_key.
+        #expect(MonitorControlKey.enter.keys == ["enter"])
+        #expect(MonitorControlKey.escape.keys == ["esc"])
+        #expect(MonitorControlKey.interrupt.keys == ["ctrl+c"])
+        #expect(MonitorControlKey.interrupt.keys != ["ctrl-c"])
+        #expect(MonitorControlKey.up.keys == ["up"])
+        #expect(MonitorControlKey.down.keys == ["down"])
+        #expect(MonitorControlKey.left.keys == ["left"])
+        #expect(MonitorControlKey.right.keys == ["right"])
+
+        for key in MonitorControlKey.allCases {
+            #expect(!key.keys.isEmpty)
+            #expect(key.keys.allSatisfy { !$0.isEmpty })
+            #expect(key.label != nil || key.systemImage != nil)
+            // Never ship the rejected near-miss form.
+            #expect(!key.keys.contains("ctrl-c"))
+        }
+    }
+
+    private func makeStore(
+        transport: ScriptedTransport,
+        target: String = "w1:p1",
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) -> AgentMonitorStore {
+        AgentMonitorStore(
+            target: target,
+            now: now,
+            read: { params in try await transport.readAgent(params) },
+            sendKeys: { params in try await transport.sendAgentKeys(params) })
+    }
+
     private func waitUntil(
         _ comment: Comment,
         timeout: Duration = .seconds(2),

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -193,8 +193,15 @@ struct AgentMonitorStoreTests {
             #expect(!key.keys.isEmpty)
             #expect(key.keys.allSatisfy { !$0.isEmpty })
             #expect(key.label != nil || key.systemImage != nil)
-            // Never ship the rejected near-miss form.
-            #expect(!key.keys.contains("ctrl-c"))
+            // Negative contract: herdr rejects hyphenated `ctrl-…` spellings
+            // with `invalid_key` (verified live on 0.8.0); only `ctrl+c` /
+            // `C-c` are accepted. Pin the whole prefix so a future key
+            // (⌃D, ⌃Z, …) cannot regress into the trap.
+            for spelling in key.keys {
+                #expect(
+                    !spelling.lowercased().hasPrefix("ctrl-"),
+                    "\(key.rawValue) must not use hyphenated ctrl- form \(spelling)")
+            }
         }
     }
 

--- a/Tests/HeelerTests/GeneratedWireTypesTests.swift
+++ b/Tests/HeelerTests/GeneratedWireTypesTests.swift
@@ -200,6 +200,20 @@ import Testing
         #expect(fields["source"] as? String == "visible")
     }
 
+    @Test func agentSendKeysParamsRoundTrip() throws {
+        let params = AgentSendKeysParams(keys: ["ctrl+c", "enter"], target: "w1:p1")
+
+        let data = try JSONEncoder().encode(params)
+        let decoded = try JSONDecoder().decode(AgentSendKeysParams.self, from: data)
+
+        #expect(decoded == params)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let fields = try #require(object)
+        #expect(fields.keys.sorted() == ["keys", "target"])
+        #expect(fields["target"] as? String == "w1:p1")
+        #expect(fields["keys"] as? [String] == ["ctrl+c", "enter"])
+    }
+
     @Test func agentStartParamsRoundTrip() throws {
         let params = AgentStartParams(
             kind: "claude", name: "reviewer", paneID: "w1:p1",

--- a/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
@@ -551,6 +551,8 @@ struct HeelerSSHTransportBehaviorE2ETests {
         #expect(agentRead.text == "\u{1B}[31mfixture agent output\u{1B}[0m")
         #expect(agentRead.source == .visible)
         #expect(agentRead.format == .ansi)
+        try await transport.sendAgentKeys(
+            AgentSendKeysParams(keys: ["ctrl+c", "enter"], target: "pane-1"))
         try await transport.closePane(PaneTarget(paneID: "pane-1"))
         try await transport.renameAgent(AgentRenameParams(target: "pane-1", name: "fixture"))
         try await transport.renameWorkspace(

--- a/Tests/HeelerTests/Support/FakeTransportConnector.swift
+++ b/Tests/HeelerTests/Support/FakeTransportConnector.swift
@@ -39,6 +39,10 @@ final actor FakeTransport: Transport {
         throw TransportError.channelFailed(detail: "FakeTransport does not script Agent reads")
     }
 
+    func sendAgentKeys(_ params: AgentSendKeysParams) async throws {
+        throw TransportError.channelFailed(detail: "FakeTransport does not script Agent send-keys")
+    }
+
     func subscribeToEvents(_ subscriptions: [EventSubscription]) async throws -> HerdrEventStream {
         throw TransportError.channelFailed(detail: "FakeTransport does not script events")
     }

--- a/Tests/HeelerTests/Support/ScriptedTransport.swift
+++ b/Tests/HeelerTests/Support/ScriptedTransport.swift
@@ -12,6 +12,10 @@ final actor ScriptedTransport: Transport {
     private(set) var capturedSubscriptions: [[EventSubscription]] = []
     private(set) var paneReadParams: [PaneReadParams] = []
     private(set) var agentReadParams: [AgentReadParams] = []
+    /// Every `agent.send_keys` received, in order; Monitor's control-key
+    /// strip (#183) asserts on the spellings and target it forwarded.
+    private(set) var agentSendKeysParams: [AgentSendKeysParams] = []
+    private var agentSendKeysFailure: (any Error)?
     /// Every `agent.start` received, in order; the new-agent flow (#12)
     /// asserts on the params it forwarded.
     private(set) var agentStarts: [AgentLaunchRequest] = []
@@ -140,6 +144,11 @@ final actor ScriptedTransport: Transport {
     /// Pauses the next Agent read after capturing its response.
     func gateNextAgentRead(using gate: ScriptedTransportCallGate) {
         nextAgentReadGate = gate
+    }
+
+    /// Makes every subsequent `sendAgentKeys` throw `failure`.
+    func setAgentSendKeysFailure(_ failure: (any Error)?) {
+        agentSendKeysFailure = failure
     }
 
     /// Scripts the `AgentInfo` `startAgent` returns; without it the fake
@@ -336,6 +345,11 @@ final actor ScriptedTransport: Transport {
             format: params.format ?? .text, paneID: params.target, revision: 0,
             source: params.source, tabID: "t", text: responseText,
             truncated: false, workspaceID: "w")
+    }
+
+    func sendAgentKeys(_ params: AgentSendKeysParams) async throws {
+        if let agentSendKeysFailure { throw agentSendKeysFailure }
+        agentSendKeysParams.append(params)
     }
 
     func startAgent(_ request: AgentLaunchRequest) async throws -> Agent {

--- a/scripts/fixtures/fake-herdr-streamlocal.py
+++ b/scripts/fixtures/fake-herdr-streamlocal.py
@@ -285,6 +285,10 @@ class Server:
                 source=source,
                 output_format=output_format,
             )
+        if method == "agent.send_keys":
+            # Thin ok-envelope RPC; key-spelling contract is asserted in unit
+            # tests against the spellings Monitor ships (enter/esc/ctrl+c/…).
+            return {"type": "ok"}
         if method == "pane.close":
             return {"type": "ok"}
         if method == "tab.create":

--- a/scripts/generate-wire-types.py
+++ b/scripts/generate-wire-types.py
@@ -53,6 +53,7 @@ METHODS = [
     "agent.list",
     "agent.read",
     "agent.rename",
+    "agent.send_keys",
     "agent.start",
     "events.subscribe",
     "tab.create",


### PR DESCRIPTION
## Summary

A control-key strip in the Monitor (Enter, Esc, Ctrl+C, arrow keys) so TUI dialogs can be answered and a working Agent interrupted without entering Attach. Delivery goes through a new agent-level send-keys on the Transport seam; a successful send triggers a one-shot snapshot refresh so the effect is visible. Key spellings follow the live-verified 0.8.0 contract (`ctrl+c` accepted, hyphenated `ctrl-c` rejected with `invalid_key`), pinned by tests including a negative-contract assertion against the hyphen form.

Closes #183 (part of #176).

## Test evidence

Full CI mirror (`scripts/run-ci-ios-tests.sh`) in the package worktree: **exit 0, 845 of 940 tests executed, 95 skipped and proven elsewhere**, including the real-SSH E2E seam test extended with send-keys assertions against the fake-herdr fixture.

## Merge order

Stacked on #186 (feat/179-monitor-skeleton). Round merge order: #177 → #178 → #179 → #180 → #181 → #182 → #183 — this PR merges LAST and will be rebased once #180/#181/#182 land (parallel siblings touching AgentMonitorView and CHANGELOG).