### PR TITLE
feat(monitor): adaptive live mirror with status-driven refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ Entries reference the issue that motivated them.
   automatically, while scrolling up holds position behind a New Output jump.
   (#180)
 
+- Monitor keeps a local scrollback. Scrolling up through what the Agent did
+  is served from the on-device cache; reaching the top while the Agent is
+  idle backfills up to herdr's 1,000-line capture window, the one loading
+  indicator in the surface. While the Agent works, the top of the cache says
+  history is unavailable instead of spinning. Reads that cannot be
+  reconciled with the cache leave an explicit gap marker, and the oldest
+  capturable line is marked as the beginning of the captured history. (#181)
+
 - Settings > About now has Acknowledgements: every redistributed third-party
   component ships with its exact upstream licence notice, including libssh2
   and its secondary sources, OpenSSL, Ghostty and its stack, the monospaced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Entries reference the issue that motivated them.
   live terminal and refreshes Monitor once. Agent Notification taps land on
   Monitor as well. (#179)
 
+- Monitor now follows a Working Agent on a two-second foreground cadence and
+  stops polling as soon as the Agent becomes Idle, Done, or Blocked. Status
+  pushes and pull-to-refresh still update the snapshot; pinned output follows
+  automatically, while scrolling up holds position behind a New Output jump.
+  (#180)
+
 - Settings > About now has Acknowledgements: every redistributed third-party
   component ships with its exact upstream licence notice, including libssh2
   and its secondary sources, OpenSSL, Ghostty and its stack, the monospaced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ Entries reference the issue that motivated them.
   automatically, while scrolling up holds position behind a New Output jump.
   (#180)
 
+- Monitor now includes a local Composer. Drafting makes no network requests;
+  Send delivers the complete message once and shows delivery, Agent work, and
+  Done states from acknowledgments and status pushes. Failed messages can be
+  retried or returned to the draft without losing text, and drafts survive
+  Attach, backgrounding, and Host reconnects. (#182)
+
 - Settings > About now has Acknowledgements: every redistributed third-party
   component ships with its exact upstream licence notice, including libssh2
   and its secondary sources, OpenSSL, Ghostty and its stack, the monospaced

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -52,11 +52,13 @@
 		2E82149F859FCBF05F9E999B /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F09325DE68693680E5A3BB /* HerdrSocketLocationTests.swift */; };
 		31E4ADB22D4D655E7CFDB749 /* TerminalInputControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05AD61D4FA60884234EA856C /* TerminalInputControllerTests.swift */; };
 		3286D6FBB12157F2A19A82CE /* AgentNotificationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB37CBDC9DE0CE539FC476A0 /* AgentNotificationRenderer.swift */; };
+		3480A4DA4478558FFD88E0C8 /* AgentMonitorHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7910FDAC85C5A3964729CC73 /* AgentMonitorHistoryTests.swift */; };
 		35205050C9CB8E473D8A28C0 /* Base64URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32413805C1AA874DBEE37547 /* Base64URL.swift */; };
 		359A3FA92C332BEC1DA1982C /* NotificationConfigFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E38A3F2A443D311C8FCC218 /* NotificationConfigFile.swift */; };
 		3662BE3559CB08401960176C /* AgentNotificationRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B02412C186BA855DFD9379A /* AgentNotificationRoutingTests.swift */; };
 		3684BDED2C234F399A6758C9 /* GhosttyTheme in Frameworks */ = {isa = PBXBuildFile; productRef = E086C559FC229264CF662993 /* GhosttyTheme */; };
 		36FB81E449F98DC68A366C2E /* HerdrAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F7065C3BE109D2F52AE3BC2 /* HerdrAPITypes.swift */; };
+		37D439F5A5583E2E3922B073 /* AgentMonitorHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F473A2ABF1D08DA49EC946 /* AgentMonitorHistory.swift */; };
 		3ABBA2BF9C6B51EF1E0C7314 /* TerminalKeysKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC019B4A164A7B01F1D46344 /* TerminalKeysKeyboard.swift */; };
 		3C5AFE8D3844A13198DDBEEA /* AttachLinkIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5870640477FDEB252DEE80B7 /* AttachLinkIndex.swift */; };
 		3C887B853B2B6DFAADEAD38E /* SnippetStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962BDE6D5BFCD443EC3B5FF4 /* SnippetStoreTests.swift */; };
@@ -387,6 +389,7 @@
 		7683DF30B1A0E9FA0064AAA2 /* HeelerSSHTransportBehaviorE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHTransportBehaviorE2ETests.swift; sourceTree = "<group>"; };
 		7780BE78D868DB0A8275E6FB /* Heeler.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Heeler.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		78F85C588963C3CE948AA9E4 /* AgentNotificationBannerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationBannerStore.swift; sourceTree = "<group>"; };
+		7910FDAC85C5A3964729CC73 /* AgentMonitorHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentMonitorHistoryTests.swift; sourceTree = "<group>"; };
 		79662827F6A91D8EFBF112F7 /* HostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostListView.swift; sourceTree = "<group>"; };
 		7A8ED9AD5019F303932B0F9C /* ImageStagingE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStagingE2ETests.swift; sourceTree = "<group>"; };
 		7B0A5D6A13F3F940E50EDCFD /* DemoScreenshotMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoScreenshotMode.swift; sourceTree = "<group>"; };
@@ -438,6 +441,7 @@
 		A579E1DA3F59AFBC3ECAD69C /* SSHChannelAdmissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHChannelAdmissionTests.swift; sourceTree = "<group>"; };
 		A5C6340A9A91119C998F64C3 /* SkillFrontmatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillFrontmatterTests.swift; sourceTree = "<group>"; };
 		A7103745D02C07787E49AC70 /* NotificationEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationEnvelopeTests.swift; sourceTree = "<group>"; };
+		A7F473A2ABF1D08DA49EC946 /* AgentMonitorHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentMonitorHistory.swift; sourceTree = "<group>"; };
 		AACC0F2C9582DE0932380D35 /* KnownHostsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStoreTests.swift; sourceTree = "<group>"; };
 		AB48C946E14722E93FAAA410 /* TerminalAttach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAttach.swift; sourceTree = "<group>"; };
 		B1AEA55D1F06B12005DEEE5F /* HeelerSSHSessionE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHSessionE2ETests.swift; sourceTree = "<group>"; };
@@ -545,6 +549,7 @@
 		11AC34F8912DA80C6DF2524F /* HeelerTests */ = {
 			isa = PBXGroup;
 			children = (
+				7910FDAC85C5A3964729CC73 /* AgentMonitorHistoryTests.swift */,
 				842E5C0930772F4B79955DFC /* AgentMonitorStoreTests.swift */,
 				64D3B8E2EB97A8376B333914 /* AgentNameTests.swift */,
 				0A319930B80D42FB33DC8E42 /* AgentNotificationBannerStoreTests.swift */,
@@ -655,6 +660,7 @@
 		1E9D44A38E208A1D0329903E /* Monitor */ = {
 			isa = PBXGroup;
 			children = (
+				A7F473A2ABF1D08DA49EC946 /* AgentMonitorHistory.swift */,
 				7D5D29D0F34EC475220D1085 /* AgentMonitorStore.swift */,
 				68C51ED25429F47720E29976 /* AgentMonitorView.swift */,
 				8C68AA831B8C9DB0ACCA4D50 /* ANSISnapshotRenderer.swift */,
@@ -1149,6 +1155,7 @@
 				17F313D8AE9647F8F5D4DBFD /* AgentAttachStore.swift in Sources */,
 				12B61E17D212416E86EE63ED /* AgentCardView.swift in Sources */,
 				E1C95FE0F5AC6271001DBF60 /* AgentDetailView.swift in Sources */,
+				37D439F5A5583E2E3922B073 /* AgentMonitorHistory.swift in Sources */,
 				2BFEB992D411C0FF7BDE4361 /* AgentMonitorStore.swift in Sources */,
 				00BB32665B566815194A17D5 /* AgentMonitorView.swift in Sources */,
 				8EB4F2396CC905928797A622 /* AgentName.swift in Sources */,
@@ -1288,6 +1295,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0D191EBCDBE44260BB137F1A /* ANSISnapshotRendererTests.swift in Sources */,
+				3480A4DA4478558FFD88E0C8 /* AgentMonitorHistoryTests.swift in Sources */,
 				CEFDE26E6526835254F14493 /* AgentMonitorStoreTests.swift in Sources */,
 				E379C1AD65B445D4E08614CF /* AgentNameTests.swift in Sources */,
 				6CD1D3CCDB58EBFF5350AC7F /* AgentNotificationBannerStoreTests.swift in Sources */,

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		2D7DC2A884FB9BA311D265A6 /* SkillProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176C059114F4646026196943 /* SkillProbeTests.swift */; };
 		2E612B94231EF97A285C83D5 /* SSHSourcePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CFDDFD7A676ECD4EF29BDE /* SSHSourcePolicyTests.swift */; };
 		2E82149F859FCBF05F9E999B /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F09325DE68693680E5A3BB /* HerdrSocketLocationTests.swift */; };
+		30A73EC02C95FB2253E030E0 /* AgentComposerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC600664EA3CE8A3E591C62 /* AgentComposerStore.swift */; };
 		31E4ADB22D4D655E7CFDB749 /* TerminalInputControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05AD61D4FA60884234EA856C /* TerminalInputControllerTests.swift */; };
 		3286D6FBB12157F2A19A82CE /* AgentNotificationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB37CBDC9DE0CE539FC476A0 /* AgentNotificationRenderer.swift */; };
 		35205050C9CB8E473D8A28C0 /* Base64URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32413805C1AA874DBEE37547 /* Base64URL.swift */; };
@@ -106,6 +107,7 @@
 		6B34378D8F7396BBF0DBB825 /* StartAgentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2E07D2395573D9EF9DE8B9 /* StartAgentView.swift */; };
 		6C33AC12CE7ACC5730240A75 /* HeelerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F710C63524E24B79F95A898 /* HeelerApp.swift */; };
 		6CD1D3CCDB58EBFF5350AC7F /* AgentNotificationBannerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A319930B80D42FB33DC8E42 /* AgentNotificationBannerStoreTests.swift */; };
+		6DA75E728052945BC787BBD3 /* AgentComposerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362EF66CE6DA07688C3E5F63 /* AgentComposerStoreTests.swift */; };
 		6FB5BA238B79801E1FDA2849 /* ConsoleActivityDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F7218F35AFEB5DCDF8BAF5 /* ConsoleActivityDriver.swift */; };
 		71661C1008468E60B82B74CD /* SSHTransportSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43AE8B2A62473EBA9EA090E /* SSHTransportSettings.swift */; };
 		7238C957097EADD61E823E9D /* NotificationEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61A04DBA56C56925B594FF1 /* NotificationEnvelope.swift */; };
@@ -194,6 +196,7 @@
 		C3CAE683F15A2DB5866FE702 /* HeelerSSHJumpHostGateE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F5C337F9BC29D46E48E35E /* HeelerSSHJumpHostGateE2ETests.swift */; };
 		C626797B247A8ED6513D2EBB /* HeelerSSHSessionE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1AEA55D1F06B12005DEEE5F /* HeelerSSHSessionE2ETests.swift */; };
 		C6E6E92365F39EDDD50CDE49 /* WeakNetworkE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB8C5EA497D1094E86F69C4 /* WeakNetworkE2ETests.swift */; };
+		C8D11877C278994387199B8B /* AgentComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9493AFCF4C4CDCF278101695 /* AgentComposerView.swift */; };
 		C9241B10F450B97F215FB28E /* RenameStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6E7022FBB1A7A39C88ACA9 /* RenameStoreTests.swift */; };
 		C99BC52057BA048DDC4DE046 /* TerminalByteFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = C681336687D32709DA583BCC /* TerminalByteFeed.swift */; };
 		C9E8028C15EC02F3F36B2B26 /* NotificationRegistrationFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67AAFD0BF81441DB59EEF7AA /* NotificationRegistrationFile.swift */; };
