### PR TITLE
feat(monitor): composer with optimistic delivery states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ Entries reference the issue that motivated them.
   automatically, while scrolling up holds position behind a New Output jump.
   (#180)
 
+- Monitor now includes a local Composer. Drafting makes no network requests;
+  Send delivers the complete message once and shows delivery, Agent work, and
+  Done states from acknowledgments and status pushes. Failed messages can be
+  retried or returned to the draft without losing text, and drafts survive
+  Attach, backgrounding, and Host reconnects. (#182)
+
 - Settings > About now has Acknowledgements: every redistributed third-party
   component ships with its exact upstream licence notice, including libssh2
   and its secondary sources, OpenSSL, Ghostty and its stack, the monospaced

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		2D7DC2A884FB9BA311D265A6 /* SkillProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176C059114F4646026196943 /* SkillProbeTests.swift */; };
 		2E612B94231EF97A285C83D5 /* SSHSourcePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CFDDFD7A676ECD4EF29BDE /* SSHSourcePolicyTests.swift */; };
 		2E82149F859FCBF05F9E999B /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F09325DE68693680E5A3BB /* HerdrSocketLocationTests.swift */; };
+		30A73EC02C95FB2253E030E0 /* AgentComposerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC600664EA3CE8A3E591C62 /* AgentComposerStore.swift */; };
 		31E4ADB22D4D655E7CFDB749 /* TerminalInputControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05AD61D4FA60884234EA856C /* TerminalInputControllerTests.swift */; };
 		3286D6FBB12157F2A19A82CE /* AgentNotificationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB37CBDC9DE0CE539FC476A0 /* AgentNotificationRenderer.swift */; };
 		35205050C9CB8E473D8A28C0 /* Base64URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32413805C1AA874DBEE37547 /* Base64URL.swift */; };
@@ -106,6 +107,7 @@
 		6B34378D8F7396BBF0DBB825 /* StartAgentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2E07D2395573D9EF9DE8B9 /* StartAgentView.swift */; };
 		6C33AC12CE7ACC5730240A75 /* HeelerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F710C63524E24B79F95A898 /* HeelerApp.swift */; };
 		6CD1D3CCDB58EBFF5350AC7F /* AgentNotificationBannerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A319930B80D42FB33DC8E42 /* AgentNotificationBannerStoreTests.swift */; };
+		6DA75E728052945BC787BBD3 /* AgentComposerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362EF66CE6DA07688C3E5F63 /* AgentComposerStoreTests.swift */; };
 		6FB5BA238B79801E1FDA2849 /* ConsoleActivityDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F7218F35AFEB5DCDF8BAF5 /* ConsoleActivityDriver.swift */; };
 		71661C1008468E60B82B74CD /* SSHTransportSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43AE8B2A62473EBA9EA090E /* SSHTransportSettings.swift */; };
 		7238C957097EADD61E823E9D /* NotificationEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61A04DBA56C56925B594FF1 /* NotificationEnvelope.swift */; };
@@ -194,6 +196,7 @@
 		C3CAE683F15A2DB5866FE702 /* HeelerSSHJumpHostGateE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F5C337F9BC29D46E48E35E /* HeelerSSHJumpHostGateE2ETests.swift */; };
 		C626797B247A8ED6513D2EBB /* HeelerSSHSessionE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1AEA55D1F06B12005DEEE5F /* HeelerSSHSessionE2ETests.swift */; };
 		C6E6E92365F39EDDD50CDE49 /* WeakNetworkE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB8C5EA497D1094E86F69C4 /* WeakNetworkE2ETests.swift */; };
+		C8D11877C278994387199B8B /* AgentComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9493AFCF4C4CDCF278101695 /* AgentComposerView.swift */; };
 		C9241B10F450B97F215FB28E /* RenameStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6E7022FBB1A7A39C88ACA9 /* RenameStoreTests.swift */; };
 		C99BC52057BA048DDC4DE046 /* TerminalByteFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = C681336687D32709DA583BCC /* TerminalByteFeed.swift */; };
 		C9E8028C15EC02F3F36B2B26 /* NotificationRegistrationFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67AAFD0BF81441DB59EEF7AA /* NotificationRegistrationFile.swift */; };