@@ -325,6 +328,7 @@
 		32413805C1AA874DBEE37547 /* Base64URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64URL.swift; sourceTree = "<group>"; };
 		32AE04F29C794799B45E5C68 /* Host.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Host.swift; sourceTree = "<group>"; };
 		33EF900D8EF7982B54965402 /* HostFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostFormView.swift; sourceTree = "<group>"; };
+		362EF66CE6DA07688C3E5F63 /* AgentComposerStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentComposerStoreTests.swift; sourceTree = "<group>"; };
 		365757614D9876F58A48CEDA /* NotificationConfigFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationConfigFileTests.swift; sourceTree = "<group>"; };
 		36B41E884E430DCF9BE26B91 /* AgentArgumentsField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentArgumentsField.swift; sourceTree = "<group>"; };
 		3801638051F3E5F394CF3FBD /* ReconnectPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectPolicyTests.swift; sourceTree = "<group>"; };
@@ -421,6 +425,7 @@
 		9394E039D63A2FEE9BAB1D25 /* HeelerNotificationService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HeelerNotificationService.entitlements; sourceTree = "<group>"; };
 		943C187E6425414801A4734E /* NotificationPrivacyCopyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPrivacyCopyTests.swift; sourceTree = "<group>"; };
 		9469465EF16322DDC174CD5E /* TerminalThemePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemePickerView.swift; sourceTree = "<group>"; };
+		9493AFCF4C4CDCF278101695 /* AgentComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentComposerView.swift; sourceTree = "<group>"; };
 		9578B0F124B9B77740E8E38F /* SkillsPaneStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsPaneStoreTests.swift; sourceTree = "<group>"; };
 		95EEB8A9845A6DE36DD3D9D1 /* Heeler.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Heeler.entitlements; sourceTree = "<group>"; };
 		962BDE6D5BFCD443EC3B5FF4 /* SnippetStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetStoreTests.swift; sourceTree = "<group>"; };
@@ -498,6 +503,7 @@
 		EB05396E5E55060B5A23621C /* NotificationKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationKeyStoreTests.swift; sourceTree = "<group>"; };
 		EB430B706185A38891A5DAC2 /* SnippetsManagementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsManagementView.swift; sourceTree = "<group>"; };
 		ED83CC7F1D133006430FD357 /* JetBrainsMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Regular.ttf"; sourceTree = "<group>"; };
+		EDC600664EA3CE8A3E591C62 /* AgentComposerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentComposerStore.swift; sourceTree = "<group>"; };
 		EEB863EF2AD319A412DB564A /* notification-payload-v1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "notification-payload-v1.json"; sourceTree = "<group>"; };
 		F07A0F64626D74A8EC9A1FE2 /* AttachTerminalStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachTerminalStore.swift; sourceTree = "<group>"; };
 		F261A0911D08819AFC013F1E /* JSONValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueTests.swift; sourceTree = "<group>"; };
@@ -545,6 +551,7 @@
 		11AC34F8912DA80C6DF2524F /* HeelerTests */ = {
 			isa = PBXGroup;
 			children = (
+				362EF66CE6DA07688C3E5F63 /* AgentComposerStoreTests.swift */,
 				842E5C0930772F4B79955DFC /* AgentMonitorStoreTests.swift */,
 				64D3B8E2EB97A8376B333914 /* AgentNameTests.swift */,
 				0A319930B80D42FB33DC8E42 /* AgentNotificationBannerStoreTests.swift */,
@@ -655,6 +662,8 @@
 		1E9D44A38E208A1D0329903E /* Monitor */ = {
 			isa = PBXGroup;
 			children = (
+				EDC600664EA3CE8A3E591C62 /* AgentComposerStore.swift */,
+				9493AFCF4C4CDCF278101695 /* AgentComposerView.swift */,
 				7D5D29D0F34EC475220D1085 /* AgentMonitorStore.swift */,
 				68C51ED25429F47720E29976 /* AgentMonitorView.swift */,
 				8C68AA831B8C9DB0ACCA4D50 /* ANSISnapshotRenderer.swift */,
@@ -1148,6 +1157,8 @@
 				6197AD73E1967C19E32176EB /* AgentArgumentsField.swift in Sources */,
 				17F313D8AE9647F8F5D4DBFD /* AgentAttachStore.swift in Sources */,
 				12B61E17D212416E86EE63ED /* AgentCardView.swift in Sources */,
+				30A73EC02C95FB2253E030E0 /* AgentComposerStore.swift in Sources */,
+				C8D11877C278994387199B8B /* AgentComposerView.swift in Sources */,
 				E1C95FE0F5AC6271001DBF60 /* AgentDetailView.swift in Sources */,
 				2BFEB992D411C0FF7BDE4361 /* AgentMonitorStore.swift in Sources */,
 				00BB32665B566815194A17D5 /* AgentMonitorView.swift in Sources */,
@@ -1288,6 +1299,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0D191EBCDBE44260BB137F1A /* ANSISnapshotRendererTests.swift in Sources */,
+				6DA75E728052945BC787BBD3 /* AgentComposerStoreTests.swift in Sources */,
 				CEFDE26E6526835254F14493 /* AgentMonitorStoreTests.swift in Sources */,
 				E379C1AD65B445D4E08614CF /* AgentNameTests.swift in Sources */,
 				6CD1D3CCDB58EBFF5350AC7F /* AgentNotificationBannerStoreTests.swift in Sources */,

--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -7,6 +7,11 @@ import Observation
 @MainActor
 @Observable
 final class ConsoleStore {
+    struct AgentStatusUpdate: Sendable, Equatable {
+        let status: AgentStatus?
+        let liveUpdatesAvailable: Bool
+    }
+
     private(set) var agents: [ConsoleAgent] = []
     private(set) var hostStatuses: [Host.ID: EventsSessionStatus] = [:]
     private(set) var hostLatencies: [Host.ID: Duration] = [:]
@@ -28,6 +33,12 @@ final class ConsoleStore {
     /// so a reconnect naturally invalidates, and evicted per Host on insert
     /// so stale generations cannot accumulate.
     @ObservationIgnored private var skillsCache: [SkillsCacheKey: [AgentSkill]] = [:]
+    /// Status events already converge through each Host's one pane-scoped
+    /// subscription. Screens consume this fan-out instead of opening a
+    /// second events channel that could outlive the connection snapshot.
+    @ObservationIgnored private var agentStatusObservers: [
+        ConsoleAgent.ID: [UUID: AsyncStream<AgentStatusUpdate>.Continuation]
+    ] = [:]
     @ObservationIgnored private let makeSession:
         @Sendable (Host, [EventSubscription]) -> EventsSession
     @ObservationIgnored private let snapshotRetryDelay: Duration
@@ -249,6 +260,23 @@ final class ConsoleStore {
         }
     }
 
+    /// A latest-value view of the existing `pane.agent_status_changed`
+    /// subscription for one Agent. Monitor uses it for adaptive polling;
+    /// Composer (#182) can reuse the same seam for delivery transitions.
+    func agentStatusUpdates(for id: ConsoleAgent.ID) -> AsyncStream<AgentStatusUpdate> {
+        let observerID = UUID()
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: AgentStatusUpdate.self, bufferingPolicy: .bufferingNewest(1))
+        agentStatusObservers[id, default: [:]][observerID] = continuation
+        continuation.yield(agentStatusUpdate(for: id))
+        continuation.onTermination = { [weak self] _ in
+            Task { @MainActor in
+                self?.removeAgentStatusObserver(observerID, for: id)
+            }
+        }
+        return stream
+    }
+
     @discardableResult
     func startAgent(
         _ request: AgentLaunchRequest,
@@ -341,6 +369,32 @@ final class ConsoleStore {
             })
         if workspacesByHost != nextWorkspacesByHost {
             workspacesByHost = nextWorkspacesByHost
+        }
+        publishAgentStatuses()
+    }
+
+    private func publishAgentStatuses() {
+        for (id, observers) in agentStatusObservers {
+            let update = agentStatusUpdate(for: id)
+            for continuation in observers.values {
+                continuation.yield(update)
+            }
+        }
+    }
+
+    private func agentStatusUpdate(for id: ConsoleAgent.ID) -> AgentStatusUpdate {
+        let status = agents.first(where: { $0.id == id })?.agent.status
+        return AgentStatusUpdate(
+            status: status,
+            liveUpdatesAvailable: status != nil
+                && hostStatuses[id.hostID] == .connected
+                && !hostsAwaitingSnapshot.contains(id.hostID))
+    }
+
+    private func removeAgentStatusObserver(_ observerID: UUID, for id: ConsoleAgent.ID) {
+        agentStatusObservers[id]?[observerID] = nil
+        if agentStatusObservers[id]?.isEmpty == true {
+            agentStatusObservers[id] = nil
         }
     }
 }

--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -39,6 +39,11 @@ final class ConsoleStore {
     @ObservationIgnored private var agentStatusObservers: [
         ConsoleAgent.ID: [UUID: AsyncStream<AgentStatusUpdate>.Continuation]
     ] = [:]
+    /// Composer ownership sits above the detail branch so a transient
+    /// missing-Agent placeholder during reconnect cannot destroy a draft.
+    @ObservationIgnored private var composerStores: [
+        ConsoleAgent.ID: AgentComposerStore
+    ] = [:]
     @ObservationIgnored private let makeSession:
         @Sendable (Host, [EventSubscription]) -> EventsSession
     @ObservationIgnored private let snapshotRetryDelay: Duration
@@ -62,6 +67,7 @@ final class ConsoleStore {
     /// projection because its connection coordinates may have changed.
     func setHosts(_ hosts: [Host]) {
         let incoming = Dictionary(hosts.map { ($0.id, $0) }) { _, last in last }
+        composerStores = composerStores.filter { incoming[$0.key.hostID] != nil }
         for (id, projection) in projections where incoming[id] != projection.host {
             projection.end()
             projections[id] = nil
@@ -258,6 +264,33 @@ final class ConsoleStore {
         try await projection(for: hostID).session.withTransport { transport in
             try await transport.readAgent(params)
         }
+    }
+
+    /// Composer's one-shot delivery source. Like Monitor reads, prompts
+    /// borrow the Host's current Console connection rather than dialing a
+    /// parallel connection or holding an RPC open for Agent completion.
+    func promptAgent(_ params: AgentPromptParams, on hostID: Host.ID) async throws -> Agent {
+        try await projection(for: hostID).session.withTransport { transport in
+            try await transport.promptAgent(params)
+        }
+    }
+
+    /// One Composer per selected Agent for the lifetime of its Host catalog
+    /// entry. The Console detail may be replaced by a reconnect placeholder;
+    /// retaining the store here keeps its entirely local draft intact.
+    func composerStore(for agent: ConsoleAgent) -> AgentComposerStore {
+        if let existing = composerStores[agent.id] { return existing }
+        let hostID = agent.hostID
+        let store = AgentComposerStore(
+            target: agent.agent.paneID,
+            initialStatus: agent.agent.status,
+            statusUpdates: agentStatusUpdates(for: agent.id)
+        ) { [weak self] params in
+            guard let self else { throw TransportError.cancelled }
+            return try await self.promptAgent(params, on: hostID)
+        }
+        composerStores[agent.id] = store
+        return store
     }
 
     /// A latest-value view of the existing `pane.agent_status_changed`

--- a/Sources/Heeler/Demo/DemoScreenshotMode.swift
+++ b/Sources/Heeler/Demo/DemoScreenshotMode.swift
@@ -376,6 +376,14 @@
                 workspaceID: agent?.workspaceID ?? "demo")
         }
 
+        func promptAgent(_ params: AgentPromptParams) async throws -> Agent {
+            guard let agent = profile.snapshot.agents.first(where: { $0.paneID == params.target })
+            else {
+                throw TransportError.malformedResponse("Demo profile has no matching Agent.")
+            }
+            return Agent(agent)
+        }
+
         func startAgent(_ request: AgentLaunchRequest) async throws -> Agent {
             guard let first = profile.snapshot.agents.first else {
                 throw TransportError.malformedResponse("Demo profile has no Agents.")

--- a/Sources/Heeler/Monitor/AgentComposerStore.swift
+++ b/Sources/Heeler/Monitor/AgentComposerStore.swift
@@ -159,11 +159,11 @@ final class AgentComposerStore: ComposerDraftOperations {
         }
         switch agentStatus {
         case .working:
-            .working
+            return .working
         case .done:
-            .done
+            return .done
         default:
-            .acknowledged
+            return .acknowledged
         }
     }
 

--- a/Sources/Heeler/Monitor/AgentComposerStore.swift
+++ b/Sources/Heeler/Monitor/AgentComposerStore.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Observation
+
+/// Local draft operations shared by the plain-text Composer now and future
+/// Snippet, Skill, and Staged Image path insertion surfaces.
+@MainActor
+protocol ComposerDraftOperations: AnyObject {
+    func replaceDraft(with text: String)
+    func insertIntoDraft(_ text: String)
+}
+
+/// Owns Monitor's local draft and optimistic delivery echoes. Draft edits do
+/// not touch Transport; only an explicit send emits one `agent.prompt` RPC.
+@MainActor
+@Observable
+final class AgentComposerStore: ComposerDraftOperations {
+    struct Message: Identifiable, Equatable {
+        let id: UUID
+        let text: String
+        fileprivate var agentWasWorkingAtSend: Bool
+        fileprivate var statusRevisionAtSend: UInt64
+        fileprivate(set) var state: DeliveryState
+    }
+
+    enum DeliveryState: Equatable {
+        case sending
+        case delivered(AgentProgress)
+        case failed(String)
+    }
+
+    enum AgentProgress: Equatable {
+        case acknowledged
+        case agentBusy
+        case working
+        case done
+    }
+
+    private(set) var messages: [Message] = []
+    private(set) var draft = ""
+
+    private let target: String
+    private var agentStatus: AgentStatus
+    private var statusRevision: UInt64 = 0
+    private let statusUpdates: AsyncStream<ConsoleStore.AgentStatusUpdate>?
+    private let prompt: @Sendable (AgentPromptParams) async throws -> Agent
+    @ObservationIgnored private var hasOpened = false
+    @ObservationIgnored private var statusTask: Task<Void, Never>?
+
+    init(
+        target: String,
+        initialStatus: AgentStatus = .idle,
+        statusUpdates: AsyncStream<ConsoleStore.AgentStatusUpdate>? = nil,
+        prompt: @escaping @Sendable (AgentPromptParams) async throws -> Agent
+    ) {
+        self.target = target
+        agentStatus = initialStatus
+        self.statusUpdates = statusUpdates
+        self.prompt = prompt
+    }
+
+    deinit {
+        statusTask?.cancel()
+    }
+
+    var canSend: Bool {
+        draft.contains(where: { !$0.isWhitespace })
+    }
+
+    func replaceDraft(with text: String) {
+        draft = text
+    }
+
+    func insertIntoDraft(_ text: String) {
+        draft.append(text)
+    }
+
+    /// Starts consuming Console's existing per-Agent status fan-out. This
+    /// does not open a Transport event stream or perform an RPC.
+    func open() {
+        guard !hasOpened else { return }
+        hasOpened = true
+        guard let statusUpdates else { return }
+        statusTask = Task { [weak self] in
+            for await update in statusUpdates {
+                guard !Task.isCancelled, let self else { return }
+                if let status = update.status {
+                    self.agentStatusDidChange(status)
+                }
+            }
+        }
+    }
+
+    func send() async {
+        guard canSend else { return }
+        let message = Message(
+            id: UUID(), text: draft,
+            agentWasWorkingAtSend: agentStatus == .working,
+            statusRevisionAtSend: statusRevision,
+            state: .sending)
+        draft = ""
+        messages.append(message)
+        await deliver(message.id)
+    }
+
+    func retry(_ id: Message.ID) async {
+        guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
+        guard case .failed = messages[index].state else { return }
+        messages[index].agentWasWorkingAtSend = agentStatus == .working
+        messages[index].statusRevisionAtSend = statusRevision
+        messages[index].state = .sending
+        await deliver(id)
+    }
+
+    /// Removes a failed echo and restores all of its text to the draft. If
+    /// the user has already started another draft, both are kept in order.
+    func withdrawToDraft(_ id: Message.ID) {
+        guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
+        guard case .failed = messages[index].state else { return }
+        let text = messages.remove(at: index).text
+        draft = draft.isEmpty ? text : "\(text)\n\(draft)"
+    }
+
+    func agentStatusDidChange(_ status: AgentStatus) {
+        guard agentStatus != status else { return }
+        agentStatus = status
+        statusRevision &+= 1
+        for index in messages.indices {
+            guard case .delivered(let progress) = messages[index].state else { continue }
+            switch status {
+            case .working where progress != .done:
+                messages[index].state = .delivered(.working)
+            case .done:
+                messages[index].state = .delivered(.done)
+            default:
+                break
+            }
+        }
+    }
+
+    private func deliver(_ id: Message.ID) async {
+        guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
+        let text = messages[index].text
+        do {
+            _ = try await prompt(AgentPromptParams(target: target, text: text))
+            guard let acknowledgedIndex = messages.firstIndex(where: { $0.id == id }) else {
+                return
+            }
+            messages[acknowledgedIndex].state = .delivered(
+                progressAfterAcknowledgment(for: messages[acknowledgedIndex]))
+        } catch {
+            guard let failedIndex = messages.firstIndex(where: { $0.id == id }) else { return }
+            messages[failedIndex].state = .failed(Self.message(for: error))
+        }
+    }
+
+    private func progressAfterAcknowledgment(for message: Message) -> AgentProgress {
+        guard message.statusRevisionAtSend != statusRevision else {
+            return message.agentWasWorkingAtSend ? .agentBusy : .acknowledged
+        }
+        switch agentStatus {
+        case .working:
+            .working
+        case .done:
+            .done
+        default:
+            .acknowledged
+        }
+    }
+
+    private static func message(for error: any Error) -> String {
+        switch error {
+        case TransportError.sshUnreachable:
+            "The Host is not connected. Check the connection and retry."
+        case TransportError.timedOut:
+            "The Host did not answer. Check the connection and retry."
+        case let error as HerdrAPIError:
+            "herdr rejected the message: \(error.message)"
+        case let error as TransportError:
+            error.connectionGuidance
+        default:
+            "The message could not be sent. Check the connection and retry."
+        }
+    }
+}

--- a/Sources/Heeler/Monitor/AgentComposerStore.swift
+++ b/Sources/Heeler/Monitor/AgentComposerStore.swift
@@ -19,6 +19,7 @@ final class AgentComposerStore: ComposerDraftOperations {
         let text: String
         fileprivate var agentWasWorkingAtSend: Bool
         fileprivate var statusRevisionAtSend: UInt64
+        fileprivate var observedWorkingAfterSend: Bool
         fileprivate(set) var state: DeliveryState
     }
 
@@ -96,6 +97,7 @@ final class AgentComposerStore: ComposerDraftOperations {
             id: UUID(), text: draft,
             agentWasWorkingAtSend: agentStatus == .working,
             statusRevisionAtSend: statusRevision,
+            observedWorkingAfterSend: false,
             state: .sending)
         draft = ""
         messages.append(message)
@@ -107,6 +109,7 @@ final class AgentComposerStore: ComposerDraftOperations {
         guard case .failed = messages[index].state else { return }
         messages[index].agentWasWorkingAtSend = agentStatus == .working
         messages[index].statusRevisionAtSend = statusRevision
+        messages[index].observedWorkingAfterSend = false
         messages[index].state = .sending
         await deliver(id)
     }
@@ -125,11 +128,21 @@ final class AgentComposerStore: ComposerDraftOperations {
         agentStatus = status
         statusRevision &+= 1
         for index in messages.indices {
+            if status == .working,
+                messages[index].statusRevisionAtSend != statusRevision
+            {
+                messages[index].observedWorkingAfterSend = true
+            }
             guard case .delivered(let progress) = messages[index].state else { continue }
             switch status {
-            case .working where progress != .done:
+            case .working
+                where progress != .done && messages[index].observedWorkingAfterSend:
                 messages[index].state = .delivered(.working)
-            case .done:
+            case .done
+                where messages[index].observedWorkingAfterSend
+                    || !messages[index].agentWasWorkingAtSend:
+                messages[index].state = .delivered(.done)
+            case .idle where messages[index].observedWorkingAfterSend:
                 messages[index].state = .delivered(.done)
             default:
                 break
@@ -154,17 +167,24 @@ final class AgentComposerStore: ComposerDraftOperations {
     }
 
     private func progressAfterAcknowledgment(for message: Message) -> AgentProgress {
-        guard message.statusRevisionAtSend != statusRevision else {
-            return message.agentWasWorkingAtSend ? .agentBusy : .acknowledged
-        }
-        switch agentStatus {
-        case .working:
-            return .working
-        case .done:
+        if message.observedWorkingAfterSend {
+            switch agentStatus {
+            case .working:
+                return .working
+            case .done, .idle:
+                return .done
+            default:
+                break
+            }
+        } else if !message.agentWasWorkingAtSend,
+            message.statusRevisionAtSend != statusRevision,
+            agentStatus == .done
+        {
+            // The status stream keeps only the newest event. A fast
+            // working-to-done pair can therefore arrive as Done alone.
             return .done
-        default:
-            return .acknowledged
         }
+        return message.agentWasWorkingAtSend ? .agentBusy : .acknowledged
     }
 
     private static func message(for error: any Error) -> String {

--- a/Sources/Heeler/Monitor/AgentComposerView.swift
+++ b/Sources/Heeler/Monitor/AgentComposerView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+/// Monitor's native, local-first message surface. It renders optimistic
+/// echoes but never infers structured conversation history from terminal
+/// output (ADR 0012).
+struct AgentComposerView: View {
+    let store: AgentComposerStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if !store.messages.isEmpty {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 8) {
+                            ForEach(store.messages) { message in
+                                messageRow(message)
+                                    .id(message.id)
+                            }
+                        }
+                    }
+                    .defaultScrollAnchor(.bottom)
+                    .onChange(of: store.messages.count) {
+                        guard let latest = store.messages.last else { return }
+                        proxy.scrollTo(latest.id, anchor: .bottom)
+                    }
+                }
+                .frame(maxHeight: 176)
+                .accessibilityLabel("Sent messages")
+            }
+
+            Text("Message")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(alignment: .bottom, spacing: 10) {
+                TextField(
+                    "Message",
+                    text: Binding(
+                        get: { store.draft },
+                        set: { store.replaceDraft(with: $0) }),
+                    axis: .vertical
+                )
+                .lineLimit(1...5)
+                .textFieldStyle(.plain)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
+                .accessibilityLabel("Message")
+
+                Button("Send", systemImage: "arrow.up.circle.fill") {
+                    Task { await store.send() }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!store.canSend)
+                .accessibilityHint("Delivers the complete draft to the Agent")
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 10)
+        .background(.bar)
+    }
+
+    private func messageRow(_ message: AgentComposerStore.Message) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(message.text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
+
+            statusLabel(for: message.state)
+                .font(.footnote)
+
+            if case .failed(let detail) = message.state {
+                Text(detail)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                HStack(spacing: 8) {
+                    Button("Retry", systemImage: "arrow.clockwise") {
+                        Task { await store.retry(message.id) }
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Button("Edit Draft", systemImage: "pencil") {
+                        store.withdrawToDraft(message.id)
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .controlSize(.small)
+            }
+        }
+        .padding(10)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    @ViewBuilder
+    private func statusLabel(for state: AgentComposerStore.DeliveryState) -> some View {
+        switch state {
+        case .sending:
+            Label("Sending…", systemImage: "arrow.up.circle")
+                .foregroundStyle(.secondary)
+        case .delivered(.acknowledged):
+            Label("Delivered", systemImage: "checkmark.circle")
+                .foregroundStyle(.secondary)
+        case .delivered(.agentBusy):
+            Label("Delivered, Agent busy", systemImage: "clock")
+                .foregroundStyle(.secondary)
+        case .delivered(.working):
+            Label("Agent working", systemImage: "gearshape.2")
+                .foregroundStyle(.secondary)
+        case .delivered(.done):
+            Label("Done", systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.secondary)
+        case .failed:
+            Label("Couldn't send", systemImage: "exclamationmark.triangle")
+                .foregroundStyle(.red)
+        }
+    }
+}

--- a/Sources/Heeler/Monitor/AgentMonitorHistory.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorHistory.swift
@@ -1,8 +1,9 @@
 import Foundation
 
 /// Monitor's local scrollback cache: captured line runs and explicit gap
-/// markers, ordered oldest first. The final line run is always the live
-/// screen, kept separate from backfilled or sealed history. In-memory only.
+/// markers, ordered oldest first. The final line run is always exactly the
+/// live screen, kept separate from backfilled, proven-stitched, or sealed
+/// history. In-memory only.
 ///
 /// herdr exposes no history cursor (`agent.read` takes a source and a line
 /// count, capped at 1000 lines), so every reconciliation is an
@@ -28,10 +29,23 @@ struct AgentMonitorHistory: Equatable, Sendable {
     /// whole-screen match is correct by construction there.
     static let minimumOverlap = 3
 
+    /// Truly distinct live screens remain useful context, but they cannot
+    /// grow without bound during a long-running alternate-screen session.
+    /// Backfilled and overlap-proven history does not count against this cap.
+    static let maximumSealedLiveGenerations = 8
+
+    private static let minimumNearDuplicateLineCount = 5
+    private static let maximumNearDuplicateLineDifferences = 2
+
     /// The final `.lines` segment is always the live screen. Backfilled and
     /// sealed live runs remain separate from it, including when they are
     /// known to be contiguous; only a `.gap` claims unknown continuity.
     private(set) var segments: [Segment] = []
+
+    /// Indices of live screens retained only because a later non-overlapping
+    /// read replaced them. Their adjacent generation gaps are tracked by
+    /// position. Other line segments are proven history and never capped.
+    private var sealedLiveGenerationIndices: [Int] = []
 
     /// The range reconciled by the most recent backfill. It normally spans
     /// the current history suffix and live run. After an unstitched read it
@@ -52,18 +66,19 @@ struct AgentMonitorHistory: Equatable, Sendable {
     enum VisibleOutcome: Equatable, Sendable {
         /// The read carried no new content.
         case unchanged
-        /// The read's top overlapped the live screen's bottom; newly scrolled
-        /// lines were appended to the live run.
+        /// The read's top overlapped the live screen's bottom; rows proven to
+        /// have scrolled off were preserved above the new exact live screen.
         case extended
-        /// No usable overlap (an alternate-screen repaint, or a reconnect
-        /// that scrolled a full screen): a new live run was installed.
+        /// The live screen changed without a scroll overlap. Near-duplicate
+        /// repaints replace it in place; distinct screens start a generation.
         case replaced
     }
 
     /// Reconciles one `visible` read with the live tail. The visible screen
     /// is a sliding window: when its top lines match the live run's bottom,
-    /// only fresh lines are appended. Otherwise the old live run is sealed
-    /// as history and the repaint becomes a new live run below a gap.
+    /// scrolled-off rows become proven history. Otherwise a near-duplicate
+    /// repaint replaces the live run in place, while a distinct screen seals
+    /// the old live run and starts a new generation below a gap.
     @discardableResult
     mutating func applyVisible(_ text: String) -> VisibleOutcome {
         let read = Self.splitLines(text)
@@ -75,20 +90,33 @@ struct AgentMonitorHistory: Equatable, Sendable {
             backfillRange = 0..<1
             return .replaced
         }
-        guard read != newest else { return .unchanged }
-        // A read fully contained at the tail (a shorter screen, or the same
-        // screen while the live run accumulated scrolling) changes nothing.
+        guard !Self.areByteIdentical(read, newest) else { return .unchanged }
+        // A read fully contained at the tail (a shorter version of the same
+        // screen) changes nothing.
         // The empty read is excluded: a cleared screen is a replacement.
-        if !read.isEmpty, read.count <= newest.count, newest.suffix(read.count) == read {
+        if !read.isEmpty,
+            read.count <= newest.count,
+            Self.areByteIdentical(newest.suffix(read.count), read)
+        {
             return .unchanged
         }
+        // Alternate-screen repaint ticks usually preserve the screen shape
+        // and change only a spinner, timer, or status row. They are the same
+        // live generation, so replace it in place rather than retaining a
+        // near-identical sealed screen on every poll.
+        if Self.isNearDuplicate(newest, read) {
+            segments[segments.count - 1] = .lines(read)
+            backfillRange = contiguousTailRange
+            return .replaced
+        }
+
         let floor = min(Self.minimumOverlap, read.count, newest.count)
         if floor >= 1,
             let overlap = Self.largestOverlap(suffixOf: newest, prefixOf: read, floor: floor)
         {
-            let fresh = read.suffix(read.count - overlap)
-            guard !fresh.isEmpty else { return .unchanged }
-            segments[segments.count - 1] = .lines(newest + fresh)
+            guard overlap < read.count else { return .unchanged }
+            let scrolledOff = Array(newest.prefix(newest.count - overlap))
+            installExtendedLiveScreen(read, preserving: scrolledOff)
             return .extended
         }
 
@@ -98,10 +126,12 @@ struct AgentMonitorHistory: Equatable, Sendable {
         if newest.isEmpty {
             segments[segments.count - 1] = .lines(read)
         } else {
+            sealedLiveGenerationIndices.append(segments.count - 1)
             segments.append(.gap)
             segments.append(.lines(read))
         }
         backfillRange = (segments.count - 1)..<segments.count
+        trimSealedLiveGenerations()
         return .replaced
     }
 
@@ -175,11 +205,55 @@ struct AgentMonitorHistory: Equatable, Sendable {
         return lines
     }
 
+    /// A conservative repaint heuristic. Both screens must have the same
+    /// shape and at least five lines, and at least 80% of corresponding lines
+    /// must be byte-identical. Even on large screens, no more than two lines
+    /// may differ. This catches spinner/status repaint ticks without folding
+    /// genuinely distinct screens into one generation.
+    static func isNearDuplicate(_ first: [String], _ second: [String]) -> Bool {
+        guard
+            first.count == second.count,
+            first.count >= minimumNearDuplicateLineCount
+        else { return false }
+
+        let allowedDifferences = min(
+            maximumNearDuplicateLineDifferences,
+            first.count / minimumNearDuplicateLineCount)
+        var differences = 0
+        for (firstLine, secondLine) in zip(first, second)
+        where !firstLine.utf8.elementsEqual(secondLine.utf8) {
+            differences += 1
+            if differences > allowedDifferences {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func areByteIdentical<First: Collection, Second: Collection>(
+        _ first: First,
+        _ second: Second
+    ) -> Bool where First.Element == String, Second.Element == String {
+        guard first.count == second.count else { return false }
+        return zip(first, second).allSatisfy { firstLine, secondLine in
+            firstLine.utf8.elementsEqual(secondLine.utf8)
+        }
+    }
+
     /// `nil` only when the cache is empty; the invariant keeps a trailing
     /// `.lines` run otherwise, even if it holds zero lines.
     private var newestLinesIfPresent: [String]? {
         guard case .lines(let lines) = segments.last else { return nil }
         return lines
+    }
+
+    private var contiguousTailRange: Range<Int> {
+        var lowerBound = segments.count - 1
+        while lowerBound > segments.startIndex {
+            guard case .lines = segments[lowerBound - 1] else { break }
+            lowerBound -= 1
+        }
+        return lowerBound..<segments.endIndex
     }
 
     private var validBackfillRange: Range<Int>? {
@@ -203,6 +277,60 @@ struct AgentMonitorHistory: Equatable, Sendable {
             result.append(contentsOf: lines)
         }
         return result
+    }
+
+    /// Keeps overlap-proven output outside the replace-generation cap. The
+    /// live segment stays an exact screen, while rows that demonstrably
+    /// scrolled off are folded into the contiguous protected history above.
+    private mutating func installExtendedLiveScreen(
+        _ read: [String],
+        preserving scrolledOff: [String]
+    ) {
+        let liveIndex = segments.count - 1
+        segments[liveIndex] = .lines(read)
+        if !scrolledOff.isEmpty {
+            if liveIndex > segments.startIndex,
+                case .lines(let provenHistory) = segments[liveIndex - 1]
+            {
+                segments[liveIndex - 1] = .lines(provenHistory + scrolledOff)
+            } else {
+                segments.insert(.lines(scrolledOff), at: liveIndex)
+            }
+        }
+        backfillRange = contiguousTailRange
+    }
+
+    private mutating func trimSealedLiveGenerations() {
+        while sealedLiveGenerationIndices.count > Self.maximumSealedLiveGenerations {
+            let sealedIndex = sealedLiveGenerationIndices.removeFirst()
+            guard
+                sealedIndex >= segments.startIndex,
+                sealedIndex < segments.endIndex,
+                case .lines = segments[sealedIndex]
+            else { continue }
+
+            // Later generations were introduced by a gap immediately above
+            // them, so discard that gap with the sealed screen. The original
+            // live screen has no preceding gap; removing it leaves its
+            // following gap as the honest boundary between protected history
+            // and the oldest retained generation.
+            let removalLowerBound =
+                sealedIndex > segments.startIndex && segments[sealedIndex - 1] == .gap
+                ? sealedIndex - 1 : sealedIndex
+            let removedRange = removalLowerBound..<(sealedIndex + 1)
+            segments.removeSubrange(removedRange)
+            sealedLiveGenerationIndices = sealedLiveGenerationIndices.map { index in
+                index >= removedRange.upperBound ? index - removedRange.count : index
+            }
+            if let range = backfillRange {
+                if range.lowerBound >= removedRange.upperBound {
+                    let offset = removedRange.count
+                    backfillRange = (range.lowerBound - offset)..<(range.upperBound - offset)
+                } else if range.overlaps(removedRange) {
+                    backfillRange = nil
+                }
+            }
+        }
     }
 
     private mutating func prepend(_ older: [String], to range: Range<Int>) {
@@ -267,7 +395,7 @@ struct AgentMonitorHistory: Equatable, Sendable {
     ) -> Int? {
         var candidate = min(first.count, second.count)
         while candidate >= floor {
-            if first.suffix(candidate) == second.prefix(candidate) {
+            if Self.areByteIdentical(first.suffix(candidate), second.prefix(candidate)) {
                 return candidate
             }
             candidate -= 1
@@ -282,7 +410,7 @@ struct AgentMonitorHistory: Equatable, Sendable {
     ) -> Int? {
         var candidate = min(first.count, second.count)
         while candidate >= floor {
-            if first.suffix(candidate) == second.suffix(candidate) {
+            if Self.areByteIdentical(first.suffix(candidate), second.suffix(candidate)) {
                 return candidate
             }
             candidate -= 1
@@ -298,7 +426,7 @@ struct AgentMonitorHistory: Equatable, Sendable {
         guard needle.count <= haystack.count else { return nil }
         var start = haystack.count - needle.count
         while start >= 0 {
-            if haystack[start..<(start + needle.count)].elementsEqual(needle) {
+            if Self.areByteIdentical(haystack[start..<(start + needle.count)], needle) {
                 return start
             }
             start -= 1

--- a/Sources/Heeler/Monitor/AgentMonitorHistory.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorHistory.swift
@@ -197,10 +197,12 @@ struct AgentMonitorHistory: Equatable, Sendable {
     }
 
     private func lines(in range: Range<Int>) -> [String] {
-        range.flatMap { index in
-            guard case .lines(let lines) = segments[index] else { return [] }
-            return lines
+        var result: [String] = []
+        for index in range {
+            guard case .lines(let lines) = segments[index] else { continue }
+            result.append(contentsOf: lines)
         }
+        return result
     }
 
     private mutating func prepend(_ older: [String], to range: Range<Int>) {

--- a/Sources/Heeler/Monitor/AgentMonitorHistory.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorHistory.swift
@@ -1,0 +1,217 @@
+import Foundation
+
+/// Monitor's local scrollback cache: an ordered list of contiguous line runs
+/// separated by explicit gap markers, oldest first. In-memory only.
+///
+/// herdr exposes no history cursor (`agent.read` takes a source and a line
+/// count, capped at 1000 lines), so every reconciliation is an
+/// overlap-stitch against what the cache already holds. This type is the
+/// pure line algebra behind that: it performs no I/O, keeps no presentation
+/// state, and is deliberately separate from `AgentMonitorStore` so the
+/// stitching rules are testable on their own.
+struct AgentMonitorHistory: Equatable, Sendable {
+    enum Segment: Equatable, Sendable {
+        /// A contiguous run of captured lines. ANSI state flows within a run;
+        /// runs never sit adjacent to another run (a stitch merges them).
+        case lines([String])
+        /// An explicit marker that the content between the neighbouring runs
+        /// could not be captured or reconciled. Never guessed around.
+        case gap
+    }
+
+    /// The smallest suffix/prefix overlap accepted as proof that two reads
+    /// cover the same content. Smaller coincidences (a shared blank line, a
+    /// repeated prompt) are treated as no overlap, because a spurious gap is
+    /// honest while a spurious stitch silently corrupts history. When one
+    /// side is shorter than this, the overlap floor drops to that length: a
+    /// whole-screen match is correct by construction there.
+    static let minimumOverlap = 3
+
+    /// Invariant: `.lines` runs are never adjacent (a stitch merges them)
+    /// and a `.gap` is never first or last, so the cache always ends with
+    /// the live run.
+    private(set) var segments: [Segment] = []
+
+    var isEmpty: Bool {
+        segments.isEmpty
+    }
+
+    /// The lines of the newest contiguous run. The live mirror of the
+    /// Agent's screen always lives here; backfill stitches onto its front
+    /// because a `recent` read ends at the same newest line.
+    var newestLines: [String] {
+        guard case .lines(let lines) = segments.last else { return [] }
+        return lines
+    }
+
+    enum VisibleOutcome: Equatable, Sendable {
+        /// The read carried no new content.
+        case unchanged
+        /// The read's top overlapped the cache's bottom; the newly scrolled
+        /// lines were appended to the newest run.
+        case extended
+        /// No usable overlap (an alternate-screen repaint, or a reconnect
+        /// that scrolled a full screen): the newest run was replaced.
+        case replaced
+    }
+
+    /// Reconciles one `visible` read with the live tail. The visible screen
+    /// is a sliding window: when its top lines match the cache's bottom
+    /// lines the window scrolled and only the fresh lines are appended;
+    /// otherwise the screen repainted and the tail is replaced outright.
+    @discardableResult
+    mutating func applyVisible(_ text: String) -> VisibleOutcome {
+        let read = Self.splitLines(text)
+        guard let newest = newestLinesIfPresent else {
+            // The first install always reports a change: even an empty
+            // screen must paint, or the store never renders and the view
+            // loads forever.
+            segments = [.lines(read)]
+            return .replaced
+        }
+        guard read != newest else { return .unchanged }
+        // A read fully contained at the tail (a shorter screen, or the same
+        // screen while the cache runs deeper) changes nothing. The empty
+        // read is excluded: a cleared screen is a replacement, not a no-op.
+        if !read.isEmpty, read.count <= newest.count, newest.suffix(read.count) == read {
+            return .unchanged
+        }
+        let floor = min(Self.minimumOverlap, read.count, newest.count)
+        if floor >= 1,
+            let overlap = Self.largestOverlap(suffixOf: newest, prefixOf: read, floor: floor)
+        {
+            let fresh = read.suffix(read.count - overlap)
+            guard !fresh.isEmpty else { return .unchanged }
+            segments[segments.count - 1] = .lines(newest + fresh)
+            return .extended
+        }
+        segments[segments.count - 1] = .lines(read)
+        return .replaced
+    }
+
+    struct BackfillOutcome: Equatable, Sendable {
+        /// Lines the read added that the cache did not already hold. Zero
+        /// means the read was fully captured — the capture limit is reached.
+        var newLines: Int
+        /// Whether an explicit gap marker was inserted because the read
+        /// could not be overlap-stitched onto the cache.
+        var insertedGap: Bool
+    }
+
+    /// Reconciles one `recent` read (the server's newest lines, up to its
+    /// cap) with the cache. While the Agent is idle the read's last line is
+    /// the cache's newest line, so the stitch is anchored at the end of the
+    /// newest run: the largest shared suffix proves the read's remaining
+    /// prefix is older content, which is prepended. Failing that, the read
+    /// may still contain the whole newest run (output raced the read): the
+    /// read then supersedes the tail outright. With no shared content at
+    /// all, the read's relation to the cache is unknowable — the old tail
+    /// is sealed, a gap marker records the missing region, and the read
+    /// becomes the new tail.
+    @discardableResult
+    mutating func stitchBackfill(_ text: String) -> BackfillOutcome {
+        let read = Self.splitLines(text)
+        guard !read.isEmpty else {
+            return BackfillOutcome(newLines: 0, insertedGap: false)
+        }
+        guard let newest = newestLinesIfPresent, !newest.isEmpty else {
+            if segments.isEmpty {
+                segments = [.lines(read)]
+            } else {
+                segments[segments.count - 1] = .lines(read)
+            }
+            return BackfillOutcome(newLines: read.count, insertedGap: false)
+        }
+        let floor = min(Self.minimumOverlap, read.count, newest.count)
+        if floor >= 1,
+            let overlap = Self.largestOverlap(suffixOf: read, suffixOf: newest, floor: floor)
+        {
+            let older = read.prefix(read.count - overlap)
+            guard !older.isEmpty else {
+                return BackfillOutcome(newLines: 0, insertedGap: false)
+            }
+            segments[segments.count - 1] = .lines(older + newest)
+            return BackfillOutcome(newLines: older.count, insertedGap: false)
+        }
+        if newest.count >= Self.minimumOverlap,
+            Self.containment(of: newest, in: read) != nil
+        {
+            segments[segments.count - 1] = .lines(read)
+            return BackfillOutcome(
+                newLines: read.count - newest.count, insertedGap: false)
+        }
+        segments.append(.gap)
+        segments.append(.lines(read))
+        return BackfillOutcome(newLines: read.count, insertedGap: true)
+    }
+
+    /// Splits read text into lines, dropping the one empty fragment a
+    /// trailing newline leaves behind. Interior empty lines are content;
+    /// empty text is zero lines (Foundation's split would say one).
+    static func splitLines(_ text: String) -> [String] {
+        guard !text.isEmpty else { return [] }
+        var lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        if text.hasSuffix("\n") {
+            lines.removeLast()
+        }
+        return lines
+    }
+
+    /// `nil` only when the cache is empty; the invariant keeps a trailing
+    /// `.lines` run otherwise, even if it holds zero lines.
+    private var newestLinesIfPresent: [String]? {
+        guard case .lines(let lines) = segments.last else { return nil }
+        return lines
+    }
+
+    /// The largest `k >= floor` such that the two collections share a
+    /// suffix/prefix (or suffix/suffix) of length `k`, searching longest
+    /// first so a genuine deep overlap always wins over a coincidental
+    /// short one.
+    private static func largestOverlap(
+        suffixOf first: [String],
+        prefixOf second: [String],
+        floor: Int
+    ) -> Int? {
+        var candidate = min(first.count, second.count)
+        while candidate >= floor {
+            if first.suffix(candidate) == second.prefix(candidate) {
+                return candidate
+            }
+            candidate -= 1
+        }
+        return nil
+    }
+
+    private static func largestOverlap(
+        suffixOf first: [String],
+        suffixOf second: [String],
+        floor: Int
+    ) -> Int? {
+        var candidate = min(first.count, second.count)
+        while candidate >= floor {
+            if first.suffix(candidate) == second.suffix(candidate) {
+                return candidate
+            }
+            candidate -= 1
+        }
+        return nil
+    }
+
+    /// The rightmost position at which `needle` appears in `haystack` as a
+    /// contiguous run, if any. Rightmost because the newest run sits at the
+    /// end of a `recent` read when content is stable; an earlier duplicate
+    /// of the same lines is history, not the tail.
+    private static func containment(of needle: [String], in haystack: [String]) -> Int? {
+        guard needle.count <= haystack.count else { return nil }
+        var start = haystack.count - needle.count
+        while start >= 0 {
+            if haystack[start..<(start + needle.count)].elementsEqual(needle) {
+                return start
+            }
+            start -= 1
+        }
+        return nil
+    }
+}

--- a/Sources/Heeler/Monitor/AgentMonitorHistory.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorHistory.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-/// Monitor's local scrollback cache: an ordered list of contiguous line runs
-/// separated by explicit gap markers, oldest first. In-memory only.
+/// Monitor's local scrollback cache: captured line runs and explicit gap
+/// markers, ordered oldest first. The final line run is always the live
+/// screen, kept separate from backfilled or sealed history. In-memory only.
 ///
 /// herdr exposes no history cursor (`agent.read` takes a source and a line
 /// count, capped at 1000 lines), so every reconciliation is an
@@ -11,8 +12,8 @@ import Foundation
 /// stitching rules are testable on their own.
 struct AgentMonitorHistory: Equatable, Sendable {
     enum Segment: Equatable, Sendable {
-        /// A contiguous run of captured lines. ANSI state flows within a run;
-        /// runs never sit adjacent to another run (a stitch merges them).
+        /// One contiguous captured run. Adjacent line segments may exist to
+        /// preserve the boundary between backfilled history and live output.
         case lines([String])
         /// An explicit marker that the content between the neighbouring runs
         /// could not be captured or reconciled. Never guessed around.
@@ -27,18 +28,22 @@ struct AgentMonitorHistory: Equatable, Sendable {
     /// whole-screen match is correct by construction there.
     static let minimumOverlap = 3
 
-    /// Invariant: `.lines` runs are never adjacent (a stitch merges them)
-    /// and a `.gap` is never first or last, so the cache always ends with
-    /// the live run.
+    /// The final `.lines` segment is always the live screen. Backfilled and
+    /// sealed live runs remain separate from it, including when they are
+    /// known to be contiguous; only a `.gap` claims unknown continuity.
     private(set) var segments: [Segment] = []
+
+    /// The range reconciled by the most recent backfill. It normally spans
+    /// the current history suffix and live run. After an unstitched read it
+    /// instead points at that read above the gap, so a later, deeper read can
+    /// extend it without moving captured history below the live screen.
+    private var backfillRange: Range<Int>?
 
     var isEmpty: Bool {
         segments.isEmpty
     }
 
-    /// The lines of the newest contiguous run. The live mirror of the
-    /// Agent's screen always lives here; backfill stitches onto its front
-    /// because a `recent` read ends at the same newest line.
+    /// The live mirror of the Agent's screen, always the final segment.
     var newestLines: [String] {
         guard case .lines(let lines) = segments.last else { return [] }
         return lines
@@ -47,18 +52,18 @@ struct AgentMonitorHistory: Equatable, Sendable {
     enum VisibleOutcome: Equatable, Sendable {
         /// The read carried no new content.
         case unchanged
-        /// The read's top overlapped the cache's bottom; the newly scrolled
-        /// lines were appended to the newest run.
+        /// The read's top overlapped the live screen's bottom; newly scrolled
+        /// lines were appended to the live run.
         case extended
         /// No usable overlap (an alternate-screen repaint, or a reconnect
-        /// that scrolled a full screen): the newest run was replaced.
+        /// that scrolled a full screen): a new live run was installed.
         case replaced
     }
 
     /// Reconciles one `visible` read with the live tail. The visible screen
-    /// is a sliding window: when its top lines match the cache's bottom
-    /// lines the window scrolled and only the fresh lines are appended;
-    /// otherwise the screen repainted and the tail is replaced outright.
+    /// is a sliding window: when its top lines match the live run's bottom,
+    /// only fresh lines are appended. Otherwise the old live run is sealed
+    /// as history and the repaint becomes a new live run below a gap.
     @discardableResult
     mutating func applyVisible(_ text: String) -> VisibleOutcome {
         let read = Self.splitLines(text)
@@ -67,12 +72,13 @@ struct AgentMonitorHistory: Equatable, Sendable {
             // screen must paint, or the store never renders and the view
             // loads forever.
             segments = [.lines(read)]
+            backfillRange = 0..<1
             return .replaced
         }
         guard read != newest else { return .unchanged }
         // A read fully contained at the tail (a shorter screen, or the same
-        // screen while the cache runs deeper) changes nothing. The empty
-        // read is excluded: a cleared screen is a replacement, not a no-op.
+        // screen while the live run accumulated scrolling) changes nothing.
+        // The empty read is excluded: a cleared screen is a replacement.
         if !read.isEmpty, read.count <= newest.count, newest.suffix(read.count) == read {
             return .unchanged
         }
@@ -85,13 +91,23 @@ struct AgentMonitorHistory: Equatable, Sendable {
             segments[segments.count - 1] = .lines(newest + fresh)
             return .extended
         }
-        segments[segments.count - 1] = .lines(read)
+
+        // Replacing only the live segment preserves every backfilled and
+        // previously sealed run. There is no content to seal when the old
+        // live screen was empty, so reuse that final slot in that case.
+        if newest.isEmpty {
+            segments[segments.count - 1] = .lines(read)
+        } else {
+            segments.append(.gap)
+            segments.append(.lines(read))
+        }
+        backfillRange = (segments.count - 1)..<segments.count
         return .replaced
     }
 
     struct BackfillOutcome: Equatable, Sendable {
         /// Lines the read added that the cache did not already hold. Zero
-        /// means the read was fully captured — the capture limit is reached.
+        /// means the read was fully captured: the capture limit is reached.
         var newLines: Int
         /// Whether an explicit gap marker was inserted because the read
         /// could not be overlap-stitched onto the cache.
@@ -99,49 +115,50 @@ struct AgentMonitorHistory: Equatable, Sendable {
     }
 
     /// Reconciles one `recent` read (the server's newest lines, up to its
-    /// cap) with the cache. While the Agent is idle the read's last line is
-    /// the cache's newest line, so the stitch is anchored at the end of the
-    /// newest run: the largest shared suffix proves the read's remaining
-    /// prefix is older content, which is prepended. Failing that, the read
-    /// may still contain the whole newest run (output raced the read): the
-    /// read then supersedes the tail outright. With no shared content at
-    /// all, the read's relation to the cache is unknowable — the old tail
-    /// is sealed, a gap marker records the missing region, and the read
-    /// becomes the new tail.
+    /// cap) with the range covered by the preceding backfill. The largest
+    /// shared suffix proves the read's remaining prefix is older content,
+    /// which is kept in a segment above the live screen. With no shared
+    /// content, the read is likewise placed above the live run with explicit
+    /// gaps rather than displacing the live screen or pretending continuity.
     @discardableResult
     mutating func stitchBackfill(_ text: String) -> BackfillOutcome {
         let read = Self.splitLines(text)
         guard !read.isEmpty else {
             return BackfillOutcome(newLines: 0, insertedGap: false)
         }
-        guard let newest = newestLinesIfPresent, !newest.isEmpty else {
-            if segments.isEmpty {
-                segments = [.lines(read)]
-            } else {
-                segments[segments.count - 1] = .lines(read)
-            }
+        guard let newest = newestLinesIfPresent else {
+            segments = [.lines(read)]
+            backfillRange = 0..<1
             return BackfillOutcome(newLines: read.count, insertedGap: false)
         }
-        let floor = min(Self.minimumOverlap, read.count, newest.count)
+        if newest.isEmpty {
+            let liveIndex = segments.count - 1
+            segments.insert(.lines(read), at: liveIndex)
+            backfillRange = liveIndex..<(liveIndex + 2)
+            return BackfillOutcome(newLines: read.count, insertedGap: false)
+        }
+
+        let range = validBackfillRange ?? ((segments.count - 1)..<segments.count)
+        let anchor = lines(in: range)
+        let floor = min(Self.minimumOverlap, read.count, anchor.count)
         if floor >= 1,
-            let overlap = Self.largestOverlap(suffixOf: read, suffixOf: newest, floor: floor)
+            let overlap = Self.largestOverlap(suffixOf: read, suffixOf: anchor, floor: floor)
         {
-            let older = read.prefix(read.count - overlap)
+            let older = Array(read.prefix(read.count - overlap))
             guard !older.isEmpty else {
                 return BackfillOutcome(newLines: 0, insertedGap: false)
             }
-            segments[segments.count - 1] = .lines(older + newest)
+            prepend(older, to: range)
             return BackfillOutcome(newLines: older.count, insertedGap: false)
         }
-        if newest.count >= Self.minimumOverlap,
-            Self.containment(of: newest, in: read) != nil
+        if anchor.count >= Self.minimumOverlap,
+            Self.containment(of: anchor, in: read) != nil
         {
-            segments[segments.count - 1] = .lines(read)
+            replaceBackfillRange(range, with: read)
             return BackfillOutcome(
-                newLines: read.count - newest.count, insertedGap: false)
+                newLines: max(0, read.count - anchor.count), insertedGap: false)
         }
-        segments.append(.gap)
-        segments.append(.lines(read))
+        insertUnstitchedBackfill(read)
         return BackfillOutcome(newLines: read.count, insertedGap: true)
     }
 
@@ -163,6 +180,78 @@ struct AgentMonitorHistory: Equatable, Sendable {
     private var newestLinesIfPresent: [String]? {
         guard case .lines(let lines) = segments.last else { return nil }
         return lines
+    }
+
+    private var validBackfillRange: Range<Int>? {
+        guard
+            let backfillRange,
+            backfillRange.lowerBound >= segments.startIndex,
+            backfillRange.upperBound <= segments.endIndex,
+            !backfillRange.isEmpty,
+            segments[backfillRange].allSatisfy({ segment in
+                if case .lines = segment { return true }
+                return false
+            })
+        else { return nil }
+        return backfillRange
+    }
+
+    private func lines(in range: Range<Int>) -> [String] {
+        range.flatMap { index in
+            guard case .lines(let lines) = segments[index] else { return [] }
+            return lines
+        }
+    }
+
+    private mutating func prepend(_ older: [String], to range: Range<Int>) {
+        guard case .lines(let first) = segments[range.lowerBound] else { return }
+        if range.lowerBound == segments.count - 1 {
+            segments.insert(.lines(older), at: range.lowerBound)
+            backfillRange = range.lowerBound..<(range.upperBound + 1)
+        } else {
+            segments[range.lowerBound] = .lines(older + first)
+            backfillRange = range
+        }
+    }
+
+    private mutating func replaceBackfillRange(
+        _ range: Range<Int>,
+        with read: [String]
+    ) {
+        guard range.upperBound == segments.endIndex else {
+            segments.replaceSubrange(range, with: [.lines(read)])
+            backfillRange = range.lowerBound..<(range.lowerBound + 1)
+            return
+        }
+
+        // A racing `recent` read can contain the previous screen before its
+        // newest lines. Preserve the live/history boundary by treating a
+        // screen-sized suffix as the new live run.
+        let liveCount = min(newestLines.count, read.count)
+        let history = Array(read.dropLast(liveCount))
+        let live = Array(read.suffix(liveCount))
+        let replacement: [Segment]
+        if history.isEmpty {
+            replacement = [.lines(live)]
+        } else {
+            replacement = [.lines(history), .lines(live)]
+        }
+        segments.replaceSubrange(range, with: replacement)
+        backfillRange = range.lowerBound..<(range.lowerBound + replacement.count)
+    }
+
+    private mutating func insertUnstitchedBackfill(_ read: [String]) {
+        let liveIndex = segments.count - 1
+        var insertion: [Segment] = []
+        if liveIndex > 0, segments[liveIndex - 1] != .gap {
+            insertion.append(.gap)
+        }
+        let readOffset = insertion.count
+        insertion.append(.lines(read))
+        insertion.append(.gap)
+        segments.insert(contentsOf: insertion, at: liveIndex)
+        let readIndex = liveIndex + readOffset
+        backfillRange = readIndex..<(readIndex + 1)
     }
 
     /// The largest `k >= floor` such that the two collections share a

--- a/Sources/Heeler/Monitor/AgentMonitorStore.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorStore.swift
@@ -371,6 +371,12 @@ final class AgentMonitorStore {
         let hadContent = !history.isEmpty
         let outcome = history.applyVisible(text)
         guard outcome != .unchanged else { return }
+        if outcome == .replaced, historyState == .exhausted {
+            // Exhaustion describes the backfill window anchored to the old
+            // live run. A repaint invalidates that anchor, so the new live
+            // generation must be allowed to backfill from the top again.
+            historyState = agentStatus == .working ? .unavailable : .idle
+        }
         renderSnapshot()
         contentChangeCount &+= 1
         if hadContent, !isBottomPinned {
@@ -378,28 +384,42 @@ final class AgentMonitorStore {
         }
     }
 
-    /// Renders the whole cache — history runs stitched above the live
-    /// screen, with gap markers spliced between unreconciled regions. Each
-    /// run renders independently, so ANSI state flows within a captured run
-    /// and resets at a gap, which is the honest boundary anyway.
+    /// Renders the whole cache, with history above the live screen and gap
+    /// markers between unreconciled regions. Storage keeps history and live
+    /// runs separate, but adjacent line segments render together so ANSI
+    /// state still flows across every byte-proven boundary. It resets only
+    /// at a gap, which is the honest boundary anyway.
     private func renderSnapshot() {
-        var rendered = AttributedString()
-        var isFirstSegment = true
+        var renderedSegments: [AttributedString] = []
+        var contiguousParts: [String] = []
+
+        func flushContiguousLines() {
+            guard !contiguousParts.isEmpty else { return }
+            renderedSegments.append(
+                ANSISnapshotRenderer.render(contiguousParts.joined(separator: "\n")))
+            contiguousParts.removeAll(keepingCapacity: true)
+        }
+
         for segment in history.segments {
-            if !isFirstSegment {
-                rendered.append(AttributedString("\n"))
-            }
-            isFirstSegment = false
             switch segment {
             case .lines(let lines):
-                rendered.append(
-                    ANSISnapshotRenderer.render(lines.joined(separator: "\n")))
+                contiguousParts.append(lines.joined(separator: "\n"))
             case .gap:
+                flushContiguousLines()
                 var marker = AttributedString(Self.gapMarkerText)
                 marker.foregroundColor = Color.secondary
                 marker.inlinePresentationIntent = .emphasized
-                rendered.append(marker)
+                renderedSegments.append(marker)
             }
+        }
+        flushContiguousLines()
+
+        var rendered = AttributedString()
+        for (index, segment) in renderedSegments.enumerated() {
+            if index > 0 {
+                rendered.append(AttributedString("\n"))
+            }
+            rendered.append(segment)
         }
         snapshot = rendered
     }

--- a/Sources/Heeler/Monitor/AgentMonitorStore.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorStore.swift
@@ -1,9 +1,18 @@
 import Foundation
 import Observation
 
-/// Owns the first Monitor cut: one ANSI snapshot on open and one refresh
-/// after an Attach round trip. It deliberately has no event subscription or
-/// polling; later Monitor packages add those behaviors from ADR 0012.
+protocol AgentMonitorClock: Sendable {
+    func sleep(for duration: Duration) async throws
+}
+
+struct ContinuousAgentMonitorClock: AgentMonitorClock {
+    func sleep(for duration: Duration) async throws {
+        try await Task.sleep(for: duration)
+    }
+}
+
+/// Owns Monitor's adaptive live mirror. Status pushes trigger one refresh;
+/// only a Working Agent in a foreground view also receives cadence refreshes.
 @MainActor
 @Observable
 final class AgentMonitorStore {
@@ -14,33 +23,97 @@ final class AgentMonitorStore {
         case failed(String)
     }
 
+    static let refreshCadence: Duration = .seconds(2)
+
     private(set) var state: State = .idle
     private(set) var snapshot: AttributedString?
     private(set) var capturedAt: Date?
+    private(set) var agentStatus: AgentStatus
+    private(set) var liveUpdatesAvailable = true
+    private(set) var contentChangeCount: UInt64 = 0
+    private(set) var isBottomPinned = true
+    private(set) var hasNewOutput = false
 
     private let target: String
     private let now: @Sendable () -> Date
+    private let clock: any AgentMonitorClock
+    private let statusUpdates: AsyncStream<ConsoleStore.AgentStatusUpdate>?
     private let read: @Sendable (AgentReadParams) async throws -> PaneReadResult
+    @ObservationIgnored private var snapshotText: String?
     @ObservationIgnored private var hasOpened = false
+    @ObservationIgnored private var isForeground = true
+    @ObservationIgnored private var isMonitorVisible = true
     @ObservationIgnored private var needsRefreshAfterAttach = false
     @ObservationIgnored private var isFetching = false
     @ObservationIgnored private var fetchWaiters: [CheckedContinuation<Void, Never>] = []
+    @ObservationIgnored private var pollingTask: Task<Void, Never>?
+    @ObservationIgnored private var statusTask: Task<Void, Never>?
 
     init(
         target: String,
+        initialStatus: AgentStatus = .idle,
         now: @escaping @Sendable () -> Date = { Date() },
+        clock: any AgentMonitorClock = ContinuousAgentMonitorClock(),
+        statusUpdates: AsyncStream<ConsoleStore.AgentStatusUpdate>? = nil,
         read: @escaping @Sendable (AgentReadParams) async throws -> PaneReadResult
     ) {
         self.target = target
+        agentStatus = initialStatus
         self.now = now
+        self.clock = clock
+        self.statusUpdates = statusUpdates
         self.read = read
     }
 
-    /// Fetches exactly once for this Monitor instance. SwiftUI may re-run its
-    /// task when Attach pops, so the return refresh has its own explicit path.
+    deinit {
+        pollingTask?.cancel()
+        statusTask?.cancel()
+    }
+
+    /// Fetches exactly once for this Monitor instance, then starts the
+    /// status-driven state machine. SwiftUI may re-run its task when Attach
+    /// pops, so the return refresh has its own explicit path.
     func open() async {
         guard !hasOpened else { return }
         hasOpened = true
+        consumeStatusUpdates()
+        await fetch()
+        reconcilePolling()
+    }
+
+    func setForeground(_ isForeground: Bool) {
+        guard self.isForeground != isForeground else { return }
+        self.isForeground = isForeground
+        reconcilePolling()
+    }
+
+    /// The reusable status seam consumed by Monitor now and Composer in #182.
+    /// Every real transition refreshes once, including terminal states; only
+    /// Working continues into the cadence loop.
+    func agentStatusDidChange(_ status: AgentStatus) async {
+        guard agentStatus != status else { return }
+        agentStatus = status
+        stopPolling()
+        guard hasOpened, isMonitorVisible, liveUpdatesAvailable else { return }
+        await waitForCurrentFetch()
+        await fetch()
+        reconcilePolling()
+    }
+
+    func setBottomPinned(_ isPinned: Bool) {
+        isBottomPinned = isPinned
+        if isPinned {
+            hasNewOutput = false
+        }
+    }
+
+    func jumpToLatestOutput() {
+        setBottomPinned(true)
+    }
+
+    /// Pull-to-refresh is always available, even when adaptive polling is off.
+    func refresh() async {
+        await waitForCurrentFetch()
         await fetch()
     }
 
@@ -48,18 +121,92 @@ final class AgentMonitorStore {
     /// callbacks still collapse to one refresh when navigation returns.
     func attachDidOpen() {
         needsRefreshAfterAttach = true
+        isMonitorVisible = false
+        stopPolling()
     }
 
     /// Refreshes once after Attach closes, then consumes the pending marker.
     func refreshOnReturn() async {
         guard needsRefreshAfterAttach else { return }
         needsRefreshAfterAttach = false
-        await waitForCurrentFetch()
-        await fetch()
+        isMonitorVisible = true
+        await refresh()
+        reconcilePolling()
     }
 
     func retry() async {
+        await refresh()
+    }
+
+    private func consumeStatusUpdates() {
+        guard statusTask == nil, let statusUpdates else { return }
+        statusTask = Task { [weak self] in
+            for await update in statusUpdates {
+                guard !Task.isCancelled, let self else { return }
+                await self.liveUpdateDidChange(update)
+            }
+        }
+    }
+
+    private func liveUpdateDidChange(_ update: ConsoleStore.AgentStatusUpdate) async {
+        let availabilityWasRestored = !liveUpdatesAvailable && update.liveUpdatesAvailable
+        liveUpdatesAvailable = update.liveUpdatesAvailable
+        if !liveUpdatesAvailable {
+            stopPolling()
+        }
+        if let status = update.status, status != agentStatus {
+            await agentStatusDidChange(status)
+            return
+        }
+        guard availabilityWasRestored, hasOpened, isMonitorVisible else {
+            reconcilePolling()
+            return
+        }
+        await refresh()
+        reconcilePolling()
+    }
+
+    private func reconcilePolling() {
+        guard
+            hasOpened,
+            isForeground,
+            isMonitorVisible,
+            liveUpdatesAvailable,
+            agentStatus == .working
+        else {
+            stopPolling()
+            return
+        }
+        guard pollingTask == nil else { return }
+        let clock = clock
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await clock.sleep(for: Self.refreshCadence)
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled, let self else { return }
+                await self.pollOnceIfNeeded()
+            }
+        }
+    }
+
+    private func stopPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+
+    private func pollOnceIfNeeded() async {
+        guard
+            isForeground, isMonitorVisible, liveUpdatesAvailable,
+            agentStatus == .working
+        else { return }
         await waitForCurrentFetch()
+        guard
+            isForeground, isMonitorVisible, liveUpdatesAvailable,
+            agentStatus == .working
+        else { return }
         await fetch()
     }
 
@@ -78,7 +225,7 @@ final class AgentMonitorStore {
                     target: target,
                     format: .ansi,
                     stripANSI: false))
-            snapshot = ANSISnapshotRenderer.render(result.text)
+            applySnapshotText(result.text)
             capturedAt = now()
             state = .loaded
         } catch is CancellationError {
@@ -88,8 +235,19 @@ final class AgentMonitorStore {
             }
         } catch {
             // #181 owns special `agent_not_idle` handling for history
-            // backfill; this visible-screen cut surfaces every error honestly.
+            // backfill; visible-screen refreshes surface every error honestly.
             state = .failed(Self.message(for: error))
+        }
+    }
+
+    private func applySnapshotText(_ text: String) {
+        guard snapshotText != text else { return }
+        let hadSnapshot = snapshotText != nil
+        snapshotText = text
+        snapshot = ANSISnapshotRenderer.render(text)
+        contentChangeCount &+= 1
+        if hadSnapshot, !isBottomPinned {
+            hasNewOutput = true
         }
     }
 

--- a/Sources/Heeler/Monitor/AgentMonitorStore.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import SwiftUI
 
 protocol AgentMonitorClock: Sendable {
     func sleep(for duration: Duration) async throws
@@ -11,8 +12,10 @@ struct ContinuousAgentMonitorClock: AgentMonitorClock {
     }
 }
 
-/// Owns Monitor's adaptive live mirror. Status pushes trigger one refresh;
-/// only a Working Agent in a foreground view also receives cadence refreshes.
+/// Owns Monitor's adaptive live mirror and its local scrollback. Status
+/// pushes trigger one refresh; only a Working Agent in a foreground view
+/// also receives cadence refreshes. History is served from the in-memory
+/// cache and backfilled through `agent.read` only while the Agent is idle.
 @MainActor
 @Observable
 final class AgentMonitorStore {
@@ -23,13 +26,37 @@ final class AgentMonitorStore {
         case failed(String)
     }
 
+    /// Where the scrollback stands relative to herdr's capture limit. herdr
+    /// has no history cursor, so "more history" is only ever one `recent`
+    /// read away; the states exist to make that read honest.
+    enum HistoryState: Equatable {
+        /// No load in flight; reaching the top of the cache may fetch more.
+        case idle
+        /// An idle backfill read is in flight — the one loading state in
+        /// Monitor.
+        case loading
+        /// The Agent is working, or herdr answered `agent_not_idle`:
+        /// history is honestly unavailable, never a spinner.
+        case unavailable
+        /// The oldest capturable content is already cached.
+        case exhausted
+        /// The backfill read itself failed; retryable from the marker.
+        case failed(String)
+    }
+
     static let refreshCadence: Duration = .seconds(2)
+    /// herdr caps every read at 1000 lines; ask for the whole window.
+    static let historyLineCount = 1000
+    /// The in-content marker for a region that could not be captured or
+    /// reconciled. Tests assert on this copy.
+    static let gapMarkerText = "— gap: content not captured —"
 
     private(set) var state: State = .idle
     private(set) var snapshot: AttributedString?
     private(set) var capturedAt: Date?
     private(set) var agentStatus: AgentStatus
     private(set) var liveUpdatesAvailable = true
+    private(set) var historyState: HistoryState = .idle
     private(set) var contentChangeCount: UInt64 = 0
     private(set) var isBottomPinned = true
     private(set) var hasNewOutput = false
@@ -39,13 +66,15 @@ final class AgentMonitorStore {
     private let clock: any AgentMonitorClock
     private let statusUpdates: AsyncStream<ConsoleStore.AgentStatusUpdate>?
     private let read: @Sendable (AgentReadParams) async throws -> PaneReadResult
-    @ObservationIgnored private var snapshotText: String?
+    @ObservationIgnored private var history = AgentMonitorHistory()
     @ObservationIgnored private var hasOpened = false
     @ObservationIgnored private var isForeground = true
     @ObservationIgnored private var isMonitorVisible = true
     @ObservationIgnored private var needsRefreshAfterAttach = false
     @ObservationIgnored private var isFetching = false
+    @ObservationIgnored private var isBackfilling = false
     @ObservationIgnored private var fetchWaiters: [CheckedContinuation<Void, Never>] = []
+    @ObservationIgnored private var backfillWaiters: [CheckedContinuation<Void, Never>] = []
     @ObservationIgnored private var pollingTask: Task<Void, Never>?
     @ObservationIgnored private var statusTask: Task<Void, Never>?
 
@@ -70,15 +99,20 @@ final class AgentMonitorStore {
         statusTask?.cancel()
     }
 
-    /// Fetches exactly once for this Monitor instance, then starts the
-    /// status-driven state machine. SwiftUI may re-run its task when Attach
-    /// pops, so the return refresh has its own explicit path.
+    /// Fetches exactly once for this Monitor instance, backfills history
+    /// once when the Agent is not working, then starts the status-driven
+    /// state machine. SwiftUI may re-run its task when Attach pops, so the
+    /// return refresh has its own explicit path.
     func open() async {
         guard !hasOpened else { return }
         hasOpened = true
         consumeStatusUpdates()
         await fetch()
         reconcilePolling()
+        // A cold cache backfills once on open so scrolling up is served
+        // from local lines from the first paint. A Working Agent skips the
+        // read entirely; the top of the cache says why instead.
+        await loadEarlierHistory()
     }
 
     func setForeground(_ isForeground: Bool) {
@@ -93,6 +127,16 @@ final class AgentMonitorStore {
     func agentStatusDidChange(_ status: AgentStatus) async {
         guard agentStatus != status else { return }
         agentStatus = status
+        if status == .working {
+            // History cannot be captured while the Agent works. An
+            // in-flight backfill resolves itself: herdr answers
+            // `agent_not_idle`, which lands as unavailability below.
+            if historyState != .loading, historyState != .exhausted {
+                historyState = .unavailable
+            }
+        } else if historyState == .unavailable {
+            historyState = .idle
+        }
         stopPolling()
         guard hasOpened, isMonitorVisible, liveUpdatesAvailable else { return }
         await waitForCurrentFetch()
@@ -136,6 +180,84 @@ final class AgentMonitorStore {
 
     func retry() async {
         await refresh()
+    }
+
+    /// The view reports the scroll reaching the top of the cache. An idle
+    /// Agent gets one backfill with a visible loading state; a working Agent
+    /// gets the honest unavailability notice instead of a spinner.
+    func topEdgeReached() {
+        guard hasOpened, liveUpdatesAvailable else { return }
+        guard agentStatus != .working else {
+            if historyState != .exhausted {
+                historyState = .unavailable
+            }
+            return
+        }
+        switch historyState {
+        case .idle, .unavailable, .failed:
+            // Set synchronously so a geometry re-fire before the task steps
+            // cannot double-fire the read.
+            historyState = .loading
+            Task { await self.loadEarlierHistory() }
+        case .loading, .exhausted:
+            break
+        }
+    }
+
+    /// One backfill read. herdr exposes no history cursor, so this reads
+    /// the server's newest lines (capped at `historyLineCount`) and
+    /// overlap-stitches them onto the cache; a stitch that finds no shared
+    /// content records an explicit gap instead of guessing. Also the retry
+    /// path for a failed backfill.
+    func loadEarlierHistory() async {
+        guard hasOpened else { return }
+        // Visible reads and backfills share one flight: a top-edge hit
+        // during a cadence poll must not interleave two reads, or the
+        // backfill could stitch against a tail the poll just replaced and
+        // record a spurious gap. The wait runs before the flag is set, so
+        // a fetch holding its own flag never waits back on this one.
+        await waitForCurrentFetch()
+        guard !isBackfilling else { return }
+        guard agentStatus != .working else {
+            if historyState != .exhausted {
+                historyState = .unavailable
+            }
+            return
+        }
+        guard historyState != .exhausted else { return }
+        isBackfilling = true
+        historyState = .loading
+        defer { finishBackfill() }
+        do {
+            let result = try await read(
+                AgentReadParams(
+                    source: .recent,
+                    target: target,
+                    format: .ansi,
+                    lines: Self.historyLineCount,
+                    stripANSI: false))
+            let outcome = history.stitchBackfill(result.text)
+            if outcome.newLines > 0 || outcome.insertedGap {
+                renderSnapshot()
+                contentChangeCount &+= 1
+            }
+            capturedAt = now()
+            // The capture limit is reached when the server had fewer lines
+            // than the cap (that was everything) or when the read added
+            // nothing (the window is already fully cached).
+            let returnedLines = AgentMonitorHistory.splitLines(result.text).count
+            historyState =
+                returnedLines < Self.historyLineCount || outcome.newLines == 0
+                ? .exhausted : .idle
+        } catch let error as HerdrAPIError where error.code == "agent_not_idle" {
+            // History is capturable only while the Agent is idle; a racing
+            // status push makes this honest unavailability, never an error.
+            historyState = .unavailable
+        } catch is CancellationError {
+            historyState = .idle
+        } catch {
+            historyState = .failed(Self.message(for: error))
+        }
     }
 
     private func consumeStatusUpdates() {
@@ -217,6 +339,9 @@ final class AgentMonitorStore {
             state = .loading
         }
         defer { finishFetch() }
+        // The other half of the shared flight: a poll that fires while a
+        // backfill reads waits for it rather than interleaving on the wire.
+        await waitForCurrentBackfill()
 
         do {
             let result = try await read(
@@ -225,7 +350,7 @@ final class AgentMonitorStore {
                     target: target,
                     format: .ansi,
                     stripANSI: false))
-            applySnapshotText(result.text)
+            applyVisibleText(result.text)
             capturedAt = now()
             state = .loaded
         } catch is CancellationError {
@@ -234,21 +359,49 @@ final class AgentMonitorStore {
                 hasOpened = false
             }
         } catch {
-            // #181 owns special `agent_not_idle` handling for history
-            // backfill; visible-screen refreshes surface every error honestly.
+            // Visible-screen refreshes surface every error honestly. The
+            // `agent_not_idle` carve-out lives in the backfill path
+            // (`loadEarlierHistory`), where it means history is unavailable
+            // while the Agent works — never an error.
             state = .failed(Self.message(for: error))
         }
     }
 
-    private func applySnapshotText(_ text: String) {
-        guard snapshotText != text else { return }
-        let hadSnapshot = snapshotText != nil
-        snapshotText = text
-        snapshot = ANSISnapshotRenderer.render(text)
+    private func applyVisibleText(_ text: String) {
+        let hadContent = !history.isEmpty
+        let outcome = history.applyVisible(text)
+        guard outcome != .unchanged else { return }
+        renderSnapshot()
         contentChangeCount &+= 1
-        if hadSnapshot, !isBottomPinned {
+        if hadContent, !isBottomPinned {
             hasNewOutput = true
         }
+    }
+
+    /// Renders the whole cache — history runs stitched above the live
+    /// screen, with gap markers spliced between unreconciled regions. Each
+    /// run renders independently, so ANSI state flows within a captured run
+    /// and resets at a gap, which is the honest boundary anyway.
+    private func renderSnapshot() {
+        var rendered = AttributedString()
+        var isFirstSegment = true
+        for segment in history.segments {
+            if !isFirstSegment {
+                rendered.append(AttributedString("\n"))
+            }
+            isFirstSegment = false
+            switch segment {
+            case .lines(let lines):
+                rendered.append(
+                    ANSISnapshotRenderer.render(lines.joined(separator: "\n")))
+            case .gap:
+                var marker = AttributedString(Self.gapMarkerText)
+                marker.foregroundColor = Color.secondary
+                marker.inlinePresentationIntent = .emphasized
+                rendered.append(marker)
+            }
+        }
+        snapshot = rendered
     }
 
     private func waitForCurrentFetch() async {
@@ -262,6 +415,22 @@ final class AgentMonitorStore {
         isFetching = false
         let waiters = fetchWaiters
         fetchWaiters.removeAll(keepingCapacity: false)
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func waitForCurrentBackfill() async {
+        guard isBackfilling else { return }
+        await withCheckedContinuation { continuation in
+            backfillWaiters.append(continuation)
+        }
+    }
+
+    private func finishBackfill() {
+        isBackfilling = false
+        let waiters = backfillWaiters
+        backfillWaiters.removeAll(keepingCapacity: false)
         for waiter in waiters {
             waiter.resume()
         }

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -16,6 +16,7 @@ struct AgentDetailView: View {
     private let onClosed: () -> Void
     @Environment(\.scenePhase) private var scenePhase
     @State private var monitor: AgentMonitorStore
+    @State private var composer: AgentComposerStore
     @State private var attach: AgentAttachStore
     @State private var isShowingAttach = false
 
@@ -31,6 +32,7 @@ struct AgentDetailView: View {
         onSwitch: @escaping (ConsoleAgent.ID) -> Void,
         onClosed: @escaping () -> Void,
         monitorStore: AgentMonitorStore? = nil,
+        composerStore: AgentComposerStore? = nil,
         attachStore: AgentAttachStore? = nil
     ) {
         self.agent = agent
@@ -51,6 +53,8 @@ struct AgentDetailView: View {
             ) { [console, agent] params in
                 try await console.readAgent(params, on: agent.hostID)
             })
+        _composer = State(
+            initialValue: composerStore ?? console.composerStore(for: agent))
         _attach = State(
             initialValue: attachStore ?? AgentAttachStore(
                 target: agent.agent.paneID,
@@ -65,7 +69,12 @@ struct AgentDetailView: View {
     }
 
     var body: some View {
-        monitorSurface
+        VStack(spacing: 0) {
+            monitorSurface
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Divider()
+            AgentComposerView(store: composer)
+        }
             .navigationTitle(title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -97,7 +106,10 @@ struct AgentDetailView: View {
                     await monitor.refreshOnReturn()
                 }
             }
-            .task { await monitor.open() }
+            .task {
+                composer.open()
+                await monitor.open()
+            }
             .onChange(of: scenePhase, initial: true) { _, phase in
                 monitor.setForeground(phase == .active)
             }

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -148,6 +148,7 @@ struct AgentDetailView: View {
         ScrollViewReader { proxy in
             ScrollView([.horizontal, .vertical]) {
                 VStack(alignment: .leading, spacing: 0) {
+                    historyTopMarker
                     Text(snapshot)
                         .font(.system(.body, design: .monospaced))
                         .textSelection(.enabled)
@@ -164,6 +165,12 @@ struct AgentDetailView: View {
                 geometry.visibleRect.maxY >= geometry.contentSize.height - 24
             } action: { _, isPinned in
                 monitor.setBottomPinned(isPinned)
+            }
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                geometry.visibleRect.minY <= 24
+            } action: { _, isAtTop in
+                guard isAtTop else { return }
+                monitor.topEdgeReached()
             }
             .onChange(of: monitor.contentChangeCount) {
                 guard monitor.isBottomPinned else { return }
@@ -184,6 +191,61 @@ struct AgentDetailView: View {
                 }
             }
         }
+    }
+
+    /// The only place history states are visible: a thin marker above the
+    /// cached content. While the Agent works the notice replaces any
+    /// spinner outright — history is unavailable, never "loading".
+    @ViewBuilder
+    private var historyTopMarker: some View {
+        if monitor.agentStatus == .working, monitor.historyState != .exhausted {
+            historyMarkerLabel(
+                "History unavailable while the Agent works",
+                systemImage: "clock.badge.exclamationmark")
+        } else {
+            switch monitor.historyState {
+            case .loading:
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading earlier history…")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+            case .unavailable:
+                historyMarkerLabel(
+                    "History unavailable while the Agent works",
+                    systemImage: "clock.badge.exclamationmark")
+            case .exhausted:
+                historyMarkerLabel(
+                    "Beginning of captured history",
+                    systemImage: "arrow.up.to.line")
+            case .failed(let message):
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Label(message, systemImage: "exclamationmark.triangle")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 8)
+                    Button("Retry") { Task { await monitor.loadEarlierHistory() } }
+                        .font(.footnote)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal)
+                .padding(.vertical, 10)
+            case .idle:
+                EmptyView()
+            }
+        }
+    }
+
+    private func historyMarkerLabel(_ text: String, systemImage: String) -> some View {
+        Label(text, systemImage: systemImage)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
     }
 
     private var statusHeader: some View {

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -14,6 +14,7 @@ struct AgentDetailView: View {
     private let isOnStage: () -> Bool
     private let onSwitch: (ConsoleAgent.ID) -> Void
     private let onClosed: () -> Void
+    @Environment(\.scenePhase) private var scenePhase
     @State private var monitor: AgentMonitorStore
     @State private var attach: AgentAttachStore
     @State private var isShowingAttach = false
@@ -43,8 +44,11 @@ struct AgentDetailView: View {
         self.onSwitch = onSwitch
         self.onClosed = onClosed
         _monitor = State(
-            initialValue: monitorStore ?? AgentMonitorStore(target: agent.agent.paneID) {
-                [console, agent] params in
+            initialValue: monitorStore ?? AgentMonitorStore(
+                target: agent.agent.paneID,
+                initialStatus: agent.agent.status,
+                statusUpdates: console.agentStatusUpdates(for: agent.id)
+            ) { [console, agent] params in
                 try await console.readAgent(params, on: agent.hostID)
             })
         _attach = State(
@@ -94,6 +98,9 @@ struct AgentDetailView: View {
                 }
             }
             .task { await monitor.open() }
+            .onChange(of: scenePhase, initial: true) { _, phase in
+                monitor.setForeground(phase == .active)
+            }
     }
 
     @ViewBuilder
@@ -103,17 +110,15 @@ struct AgentDetailView: View {
                 statusHeader
                 Divider()
                 if snapshot.characters.isEmpty {
-                    ContentUnavailableView(
-                        "No Output", systemImage: "rectangle.dashed",
-                        description: Text("The Agent's latest screen is empty."))
-                } else {
-                    ScrollView([.horizontal, .vertical]) {
-                        Text(snapshot)
-                            .font(.system(.body, design: .monospaced))
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .topLeading)
-                            .padding()
+                    ScrollView {
+                        ContentUnavailableView(
+                            "No Output", systemImage: "rectangle.dashed",
+                            description: Text("The Agent's latest screen is empty."))
+                            .frame(maxWidth: .infinity, minHeight: 360)
                     }
+                    .refreshable { await monitor.refresh() }
+                } else {
+                    snapshotScrollView(snapshot)
                 }
             }
         } else {
@@ -122,7 +127,12 @@ struct AgentDetailView: View {
                 ContentUnavailableView {
                     Label("Couldn't Load Screen", systemImage: "exclamationmark.triangle")
                 } description: {
-                    Text(message)
+                    VStack(spacing: 8) {
+                        Text(message)
+                        if !monitor.liveUpdatesAvailable {
+                            liveUpdatesUnavailableLabel
+                        }
+                    }
                 } actions: {
                     Button("Retry") { Task { await monitor.retry() } }
                         .buttonStyle(.borderedProminent)
@@ -134,14 +144,63 @@ struct AgentDetailView: View {
         }
     }
 
+    private func snapshotScrollView(_ snapshot: AttributedString) -> some View {
+        ScrollViewReader { proxy in
+            ScrollView([.horizontal, .vertical]) {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(snapshot)
+                        .font(.system(.body, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .topLeading)
+                        .padding()
+                    Color.clear
+                        .frame(height: 1)
+                        .id(Self.outputBottomID)
+                }
+            }
+            .defaultScrollAnchor(.bottom, for: .initialOffset)
+            .refreshable { await monitor.refresh() }
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                geometry.visibleRect.maxY >= geometry.contentSize.height - 24
+            } action: { _, isPinned in
+                monitor.setBottomPinned(isPinned)
+            }
+            .onChange(of: monitor.contentChangeCount) {
+                guard monitor.isBottomPinned else { return }
+                proxy.scrollTo(Self.outputBottomID, anchor: .bottom)
+            }
+            .overlay(alignment: .bottomTrailing) {
+                if monitor.hasNewOutput {
+                    Button("New Output", systemImage: "arrow.down") {
+                        monitor.jumpToLatestOutput()
+                        withAnimation(.snappy) {
+                            proxy.scrollTo(Self.outputBottomID, anchor: .bottom)
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .padding()
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+            }
+        }
+    }
+
     private var statusHeader: some View {
         VStack(alignment: .leading, spacing: 8) {
-            if let capturedAt = monitor.capturedAt {
-                Label(
-                    "Updated \(capturedAt.formatted(date: .omitted, time: .standard))",
-                    systemImage: "clock")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+            HStack {
+                AgentStatusBadge(status: monitor.agentStatus)
+                Spacer(minLength: 8)
+                if let capturedAt = monitor.capturedAt {
+                    Label(
+                        "Updated \(capturedAt.formatted(date: .omitted, time: .standard))",
+                        systemImage: "clock")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if !monitor.liveUpdatesAvailable {
+                liveUpdatesUnavailableLabel
             }
             if case .failed(let message) = monitor.state {
                 HStack(alignment: .firstTextBaseline, spacing: 8) {
@@ -162,4 +221,14 @@ struct AgentDetailView: View {
     private var title: String {
         AgentAttachView.displayTitle(for: agent)
     }
+
+    private var liveUpdatesUnavailableLabel: some View {
+        Label(
+            "Live updates unavailable. Pull to refresh.",
+            systemImage: "wifi.slash")
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+    }
+
+    private static let outputBottomID = "agent-monitor-output-bottom"
 }

--- a/Sources/Heeler/Transport/Generated/HerdrAPITypes.swift
+++ b/Sources/Heeler/Transport/Generated/HerdrAPITypes.swift
@@ -137,6 +137,44 @@ struct AgentListResponse: Codable, Equatable, Sendable {
     }
 }
 
+/// herdr schema `$defs/AgentPromptParams`.
+struct AgentPromptParams: Codable, Equatable, Sendable {
+    let target: String
+    let text: String
+    let wait: AgentPromptWaitOptions?
+
+    init(target: String, text: String, wait: AgentPromptWaitOptions? = nil) {
+        self.target = target
+        self.text = text
+        self.wait = wait
+    }
+}
+
+/// herdr schema `$defs/AgentPromptWaitOptions`.
+struct AgentPromptWaitOptions: Codable, Equatable, Sendable {
+    let timeoutMs: Int?
+    let until: [AgentStatus]?
+
+    init(timeoutMs: Int? = nil, until: [AgentStatus]? = nil) {
+        self.timeoutMs = timeoutMs
+        self.until = until
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case timeoutMs = "timeout_ms"
+        case until
+    }
+}
+
+/// The `"type":"agent_prompted"` result payload of herdr's success_response schema.
+struct AgentPromptedResponse: Codable, Equatable, Sendable {
+    let agent: AgentInfo
+
+    init(agent: AgentInfo) {
+        self.agent = agent
+    }
+}
+
 /// herdr schema `$defs/AgentReadParams`.
 struct AgentReadParams: Codable, Equatable, Sendable {
     let format: ReadFormat?

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -617,6 +617,12 @@ actor HeelerSSHTransport: Transport {
             .read
     }
 
+    func promptAgent(_ params: AgentPromptParams) async throws -> Agent {
+        let response = try await request(
+            method: "agent.prompt", params: params, decoding: AgentPromptedResponse.self)
+        return Agent(response.agent)
+    }
+
     func startAgent(_ launch: AgentLaunchRequest) async throws -> Agent {
         let created = try await request(
             method: "tab.create",

--- a/Sources/Heeler/Transport/Transport.swift
+++ b/Sources/Heeler/Transport/Transport.swift
@@ -37,6 +37,11 @@ protocol Transport: Sendable {
     /// snapshot and requests ANSI output for local rendering (ADR 0012).
     func readAgent(_ params: AgentReadParams) async throws -> PaneReadResult
 
+    /// Delivers one complete local draft through `agent.prompt`. The request
+    /// deliberately omits `wait`: the response acknowledges delivery into
+    /// the Agent's pane, while Agent Status events report subsequent work.
+    func promptAgent(_ params: AgentPromptParams) async throws -> Agent
+
     /// Starts a new Agent: the new-agent flow (#12, User Story 8 — dispatch
     /// work from the road). Creates a fresh herdr tab in the chosen workspace,
     /// starts the requested agent in its root pane, and returns the Agent once

--- a/Tests/HeelerTests/AgentComposerStoreTests.swift
+++ b/Tests/HeelerTests/AgentComposerStoreTests.swift
@@ -1,0 +1,231 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@MainActor
+@Suite("Agent Composer store")
+struct AgentComposerStoreTests {
+    @Test func typingStaysLocalAndSendUsesOnePromptRPC() async throws {
+        let transport = ScriptedTransport()
+        let promptGate = ScriptedTransportCallGate()
+        await transport.gateNextAgentPrompt(using: promptGate)
+        let store = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+
+        store.replaceDraft(with: "Fix the failing tests")
+
+        #expect(store.draft == "Fix the failing tests")
+        #expect(await transport.agentPromptParams.isEmpty)
+
+        let send = Task { await store.send() }
+        try await waitUntil("the prompt should be waiting for its acknowledgment") {
+            await promptGate.entryCount == 1
+        }
+
+        #expect(store.draft.isEmpty)
+        #expect(store.messages.map(\.text) == ["Fix the failing tests"])
+        #expect(store.messages.map(\.state) == [.sending])
+        #expect(
+            await transport.agentPromptParams == [
+                AgentPromptParams(target: "w1:p1", text: "Fix the failing tests")
+            ])
+
+        await promptGate.open()
+        await send.value
+
+        #expect(store.messages.map(\.state) == [.delivered(.acknowledged)])
+        #expect(await transport.agentPromptParams.count == 1)
+    }
+
+    @Test func statusPushesAdvanceAcknowledgedMessageFromWorkingToDone() async throws {
+        let transport = ScriptedTransport()
+        let (updates, continuation) = AsyncStream.makeStream(
+            of: ConsoleStore.AgentStatusUpdate.self)
+        let store = AgentComposerStore(
+            target: "w1:p1", statusUpdates: updates
+        ) { params in
+            try await transport.promptAgent(params)
+        }
+        store.open()
+        store.replaceDraft(with: "Continue")
+
+        await store.send()
+        #expect(store.messages.map(\.state) == [.delivered(.acknowledged)])
+
+        continuation.yield(
+            ConsoleStore.AgentStatusUpdate(status: .working, liveUpdatesAvailable: true))
+        try await waitUntil("Working should come from the status stream") {
+            store.messages.map(\.state) == [.delivered(.working)]
+        }
+
+        continuation.yield(
+            ConsoleStore.AgentStatusUpdate(status: .done, liveUpdatesAvailable: true))
+        try await waitUntil("Done should come from the status stream") {
+            store.messages.map(\.state) == [.delivered(.done)]
+        }
+
+        #expect(await transport.agentPromptParams.count == 1)
+        #expect(await transport.agentPromptParams.first?.wait == nil)
+        continuation.finish()
+    }
+
+    @Test func sendingWhileWorkingAcknowledgesThatTheAgentIsBusy() async {
+        let transport = ScriptedTransport()
+        let store = AgentComposerStore(target: "w1:p1", initialStatus: .working) { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Queue this next")
+
+        await store.send()
+
+        #expect(store.messages.map(\.state) == [.delivered(.agentBusy)])
+        #expect(await transport.agentPromptParams.count == 1)
+    }
+
+    @Test func priorDoneStatusDoesNotClaimThatANewMessageIsDone() async {
+        let transport = ScriptedTransport()
+        let store = AgentComposerStore(target: "w1:p1", initialStatus: .done) { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "One more request")
+
+        await store.send()
+
+        #expect(store.messages.map(\.state) == [.delivered(.acknowledged)])
+    }
+
+    @Test func statusArrivingBeforeAcknowledgmentIsAppliedAfterDelivery() async throws {
+        let transport = ScriptedTransport()
+        let promptGate = ScriptedTransportCallGate()
+        await transport.gateNextAgentPrompt(using: promptGate)
+        let store = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Start now")
+        let send = Task { await store.send() }
+        try await waitUntil("the prompt should be in flight") {
+            await promptGate.entryCount == 1
+        }
+
+        store.agentStatusDidChange(.working)
+        await promptGate.open()
+        await send.value
+
+        #expect(store.messages.map(\.state) == [.delivered(.working)])
+    }
+
+    @Test func failedSendCanRetryWithoutLosingItsText() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentPromptFailure(TransportError.timedOut)
+        let store = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Please retry this")
+        await store.send()
+        let message = try #require(store.messages.first)
+
+        #expect(
+            message.state
+                == .failed("The Host did not answer. Check the connection and retry."))
+        #expect(message.text == "Please retry this")
+
+        await transport.setAgentPromptFailure(nil)
+        let retryGate = ScriptedTransportCallGate()
+        await transport.gateNextAgentPrompt(using: retryGate)
+        let retry = Task { await store.retry(message.id) }
+        try await waitUntil("retry should return to Sending") {
+            await retryGate.entryCount == 1 && store.messages.first?.state == .sending
+        }
+        await retryGate.open()
+        await retry.value
+
+        #expect(store.messages.first?.text == "Please retry this")
+        #expect(store.messages.first?.state == .delivered(.acknowledged))
+        #expect(await transport.agentPromptParams.count == 2)
+    }
+
+    @Test func withdrawingFailurePreservesTheFailedTextAndNewDraft() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentPromptFailure(TransportError.sshUnreachable)
+        let store = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Earlier message")
+        await store.send()
+        let failedID = try #require(store.messages.first?.id)
+        store.replaceDraft(with: "New thought")
+
+        store.withdrawToDraft(failedID)
+
+        #expect(store.messages.isEmpty)
+        #expect(store.draft == "Earlier message\nNew thought")
+        #expect(await transport.agentPromptParams.count == 1)
+    }
+
+    @Test func reconnectStatusUpdatesDoNotTouchTheLocalDraft() async throws {
+        let transport = ScriptedTransport()
+        let (updates, continuation) = AsyncStream.makeStream(
+            of: ConsoleStore.AgentStatusUpdate.self)
+        let store = AgentComposerStore(
+            target: "w1:p1", statusUpdates: updates
+        ) { params in
+            try await transport.promptAgent(params)
+        }
+        store.open()
+        store.replaceDraft(with: "Survive Attach, background, and reconnect")
+
+        continuation.yield(
+            ConsoleStore.AgentStatusUpdate(status: nil, liveUpdatesAvailable: false))
+        continuation.yield(
+            ConsoleStore.AgentStatusUpdate(status: .idle, liveUpdatesAvailable: true))
+        try await waitUntil("status recovery should be consumed") {
+            await transport.agentPromptParams.isEmpty
+        }
+
+        #expect(store.draft == "Survive Attach, background, and reconnect")
+        #expect(store.messages.isEmpty)
+        #expect(await transport.agentPromptParams.isEmpty)
+        continuation.finish()
+    }
+
+    @Test func consoleOwnershipPreservesDraftAcrossReconnectViewReplacement() throws {
+        let console = ConsoleStore()
+        let hostID = try #require(
+            UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+        let agentBeforeReconnect = makeAgent(hostID: hostID, status: .working)
+        let firstStore = console.composerStore(for: agentBeforeReconnect)
+        firstStore.replaceDraft(with: "Keep this local draft")
+
+        let agentAfterReconnect = makeAgent(hostID: hostID, status: .idle)
+        let replacementStore = console.composerStore(for: agentAfterReconnect)
+
+        #expect(firstStore === replacementStore)
+        #expect(replacementStore.draft == "Keep this local draft")
+    }
+
+    private func waitUntil(
+        _ comment: Comment,
+        timeout: Duration = .seconds(2),
+        condition: () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            await Task.yield()
+        }
+        #expect(await condition(), comment)
+    }
+
+    private func makeAgent(hostID: Host.ID, status: AgentStatus) -> ConsoleAgent {
+        ConsoleAgent(
+            hostID: hostID,
+            hostName: "devbox",
+            agent: Agent(
+                terminalID: "term-1", kind: "claude", title: "Task",
+                status: status, workspaceID: "w1", tabID: "w1:t1", paneID: "w1:p1",
+                cwd: "/work", revision: 1),
+            workspaceLabel: "Project", repoName: "Project")
+    }
+}

--- a/Tests/HeelerTests/AgentComposerStoreTests.swift
+++ b/Tests/HeelerTests/AgentComposerStoreTests.swift
@@ -148,7 +148,8 @@ struct AgentComposerStoreTests {
 
     @Test func withdrawingFailurePreservesTheFailedTextAndNewDraft() async throws {
         let transport = ScriptedTransport()
-        await transport.setAgentPromptFailure(TransportError.sshUnreachable)
+        await transport.setAgentPromptFailure(
+            TransportError.sshUnreachable(detail: "connection dropped"))
         let store = AgentComposerStore(target: "w1:p1") { params in
             try await transport.promptAgent(params)
         }

--- a/Tests/HeelerTests/AgentComposerStoreTests.swift
+++ b/Tests/HeelerTests/AgentComposerStoreTests.swift
@@ -71,6 +71,74 @@ struct AgentComposerStoreTests {
         continuation.finish()
     }
 
+    @Test func queuedMessageWaitsForItsOwnWorkingPhaseBeforeDone() async {
+        let transport = ScriptedTransport()
+        let store = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "First message")
+        await store.send()
+        store.agentStatusDidChange(.working)
+
+        store.replaceDraft(with: "Queued message")
+        await store.send()
+
+        #expect(
+            store.messages.map(\.state)
+                == [.delivered(.working), .delivered(.agentBusy)])
+
+        store.agentStatusDidChange(.done)
+        #expect(
+            store.messages.map(\.state)
+                == [.delivered(.done), .delivered(.agentBusy)])
+
+        store.agentStatusDidChange(.working)
+        #expect(
+            store.messages.map(\.state)
+                == [.delivered(.done), .delivered(.working)])
+
+        store.agentStatusDidChange(.done)
+        #expect(
+            store.messages.map(\.state)
+                == [.delivered(.done), .delivered(.done)])
+        #expect(await transport.agentPromptParams.count == 2)
+    }
+
+    @Test func queuedMessageStaysBusyWhenPriorWorkFinishesBeforeAcknowledgment() async throws {
+        let transport = ScriptedTransport()
+        let promptGate = ScriptedTransportCallGate()
+        let store = AgentComposerStore(target: "w1:p1", initialStatus: .working) { params in
+            try await transport.promptAgent(params)
+        }
+        await transport.gateNextAgentPrompt(using: promptGate)
+        store.replaceDraft(with: "Queued message")
+        let send = Task { await store.send() }
+        try await waitUntil("the queued prompt should be in flight") {
+            await promptGate.entryCount == 1
+        }
+
+        store.agentStatusDidChange(.done)
+        await promptGate.open()
+        await send.value
+
+        #expect(store.messages.map(\.state) == [.delivered(.agentBusy)])
+    }
+
+    @Test func idleEndsAWorkingMessage() async {
+        let transport = ScriptedTransport()
+        let store = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Interrupt this")
+        await store.send()
+        store.agentStatusDidChange(.working)
+
+        store.agentStatusDidChange(.idle)
+
+        #expect(store.messages.map(\.state) == [.delivered(.done)])
+        #expect(await transport.agentPromptParams.count == 1)
+    }
+
     @Test func sendingWhileWorkingAcknowledgesThatTheAgentIsBusy() async {
         let transport = ScriptedTransport()
         let store = AgentComposerStore(target: "w1:p1", initialStatus: .working) { params in

--- a/Tests/HeelerTests/AgentMonitorHistoryTests.swift
+++ b/Tests/HeelerTests/AgentMonitorHistoryTests.swift
@@ -21,7 +21,12 @@ struct AgentMonitorHistoryTests {
 
         // Scrolled by one: the four-line overlap extends the tail.
         #expect(history.applyVisible("l2\nl3\nl4\nl5\nl6") == .extended)
-        #expect(history.newestLines == ["l1", "l2", "l3", "l4", "l5", "l6"])
+        #expect(history.newestLines == ["l2", "l3", "l4", "l5", "l6"])
+        #expect(
+            history.segments == [
+                .lines(["l1"]),
+                .lines(["l2", "l3", "l4", "l5", "l6"]),
+            ])
 
         // Repaint: no overlap, a new live run is installed.
         #expect(history.applyVisible("n1\nn2\nn3\nn4\nn5") == .replaced)
@@ -177,5 +182,70 @@ struct AgentMonitorHistoryTests {
                 .gap,
                 .lines([]),
             ])
+    }
+
+    @Test func nearDuplicateRuleIsConservativeAndByteExact() {
+        let original = (1...10).map { "line \($0)" }
+        var oneChangedLine = original
+        oneChangedLine[4] = "spinner frame 2"
+        var twoChangedLines = oneChangedLine
+        twoChangedLines[7] = "elapsed 00:02"
+        var threeChangedLines = twoChangedLines
+        threeChangedLines[9] = "tokens 42"
+
+        #expect(AgentMonitorHistory.isNearDuplicate(original, oneChangedLine))
+        #expect(AgentMonitorHistory.isNearDuplicate(original, twoChangedLines))
+        #expect(!AgentMonitorHistory.isNearDuplicate(original, threeChangedLines))
+        #expect(!AgentMonitorHistory.isNearDuplicate(original, Array(original.dropLast())))
+        #expect(
+            !AgentMonitorHistory.isNearDuplicate(
+                ["one", "two", "three", "four"],
+                ["one", "two", "changed", "four"]))
+
+        // Swift String equality treats these canonically equivalent forms
+        // as equal. Repaint dedupe deliberately compares their UTF-8 bytes.
+        let composed = ["header", "café", "three", "four", "five"]
+        let decomposed = ["changed", "cafe\u{301}", "three", "four", "five"]
+        #expect(!AgentMonitorHistory.isNearDuplicate(composed, decomposed))
+    }
+
+    @Test func nearDuplicateRepaintReplacesTheLiveRunInPlace() {
+        var history = AgentMonitorHistory()
+        let first = (1...10).map { "line \($0)" }
+        var repaint = first
+        repaint[5] = "spinner frame 2"
+
+        history.applyVisible(first.joined(separator: "\n"))
+        #expect(history.applyVisible(repaint.joined(separator: "\n")) == .replaced)
+        #expect(history.segments == [.lines(repaint)])
+    }
+
+    @Test func sealedLiveGenerationsAreCappedWithoutDroppingProvenHistory() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("l0\nl1\nl2\nl3\nl4")
+        #expect(history.applyVisible("l1\nl2\nl3\nl4\nl5") == .extended)
+        history.stitchBackfill("h1\nh2\nl0\nl1\nl2\nl3\nl4\nl5")
+
+        let replacementCount = AgentMonitorHistory.maximumSealedLiveGenerations + 3
+        for generation in 1...replacementCount {
+            let screen = (1...5).map { "generation \(generation), line \($0)" }
+            #expect(history.applyVisible(screen.joined(separator: "\n")) == .replaced)
+        }
+
+        var expected: [AgentMonitorHistory.Segment] = [
+            .lines(["h1", "h2", "l0"]),
+            .gap,
+        ]
+        let firstRetainedGeneration =
+            replacementCount - AgentMonitorHistory.maximumSealedLiveGenerations
+        for generation in firstRetainedGeneration..<replacementCount {
+            expected.append(
+                .lines((1...5).map { "generation \(generation), line \($0)" }))
+            expected.append(.gap)
+        }
+        expected.append(
+            .lines((1...5).map { "generation \(replacementCount), line \($0)" }))
+
+        #expect(history.segments == expected)
     }
 }

--- a/Tests/HeelerTests/AgentMonitorHistoryTests.swift
+++ b/Tests/HeelerTests/AgentMonitorHistoryTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@MainActor
+@Suite("Agent Monitor history")
+struct AgentMonitorHistoryTests {
+    @Test func splitLinesDropsOnlyTheTrailingNewlineFragment() {
+        #expect(AgentMonitorHistory.splitLines("") == [])
+        #expect(AgentMonitorHistory.splitLines("a") == ["a"])
+        #expect(AgentMonitorHistory.splitLines("a\n") == ["a"])
+        #expect(AgentMonitorHistory.splitLines("a\n\nb") == ["a", "", "b"])
+        #expect(AgentMonitorHistory.splitLines("\n") == [""])
+    }
+
+    @Test func visibleReadsExtendReplaceAndSettle() {
+        var history = AgentMonitorHistory()
+        #expect(history.applyVisible("l1\nl2\nl3\nl4\nl5") == .replaced)
+        #expect(history.applyVisible("l1\nl2\nl3\nl4\nl5") == .unchanged)
+
+        // Scrolled by one: the four-line overlap extends the tail.
+        #expect(history.applyVisible("l2\nl3\nl4\nl5\nl6") == .extended)
+        #expect(history.newestLines == ["l1", "l2", "l3", "l4", "l5", "l6"])
+
+        // Repaint: no overlap, the tail is replaced.
+        #expect(history.applyVisible("n1\nn2\nn3\nn4\nn5") == .replaced)
+        #expect(history.newestLines == ["n1", "n2", "n3", "n4", "n5"])
+
+        // A cleared screen replaces; re-reading it changes nothing.
+        #expect(history.applyVisible("") == .replaced)
+        #expect(history.newestLines == [])
+        #expect(history.applyVisible("") == .unchanged)
+    }
+
+    @Test func backfillStitchesBySharedSuffix() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("s1\ns2\ns3\ns4")
+
+        let first = history.stitchBackfill("o1\no2\ns1\ns2\ns3\ns4")
+        #expect(first == .init(newLines: 2, insertedGap: false))
+        #expect(history.newestLines == ["o1", "o2", "s1", "s2", "s3", "s4"])
+
+        // The same window again: fully captured, nothing new.
+        let repeatRead = history.stitchBackfill("o1\no2\ns1\ns2\ns3\ns4")
+        #expect(repeatRead == .init(newLines: 0, insertedGap: false))
+
+        // A window contained inside a deeper cache adds nothing either.
+        let contained = history.stitchBackfill("s1\ns2\ns3\ns4")
+        #expect(contained == .init(newLines: 0, insertedGap: false))
+        #expect(history.newestLines == ["o1", "o2", "s1", "s2", "s3", "s4"])
+    }
+
+    @Test func backfillSupersedesTheTailWhenTheWindowContainsIt() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("s1\ns2\ns3\ns4")
+
+        // Output raced the read: the tail sits mid-window, not at its end.
+        // The read is the better truth for the whole region.
+        let outcome = history.stitchBackfill("o1\ns1\ns2\ns3\ns4\nn1\nn2")
+        #expect(outcome == .init(newLines: 3, insertedGap: false))
+        #expect(history.newestLines == ["o1", "s1", "s2", "s3", "s4", "n1", "n2"])
+    }
+
+    @Test func backfillWithoutSharedContentRecordsAGap() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("stale a\nstale b\nstale c")
+
+        let outcome = history.stitchBackfill("fresh 1\nfresh 2\nfresh 3")
+        #expect(outcome == .init(newLines: 3, insertedGap: true))
+        #expect(
+            history.segments == [
+                .lines(["stale a", "stale b", "stale c"]),
+                .gap,
+                .lines(["fresh 1", "fresh 2", "fresh 3"]),
+            ])
+
+        // The next read stitches onto the new tail, below the gap.
+        let second = history.stitchBackfill("older\nfresh 1\nfresh 2\nfresh 3")
+        #expect(second == .init(newLines: 1, insertedGap: false))
+        #expect(
+            history.segments == [
+                .lines(["stale a", "stale b", "stale c"]),
+                .gap,
+                .lines(["older", "fresh 1", "fresh 2", "fresh 3"]),
+            ])
+    }
+
+    @Test func tinyScreensMatchOnTheirWholeLength() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("only line")
+
+        // Below the minimum overlap the floor drops to the screen's length:
+        // a whole-screen match is correct by construction.
+        let outcome = history.stitchBackfill("older 1\nolder 2\nonly line")
+        #expect(outcome == .init(newLines: 2, insertedGap: false))
+        #expect(history.newestLines == ["older 1", "older 2", "only line"])
+    }
+
+    @Test func emptyFirstReadStillInstalls() {
+        var history = AgentMonitorHistory()
+        // The first install must report a change even for empty content, or
+        // the store never renders and the view loads forever.
+        #expect(history.applyVisible("") == .replaced)
+        #expect(history.newestLines == [])
+        #expect(history.applyVisible("") == .unchanged)
+    }
+
+    @Test func coincidentalShortOverlapsDoNotStitch() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("a\nb\nc\nd")
+
+        // Two shared lines at the end are below the minimum overlap: the
+        // read is treated as unrelated content, never stitched history.
+        let short = history.stitchBackfill("x\ny\nc\nd")
+        #expect(short.insertedGap)
+        #expect(
+            history.segments == [
+                .lines(["a", "b", "c", "d"]),
+                .gap,
+                .lines(["x", "y", "c", "d"]),
+            ])
+
+        // The live tail holds the same line: a two-line overlap is a
+        // repaint, not an extension.
+        var visible = AgentMonitorHistory()
+        visible.applyVisible("a\nb\nc\nd")
+        #expect(visible.applyVisible("c\nd\ne") == .replaced)
+        #expect(visible.newestLines == ["c", "d", "e"])
+    }
+
+    @Test func emptyBackfillAddsNothing() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("s1\ns2\ns3")
+
+        #expect(history.stitchBackfill("") == .init(newLines: 0, insertedGap: false))
+        #expect(history.newestLines == ["s1", "s2", "s3"])
+    }
+}

--- a/Tests/HeelerTests/AgentMonitorHistoryTests.swift
+++ b/Tests/HeelerTests/AgentMonitorHistoryTests.swift
@@ -23,7 +23,7 @@ struct AgentMonitorHistoryTests {
         #expect(history.applyVisible("l2\nl3\nl4\nl5\nl6") == .extended)
         #expect(history.newestLines == ["l1", "l2", "l3", "l4", "l5", "l6"])
 
-        // Repaint: no overlap, the tail is replaced.
+        // Repaint: no overlap, a new live run is installed.
         #expect(history.applyVisible("n1\nn2\nn3\nn4\nn5") == .replaced)
         #expect(history.newestLines == ["n1", "n2", "n3", "n4", "n5"])
 
@@ -39,7 +39,11 @@ struct AgentMonitorHistoryTests {
 
         let first = history.stitchBackfill("o1\no2\ns1\ns2\ns3\ns4")
         #expect(first == .init(newLines: 2, insertedGap: false))
-        #expect(history.newestLines == ["o1", "o2", "s1", "s2", "s3", "s4"])
+        #expect(
+            history.segments == [
+                .lines(["o1", "o2"]),
+                .lines(["s1", "s2", "s3", "s4"]),
+            ])
 
         // The same window again: fully captured, nothing new.
         let repeatRead = history.stitchBackfill("o1\no2\ns1\ns2\ns3\ns4")
@@ -48,7 +52,7 @@ struct AgentMonitorHistoryTests {
         // A window contained inside a deeper cache adds nothing either.
         let contained = history.stitchBackfill("s1\ns2\ns3\ns4")
         #expect(contained == .init(newLines: 0, insertedGap: false))
-        #expect(history.newestLines == ["o1", "o2", "s1", "s2", "s3", "s4"])
+        #expect(history.newestLines == ["s1", "s2", "s3", "s4"])
     }
 
     @Test func backfillSupersedesTheTailWhenTheWindowContainsIt() {
@@ -59,7 +63,11 @@ struct AgentMonitorHistoryTests {
         // The read is the better truth for the whole region.
         let outcome = history.stitchBackfill("o1\ns1\ns2\ns3\ns4\nn1\nn2")
         #expect(outcome == .init(newLines: 3, insertedGap: false))
-        #expect(history.newestLines == ["o1", "s1", "s2", "s3", "s4", "n1", "n2"])
+        #expect(
+            history.segments == [
+                .lines(["o1", "s1", "s2"]),
+                .lines(["s3", "s4", "n1", "n2"]),
+            ])
     }
 
     @Test func backfillWithoutSharedContentRecordsAGap() {
@@ -70,19 +78,19 @@ struct AgentMonitorHistoryTests {
         #expect(outcome == .init(newLines: 3, insertedGap: true))
         #expect(
             history.segments == [
-                .lines(["stale a", "stale b", "stale c"]),
-                .gap,
                 .lines(["fresh 1", "fresh 2", "fresh 3"]),
+                .gap,
+                .lines(["stale a", "stale b", "stale c"]),
             ])
 
-        // The next read stitches onto the new tail, below the gap.
+        // The next read extends the backfill run above the live screen.
         let second = history.stitchBackfill("older\nfresh 1\nfresh 2\nfresh 3")
         #expect(second == .init(newLines: 1, insertedGap: false))
         #expect(
             history.segments == [
-                .lines(["stale a", "stale b", "stale c"]),
-                .gap,
                 .lines(["older", "fresh 1", "fresh 2", "fresh 3"]),
+                .gap,
+                .lines(["stale a", "stale b", "stale c"]),
             ])
     }
 
@@ -94,7 +102,11 @@ struct AgentMonitorHistoryTests {
         // a whole-screen match is correct by construction.
         let outcome = history.stitchBackfill("older 1\nolder 2\nonly line")
         #expect(outcome == .init(newLines: 2, insertedGap: false))
-        #expect(history.newestLines == ["older 1", "older 2", "only line"])
+        #expect(
+            history.segments == [
+                .lines(["older 1", "older 2"]),
+                .lines(["only line"]),
+            ])
     }
 
     @Test func emptyFirstReadStillInstalls() {
@@ -116,9 +128,9 @@ struct AgentMonitorHistoryTests {
         #expect(short.insertedGap)
         #expect(
             history.segments == [
-                .lines(["a", "b", "c", "d"]),
-                .gap,
                 .lines(["x", "y", "c", "d"]),
+                .gap,
+                .lines(["a", "b", "c", "d"]),
             ])
 
         // The live tail holds the same line: a two-line overlap is a
@@ -135,5 +147,35 @@ struct AgentMonitorHistoryTests {
 
         #expect(history.stitchBackfill("") == .init(newLines: 0, insertedGap: false))
         #expect(history.newestLines == ["s1", "s2", "s3"])
+    }
+
+    @Test func nonoverlappingRepaintPreservesBackfilledHistory() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("s1\ns2\ns3\ns4")
+        history.stitchBackfill("h1\nh2\nh3\nh4\nh5\nh6\ns1\ns2\ns3\ns4")
+
+        #expect(history.applyVisible("r1\nr2\nr3\nr4") == .replaced)
+        #expect(
+            history.segments == [
+                .lines(["h1", "h2", "h3", "h4", "h5", "h6"]),
+                .lines(["s1", "s2", "s3", "s4"]),
+                .gap,
+                .lines(["r1", "r2", "r3", "r4"]),
+            ])
+    }
+
+    @Test func emptyVisibleReadPreservesCapturedHistory() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("s1\ns2\ns3\ns4")
+        history.stitchBackfill("h1\nh2\nh3\ns1\ns2\ns3\ns4")
+
+        #expect(history.applyVisible("") == .replaced)
+        #expect(
+            history.segments == [
+                .lines(["h1", "h2", "h3"]),
+                .lines(["s1", "s2", "s3", "s4"]),
+                .gap,
+                .lines([]),
+            ])
     }
 }

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -22,15 +22,18 @@ struct AgentMonitorStoreTests {
         }
         await transport.setAgentText("second", target: "w1:p1")
         #expect(await clock.advance() == .seconds(2))
+        let expected = [
+            "first", AgentMonitorStore.gapMarkerText, "second",
+        ].joined(separator: "\n")
         try await waitUntil("one clock tick should perform one refresh") {
-            guard store.snapshot.map({ String($0.characters) }) == "second" else {
+            guard store.snapshot.map({ String($0.characters) }) == expected else {
                 return false
             }
             return await transport.agentReadParams.count == 2
         }
 
         #expect(store.agentStatus == .working)
-        #expect(String(try #require(store.snapshot).characters) == "second")
+        #expect(String(try #require(store.snapshot).characters) == expected)
     }
 
     @Test func idleAndBackgroundStatesDoNotPoll() async throws {
@@ -104,30 +107,42 @@ struct AgentMonitorStoreTests {
 
         await transport.setAgentText("working", target: "w1:p1")
         #expect(await transport.emit(.agentStatusChanged(paneID: "w1:p1", status: .working)))
+        let workingSnapshot = [
+            "idle", AgentMonitorStore.gapMarkerText, "working",
+        ].joined(separator: "\n")
         try await waitUntil("Working should surface and refresh") {
             guard
                 store.agentStatus == .working,
-                store.snapshot.map({ String($0.characters) }) == "working"
+                store.snapshot.map({ String($0.characters) }) == workingSnapshot
             else { return false }
             return await agentReads(transport, source: .visible).count == 2
         }
 
         await transport.setAgentText("done", target: "w1:p1")
         #expect(await transport.emit(.agentStatusChanged(paneID: "w1:p1", status: .done)))
+        let doneSnapshot = [
+            "idle", AgentMonitorStore.gapMarkerText, "working",
+            AgentMonitorStore.gapMarkerText, "done",
+        ].joined(separator: "\n")
         try await waitUntil("Done should surface and refresh") {
             guard
                 store.agentStatus == .done,
-                store.snapshot.map({ String($0.characters) }) == "done"
+                store.snapshot.map({ String($0.characters) }) == doneSnapshot
             else { return false }
             return await agentReads(transport, source: .visible).count == 3
         }
 
         await transport.setAgentText("blocked", target: "w1:p1")
         #expect(await transport.emit(.agentStatusChanged(paneID: "w1:p1", status: .blocked)))
+        let blockedSnapshot = [
+            "idle", AgentMonitorStore.gapMarkerText, "working",
+            AgentMonitorStore.gapMarkerText, "done",
+            AgentMonitorStore.gapMarkerText, "blocked",
+        ].joined(separator: "\n")
         try await waitUntil("Blocked should surface and refresh") {
             guard
                 store.agentStatus == .blocked,
-                store.snapshot.map({ String($0.characters) }) == "blocked"
+                store.snapshot.map({ String($0.characters) }) == blockedSnapshot
             else { return false }
             return await agentReads(transport, source: .visible).count == 4
         }
@@ -322,7 +337,10 @@ struct AgentMonitorStoreTests {
         await store.refreshOnReturn()
 
         let snapshot = try #require(store.snapshot)
-        #expect(String(snapshot.characters) == "after")
+        #expect(
+            String(snapshot.characters)
+                == ["before", AgentMonitorStore.gapMarkerText, "after"]
+                .joined(separator: "\n"))
         #expect(await agentReads(transport, source: .visible).count == 2)
     }
 
@@ -355,7 +373,10 @@ struct AgentMonitorStoreTests {
         await returning.value
 
         let snapshot = try #require(store.snapshot)
-        #expect(String(snapshot.characters) == "after Attach")
+        #expect(
+            String(snapshot.characters)
+                == ["opening", AgentMonitorStore.gapMarkerText, "after Attach"]
+                .joined(separator: "\n"))
         #expect(await agentReads(transport, source: .visible).count == 2)
     }
 
@@ -520,9 +541,9 @@ struct AgentMonitorStoreTests {
         await store.open()
 
         let expected = [
-            "stale a", "stale b", "stale c",
-            AgentMonitorStore.gapMarkerText,
             "fresh 1", "fresh 2", "fresh 3",
+            AgentMonitorStore.gapMarkerText,
+            "stale a", "stale b", "stale c",
         ].joined(separator: "\n")
         #expect(String(try #require(store.snapshot).characters) == expected)
         #expect(store.historyState == .exhausted)
@@ -646,10 +667,54 @@ struct AgentMonitorStoreTests {
         #expect(
             String(try #require(store.snapshot).characters) == "l1\nl2\nl3\nl4\nl5\nl6")
 
-        // A repaint shares no overlap: the tail is replaced, not extended.
+        // A repaint shares no overlap: a new live run is installed.
         await transport.setAgentText("n1\nn2\nn3\nn4\nn5", target: "w1:p1")
         await store.refresh()
-        #expect(String(try #require(store.snapshot).characters) == "n1\nn2\nn3\nn4\nn5")
+        #expect(
+            String(try #require(store.snapshot).characters)
+                == [
+                    "l1", "l2", "l3", "l4", "l5", "l6",
+                    AgentMonitorStore.gapMarkerText,
+                    "n1", "n2", "n3", "n4", "n5",
+                ].joined(separator: "\n"))
+    }
+
+    @Test func liveReplacementResetsExhaustionAndAllowsAnotherBackfill() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("s1\ns2\ns3\ns4", target: "w1:p1")
+        await transport.setAgentHistoryText(
+            "h1\nh2\nh3\nh4\nh5\nh6\ns1\ns2\ns3\ns4", target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+        #expect(store.historyState == .exhausted)
+
+        await transport.setAgentText("r1\nr2\nr3\nr4", target: "w1:p1")
+        await store.refresh()
+
+        #expect(store.historyState == .idle)
+        let preserved = [
+            "h1", "h2", "h3", "h4", "h5", "h6", "s1", "s2", "s3", "s4",
+            AgentMonitorStore.gapMarkerText, "r1", "r2", "r3", "r4",
+        ].joined(separator: "\n")
+        #expect(String(try #require(store.snapshot).characters) == preserved)
+
+        await transport.setAgentHistoryText(
+            "new older 1\nnew older 2\nr1\nr2\nr3\nr4", target: "w1:p1")
+        store.topEdgeReached()
+        try await waitUntil("the replacement should allow a new backfill") {
+            store.historyState == .exhausted
+        }
+
+        #expect(await agentReads(transport, source: .recent).count == 2)
+        #expect(
+            String(try #require(store.snapshot).characters)
+                == [
+                    "h1", "h2", "h3", "h4", "h5", "h6", "s1", "s2", "s3", "s4",
+                    AgentMonitorStore.gapMarkerText, "new older 1", "new older 2", "r1",
+                    "r2", "r3", "r4",
+                ].joined(separator: "\n"))
     }
 
     private func agentReads(

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -6,6 +6,268 @@ import Testing
 @MainActor
 @Suite("Agent Monitor store")
 struct AgentMonitorStoreTests {
+    @Test func workingForegroundPollsEveryInjectedClockTick() async throws {
+        let transport = ScriptedTransport()
+        let clock = ManualAgentMonitorClock()
+        await transport.setAgentText("first", target: "w1:p1")
+        let store = AgentMonitorStore(
+            target: "w1:p1", initialStatus: .working, clock: clock
+        ) { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+        try await waitUntil("the cadence should be sleeping") {
+            await clock.pendingSleepCount == 1
+        }
+        await transport.setAgentText("second", target: "w1:p1")
+        #expect(await clock.advance() == .seconds(2))
+        try await waitUntil("one clock tick should perform one refresh") {
+            guard store.snapshot.map({ String($0.characters) }) == "second" else {
+                return false
+            }
+            return await transport.agentReadParams.count == 2
+        }
+
+        #expect(store.agentStatus == .working)
+        #expect(String(try #require(store.snapshot).characters) == "second")
+    }
+
+    @Test func idleAndBackgroundStatesDoNotPoll() async throws {
+        let idleTransport = ScriptedTransport()
+        let idleClock = ManualAgentMonitorClock()
+        let idleStore = AgentMonitorStore(target: "w1:p1", clock: idleClock) { params in
+            try await idleTransport.readAgent(params)
+        }
+        await idleStore.open()
+
+        #expect(await idleClock.pendingSleepCount == 0)
+        #expect(await idleTransport.agentReadParams.count == 1)
+
+        let workingTransport = ScriptedTransport()
+        let workingClock = ManualAgentMonitorClock()
+        let workingStore = AgentMonitorStore(
+            target: "w1:p2", initialStatus: .working, clock: workingClock
+        ) { params in
+            try await workingTransport.readAgent(params)
+        }
+        await workingStore.open()
+        try await waitUntil("Working should schedule its cadence") {
+            await workingClock.pendingSleepCount == 1
+        }
+        workingStore.setForeground(false)
+        try await waitUntil("backgrounding should cancel the cadence") {
+            await workingClock.pendingSleepCount == 0
+        }
+
+        #expect(await workingTransport.agentReadParams.count == 1)
+    }
+
+    @Test func scriptedStatusPushesRefreshAndSurfaceWithoutPollingTerminalStates() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: .fixture(agents: [.fixture(paneID: "w1:p1", status: .idle)]))
+        await transport.setAgentText("idle", target: "w1:p1")
+        let console = ConsoleStore(snapshotRetryDelay: .milliseconds(10)) {
+            _, subscriptions in
+            EventsSession(
+                subscriptions: subscriptions,
+                connect: { transport },
+                reconnectPolicy: ReconnectPolicy(
+                    initialDelay: .milliseconds(10), multiplier: 1,
+                    maxDelay: .milliseconds(10)),
+                keepalive: nil)
+        }
+        console.setHosts([host])
+        await console.resume()
+        try await waitUntil("the Agent snapshot should arrive") {
+            console.agents.count == 1
+        }
+        let id = try #require(console.agents.first?.id)
+        let clock = ManualAgentMonitorClock()
+        let store = AgentMonitorStore(
+            target: "w1:p1",
+            initialStatus: .idle,
+            clock: clock,
+            statusUpdates: console.agentStatusUpdates(for: id)
+        ) { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+        try await waitUntil("the pane-scoped status subscription should be live") {
+            await transport.capturedSubscriptions.last?.contains(
+                .pane(.agentStatusChanged, paneID: "w1:p1")) == true
+        }
+
+        await transport.setAgentText("working", target: "w1:p1")
+        #expect(await transport.emit(.agentStatusChanged(paneID: "w1:p1", status: .working)))
+        try await waitUntil("Working should surface and refresh") {
+            guard
+                store.agentStatus == .working,
+                store.snapshot.map({ String($0.characters) }) == "working"
+            else { return false }
+            return await transport.agentReadParams.count == 2
+        }
+
+        await transport.setAgentText("done", target: "w1:p1")
+        #expect(await transport.emit(.agentStatusChanged(paneID: "w1:p1", status: .done)))
+        try await waitUntil("Done should surface and refresh") {
+            guard
+                store.agentStatus == .done,
+                store.snapshot.map({ String($0.characters) }) == "done"
+            else { return false }
+            return await transport.agentReadParams.count == 3
+        }
+
+        await transport.setAgentText("blocked", target: "w1:p1")
+        #expect(await transport.emit(.agentStatusChanged(paneID: "w1:p1", status: .blocked)))
+        try await waitUntil("Blocked should surface and refresh") {
+            guard
+                store.agentStatus == .blocked,
+                store.snapshot.map({ String($0.characters) }) == "blocked"
+            else { return false }
+            return await transport.agentReadParams.count == 4
+        }
+        try await waitUntil("Blocked should cancel the cadence") {
+            await clock.pendingSleepCount == 0
+        }
+        console.setHosts([])
+    }
+
+    @Test func eventStreamFailureSurfacesDegradationAndResubscribes() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: .fixture(agents: [.fixture(paneID: "w1:p1", status: .working)]))
+        await transport.setAgentText("working", target: "w1:p1")
+        let console = makeConsole(host: host, transport: transport)
+        console.setHosts([host])
+        await console.resume()
+        try await waitUntil("the Agent and pane subscription should settle") {
+            guard console.agents.count == 1 else { return false }
+            return await transport.capturedSubscriptions.last?.contains(
+                .pane(.agentStatusChanged, paneID: "w1:p1")) == true
+        }
+        let id = try #require(console.agents.first?.id)
+        let store = AgentMonitorStore(
+            target: "w1:p1",
+            initialStatus: .working,
+            clock: ManualAgentMonitorClock(),
+            statusUpdates: console.agentStatusUpdates(for: id)
+        ) { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+        try await waitUntil("live status updates should initially be available") {
+            store.liveUpdatesAvailable
+        }
+
+        let reconnectGate = ScriptedTransportCallGate()
+        await transport.gateNextSubscription(using: reconnectGate)
+        await transport.failEventStream(.channelFailed(detail: "events stream dropped"))
+
+        try await waitUntil("the Monitor should expose the events outage") {
+            !store.liveUpdatesAvailable
+        }
+        let subscriptionsBeforeRecovery = await transport.capturedSubscriptions.count
+        #expect(subscriptionsBeforeRecovery >= 3)
+
+        await reconnectGate.open()
+        try await waitUntil("the pane status subscription should be re-established") {
+            guard store.liveUpdatesAvailable else { return false }
+            return await transport.capturedSubscriptions.last?.contains(
+                .pane(.agentStatusChanged, paneID: "w1:p1")) == true
+        }
+
+        console.setHosts([])
+    }
+
+    @Test func deadPaneReconnectDropsItsSubscriptionAndDegradesGracefully() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: .fixture(agents: [.fixture(paneID: "w1:p1", status: .working)]))
+        let console = makeConsole(host: host, transport: transport)
+        console.setHosts([host])
+        await console.resume()
+        try await waitUntil("the original pane subscription should settle") {
+            guard console.agents.count == 1 else { return false }
+            return await transport.capturedSubscriptions.last?.contains(
+                .pane(.agentStatusChanged, paneID: "w1:p1")) == true
+        }
+        let id = try #require(console.agents.first?.id)
+        let store = AgentMonitorStore(
+            target: "w1:p1",
+            initialStatus: .working,
+            clock: ManualAgentMonitorClock(),
+            statusUpdates: console.agentStatusUpdates(for: id)
+        ) { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+        let subscriptionsBeforeFailure = await transport.capturedSubscriptions.count
+
+        await transport.setSnapshot(.fixture(agents: []))
+        await transport.setMissingPanes(["w1:p1"])
+        await transport.failEventStream(.channelFailed(detail: "connection dropped"))
+
+        try await waitUntil("the Host should recover without the dead Agent") {
+            console.hostStatuses[host.id] == .connected
+                && console.agents.isEmpty
+                && !store.liveUpdatesAvailable
+        }
+        let subscriptions = await transport.capturedSubscriptions
+        let recoverySubscriptions = Array(
+            subscriptions.dropFirst(subscriptionsBeforeFailure))
+        #expect(!recoverySubscriptions.isEmpty)
+        #expect(
+            recoverySubscriptions.allSatisfy {
+                !$0.contains(.pane(.agentStatusChanged, paneID: "w1:p1"))
+            })
+
+        console.setHosts([])
+    }
+
+    @Test func scrolledOutputFreezesWithPillWhilePinnedOutputFollows() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("one", target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+
+        store.setBottomPinned(false)
+        await transport.setAgentText("two", target: "w1:p1")
+        await store.refresh()
+        #expect(store.hasNewOutput)
+        #expect(!store.isBottomPinned)
+
+        store.jumpToLatestOutput()
+        #expect(!store.hasNewOutput)
+        #expect(store.isBottomPinned)
+
+        await transport.setAgentText("three", target: "w1:p1")
+        await store.refresh()
+        #expect(!store.hasNewOutput)
+        #expect(store.isBottomPinned)
+    }
+
+    @Test func unchangedTextDoesNotSignalNewOutput() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("same", target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+        let initialChange = store.contentChangeCount
+        store.setBottomPinned(false)
+
+        // Scripted reads report revision 0, like herdr 0.8.0. Only text is
+        // compared, so another response with the same bytes is not output.
+        await store.refresh()
+
+        #expect(store.contentChangeCount == initialChange)
+        #expect(!store.hasNewOutput)
+    }
+
     @Test func openingFetchesOneVisibleANSISnapshot() async throws {
         let transport = ScriptedTransport()
         await transport.setAgentText("plain \u{1B}[31mred\u{1B}[0m", target: "w1:p1")
@@ -125,8 +387,67 @@ struct AgentMonitorStoreTests {
         let deadline = ContinuousClock.now + timeout
         while ContinuousClock.now < deadline {
             if await condition() { return }
-            try await Task.sleep(for: .milliseconds(5))
+            await Task.yield()
         }
         #expect(await condition(), comment)
+    }
+
+    private func makeConsole(host: Host, transport: ScriptedTransport) -> ConsoleStore {
+        ConsoleStore(snapshotRetryDelay: .zero) { requestedHost, subscriptions in
+            EventsSession(
+                subscriptions: subscriptions,
+                connect: {
+                    guard requestedHost.id == host.id else {
+                        throw TransportError.sshUnreachable(detail: "unscripted host")
+                    }
+                    return transport
+                },
+                reconnectPolicy: ReconnectPolicy(
+                    initialDelay: .zero, multiplier: 1, maxDelay: .zero),
+                keepalive: nil)
+        }
+    }
+}
+
+private actor ManualAgentMonitorClock: AgentMonitorClock {
+    private struct Sleeper {
+        let id: UUID
+        let duration: Duration
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private var sleepers: [Sleeper] = []
+
+    var pendingSleepCount: Int { sleepers.count }
+
+    func sleep(for duration: Duration) async throws {
+        let id = UUID()
+        try Task.checkCancellation()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else {
+                    sleepers.append(
+                        Sleeper(id: id, duration: duration, continuation: continuation))
+                }
+            }
+        } onCancel: {
+            Task { await self.cancel(id: id) }
+        }
+    }
+
+    func advance() -> Duration? {
+        guard !sleepers.isEmpty else { return nil }
+        let sleeper = sleepers.removeFirst()
+        sleeper.continuation.resume()
+        return sleeper.duration
+    }
+
+    private func cancel(id: UUID) {
+        guard let index = sleepers.firstIndex(where: { $0.id == id }) else { return }
+        let sleeper = sleepers.remove(at: index)
+        sleeper.continuation.resume(throwing: CancellationError())
     }
 }

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -42,7 +42,9 @@ struct AgentMonitorStoreTests {
         await idleStore.open()
 
         #expect(await idleClock.pendingSleepCount == 0)
-        #expect(await idleTransport.agentReadParams.count == 1)
+        // One visible snapshot plus the one idle backfill on open (#181).
+        #expect(await agentReads(idleTransport, source: .visible).count == 1)
+        #expect(await agentReads(idleTransport, source: .recent).count == 1)
 
         let workingTransport = ScriptedTransport()
         let workingClock = ManualAgentMonitorClock()
@@ -60,6 +62,7 @@ struct AgentMonitorStoreTests {
             await workingClock.pendingSleepCount == 0
         }
 
+        // A Working Agent never backfills, so its only read is the snapshot.
         #expect(await workingTransport.agentReadParams.count == 1)
     }
 
@@ -106,7 +109,7 @@ struct AgentMonitorStoreTests {
                 store.agentStatus == .working,
                 store.snapshot.map({ String($0.characters) }) == "working"
             else { return false }
-            return await transport.agentReadParams.count == 2
+            return await agentReads(transport, source: .visible).count == 2
         }
 
         await transport.setAgentText("done", target: "w1:p1")
@@ -116,7 +119,7 @@ struct AgentMonitorStoreTests {
                 store.agentStatus == .done,
                 store.snapshot.map({ String($0.characters) }) == "done"
             else { return false }
-            return await transport.agentReadParams.count == 3
+            return await agentReads(transport, source: .visible).count == 3
         }
 
         await transport.setAgentText("blocked", target: "w1:p1")
@@ -126,7 +129,7 @@ struct AgentMonitorStoreTests {
                 store.agentStatus == .blocked,
                 store.snapshot.map({ String($0.characters) }) == "blocked"
             else { return false }
-            return await transport.agentReadParams.count == 4
+            return await agentReads(transport, source: .visible).count == 4
         }
         try await waitUntil("Blocked should cancel the cadence") {
             await clock.pendingSleepCount == 0
@@ -284,13 +287,25 @@ struct AgentMonitorStoreTests {
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "plain red")
         #expect(
-            await transport.agentReadParams == [
+            await agentReads(transport, source: .visible) == [
                 AgentReadParams(
                     source: .visible,
                     target: "w1:p1",
                     format: .ansi,
                     stripANSI: false)
             ])
+        // The idle open also backfills once (#181); the scripted window
+        // equals the screen, so nothing new lands and history is exhausted.
+        #expect(
+            await agentReads(transport, source: .recent) == [
+                AgentReadParams(
+                    source: .recent,
+                    target: "w1:p1",
+                    format: .ansi,
+                    lines: AgentMonitorStore.historyLineCount,
+                    stripANSI: false)
+            ])
+        #expect(store.historyState == .exhausted)
     }
 
     @Test func returningFromAttachRefreshesExactlyOnce() async throws {
@@ -308,12 +323,19 @@ struct AgentMonitorStoreTests {
 
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "after")
-        #expect(await transport.agentReadParams.count == 2)
+        #expect(await agentReads(transport, source: .visible).count == 2)
     }
 
     @Test func returningWhileOpenIsLoadingStillPerformsTheRefresh() async throws {
         let transport = ScriptedTransport()
         await transport.setAgentText("opening", target: "w1:p1")
+        // The open also backfills (#181), and the gated visible read lets
+        // the scripted screen move on before that backfill executes. Pin
+        // the history window to the pre-Attach screen so it stitches to
+        // nothing; the return refresh alone then decides the final screen.
+        // (A window disjoint from the stale tail would honestly record a
+        // gap — correct store behavior, but not what this test is about.)
+        await transport.setAgentHistoryText("opening", target: "w1:p1")
         let gate = ScriptedTransportCallGate()
         await transport.gateNextAgentRead(using: gate)
         let store = AgentMonitorStore(target: "w1:p1") { params in
@@ -334,7 +356,7 @@ struct AgentMonitorStoreTests {
 
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "after Attach")
-        #expect(await transport.agentReadParams.count == 2)
+        #expect(await agentReads(transport, source: .visible).count == 2)
     }
 
     @Test func failedOpenSurfacesTheServerErrorAndRetryRecovers() async throws {
@@ -357,7 +379,7 @@ struct AgentMonitorStoreTests {
         #expect(store.state == .loaded)
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "recovered")
-        #expect(await transport.agentReadParams.count == 2)
+        #expect(await agentReads(transport, source: .visible).count == 2)
     }
 
     @Test func failedReturnKeepsTheLastSnapshotAndItsFreshness() async throws {
@@ -377,6 +399,264 @@ struct AgentMonitorStoreTests {
         #expect(store.capturedAt == capturedAt)
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "known screen")
+    }
+
+    // MARK: History backfill (#181)
+
+    @Test func openWhileIdleBackfillsHistoryAboveTheScreen() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("screen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        await transport.setAgentHistoryText(
+            "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+        await store.open()
+
+        // The window overlaps the screen by its three lines, so only the
+        // older prefix is prepended; a short read ends history immediately.
+        let snapshot = try #require(store.snapshot)
+        #expect(
+            String(snapshot.characters) == "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3")
+        #expect(store.historyState == .exhausted)
+        #expect(await agentReads(transport, source: .visible).count == 1)
+        #expect(await agentReads(transport, source: .recent).count == 1)
+    }
+
+    @Test func openWhileWorkingSkipsBackfillAndTopEdgeStaysHonest() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("live screen", target: "w1:p1")
+        let store = AgentMonitorStore(
+            target: "w1:p1", initialStatus: .working
+        ) { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        #expect(store.historyState == .unavailable)
+        #expect(await transport.agentReadParams.count == 1)
+
+        store.topEdgeReached()
+
+        // Working never spins and never reads: the notice is the answer.
+        #expect(store.historyState == .unavailable)
+        #expect(await transport.agentReadParams.count == 1)
+    }
+
+    @Test func topEdgeWhileIdleShowsLoadingThenStitchesOlderLines() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("screen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        let store = AgentMonitorStore(
+            target: "w1:p1", initialStatus: .working
+        ) { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+        #expect(store.historyState == .unavailable)
+
+        // Going idle refreshes the screen but does not backfill on its own.
+        await store.agentStatusDidChange(.idle)
+        #expect(store.historyState == .idle)
+
+        await transport.setAgentHistoryText(
+            "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        let gate = ScriptedTransportCallGate()
+        await transport.gateNextAgentRead(using: gate)
+        store.topEdgeReached()
+        #expect(store.historyState == .loading)
+        try await waitUntil("the backfill read should be in flight") {
+            await gate.entryCount == 1
+        }
+
+        await gate.open()
+        try await waitUntil("the backfill should land") {
+            store.historyState == .exhausted
+        }
+
+        let snapshot = try #require(store.snapshot)
+        #expect(
+            String(snapshot.characters) == "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3")
+        #expect(await agentReads(transport, source: .recent).count == 1)
+    }
+
+    @Test func repeatBackfillAtTheCaptureLimitEndsHistory() async throws {
+        let transport = ScriptedTransport()
+        let screen = (998...1000).map { "line \($0)" }.joined(separator: "\n")
+        let window = (1...1000).map { "line \($0)" }.joined(separator: "\n")
+        await transport.setAgentText(screen, target: "w1:p1")
+        await transport.setAgentHistoryText(window, target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        // A full-window read that added lines might have more behind it.
+        #expect(store.historyState == .idle)
+        #expect(String(try #require(store.snapshot).characters) == window)
+
+        // The same window comes back: nothing new, so the limit is honest.
+        store.topEdgeReached()
+        try await waitUntil("the confirming read should declare the limit") {
+            store.historyState == .exhausted
+        }
+        #expect(String(try #require(store.snapshot).characters) == window)
+        #expect(await agentReads(transport, source: .recent).count == 2)
+    }
+
+    @Test func unstitchableReadInsertsAnExplicitGapMarker() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("stale a\nstale b\nstale c", target: "w1:p1")
+        // The server's buffer shares not one line with the cache (restarted
+        // pane, cleared scrollback): no overlap, no guessing.
+        await transport.setAgentHistoryText("fresh 1\nfresh 2\nfresh 3", target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        let expected = [
+            "stale a", "stale b", "stale c",
+            AgentMonitorStore.gapMarkerText,
+            "fresh 1", "fresh 2", "fresh 3",
+        ].joined(separator: "\n")
+        #expect(String(try #require(store.snapshot).characters) == expected)
+        #expect(store.historyState == .exhausted)
+    }
+
+    @Test func agentNotIdleSurfacesAsUnavailableNeverAnError() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("live screen", target: "w1:p1")
+        await transport.setAgentHistoryReadFailure(
+            HerdrAPIError(code: "agent_not_idle", message: "agent is working"))
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        // The screen loaded; only history is unavailable, and honestly so.
+        #expect(store.state == .loaded)
+        #expect(store.historyState == .unavailable)
+        #expect(String(try #require(store.snapshot).characters) == "live screen")
+
+        // A later top-edge hit retries the read and lands the same way.
+        store.topEdgeReached()
+        try await waitUntil("the retried read should settle as unavailable") {
+            store.historyState == .unavailable
+        }
+        #expect(store.state == .loaded)
+        #expect(await agentReads(transport, source: .recent).count == 2)
+    }
+
+    @Test func failedBackfillSurfacesARetryableError() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("screen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        await transport.setAgentHistoryReadFailure(TransportError.timedOut)
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        #expect(store.state == .loaded)
+        #expect(store.historyState == .failed("The Host did not answer in time."))
+
+        await transport.setAgentHistoryReadFailure(nil)
+        await transport.setAgentHistoryText(
+            "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        await store.loadEarlierHistory()
+
+        #expect(store.historyState == .exhausted)
+        #expect(
+            String(try #require(store.snapshot).characters)
+                == "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3")
+    }
+
+    @Test func openingOnAnEmptyScreenPaintsTheEmptyState() async throws {
+        let transport = ScriptedTransport()
+        // No scripted text: the visible read answers "". The first install
+        // must still render, or the view loads forever.
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        #expect(store.state == .loaded)
+        let snapshot = try #require(store.snapshot)
+        #expect(snapshot.characters.isEmpty)
+        #expect(store.historyState == .exhausted)
+    }
+
+    @Test func backfillWaitsForAnInFlightVisibleRead() async throws {
+        let transport = ScriptedTransport()
+        let screen = (998...1000).map { "line \($0)" }.joined(separator: "\n")
+        let window = (1...1000).map { "line \($0)" }.joined(separator: "\n")
+        await transport.setAgentText(screen, target: "w1:p1")
+        await transport.setAgentHistoryText(window, target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+        #expect(store.historyState == .idle)
+
+        // A visible read in flight (a cadence poll or pull-to-refresh) holds
+        // the shared flight; the top-edge backfill must queue behind it
+        // rather than interleave and risk a spurious gap.
+        let gate = ScriptedTransportCallGate()
+        await transport.gateNextAgentRead(using: gate)
+        let refreshing = Task { await store.refresh() }
+        try await waitUntil("the visible read should be in flight") {
+            await gate.entryCount == 1
+        }
+        store.topEdgeReached()
+        #expect(store.historyState == .loading)
+        #expect(await agentReads(transport, source: .recent).count == 1)
+
+        await gate.open()
+        await refreshing.value
+        try await waitUntil("the queued backfill should run and exhaust") {
+            store.historyState == .exhausted
+        }
+
+        #expect(await agentReads(transport, source: .recent).count == 2)
+        let snapshot = try #require(store.snapshot)
+        #expect(String(snapshot.characters) == window)
+        #expect(!String(snapshot.characters).contains(AgentMonitorStore.gapMarkerText))
+    }
+
+    @Test func visibleReadsExtendTheLiveTailWhileWorking() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("l1\nl2\nl3\nl4\nl5", target: "w1:p1")
+        let store = AgentMonitorStore(
+            target: "w1:p1", initialStatus: .working
+        ) { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+
+        // A scrolled screen overlaps the cached tail: only fresh lines land.
+        await transport.setAgentText("l2\nl3\nl4\nl5\nl6", target: "w1:p1")
+        await store.refresh()
+        #expect(
+            String(try #require(store.snapshot).characters) == "l1\nl2\nl3\nl4\nl5\nl6")
+
+        // A repaint shares no overlap: the tail is replaced, not extended.
+        await transport.setAgentText("n1\nn2\nn3\nn4\nn5", target: "w1:p1")
+        await store.refresh()
+        #expect(String(try #require(store.snapshot).characters) == "n1\nn2\nn3\nn4\nn5")
+    }
+
+    private func agentReads(
+        _ transport: ScriptedTransport,
+        source: ReadSource
+    ) async -> [AgentReadParams] {
+        await transport.agentReadParams.filter { $0.source == source }
     }
 
     private func waitUntil(

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -735,13 +735,19 @@ struct AgentMonitorStoreTests {
 
         #expect(store.sendError == nil)
         #expect(store.isSendingKey == false)
+        // The refreshed screen shares nothing with the old one, so the
+        // scrollback seals the pre-send screen above a gap (#181) rather
+        // than discarding it.
         let snapshot = try #require(store.snapshot)
-        #expect(String(snapshot.characters) == "after ctrl+c")
+        #expect(
+            String(snapshot.characters)
+                == ["before", AgentMonitorStore.gapMarkerText, "after ctrl+c"]
+                .joined(separator: "\n"))
         #expect(
             await transport.agentSendKeysParams == [
                 AgentSendKeysParams(keys: ["ctrl+c"], target: "w1:p1")
             ])
-        #expect(await transport.agentReadParams.count == 2)
+        #expect(await agentReads(transport, source: .visible).count == 2)
     }
 
     @Test func sendFailureSurfacesWithoutRefreshing() async throws {
@@ -758,7 +764,7 @@ struct AgentMonitorStoreTests {
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "known screen")
         #expect(await transport.agentSendKeysParams.isEmpty)
-        #expect(await transport.agentReadParams.count == 1)
+        #expect(await agentReads(transport, source: .visible).count == 1)
     }
 
     @Test func successfulSendClearsAPriorSendError() async throws {
@@ -776,8 +782,13 @@ struct AgentMonitorStoreTests {
         await store.send(.escape)
 
         #expect(store.sendError == nil)
+        // As above: the unrelated refreshed screen lands below a gap while
+        // the pre-send screen stays in the scrollback (#181).
         let snapshot = try #require(store.snapshot)
-        #expect(String(snapshot.characters) == "dismissed")
+        #expect(
+            String(snapshot.characters)
+                == ["screen", AgentMonitorStore.gapMarkerText, "dismissed"]
+                .joined(separator: "\n"))
         #expect(
             await transport.agentSendKeysParams == [
                 AgentSendKeysParams(keys: ["esc"], target: "w1:p1")

--- a/Tests/HeelerTests/GeneratedWireTypesTests.swift
+++ b/Tests/HeelerTests/GeneratedWireTypesTests.swift
@@ -71,6 +71,15 @@ import Testing
         #expect(response.agent.paneID == "w3:pB")
     }
 
+    @Test func agentPromptedResponseRoundTripsLiveCapture() throws {
+        let json = #"{"type":"agent_prompted","agent":{"terminal_id":"term_656c59f7b902d1e","agent":"codex","terminal_title":"GoDrop","terminal_title_stripped":"GoDrop","agent_status":"working","workspace_id":"w3","tab_id":"w3:t2","pane_id":"w3:pB","focused":false,"cwd":"/Users/u/GoDrop","foreground_cwd":"/Users/u/GoDrop","revision":6}}"#
+
+        let response = try roundTrip(AgentPromptedResponse.self, json)
+
+        #expect(response.agent.agentStatus == .working)
+        #expect(response.agent.paneID == "w3:pB")
+    }
+
     @Test func sessionSnapshotResponseRoundTripsLiveCapture() throws {
         // Trimmed to one workspace/tab/pane/layout/agent; the layout keeps a
         // real split so PaneLayoutSplit is exercised.
@@ -212,6 +221,18 @@ import Testing
         let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         let fields = try #require(object)
         #expect(fields.keys.sorted() == ["args", "kind", "name", "pane_id", "timeout_ms"])
+    }
+
+    @Test func agentPromptParamsOmitWait() throws {
+        let params = AgentPromptParams(target: "w1:p1", text: "Continue")
+
+        let data = try JSONEncoder().encode(params)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let fields = try #require(object)
+
+        #expect(fields.keys.sorted() == ["target", "text"])
+        #expect(fields["target"] as? String == "w1:p1")
+        #expect(fields["text"] as? String == "Continue")
     }
 
     @Test func tabCreateParamsEncodeProtocolSeventeenFields() throws {

--- a/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
@@ -551,6 +551,10 @@ struct HeelerSSHTransportBehaviorE2ETests {
         #expect(agentRead.text == "\u{1B}[31mfixture agent output\u{1B}[0m")
         #expect(agentRead.source == .visible)
         #expect(agentRead.format == .ansi)
+        let prompted = try await transport.promptAgent(
+            AgentPromptParams(target: "pane-1", text: "fixture prompt"))
+        #expect(prompted.paneID == "pane-1")
+        #expect(prompted.status == .working)
         try await transport.closePane(PaneTarget(paneID: "pane-1"))
         try await transport.renameAgent(AgentRenameParams(target: "pane-1", name: "fixture"))
         try await transport.renameWorkspace(

--- a/Tests/HeelerTests/Support/FakeTransportConnector.swift
+++ b/Tests/HeelerTests/Support/FakeTransportConnector.swift
@@ -39,6 +39,10 @@ final actor FakeTransport: Transport {
         throw TransportError.channelFailed(detail: "FakeTransport does not script Agent reads")
     }
 
+    func promptAgent(_ params: AgentPromptParams) async throws -> Agent {
+        throw TransportError.channelFailed(detail: "FakeTransport does not script Agent prompts")
+    }
+
     func subscribeToEvents(_ subscriptions: [EventSubscription]) async throws -> HerdrEventStream {
         throw TransportError.channelFailed(detail: "FakeTransport does not script events")
     }

--- a/Tests/HeelerTests/Support/ScriptedTransport.swift
+++ b/Tests/HeelerTests/Support/ScriptedTransport.swift
@@ -12,6 +12,7 @@ final actor ScriptedTransport: Transport {
     private(set) var capturedSubscriptions: [[EventSubscription]] = []
     private(set) var paneReadParams: [PaneReadParams] = []
     private(set) var agentReadParams: [AgentReadParams] = []
+    private(set) var agentPromptParams: [AgentPromptParams] = []
     /// Every `agent.start` received, in order; the new-agent flow (#12)
     /// asserts on the params it forwarded.
     private(set) var agentStarts: [AgentLaunchRequest] = []
@@ -58,6 +59,8 @@ final actor ScriptedTransport: Transport {
     private var agentTexts: [String: String] = [:]
     private var agentReadFailure: (any Error)?
     private var nextAgentReadGate: ScriptedTransportCallGate?
+    private var agentPromptFailure: (any Error)?
+    private var nextAgentPromptGate: ScriptedTransportCallGate?
     private var missingPaneIDs: Set<String> = []
     private var nextStreamID: UInt64 = 0
     private var liveStreamID: UInt64?
@@ -141,6 +144,16 @@ final actor ScriptedTransport: Transport {
     /// Pauses the next Agent read after capturing its response.
     func gateNextAgentRead(using gate: ScriptedTransportCallGate) {
         nextAgentReadGate = gate
+    }
+
+    /// Makes every subsequent `promptAgent` throw `failure`.
+    func setAgentPromptFailure(_ failure: (any Error)?) {
+        agentPromptFailure = failure
+    }
+
+    /// Pauses the next Agent prompt after recording its params.
+    func gateNextAgentPrompt(using gate: ScriptedTransportCallGate) {
+        nextAgentPromptGate = gate
     }
 
     /// Scripts the `AgentInfo` `startAgent` returns; without it the fake
@@ -342,6 +355,16 @@ final actor ScriptedTransport: Transport {
             format: params.format ?? .text, paneID: params.target, revision: 0,
             source: params.source, tabID: "t", text: responseText,
             truncated: false, workspaceID: "w")
+    }
+
+    func promptAgent(_ params: AgentPromptParams) async throws -> Agent {
+        agentPromptParams.append(params)
+        let failure = agentPromptFailure
+        let gate = nextAgentPromptGate
+        nextAgentPromptGate = nil
+        await gate?.waitUntilOpen()
+        if let failure { throw failure }
+        return Agent(.fixture(paneID: params.target, status: .working))
     }
 
     func startAgent(_ request: AgentLaunchRequest) async throws -> Agent {

--- a/Tests/HeelerTests/Support/ScriptedTransport.swift
+++ b/Tests/HeelerTests/Support/ScriptedTransport.swift
@@ -62,6 +62,7 @@ final actor ScriptedTransport: Transport {
     private var nextStreamID: UInt64 = 0
     private var liveStreamID: UInt64?
     private var eventContinuation: AsyncThrowingStream<HerdrEvent, any Error>.Continuation?
+    private var nextSubscriptionGate: ScriptedTransportCallGate?
     private var nextAttachID: UInt64 = 0
     private var liveAttachID: UInt64?
     private var attachContinuation: AsyncThrowingStream<Data, any Error>.Continuation?
@@ -181,6 +182,11 @@ final actor ScriptedTransport: Transport {
 
     func gateNextAttachEnd(on gate: ScriptedTransportCallGate) {
         nextAttachEndGate = gate
+    }
+
+    /// Pauses the next events subscription after recording its requested set.
+    func gateNextSubscription(using gate: ScriptedTransportCallGate) {
+        nextSubscriptionGate = gate
     }
 
     /// Pushes one event onto the live stream; false if none is live.
@@ -385,6 +391,9 @@ final actor ScriptedTransport: Transport {
             throw TransportError.eventsChannelAlreadyOpen
         }
         capturedSubscriptions.append(subscriptions)
+        let gate = nextSubscriptionGate
+        nextSubscriptionGate = nil
+        await gate?.waitUntilOpen()
         if let missing = subscriptions.firstMissingPane(in: missingPaneIDs) {
             throw HerdrAPIError(code: "pane_not_found", message: "pane \(missing) not found")
         }

--- a/Tests/HeelerTests/Support/ScriptedTransport.swift
+++ b/Tests/HeelerTests/Support/ScriptedTransport.swift
@@ -58,6 +58,11 @@ final actor ScriptedTransport: Transport {
     private var agentTexts: [String: String] = [:]
     private var agentReadFailure: (any Error)?
     private var nextAgentReadGate: ScriptedTransportCallGate?
+    /// History-source (`recent`/`recent_unwrapped`) read scripting, separate
+    /// from the visible screen: Monitor's backfill tests script a wider
+    /// window than the live tail without disturbing visible-read tests.
+    private var agentHistoryTexts: [String: String] = [:]
+    private var agentHistoryReadFailure: (any Error)?
     private var missingPaneIDs: Set<String> = []
     private var nextStreamID: UInt64 = 0
     private var liveStreamID: UInt64?
@@ -136,6 +141,21 @@ final actor ScriptedTransport: Transport {
     /// Makes every subsequent `readAgent` throw `failure`.
     func setAgentReadFailure(_ failure: (any Error)?) {
         agentReadFailure = failure
+    }
+
+    /// Scripts the text `readAgent` returns for history sources (`recent`,
+    /// `recent_unwrapped`) on `target`; unscripted targets fall back to the
+    /// `setAgentText` value, as a server whose window equals its screen
+    /// would answer.
+    func setAgentHistoryText(_ text: String, target: String) {
+        agentHistoryTexts[target] = text
+    }
+
+    /// Makes every subsequent history-source `readAgent` throw `failure`
+    /// while leaving visible reads untouched — the `agent_not_idle` race
+    /// between the screen and a backfill.
+    func setAgentHistoryReadFailure(_ failure: (any Error)?) {
+        agentHistoryReadFailure = failure
     }
 
     /// Pauses the next Agent read after capturing its response.
@@ -332,8 +352,12 @@ final actor ScriptedTransport: Transport {
 
     func readAgent(_ params: AgentReadParams) async throws -> PaneReadResult {
         agentReadParams.append(params)
-        let responseText = agentTexts[params.target] ?? ""
-        let failure = agentReadFailure
+        let isHistoryRead = params.source != .visible
+        let responseText =
+            isHistoryRead
+            ? (agentHistoryTexts[params.target] ?? agentTexts[params.target] ?? "")
+            : (agentTexts[params.target] ?? "")
+        let failure = isHistoryRead ? (agentHistoryReadFailure ?? agentReadFailure) : agentReadFailure
         let gate = nextAgentReadGate
         nextAgentReadGate = nil
         await gate?.waitUntilOpen()

--- a/scripts/fixtures/fake-herdr-streamlocal.py
+++ b/scripts/fixtures/fake-herdr-streamlocal.py
@@ -285,6 +285,18 @@ class Server:
                 source=source,
                 output_format=output_format,
             )
+        if method == "agent.prompt":
+            request = params if isinstance(params, dict) else {}
+            is_expected_prompt = (
+                request.get("target") == "pane-1"
+                and request.get("text") == "fixture prompt"
+                and "wait" not in request
+            )
+            pane_id = "pane-1" if is_expected_prompt else "fixture:invalid-prompt"
+            return {
+                "type": "agent_prompted",
+                "agent": self._agent(pane_id, "workspace-1", status="working"),
+            }
         if method == "pane.close":
             return {"type": "ok"}
         if method == "tab.create":
@@ -349,13 +361,18 @@ class Server:
             },
         }
 
-    def _agent(self, pane_id: str = "pane-1", workspace_id: str = "workspace-1") -> object:
+    def _agent(
+        self,
+        pane_id: str = "pane-1",
+        workspace_id: str = "workspace-1",
+        status: str = "idle",
+    ) -> object:
         return {
             "terminal_id": "terminal-1",
             "agent": "codex",
             "terminal_title": "fixture",
             "terminal_title_stripped": "fixture",
-            "agent_status": "idle",
+            "agent_status": status,
             "workspace_id": workspace_id,
             "tab_id": "tab-worktree" if workspace_id == "workspace-worktree" else "tab-new",
             "pane_id": pane_id,

--- a/scripts/generate-wire-types.py
+++ b/scripts/generate-wire-types.py
@@ -51,6 +51,7 @@ METHODS = [
     "agent.focus",
     "agent.get",
     "agent.list",
+    "agent.prompt",
     "agent.read",
     "agent.rename",
     "agent.start",
@@ -82,6 +83,7 @@ RESULT_TAGS = [
     "pong",  # ping
     "agent_explain",  # agent.explain
     "agent_info",  # agent.get, agent.focus, agent.rename
+    "agent_prompted",  # agent.prompt
     "agent_started",  # agent.start
     "agent_list",  # agent.list
     "pane_read",  # pane.read, agent.read


### PR DESCRIPTION
## Summary

The Monitor follows a working Agent without a live terminal: a 2-second snapshot cadence while the Agent is working and the view is foreground (injected clock, no real sleeps in tests); zero polling on idle/done/blocked, relying on `pane.agent_status_changed` pushes plus pull-to-refresh. Status transitions surface without user action. A bottom-pinned view follows new output; a scrolled view freezes with a new-output pill. Change detection is textual (the wire revision field is always 0 and is never consulted).

The events stream reconnects with backoff and re-resolves the pane id on every resubscribe, so a dead pane degrades to an honest "live updates unavailable — pull to refresh" state instead of wedging the all-or-nothing subscribe (the `dropPaneSubscriptions` trap). The status-event relay in ConsoleStore is deliberate groundwork for the Composer (#182).

Closes #180 (part of #176).

## Test evidence

`xcodebuild test -only-testing:HeelerTests/AgentMonitorStoreTests -only-testing:HeelerTests/ConsoleStoreTests` in the package worktree: **57 tests in 2 suites, 0 failures**. No transport wire changes in this package; the full CI mirror runs again on the stacked transport packages and on merged main.

## Merge order

Stacked on #186 (feat/179-monitor-skeleton). Round merge order: #177 → #178 → #179 → #180 → #181 → #182 → #183; #183 rebases after this lands (both touch AgentMonitorView and CHANGELOG).