@@ -325,6 +328,7 @@
 		32413805C1AA874DBEE37547 /* Base64URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64URL.swift; sourceTree = "<group>"; };
 		32AE04F29C794799B45E5C68 /* Host.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Host.swift; sourceTree = "<group>"; };
 		33EF900D8EF7982B54965402 /* HostFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostFormView.swift; sourceTree = "<group>"; };
+		362EF66CE6DA07688C3E5F63 /* AgentComposerStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentComposerStoreTests.swift; sourceTree = "<group>"; };
 		365757614D9876F58A48CEDA /* NotificationConfigFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationConfigFileTests.swift; sourceTree = "<group>"; };
 		36B41E884E430DCF9BE26B91 /* AgentArgumentsField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentArgumentsField.swift; sourceTree = "<group>"; };
 		3801638051F3E5F394CF3FBD /* ReconnectPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectPolicyTests.swift; sourceTree = "<group>"; };
@@ -421,6 +425,7 @@
 		9394E039D63A2FEE9BAB1D25 /* HeelerNotificationService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HeelerNotificationService.entitlements; sourceTree = "<group>"; };
 		943C187E6425414801A4734E /* NotificationPrivacyCopyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPrivacyCopyTests.swift; sourceTree = "<group>"; };
 		9469465EF16322DDC174CD5E /* TerminalThemePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemePickerView.swift; sourceTree = "<group>"; };
+		9493AFCF4C4CDCF278101695 /* AgentComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentComposerView.swift; sourceTree = "<group>"; };
 		9578B0F124B9B77740E8E38F /* SkillsPaneStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsPaneStoreTests.swift; sourceTree = "<group>"; };
 		95EEB8A9845A6DE36DD3D9D1 /* Heeler.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Heeler.entitlements; sourceTree = "<group>"; };
 		962BDE6D5BFCD443EC3B5FF4 /* SnippetStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetStoreTests.swift; sourceTree = "<group>"; };
@@ -498,6 +503,7 @@
 		EB05396E5E55060B5A23621C /* NotificationKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationKeyStoreTests.swift; sourceTree = "<group>"; };
 		EB430B706185A38891A5DAC2 /* SnippetsManagementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsManagementView.swift; sourceTree = "<group>"; };
 		ED83CC7F1D133006430FD357 /* JetBrainsMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Regular.ttf"; sourceTree = "<group>"; };
+		EDC600664EA3CE8A3E591C62 /* AgentComposerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentComposerStore.swift; sourceTree = "<group>"; };
 		EEB863EF2AD319A412DB564A /* notification-payload-v1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "notification-payload-v1.json"; sourceTree = "<group>"; };
 		F07A0F64626D74A8EC9A1FE2 /* AttachTerminalStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachTerminalStore.swift; sourceTree = "<group>"; };
 		F261A0911D08819AFC013F1E /* JSONValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueTests.swift; sourceTree = "<group>"; };
@@ -545,6 +551,7 @@
 		11AC34F8912DA80C6DF2524F /* HeelerTests */ = {
 			isa = PBXGroup;
 			children = (
+				362EF66CE6DA07688C3E5F63 /* AgentComposerStoreTests.swift */,
 				842E5C0930772F4B79955DFC /* AgentMonitorStoreTests.swift */,
 				64D3B8E2EB97A8376B333914 /* AgentNameTests.swift */,
 				0A319930B80D42FB33DC8E42 /* AgentNotificationBannerStoreTests.swift */,
@@ -655,6 +662,8 @@
 		1E9D44A38E208A1D0329903E /* Monitor */ = {
 			isa = PBXGroup;
 			children = (
+				EDC600664EA3CE8A3E591C62 /* AgentComposerStore.swift */,
+				9493AFCF4C4CDCF278101695 /* AgentComposerView.swift */,
 				7D5D29D0F34EC475220D1085 /* AgentMonitorStore.swift */,
 				68C51ED25429F47720E29976 /* AgentMonitorView.swift */,
 				8C68AA831B8C9DB0ACCA4D50 /* ANSISnapshotRenderer.swift */,
@@ -1148,6 +1157,8 @@
 				6197AD73E1967C19E32176EB /* AgentArgumentsField.swift in Sources */,
 				17F313D8AE9647F8F5D4DBFD /* AgentAttachStore.swift in Sources */,
 				12B61E17D212416E86EE63ED /* AgentCardView.swift in Sources */,
+				30A73EC02C95FB2253E030E0 /* AgentComposerStore.swift in Sources */,
+				C8D11877C278994387199B8B /* AgentComposerView.swift in Sources */,
 				E1C95FE0F5AC6271001DBF60 /* AgentDetailView.swift in Sources */,
 				2BFEB992D411C0FF7BDE4361 /* AgentMonitorStore.swift in Sources */,
 				00BB32665B566815194A17D5 /* AgentMonitorView.swift in Sources */,
@@ -1288,6 +1299,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0D191EBCDBE44260BB137F1A /* ANSISnapshotRendererTests.swift in Sources */,
+				6DA75E728052945BC787BBD3 /* AgentComposerStoreTests.swift in Sources */,
 				CEFDE26E6526835254F14493 /* AgentMonitorStoreTests.swift in Sources */,
 				E379C1AD65B445D4E08614CF /* AgentNameTests.swift in Sources */,
 				6CD1D3CCDB58EBFF5350AC7F /* AgentNotificationBannerStoreTests.swift in Sources */,

--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -39,6 +39,11 @@ final class ConsoleStore {
     @ObservationIgnored private var agentStatusObservers: [
         ConsoleAgent.ID: [UUID: AsyncStream<AgentStatusUpdate>.Continuation]
     ] = [:]
+    /// Composer ownership sits above the detail branch so a transient
+    /// missing-Agent placeholder during reconnect cannot destroy a draft.
+    @ObservationIgnored private var composerStores: [
+        ConsoleAgent.ID: AgentComposerStore
+    ] = [:]
     @ObservationIgnored private let makeSession:
         @Sendable (Host, [EventSubscription]) -> EventsSession
     @ObservationIgnored private let snapshotRetryDelay: Duration
@@ -62,6 +67,7 @@ final class ConsoleStore {
     /// projection because its connection coordinates may have changed.
     func setHosts(_ hosts: [Host]) {
         let incoming = Dictionary(hosts.map { ($0.id, $0) }) { _, last in last }
+        composerStores = composerStores.filter { incoming[$0.key.hostID] != nil }
         for (id, projection) in projections where incoming[id] != projection.host {
             projection.end()
             projections[id] = nil
@@ -258,6 +264,33 @@ final class ConsoleStore {
         try await projection(for: hostID).session.withTransport { transport in
             try await transport.readAgent(params)
         }
+    }
+
+    /// Composer's one-shot delivery source. Like Monitor reads, prompts
+    /// borrow the Host's current Console connection rather than dialing a
+    /// parallel connection or holding an RPC open for Agent completion.
+    func promptAgent(_ params: AgentPromptParams, on hostID: Host.ID) async throws -> Agent {
+        try await projection(for: hostID).session.withTransport { transport in
+            try await transport.promptAgent(params)
+        }
+    }
+
+    /// One Composer per selected Agent for the lifetime of its Host catalog
+    /// entry. The Console detail may be replaced by a reconnect placeholder;
+    /// retaining the store here keeps its entirely local draft intact.
+    func composerStore(for agent: ConsoleAgent) -> AgentComposerStore {
+        if let existing = composerStores[agent.id] { return existing }
+        let hostID = agent.hostID
+        let store = AgentComposerStore(
+            target: agent.agent.paneID,
+            initialStatus: agent.agent.status,
+            statusUpdates: agentStatusUpdates(for: agent.id)
+        ) { [weak self] params in
+            guard let self else { throw TransportError.cancelled }
+            return try await self.promptAgent(params, on: hostID)
+        }
+        composerStores[agent.id] = store
+        return store
     }
 
     /// A latest-value view of the existing `pane.agent_status_changed`

--- a/Sources/Heeler/Demo/DemoScreenshotMode.swift
+++ b/Sources/Heeler/Demo/DemoScreenshotMode.swift
@@ -376,6 +376,14 @@
                 workspaceID: agent?.workspaceID ?? "demo")
         }
 
+        func promptAgent(_ params: AgentPromptParams) async throws -> Agent {
+            guard let agent = profile.snapshot.agents.first(where: { $0.paneID == params.target })
+            else {
+                throw TransportError.malformedResponse("Demo profile has no matching Agent.")
+            }
+            return Agent(agent)
+        }
+
         func startAgent(_ request: AgentLaunchRequest) async throws -> Agent {
             guard let first = profile.snapshot.agents.first else {
                 throw TransportError.malformedResponse("Demo profile has no Agents.")

--- a/Sources/Heeler/Monitor/AgentComposerStore.swift
+++ b/Sources/Heeler/Monitor/AgentComposerStore.swift
@@ -159,11 +159,11 @@ final class AgentComposerStore: ComposerDraftOperations {
         }
         switch agentStatus {
         case .working:
-            .working
+            return .working
         case .done:
-            .done
+            return .done
         default:
-            .acknowledged
+            return .acknowledged
         }
     }
 

--- a/Sources/Heeler/Monitor/AgentComposerStore.swift
+++ b/Sources/Heeler/Monitor/AgentComposerStore.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Observation
+
+/// Local draft operations shared by the plain-text Composer now and future
+/// Snippet, Skill, and Staged Image path insertion surfaces.
+@MainActor
+protocol ComposerDraftOperations: AnyObject {
+    func replaceDraft(with text: String)
+    func insertIntoDraft(_ text: String)
+}
+
+/// Owns Monitor's local draft and optimistic delivery echoes. Draft edits do
+/// not touch Transport; only an explicit send emits one `agent.prompt` RPC.
+@MainActor
+@Observable
+final class AgentComposerStore: ComposerDraftOperations {
+    struct Message: Identifiable, Equatable {
+        let id: UUID
+        let text: String
+        fileprivate var agentWasWorkingAtSend: Bool
+        fileprivate var statusRevisionAtSend: UInt64
+        fileprivate(set) var state: DeliveryState
+    }
+
+    enum DeliveryState: Equatable {
+        case sending
+        case delivered(AgentProgress)
+        case failed(String)
+    }
+
+    enum AgentProgress: Equatable {
+        case acknowledged
+        case agentBusy
+        case working
+        case done
+    }
+
+    private(set) var messages: [Message] = []
+    private(set) var draft = ""
+
+    private let target: String
+    private var agentStatus: AgentStatus
+    private var statusRevision: UInt64 = 0
+    private let statusUpdates: AsyncStream<ConsoleStore.AgentStatusUpdate>?
+    private let prompt: @Sendable (AgentPromptParams) async throws -> Agent
+    @ObservationIgnored private var hasOpened = false
+    @ObservationIgnored private var statusTask: Task<Void, Never>?
+
+    init(
+        target: String,
+        initialStatus: AgentStatus = .idle,
+        statusUpdates: AsyncStream<ConsoleStore.AgentStatusUpdate>? = nil,
+        prompt: @escaping @Sendable (AgentPromptParams) async throws -> Agent
+    ) {
+        self.target = target
+        agentStatus = initialStatus
+        self.statusUpdates = statusUpdates
+        self.prompt = prompt
+    }
+
+    deinit {
+        statusTask?.cancel()
+    }
+
+    var canSend: Bool {
+        draft.contains(where: { !$0.isWhitespace })
+    }
+
+    func replaceDraft(with text: String) {
+        draft = text
+    }
+
+    func insertIntoDraft(_ text: String) {
+        draft.append(text)
+    }
+
+    /// Starts consuming Console's existing per-Agent status fan-out. This
+    /// does not open a Transport event stream or perform an RPC.
+    func open() {
+        guard !hasOpened else { return }
+        hasOpened = true
+        guard let statusUpdates else { return }
+        statusTask = Task { [weak self] in
+            for await update in statusUpdates {
+                guard !Task.isCancelled, let self else { return }
+                if let status = update.status {
+                    self.agentStatusDidChange(status)
+                }
+            }
+        }
+    }
+
+    func send() async {
+        guard canSend else { return }
+        let message = Message(
+            id: UUID(), text: draft,
+            agentWasWorkingAtSend: agentStatus == .working,
+            statusRevisionAtSend: statusRevision,
+            state: .sending)
+        draft = ""
+        messages.append(message)
+        await deliver(message.id)
+    }
+
+    func retry(_ id: Message.ID) async {
+        guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
+        guard case .failed = messages[index].state else { return }
+        messages[index].agentWasWorkingAtSend = agentStatus == .working
+        messages[index].statusRevisionAtSend = statusRevision
+        messages[index].state = .sending
+        await deliver(id)
+    }
+
+    /// Removes a failed echo and restores all of its text to the draft. If
+    /// the user has already started another draft, both are kept in order.
+    func withdrawToDraft(_ id: Message.ID) {
+        guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
+        guard case .failed = messages[index].state else { return }
+        let text = messages.remove(at: index).text
+        draft = draft.isEmpty ? text : "\(text)\n\(draft)"
+    }
+
+    func agentStatusDidChange(_ status: AgentStatus) {
+        guard agentStatus != status else { return }
+        agentStatus = status
+        statusRevision &+= 1
+        for index in messages.indices {
+            guard case .delivered(let progress) = messages[index].state else { continue }
+            switch status {
+            case .working where progress != .done:
+                messages[index].state = .delivered(.working)
+            case .done:
+                messages[index].state = .delivered(.done)
+            default:
+                break
+            }
+        }
+    }
+
+    private func deliver(_ id: Message.ID) async {
+        guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
+        let text = messages[index].text
+        do {
+            _ = try await prompt(AgentPromptParams(target: target, text: text))
+            guard let acknowledgedIndex = messages.firstIndex(where: { $0.id == id }) else {
+                return
+            }
+            messages[acknowledgedIndex].state = .delivered(
+                progressAfterAcknowledgment(for: messages[acknowledgedIndex]))
+        } catch {
+            guard let failedIndex = messages.firstIndex(where: { $0.id == id }) else { return }
+            messages[failedIndex].state = .failed(Self.message(for: error))
+        }
+    }
+
+    private func progressAfterAcknowledgment(for message: Message) -> AgentProgress {
+        guard message.statusRevisionAtSend != statusRevision else {
+            return message.agentWasWorkingAtSend ? .agentBusy : .acknowledged
+        }
+        switch agentStatus {
+        case .working:
+            .working
+        case .done:
+            .done
+        default:
+            .acknowledged
+        }
+    }
+
+    private static func message(for error: any Error) -> String {
+        switch error {
+        case TransportError.sshUnreachable:
+            "The Host is not connected. Check the connection and retry."
+        case TransportError.timedOut:
+            "The Host did not answer. Check the connection and retry."
+        case let error as HerdrAPIError:
+            "herdr rejected the message: \(error.message)"
+        case let error as TransportError:
+            error.connectionGuidance
+        default:
+            "The message could not be sent. Check the connection and retry."
+        }
+    }
+}

--- a/Sources/Heeler/Monitor/AgentComposerStore.swift
+++ b/Sources/Heeler/Monitor/AgentComposerStore.swift
@@ -19,6 +19,7 @@ final class AgentComposerStore: ComposerDraftOperations {
         let text: String
         fileprivate var agentWasWorkingAtSend: Bool
         fileprivate var statusRevisionAtSend: UInt64
+        fileprivate var observedWorkingAfterSend: Bool
         fileprivate(set) var state: DeliveryState
     }
 
@@ -96,6 +97,7 @@ final class AgentComposerStore: ComposerDraftOperations {
             id: UUID(), text: draft,
             agentWasWorkingAtSend: agentStatus == .working,
             statusRevisionAtSend: statusRevision,
+            observedWorkingAfterSend: false,
             state: .sending)
         draft = ""
         messages.append(message)
@@ -107,6 +109,7 @@ final class AgentComposerStore: ComposerDraftOperations {
         guard case .failed = messages[index].state else { return }
         messages[index].agentWasWorkingAtSend = agentStatus == .working
         messages[index].statusRevisionAtSend = statusRevision
+        messages[index].observedWorkingAfterSend = false
         messages[index].state = .sending
         await deliver(id)
     }
@@ -125,11 +128,21 @@ final class AgentComposerStore: ComposerDraftOperations {
         agentStatus = status
         statusRevision &+= 1
         for index in messages.indices {
+            if status == .working,
+                messages[index].statusRevisionAtSend != statusRevision
+            {
+                messages[index].observedWorkingAfterSend = true
+            }
             guard case .delivered(let progress) = messages[index].state else { continue }
             switch status {
-            case .working where progress != .done:
+            case .working
+                where progress != .done && messages[index].observedWorkingAfterSend:
                 messages[index].state = .delivered(.working)
-            case .done:
+            case .done
+                where messages[index].observedWorkingAfterSend
+                    || !messages[index].agentWasWorkingAtSend:
+                messages[index].state = .delivered(.done)
+            case .idle where messages[index].observedWorkingAfterSend:
                 messages[index].state = .delivered(.done)
             default:
                 break
@@ -154,17 +167,24 @@ final class AgentComposerStore: ComposerDraftOperations {
     }
 
     private func progressAfterAcknowledgment(for message: Message) -> AgentProgress {
-        guard message.statusRevisionAtSend != statusRevision else {
-            return message.agentWasWorkingAtSend ? .agentBusy : .acknowledged
-        }
-        switch agentStatus {
-        case .working:
-            return .working
-        case .done:
+        if message.observedWorkingAfterSend {
+            switch agentStatus {
+            case .working:
+                return .working
+            case .done, .idle:
+                return .done
+            default:
+                break
+            }
+        } else if !message.agentWasWorkingAtSend,
+            message.statusRevisionAtSend != statusRevision,
+            agentStatus == .done
+        {
+            // The status stream keeps only the newest event. A fast
+            // working-to-done pair can therefore arrive as Done alone.
             return .done
-        default:
-            return .acknowledged
         }
+        return message.agentWasWorkingAtSend ? .agentBusy : .acknowledged
     }
 
     private static func message(for error: any Error) -> String {

--- a/Sources/Heeler/Monitor/AgentComposerView.swift
+++ b/Sources/Heeler/Monitor/AgentComposerView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+/// Monitor's native, local-first message surface. It renders optimistic
+/// echoes but never infers structured conversation history from terminal
+/// output (ADR 0012).
+struct AgentComposerView: View {
+    let store: AgentComposerStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if !store.messages.isEmpty {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 8) {
+                            ForEach(store.messages) { message in
+                                messageRow(message)
+                                    .id(message.id)
+                            }
+                        }
+                    }
+                    .defaultScrollAnchor(.bottom)
+                    .onChange(of: store.messages.count) {
+                        guard let latest = store.messages.last else { return }
+                        proxy.scrollTo(latest.id, anchor: .bottom)
+                    }
+                }
+                .frame(maxHeight: 176)
+                .accessibilityLabel("Sent messages")
+            }
+
+            Text("Message")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(alignment: .bottom, spacing: 10) {
+                TextField(
+                    "Message",
+                    text: Binding(
+                        get: { store.draft },
+                        set: { store.replaceDraft(with: $0) }),
+                    axis: .vertical
+                )
+                .lineLimit(1...5)
+                .textFieldStyle(.plain)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
+                .accessibilityLabel("Message")
+
+                Button("Send", systemImage: "arrow.up.circle.fill") {
+                    Task { await store.send() }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!store.canSend)
+                .accessibilityHint("Delivers the complete draft to the Agent")
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 10)
+        .background(.bar)
+    }
+
+    private func messageRow(_ message: AgentComposerStore.Message) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(message.text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
+
+            statusLabel(for: message.state)
+                .font(.footnote)
+
+            if case .failed(let detail) = message.state {
+                Text(detail)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                HStack(spacing: 8) {
+                    Button("Retry", systemImage: "arrow.clockwise") {
+                        Task { await store.retry(message.id) }
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Button("Edit Draft", systemImage: "pencil") {
+                        store.withdrawToDraft(message.id)
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .controlSize(.small)
+            }
+        }
+        .padding(10)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    @ViewBuilder
+    private func statusLabel(for state: AgentComposerStore.DeliveryState) -> some View {
+        switch state {
+        case .sending:
+            Label("Sending…", systemImage: "arrow.up.circle")
+                .foregroundStyle(.secondary)
+        case .delivered(.acknowledged):
+            Label("Delivered", systemImage: "checkmark.circle")
+                .foregroundStyle(.secondary)
+        case .delivered(.agentBusy):
+            Label("Delivered, Agent busy", systemImage: "clock")
+                .foregroundStyle(.secondary)
+        case .delivered(.working):
+            Label("Agent working", systemImage: "gearshape.2")
+                .foregroundStyle(.secondary)
+        case .delivered(.done):
+            Label("Done", systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.secondary)
+        case .failed:
+            Label("Couldn't send", systemImage: "exclamationmark.triangle")
+                .foregroundStyle(.red)
+        }
+    }
+}

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -16,6 +16,7 @@ struct AgentDetailView: View {
     private let onClosed: () -> Void
     @Environment(\.scenePhase) private var scenePhase
     @State private var monitor: AgentMonitorStore
+    @State private var composer: AgentComposerStore
     @State private var attach: AgentAttachStore
     @State private var isShowingAttach = false
 
@@ -31,6 +32,7 @@ struct AgentDetailView: View {
         onSwitch: @escaping (ConsoleAgent.ID) -> Void,
         onClosed: @escaping () -> Void,
         monitorStore: AgentMonitorStore? = nil,
+        composerStore: AgentComposerStore? = nil,
         attachStore: AgentAttachStore? = nil
     ) {
         self.agent = agent
@@ -51,6 +53,8 @@ struct AgentDetailView: View {
             ) { [console, agent] params in
                 try await console.readAgent(params, on: agent.hostID)
             })
+        _composer = State(
+            initialValue: composerStore ?? console.composerStore(for: agent))
         _attach = State(
             initialValue: attachStore ?? AgentAttachStore(
                 target: agent.agent.paneID,
@@ -65,7 +69,12 @@ struct AgentDetailView: View {
     }
 
     var body: some View {
-        monitorSurface
+        VStack(spacing: 0) {
+            monitorSurface
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Divider()
+            AgentComposerView(store: composer)
+        }
             .navigationTitle(title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -97,7 +106,10 @@ struct AgentDetailView: View {
                     await monitor.refreshOnReturn()
                 }
             }
-            .task { await monitor.open() }
+            .task {
+                composer.open()
+                await monitor.open()
+            }
             .onChange(of: scenePhase, initial: true) { _, phase in
                 monitor.setForeground(phase == .active)
             }

--- a/Sources/Heeler/Transport/Generated/HerdrAPITypes.swift
+++ b/Sources/Heeler/Transport/Generated/HerdrAPITypes.swift
@@ -137,6 +137,44 @@ struct AgentListResponse: Codable, Equatable, Sendable {
     }
 }
 
+/// herdr schema `$defs/AgentPromptParams`.
+struct AgentPromptParams: Codable, Equatable, Sendable {
+    let target: String
+    let text: String
+    let wait: AgentPromptWaitOptions?
+
+    init(target: String, text: String, wait: AgentPromptWaitOptions? = nil) {
+        self.target = target
+        self.text = text
+        self.wait = wait
+    }
+}
+
+/// herdr schema `$defs/AgentPromptWaitOptions`.
+struct AgentPromptWaitOptions: Codable, Equatable, Sendable {
+    let timeoutMs: Int?
+    let until: [AgentStatus]?
+
+    init(timeoutMs: Int? = nil, until: [AgentStatus]? = nil) {
+        self.timeoutMs = timeoutMs
+        self.until = until
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case timeoutMs = "timeout_ms"
+        case until
+    }
+}
+
+/// The `"type":"agent_prompted"` result payload of herdr's success_response schema.
+struct AgentPromptedResponse: Codable, Equatable, Sendable {
+    let agent: AgentInfo
+
+    init(agent: AgentInfo) {
+        self.agent = agent
+    }
+}
+
 /// herdr schema `$defs/AgentReadParams`.
 struct AgentReadParams: Codable, Equatable, Sendable {
     let format: ReadFormat?

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -617,6 +617,12 @@ actor HeelerSSHTransport: Transport {
             .read
     }
 
+    func promptAgent(_ params: AgentPromptParams) async throws -> Agent {
+        let response = try await request(
+            method: "agent.prompt", params: params, decoding: AgentPromptedResponse.self)
+        return Agent(response.agent)
+    }
+
     func startAgent(_ launch: AgentLaunchRequest) async throws -> Agent {
         let created = try await request(
             method: "tab.create",

--- a/Sources/Heeler/Transport/Transport.swift
+++ b/Sources/Heeler/Transport/Transport.swift
@@ -37,6 +37,11 @@ protocol Transport: Sendable {
     /// snapshot and requests ANSI output for local rendering (ADR 0012).
     func readAgent(_ params: AgentReadParams) async throws -> PaneReadResult
 
+    /// Delivers one complete local draft through `agent.prompt`. The request
+    /// deliberately omits `wait`: the response acknowledges delivery into
+    /// the Agent's pane, while Agent Status events report subsequent work.
+    func promptAgent(_ params: AgentPromptParams) async throws -> Agent
+
     /// Starts a new Agent: the new-agent flow (#12, User Story 8 — dispatch
     /// work from the road). Creates a fresh herdr tab in the chosen workspace,
     /// starts the requested agent in its root pane, and returns the Agent once

--- a/Tests/HeelerTests/AgentComposerStoreTests.swift
+++ b/Tests/HeelerTests/AgentComposerStoreTests.swift
@@ -1,0 +1,231 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@MainActor
+@Suite("Agent Composer store")
+struct AgentComposerStoreTests {
+    @Test func typingStaysLocalAndSendUsesOnePromptRPC() async throws {
+        let transport = ScriptedTransport()
+        let promptGate = ScriptedTransportCallGate()
+        await transport.gateNextAgentPrompt(using: promptGate)
+        let store = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+
+        store.replaceDraft(with: "Fix the failing tests")
+
+        #expect(store.draft == "Fix the failing tests")
+        #expect(await transport.agentPromptParams.isEmpty)
+
+        let send = Task { await store.send() }
+        try await waitUntil("the prompt should be waiting for its acknowledgment") {
+            await promptGate.entryCount == 1
+        }
+
+        #expect(store.draft.isEmpty)
+        #expect(store.messages.map(\.text) == ["Fix the failing tests"])
+        #expect(store.messages.map(\.state) == [.sending])
+        #expect(
+            await transport.agentPromptParams == [
+                AgentPromptParams(target: "w1:p1", text: "Fix the failing tests")
+            ])
+
+        await promptGate.open()
+        await send.value
+
+        #expect(store.messages.map(\.state) == [.delivered(.acknowledged)])
+        #expect(await transport.agentPromptParams.count == 1)
+    }
+
+    @Test func statusPushesAdvanceAcknowledgedMessageFromWorkingToDone() async throws {
+        let transport = ScriptedTransport()
+        let (updates, continuation) = AsyncStream.makeStream(
+            of: ConsoleStore.AgentStatusUpdate.self)
+        let store = AgentComposerStore(
+            target: "w1:p1", statusUpdates: updates
+        ) { params in
+            try await transport.promptAgent(params)
+        }
+        store.open()
+        store.replaceDraft(with: "Continue")
+
+        await store.send()
+        #expect(store.messages.map(\.state) == [.delivered(.acknowledged)])
+
+        continuation.yield(
+            ConsoleStore.AgentStatusUpdate(status: .working, liveUpdatesAvailable: true))
+        try await waitUntil("Working should come from the status stream") {
+            store.messages.map(\.state) == [.delivered(.working)]
+        }
+
+        continuation.yield(
+            ConsoleStore.AgentStatusUpdate(status: .done, liveUpdatesAvailable: true))
+        try await waitUntil("Done should come from the status stream") {
+            store.messages.map(\.state) == [.delivered(.done)]
+        }
+
+        #expect(await transport.agentPromptParams.count == 1)
+        #expect(await transport.agentPromptParams.first?.wait == nil)
+        continuation.finish()
+    }
+
+    @Test func sendingWhileWorkingAcknowledgesThatTheAgentIsBusy() async {
+        let transport = ScriptedTransport()
+        let store = AgentComposerStore(target: "w1:p1", initialStatus: .working) { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Queue this next")
+
+        await store.send()
+
+        #expect(store.messages.map(\.state) == [.delivered(.agentBusy)])
+        #expect(await transport.agentPromptParams.count == 1)
+    }
+
+    @Test func priorDoneStatusDoesNotClaimThatANewMessageIsDone() async {
+        let transport = ScriptedTransport()
+        let store = AgentComposerStore(target: "w1:p1", initialStatus: .done) { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "One more request")
+
+        await store.send()
+
+        #expect(store.messages.map(\.state) == [.delivered(.acknowledged)])
+    }
+
+    @Test func statusArrivingBeforeAcknowledgmentIsAppliedAfterDelivery() async throws {
+        let transport = ScriptedTransport()
+        let promptGate = ScriptedTransportCallGate()
+        await transport.gateNextAgentPrompt(using: promptGate)
+        let store = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Start now")
+        let send = Task { await store.send() }
+        try await waitUntil("the prompt should be in flight") {
+            await promptGate.entryCount == 1
+        }
+
+        store.agentStatusDidChange(.working)
+        await promptGate.open()
+        await send.value
+
+        #expect(store.messages.map(\.state) == [.delivered(.working)])
+    }
+
+    @Test func failedSendCanRetryWithoutLosingItsText() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentPromptFailure(TransportError.timedOut)
+        let store = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Please retry this")
+        await store.send()
+        let message = try #require(store.messages.first)
+
+        #expect(
+            message.state
+                == .failed("The Host did not answer. Check the connection and retry."))
+        #expect(message.text == "Please retry this")
+
+        await transport.setAgentPromptFailure(nil)
+        let retryGate = ScriptedTransportCallGate()
+        await transport.gateNextAgentPrompt(using: retryGate)
+        let retry = Task { await store.retry(message.id) }
+        try await waitUntil("retry should return to Sending") {
+            await retryGate.entryCount == 1 && store.messages.first?.state == .sending
+        }
+        await retryGate.open()
+        await retry.value
+
+        #expect(store.messages.first?.text == "Please retry this")
+        #expect(store.messages.first?.state == .delivered(.acknowledged))
+        #expect(await transport.agentPromptParams.count == 2)
+    }
+
+    @Test func withdrawingFailurePreservesTheFailedTextAndNewDraft() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentPromptFailure(TransportError.sshUnreachable)
+        let store = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Earlier message")
+        await store.send()
+        let failedID = try #require(store.messages.first?.id)
+        store.replaceDraft(with: "New thought")
+
+        store.withdrawToDraft(failedID)
+
+        #expect(store.messages.isEmpty)
+        #expect(store.draft == "Earlier message\nNew thought")
+        #expect(await transport.agentPromptParams.count == 1)
+    }
+
+    @Test func reconnectStatusUpdatesDoNotTouchTheLocalDraft() async throws {
+        let transport = ScriptedTransport()
+        let (updates, continuation) = AsyncStream.makeStream(
+            of: ConsoleStore.AgentStatusUpdate.self)
+        let store = AgentComposerStore(
+            target: "w1:p1", statusUpdates: updates
+        ) { params in
+            try await transport.promptAgent(params)
+        }
+        store.open()
+        store.replaceDraft(with: "Survive Attach, background, and reconnect")
+
+        continuation.yield(
+            ConsoleStore.AgentStatusUpdate(status: nil, liveUpdatesAvailable: false))
+        continuation.yield(
+            ConsoleStore.AgentStatusUpdate(status: .idle, liveUpdatesAvailable: true))
+        try await waitUntil("status recovery should be consumed") {
+            await transport.agentPromptParams.isEmpty
+        }
+
+        #expect(store.draft == "Survive Attach, background, and reconnect")
+        #expect(store.messages.isEmpty)
+        #expect(await transport.agentPromptParams.isEmpty)
+        continuation.finish()
+    }
+
+    @Test func consoleOwnershipPreservesDraftAcrossReconnectViewReplacement() throws {
+        let console = ConsoleStore()
+        let hostID = try #require(
+            UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+        let agentBeforeReconnect = makeAgent(hostID: hostID, status: .working)
+        let firstStore = console.composerStore(for: agentBeforeReconnect)
+        firstStore.replaceDraft(with: "Keep this local draft")
+
+        let agentAfterReconnect = makeAgent(hostID: hostID, status: .idle)
+        let replacementStore = console.composerStore(for: agentAfterReconnect)
+
+        #expect(firstStore === replacementStore)
+        #expect(replacementStore.draft == "Keep this local draft")
+    }
+
+    private func waitUntil(
+        _ comment: Comment,
+        timeout: Duration = .seconds(2),
+        condition: () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            await Task.yield()
+        }
+        #expect(await condition(), comment)
+    }
+
+    private func makeAgent(hostID: Host.ID, status: AgentStatus) -> ConsoleAgent {
+        ConsoleAgent(
+            hostID: hostID,
+            hostName: "devbox",
+            agent: Agent(
+                terminalID: "term-1", kind: "claude", title: "Task",
+                status: status, workspaceID: "w1", tabID: "w1:t1", paneID: "w1:p1",
+                cwd: "/work", revision: 1),
+            workspaceLabel: "Project", repoName: "Project")
+    }
+}

--- a/Tests/HeelerTests/AgentComposerStoreTests.swift
+++ b/Tests/HeelerTests/AgentComposerStoreTests.swift
@@ -148,7 +148,8 @@ struct AgentComposerStoreTests {
 
     @Test func withdrawingFailurePreservesTheFailedTextAndNewDraft() async throws {
         let transport = ScriptedTransport()
-        await transport.setAgentPromptFailure(TransportError.sshUnreachable)
+        await transport.setAgentPromptFailure(
+            TransportError.sshUnreachable(detail: "connection dropped"))
         let store = AgentComposerStore(target: "w1:p1") { params in
             try await transport.promptAgent(params)
         }

--- a/Tests/HeelerTests/AgentComposerStoreTests.swift
+++ b/Tests/HeelerTests/AgentComposerStoreTests.swift
@@ -71,6 +71,74 @@ struct AgentComposerStoreTests {
         continuation.finish()
     }
 
+    @Test func queuedMessageWaitsForItsOwnWorkingPhaseBeforeDone() async {
+        let transport = ScriptedTransport()
+        let store = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "First message")
+        await store.send()
+        store.agentStatusDidChange(.working)
+
+        store.replaceDraft(with: "Queued message")
+        await store.send()
+
+        #expect(
+            store.messages.map(\.state)
+                == [.delivered(.working), .delivered(.agentBusy)])
+
+        store.agentStatusDidChange(.done)
+        #expect(
+            store.messages.map(\.state)
+                == [.delivered(.done), .delivered(.agentBusy)])
+
+        store.agentStatusDidChange(.working)
+        #expect(
+            store.messages.map(\.state)
+                == [.delivered(.done), .delivered(.working)])
+
+        store.agentStatusDidChange(.done)
+        #expect(
+            store.messages.map(\.state)
+                == [.delivered(.done), .delivered(.done)])
+        #expect(await transport.agentPromptParams.count == 2)
+    }
+
+    @Test func queuedMessageStaysBusyWhenPriorWorkFinishesBeforeAcknowledgment() async throws {
+        let transport = ScriptedTransport()
+        let promptGate = ScriptedTransportCallGate()
+        let store = AgentComposerStore(target: "w1:p1", initialStatus: .working) { params in
+            try await transport.promptAgent(params)
+        }
+        await transport.gateNextAgentPrompt(using: promptGate)
+        store.replaceDraft(with: "Queued message")
+        let send = Task { await store.send() }
+        try await waitUntil("the queued prompt should be in flight") {
+            await promptGate.entryCount == 1
+        }
+
+        store.agentStatusDidChange(.done)
+        await promptGate.open()
+        await send.value
+
+        #expect(store.messages.map(\.state) == [.delivered(.agentBusy)])
+    }
+
+    @Test func idleEndsAWorkingMessage() async {
+        let transport = ScriptedTransport()
+        let store = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Interrupt this")
+        await store.send()
+        store.agentStatusDidChange(.working)
+
+        store.agentStatusDidChange(.idle)
+
+        #expect(store.messages.map(\.state) == [.delivered(.done)])
+        #expect(await transport.agentPromptParams.count == 1)
+    }
+
     @Test func sendingWhileWorkingAcknowledgesThatTheAgentIsBusy() async {
         let transport = ScriptedTransport()
         let store = AgentComposerStore(target: "w1:p1", initialStatus: .working) { params in

--- a/Tests/HeelerTests/GeneratedWireTypesTests.swift
+++ b/Tests/HeelerTests/GeneratedWireTypesTests.swift
@@ -71,6 +71,15 @@ import Testing
         #expect(response.agent.paneID == "w3:pB")
     }
 
+    @Test func agentPromptedResponseRoundTripsLiveCapture() throws {
+        let json = #"{"type":"agent_prompted","agent":{"terminal_id":"term_656c59f7b902d1e","agent":"codex","terminal_title":"GoDrop","terminal_title_stripped":"GoDrop","agent_status":"working","workspace_id":"w3","tab_id":"w3:t2","pane_id":"w3:pB","focused":false,"cwd":"/Users/u/GoDrop","foreground_cwd":"/Users/u/GoDrop","revision":6}}"#
+
+        let response = try roundTrip(AgentPromptedResponse.self, json)
+
+        #expect(response.agent.agentStatus == .working)
+        #expect(response.agent.paneID == "w3:pB")
+    }
+
     @Test func sessionSnapshotResponseRoundTripsLiveCapture() throws {
         // Trimmed to one workspace/tab/pane/layout/agent; the layout keeps a
         // real split so PaneLayoutSplit is exercised.
@@ -212,6 +221,18 @@ import Testing
         let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         let fields = try #require(object)
         #expect(fields.keys.sorted() == ["args", "kind", "name", "pane_id", "timeout_ms"])
+    }
+
+    @Test func agentPromptParamsOmitWait() throws {
+        let params = AgentPromptParams(target: "w1:p1", text: "Continue")
+
+        let data = try JSONEncoder().encode(params)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let fields = try #require(object)
+
+        #expect(fields.keys.sorted() == ["target", "text"])
+        #expect(fields["target"] as? String == "w1:p1")
+        #expect(fields["text"] as? String == "Continue")
     }
 
     @Test func tabCreateParamsEncodeProtocolSeventeenFields() throws {

--- a/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
@@ -551,6 +551,10 @@ struct HeelerSSHTransportBehaviorE2ETests {
         #expect(agentRead.text == "\u{1B}[31mfixture agent output\u{1B}[0m")
         #expect(agentRead.source == .visible)
         #expect(agentRead.format == .ansi)
+        let prompted = try await transport.promptAgent(
+            AgentPromptParams(target: "pane-1", text: "fixture prompt"))
+        #expect(prompted.paneID == "pane-1")
+        #expect(prompted.status == .working)
         try await transport.closePane(PaneTarget(paneID: "pane-1"))
         try await transport.renameAgent(AgentRenameParams(target: "pane-1", name: "fixture"))
         try await transport.renameWorkspace(

--- a/Tests/HeelerTests/Support/FakeTransportConnector.swift
+++ b/Tests/HeelerTests/Support/FakeTransportConnector.swift
@@ -39,6 +39,10 @@ final actor FakeTransport: Transport {
         throw TransportError.channelFailed(detail: "FakeTransport does not script Agent reads")
     }
 
+    func promptAgent(_ params: AgentPromptParams) async throws -> Agent {
+        throw TransportError.channelFailed(detail: "FakeTransport does not script Agent prompts")
+    }
+
     func subscribeToEvents(_ subscriptions: [EventSubscription]) async throws -> HerdrEventStream {
         throw TransportError.channelFailed(detail: "FakeTransport does not script events")
     }

--- a/Tests/HeelerTests/Support/ScriptedTransport.swift
+++ b/Tests/HeelerTests/Support/ScriptedTransport.swift
@@ -12,6 +12,7 @@ final actor ScriptedTransport: Transport {
     private(set) var capturedSubscriptions: [[EventSubscription]] = []
     private(set) var paneReadParams: [PaneReadParams] = []
     private(set) var agentReadParams: [AgentReadParams] = []
+    private(set) var agentPromptParams: [AgentPromptParams] = []
     /// Every `agent.start` received, in order; the new-agent flow (#12)
     /// asserts on the params it forwarded.
     private(set) var agentStarts: [AgentLaunchRequest] = []
@@ -58,6 +59,8 @@ final actor ScriptedTransport: Transport {
     private var agentTexts: [String: String] = [:]
     private var agentReadFailure: (any Error)?
     private var nextAgentReadGate: ScriptedTransportCallGate?
+    private var agentPromptFailure: (any Error)?
+    private var nextAgentPromptGate: ScriptedTransportCallGate?
     private var missingPaneIDs: Set<String> = []
     private var nextStreamID: UInt64 = 0
     private var liveStreamID: UInt64?
@@ -141,6 +144,16 @@ final actor ScriptedTransport: Transport {
     /// Pauses the next Agent read after capturing its response.
     func gateNextAgentRead(using gate: ScriptedTransportCallGate) {
         nextAgentReadGate = gate
+    }
+
+    /// Makes every subsequent `promptAgent` throw `failure`.
+    func setAgentPromptFailure(_ failure: (any Error)?) {
+        agentPromptFailure = failure
+    }
+
+    /// Pauses the next Agent prompt after recording its params.
+    func gateNextAgentPrompt(using gate: ScriptedTransportCallGate) {
+        nextAgentPromptGate = gate
     }
 
     /// Scripts the `AgentInfo` `startAgent` returns; without it the fake
@@ -342,6 +355,16 @@ final actor ScriptedTransport: Transport {
             format: params.format ?? .text, paneID: params.target, revision: 0,
             source: params.source, tabID: "t", text: responseText,
             truncated: false, workspaceID: "w")
+    }
+
+    func promptAgent(_ params: AgentPromptParams) async throws -> Agent {
+        agentPromptParams.append(params)
+        let failure = agentPromptFailure
+        let gate = nextAgentPromptGate
+        nextAgentPromptGate = nil
+        await gate?.waitUntilOpen()
+        if let failure { throw failure }
+        return Agent(.fixture(paneID: params.target, status: .working))
     }
 
     func startAgent(_ request: AgentLaunchRequest) async throws -> Agent {

--- a/scripts/fixtures/fake-herdr-streamlocal.py
+++ b/scripts/fixtures/fake-herdr-streamlocal.py
@@ -285,6 +285,18 @@ class Server:
                 source=source,
                 output_format=output_format,
             )
+        if method == "agent.prompt":
+            request = params if isinstance(params, dict) else {}
+            is_expected_prompt = (
+                request.get("target") == "pane-1"
+                and request.get("text") == "fixture prompt"
+                and "wait" not in request
+            )
+            pane_id = "pane-1" if is_expected_prompt else "fixture:invalid-prompt"
+            return {
+                "type": "agent_prompted",
+                "agent": self._agent(pane_id, "workspace-1", status="working"),
+            }
         if method == "pane.close":
             return {"type": "ok"}
         if method == "tab.create":
@@ -349,13 +361,18 @@ class Server:
             },
         }
 
-    def _agent(self, pane_id: str = "pane-1", workspace_id: str = "workspace-1") -> object:
+    def _agent(
+        self,
+        pane_id: str = "pane-1",
+        workspace_id: str = "workspace-1",
+        status: str = "idle",
+    ) -> object:
         return {
             "terminal_id": "terminal-1",
             "agent": "codex",
             "terminal_title": "fixture",
             "terminal_title_stripped": "fixture",
-            "agent_status": "idle",
+            "agent_status": status,
             "workspace_id": workspace_id,
             "tab_id": "tab-worktree" if workspace_id == "workspace-worktree" else "tab-new",
             "pane_id": pane_id,

--- a/scripts/generate-wire-types.py
+++ b/scripts/generate-wire-types.py
@@ -51,6 +51,7 @@ METHODS = [
     "agent.focus",
     "agent.get",
     "agent.list",
+    "agent.prompt",
     "agent.read",
     "agent.rename",
     "agent.start",
@@ -82,6 +83,7 @@ RESULT_TAGS = [
     "pong",  # ping
     "agent_explain",  # agent.explain
     "agent_info",  # agent.get, agent.focus, agent.rename
+    "agent_prompted",  # agent.prompt
     "agent_started",  # agent.start
     "agent_list",  # agent.list
     "pane_read",  # pane.read, agent.read


### PR DESCRIPTION
## Summary

Replying happens in the Composer: a native draft field on the Monitor where typing costs zero round trips. Send is one RPC — the agent-level prompt without `wait` — and the optimistic echo goes sending → delivered on the acknowledgment, with working → done driven by Agent Status pushes (reusing #180's status relay; no second events subscription, no wait-based RPC anywhere). A failed send offers retry (exactly-once) and withdraw-to-draft that merges with any newer draft rather than overwriting it. Sending while the Agent works is allowed and labeled honestly ("Delivered, Agent busy"): per-message honesty tracking (`observedWorkingAfterSend` + send-time status) keeps a queued message from ever showing a false Done, including when the bufferingNewest(1) stream coalesces working→done into a lone done. The unsent draft survives Attach round trips, backgrounding, and reconnects (store retained by ConsoleStore keyed by agent identity). The draft-operations protocol leaves room for Snippets/Skills/image-path insertion.

Transport gains `promptAgent`; wire types regenerated from the committed schema; the real-SSH E2E seam test and fake-herdr fixture cover the new method (pinned suite count unchanged).

Closes #182 (part of #176).

## Test evidence

Full CI mirror (`scripts/run-ci-ios-tests.sh`) at HEAD b8c6955: **exit 0, 861 of 956 tests executed, 95 skipped and proven elsewhere**, including 12 Composer store-seam tests (queued A/B honesty, coalesced done, idle interrupt, retry, withdraw merge).

## Merge order

Stacked on #188 (feat/180-monitor-live-mirror). Round merge order: #177 → #178 → #179 → #180 → #181 → #182 → #183 — merges after #181 (parallel sibling off the same base; both touch the Monitor surface and CHANGELOG), and #183 rebases last.