### PR TITLE
feat(monitor): local scrollback with idle history backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ Entries reference the issue that motivated them.
   automatically, while scrolling up holds position behind a New Output jump.
   (#180)
 
+- Monitor keeps a local scrollback. Scrolling up through what the Agent did
+  is served from the on-device cache; reaching the top while the Agent is
+  idle backfills up to herdr's 1,000-line capture window, the one loading
+  indicator in the surface. While the Agent works, the top of the cache says
+  history is unavailable instead of spinning. Reads that cannot be
+  reconciled with the cache leave an explicit gap marker, and the oldest
+  capturable line is marked as the beginning of the captured history. (#181)
+
 - Settings > About now has Acknowledgements: every redistributed third-party
   component ships with its exact upstream licence notice, including libssh2
   and its secondary sources, OpenSSL, Ghostty and its stack, the monospaced

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -52,11 +52,13 @@
 		2E82149F859FCBF05F9E999B /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F09325DE68693680E5A3BB /* HerdrSocketLocationTests.swift */; };
 		31E4ADB22D4D655E7CFDB749 /* TerminalInputControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05AD61D4FA60884234EA856C /* TerminalInputControllerTests.swift */; };
 		3286D6FBB12157F2A19A82CE /* AgentNotificationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB37CBDC9DE0CE539FC476A0 /* AgentNotificationRenderer.swift */; };
+		3480A4DA4478558FFD88E0C8 /* AgentMonitorHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7910FDAC85C5A3964729CC73 /* AgentMonitorHistoryTests.swift */; };
 		35205050C9CB8E473D8A28C0 /* Base64URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32413805C1AA874DBEE37547 /* Base64URL.swift */; };
 		359A3FA92C332BEC1DA1982C /* NotificationConfigFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E38A3F2A443D311C8FCC218 /* NotificationConfigFile.swift */; };
 		3662BE3559CB08401960176C /* AgentNotificationRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B02412C186BA855DFD9379A /* AgentNotificationRoutingTests.swift */; };
 		3684BDED2C234F399A6758C9 /* GhosttyTheme in Frameworks */ = {isa = PBXBuildFile; productRef = E086C559FC229264CF662993 /* GhosttyTheme */; };
 		36FB81E449F98DC68A366C2E /* HerdrAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F7065C3BE109D2F52AE3BC2 /* HerdrAPITypes.swift */; };
+		37D439F5A5583E2E3922B073 /* AgentMonitorHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F473A2ABF1D08DA49EC946 /* AgentMonitorHistory.swift */; };
 		3ABBA2BF9C6B51EF1E0C7314 /* TerminalKeysKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC019B4A164A7B01F1D46344 /* TerminalKeysKeyboard.swift */; };
 		3C5AFE8D3844A13198DDBEEA /* AttachLinkIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5870640477FDEB252DEE80B7 /* AttachLinkIndex.swift */; };
 		3C887B853B2B6DFAADEAD38E /* SnippetStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962BDE6D5BFCD443EC3B5FF4 /* SnippetStoreTests.swift */; };
@@ -387,6 +389,7 @@
 		7683DF30B1A0E9FA0064AAA2 /* HeelerSSHTransportBehaviorE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHTransportBehaviorE2ETests.swift; sourceTree = "<group>"; };
 		7780BE78D868DB0A8275E6FB /* Heeler.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Heeler.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		78F85C588963C3CE948AA9E4 /* AgentNotificationBannerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationBannerStore.swift; sourceTree = "<group>"; };
+		7910FDAC85C5A3964729CC73 /* AgentMonitorHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentMonitorHistoryTests.swift; sourceTree = "<group>"; };
 		79662827F6A91D8EFBF112F7 /* HostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostListView.swift; sourceTree = "<group>"; };
 		7A8ED9AD5019F303932B0F9C /* ImageStagingE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStagingE2ETests.swift; sourceTree = "<group>"; };
 		7B0A5D6A13F3F940E50EDCFD /* DemoScreenshotMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoScreenshotMode.swift; sourceTree = "<group>"; };
@@ -438,6 +441,7 @@
 		A579E1DA3F59AFBC3ECAD69C /* SSHChannelAdmissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHChannelAdmissionTests.swift; sourceTree = "<group>"; };
 		A5C6340A9A91119C998F64C3 /* SkillFrontmatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillFrontmatterTests.swift; sourceTree = "<group>"; };
 		A7103745D02C07787E49AC70 /* NotificationEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationEnvelopeTests.swift; sourceTree = "<group>"; };
+		A7F473A2ABF1D08DA49EC946 /* AgentMonitorHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentMonitorHistory.swift; sourceTree = "<group>"; };
 		AACC0F2C9582DE0932380D35 /* KnownHostsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStoreTests.swift; sourceTree = "<group>"; };
 		AB48C946E14722E93FAAA410 /* TerminalAttach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAttach.swift; sourceTree = "<group>"; };
 		B1AEA55D1F06B12005DEEE5F /* HeelerSSHSessionE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHSessionE2ETests.swift; sourceTree = "<group>"; };
@@ -545,6 +549,7 @@
 		11AC34F8912DA80C6DF2524F /* HeelerTests */ = {
 			isa = PBXGroup;
 			children = (
+				7910FDAC85C5A3964729CC73 /* AgentMonitorHistoryTests.swift */,
 				842E5C0930772F4B79955DFC /* AgentMonitorStoreTests.swift */,
 				64D3B8E2EB97A8376B333914 /* AgentNameTests.swift */,
 				0A319930B80D42FB33DC8E42 /* AgentNotificationBannerStoreTests.swift */,
@@ -655,6 +660,7 @@
 		1E9D44A38E208A1D0329903E /* Monitor */ = {
 			isa = PBXGroup;
 			children = (
+				A7F473A2ABF1D08DA49EC946 /* AgentMonitorHistory.swift */,
 				7D5D29D0F34EC475220D1085 /* AgentMonitorStore.swift */,
 				68C51ED25429F47720E29976 /* AgentMonitorView.swift */,
 				8C68AA831B8C9DB0ACCA4D50 /* ANSISnapshotRenderer.swift */,
@@ -1149,6 +1155,7 @@
 				17F313D8AE9647F8F5D4DBFD /* AgentAttachStore.swift in Sources */,
 				12B61E17D212416E86EE63ED /* AgentCardView.swift in Sources */,
 				E1C95FE0F5AC6271001DBF60 /* AgentDetailView.swift in Sources */,
+				37D439F5A5583E2E3922B073 /* AgentMonitorHistory.swift in Sources */,
 				2BFEB992D411C0FF7BDE4361 /* AgentMonitorStore.swift in Sources */,
 				00BB32665B566815194A17D5 /* AgentMonitorView.swift in Sources */,
 				8EB4F2396CC905928797A622 /* AgentName.swift in Sources */,
@@ -1288,6 +1295,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0D191EBCDBE44260BB137F1A /* ANSISnapshotRendererTests.swift in Sources */,
+				3480A4DA4478558FFD88E0C8 /* AgentMonitorHistoryTests.swift in Sources */,
 				CEFDE26E6526835254F14493 /* AgentMonitorStoreTests.swift in Sources */,
 				E379C1AD65B445D4E08614CF /* AgentNameTests.swift in Sources */,
 				6CD1D3CCDB58EBFF5350AC7F /* AgentNotificationBannerStoreTests.swift in Sources */,

--- a/Sources/Heeler/Monitor/AgentMonitorHistory.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorHistory.swift
@@ -1,8 +1,9 @@
 import Foundation
 
 /// Monitor's local scrollback cache: captured line runs and explicit gap
-/// markers, ordered oldest first. The final line run is always the live
-/// screen, kept separate from backfilled or sealed history. In-memory only.
+/// markers, ordered oldest first. The final line run is always exactly the
+/// live screen, kept separate from backfilled, proven-stitched, or sealed
+/// history. In-memory only.
 ///
 /// herdr exposes no history cursor (`agent.read` takes a source and a line
 /// count, capped at 1000 lines), so every reconciliation is an
@@ -28,10 +29,23 @@ struct AgentMonitorHistory: Equatable, Sendable {
     /// whole-screen match is correct by construction there.
     static let minimumOverlap = 3
 
+    /// Truly distinct live screens remain useful context, but they cannot
+    /// grow without bound during a long-running alternate-screen session.
+    /// Backfilled and overlap-proven history does not count against this cap.
+    static let maximumSealedLiveGenerations = 8
+
+    private static let minimumNearDuplicateLineCount = 5
+    private static let maximumNearDuplicateLineDifferences = 2
+
     /// The final `.lines` segment is always the live screen. Backfilled and
     /// sealed live runs remain separate from it, including when they are
     /// known to be contiguous; only a `.gap` claims unknown continuity.
     private(set) var segments: [Segment] = []
+
+    /// Indices of live screens retained only because a later non-overlapping
+    /// read replaced them. Their adjacent generation gaps are tracked by
+    /// position. Other line segments are proven history and never capped.
+    private var sealedLiveGenerationIndices: [Int] = []
 
     /// The range reconciled by the most recent backfill. It normally spans
     /// the current history suffix and live run. After an unstitched read it
@@ -52,18 +66,19 @@ struct AgentMonitorHistory: Equatable, Sendable {
     enum VisibleOutcome: Equatable, Sendable {
         /// The read carried no new content.
         case unchanged
-        /// The read's top overlapped the live screen's bottom; newly scrolled
-        /// lines were appended to the live run.
+        /// The read's top overlapped the live screen's bottom; rows proven to
+        /// have scrolled off were preserved above the new exact live screen.
         case extended
-        /// No usable overlap (an alternate-screen repaint, or a reconnect
-        /// that scrolled a full screen): a new live run was installed.
+        /// The live screen changed without a scroll overlap. Near-duplicate
+        /// repaints replace it in place; distinct screens start a generation.
         case replaced
     }
 
     /// Reconciles one `visible` read with the live tail. The visible screen
     /// is a sliding window: when its top lines match the live run's bottom,
-    /// only fresh lines are appended. Otherwise the old live run is sealed
-    /// as history and the repaint becomes a new live run below a gap.
+    /// scrolled-off rows become proven history. Otherwise a near-duplicate
+    /// repaint replaces the live run in place, while a distinct screen seals
+    /// the old live run and starts a new generation below a gap.
     @discardableResult
     mutating func applyVisible(_ text: String) -> VisibleOutcome {
         let read = Self.splitLines(text)
@@ -75,20 +90,33 @@ struct AgentMonitorHistory: Equatable, Sendable {
             backfillRange = 0..<1
             return .replaced
         }
-        guard read != newest else { return .unchanged }
-        // A read fully contained at the tail (a shorter screen, or the same
-        // screen while the live run accumulated scrolling) changes nothing.
+        guard !Self.areByteIdentical(read, newest) else { return .unchanged }
+        // A read fully contained at the tail (a shorter version of the same
+        // screen) changes nothing.
         // The empty read is excluded: a cleared screen is a replacement.
-        if !read.isEmpty, read.count <= newest.count, newest.suffix(read.count) == read {
+        if !read.isEmpty,
+            read.count <= newest.count,
+            Self.areByteIdentical(newest.suffix(read.count), read)
+        {
             return .unchanged
         }
+        // Alternate-screen repaint ticks usually preserve the screen shape
+        // and change only a spinner, timer, or status row. They are the same
+        // live generation, so replace it in place rather than retaining a
+        // near-identical sealed screen on every poll.
+        if Self.isNearDuplicate(newest, read) {
+            segments[segments.count - 1] = .lines(read)
+            backfillRange = contiguousTailRange
+            return .replaced
+        }
+
         let floor = min(Self.minimumOverlap, read.count, newest.count)
         if floor >= 1,
             let overlap = Self.largestOverlap(suffixOf: newest, prefixOf: read, floor: floor)
         {
-            let fresh = read.suffix(read.count - overlap)
-            guard !fresh.isEmpty else { return .unchanged }
-            segments[segments.count - 1] = .lines(newest + fresh)
+            guard overlap < read.count else { return .unchanged }
+            let scrolledOff = Array(newest.prefix(newest.count - overlap))
+            installExtendedLiveScreen(read, preserving: scrolledOff)
             return .extended
         }
 
@@ -98,10 +126,12 @@ struct AgentMonitorHistory: Equatable, Sendable {
         if newest.isEmpty {
             segments[segments.count - 1] = .lines(read)
         } else {
+            sealedLiveGenerationIndices.append(segments.count - 1)
             segments.append(.gap)
             segments.append(.lines(read))
         }
         backfillRange = (segments.count - 1)..<segments.count
+        trimSealedLiveGenerations()
         return .replaced
     }
 
@@ -175,11 +205,55 @@ struct AgentMonitorHistory: Equatable, Sendable {
         return lines
     }
 
+    /// A conservative repaint heuristic. Both screens must have the same
+    /// shape and at least five lines, and at least 80% of corresponding lines
+    /// must be byte-identical. Even on large screens, no more than two lines
+    /// may differ. This catches spinner/status repaint ticks without folding
+    /// genuinely distinct screens into one generation.
+    static func isNearDuplicate(_ first: [String], _ second: [String]) -> Bool {
+        guard
+            first.count == second.count,
+            first.count >= minimumNearDuplicateLineCount
+        else { return false }
+
+        let allowedDifferences = min(
+            maximumNearDuplicateLineDifferences,
+            first.count / minimumNearDuplicateLineCount)
+        var differences = 0
+        for (firstLine, secondLine) in zip(first, second)
+        where !firstLine.utf8.elementsEqual(secondLine.utf8) {
+            differences += 1
+            if differences > allowedDifferences {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func areByteIdentical<First: Collection, Second: Collection>(
+        _ first: First,
+        _ second: Second
+    ) -> Bool where First.Element == String, Second.Element == String {
+        guard first.count == second.count else { return false }
+        return zip(first, second).allSatisfy { firstLine, secondLine in
+            firstLine.utf8.elementsEqual(secondLine.utf8)
+        }
+    }
+
     /// `nil` only when the cache is empty; the invariant keeps a trailing
     /// `.lines` run otherwise, even if it holds zero lines.
     private var newestLinesIfPresent: [String]? {
         guard case .lines(let lines) = segments.last else { return nil }
         return lines
+    }
+
+    private var contiguousTailRange: Range<Int> {
+        var lowerBound = segments.count - 1
+        while lowerBound > segments.startIndex {
+            guard case .lines = segments[lowerBound - 1] else { break }
+            lowerBound -= 1
+        }
+        return lowerBound..<segments.endIndex
     }
 
     private var validBackfillRange: Range<Int>? {
@@ -203,6 +277,60 @@ struct AgentMonitorHistory: Equatable, Sendable {
             result.append(contentsOf: lines)
         }
         return result
+    }
+
+    /// Keeps overlap-proven output outside the replace-generation cap. The
+    /// live segment stays an exact screen, while rows that demonstrably
+    /// scrolled off are folded into the contiguous protected history above.
+    private mutating func installExtendedLiveScreen(
+        _ read: [String],
+        preserving scrolledOff: [String]
+    ) {
+        let liveIndex = segments.count - 1
+        segments[liveIndex] = .lines(read)
+        if !scrolledOff.isEmpty {
+            if liveIndex > segments.startIndex,
+                case .lines(let provenHistory) = segments[liveIndex - 1]
+            {
+                segments[liveIndex - 1] = .lines(provenHistory + scrolledOff)
+            } else {
+                segments.insert(.lines(scrolledOff), at: liveIndex)
+            }
+        }
+        backfillRange = contiguousTailRange
+    }
+
+    private mutating func trimSealedLiveGenerations() {
+        while sealedLiveGenerationIndices.count > Self.maximumSealedLiveGenerations {
+            let sealedIndex = sealedLiveGenerationIndices.removeFirst()
+            guard
+                sealedIndex >= segments.startIndex,
+                sealedIndex < segments.endIndex,
+                case .lines = segments[sealedIndex]
+            else { continue }
+
+            // Later generations were introduced by a gap immediately above
+            // them, so discard that gap with the sealed screen. The original
+            // live screen has no preceding gap; removing it leaves its
+            // following gap as the honest boundary between protected history
+            // and the oldest retained generation.
+            let removalLowerBound =
+                sealedIndex > segments.startIndex && segments[sealedIndex - 1] == .gap
+                ? sealedIndex - 1 : sealedIndex
+            let removedRange = removalLowerBound..<(sealedIndex + 1)
+            segments.removeSubrange(removedRange)
+            sealedLiveGenerationIndices = sealedLiveGenerationIndices.map { index in
+                index >= removedRange.upperBound ? index - removedRange.count : index
+            }
+            if let range = backfillRange {
+                if range.lowerBound >= removedRange.upperBound {
+                    let offset = removedRange.count
+                    backfillRange = (range.lowerBound - offset)..<(range.upperBound - offset)
+                } else if range.overlaps(removedRange) {
+                    backfillRange = nil
+                }
+            }
+        }
     }
 
     private mutating func prepend(_ older: [String], to range: Range<Int>) {
@@ -267,7 +395,7 @@ struct AgentMonitorHistory: Equatable, Sendable {
     ) -> Int? {
         var candidate = min(first.count, second.count)
         while candidate >= floor {
-            if first.suffix(candidate) == second.prefix(candidate) {
+            if Self.areByteIdentical(first.suffix(candidate), second.prefix(candidate)) {
                 return candidate
             }
             candidate -= 1
@@ -282,7 +410,7 @@ struct AgentMonitorHistory: Equatable, Sendable {
     ) -> Int? {
         var candidate = min(first.count, second.count)
         while candidate >= floor {
-            if first.suffix(candidate) == second.suffix(candidate) {
+            if Self.areByteIdentical(first.suffix(candidate), second.suffix(candidate)) {
                 return candidate
             }
             candidate -= 1
@@ -298,7 +426,7 @@ struct AgentMonitorHistory: Equatable, Sendable {
         guard needle.count <= haystack.count else { return nil }
         var start = haystack.count - needle.count
         while start >= 0 {
-            if haystack[start..<(start + needle.count)].elementsEqual(needle) {
+            if Self.areByteIdentical(haystack[start..<(start + needle.count)], needle) {
                 return start
             }
             start -= 1

--- a/Sources/Heeler/Monitor/AgentMonitorHistory.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorHistory.swift
@@ -197,10 +197,12 @@ struct AgentMonitorHistory: Equatable, Sendable {
     }
 
     private func lines(in range: Range<Int>) -> [String] {
-        range.flatMap { index in
-            guard case .lines(let lines) = segments[index] else { return [] }
-            return lines
+        var result: [String] = []
+        for index in range {
+            guard case .lines(let lines) = segments[index] else { continue }
+            result.append(contentsOf: lines)
         }
+        return result
     }
 
     private mutating func prepend(_ older: [String], to range: Range<Int>) {

--- a/Sources/Heeler/Monitor/AgentMonitorHistory.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorHistory.swift
@@ -1,0 +1,217 @@
+import Foundation
+
+/// Monitor's local scrollback cache: an ordered list of contiguous line runs
+/// separated by explicit gap markers, oldest first. In-memory only.
+///
+/// herdr exposes no history cursor (`agent.read` takes a source and a line
+/// count, capped at 1000 lines), so every reconciliation is an
+/// overlap-stitch against what the cache already holds. This type is the
+/// pure line algebra behind that: it performs no I/O, keeps no presentation
+/// state, and is deliberately separate from `AgentMonitorStore` so the
+/// stitching rules are testable on their own.
+struct AgentMonitorHistory: Equatable, Sendable {
+    enum Segment: Equatable, Sendable {
+        /// A contiguous run of captured lines. ANSI state flows within a run;
+        /// runs never sit adjacent to another run (a stitch merges them).
+        case lines([String])
+        /// An explicit marker that the content between the neighbouring runs
+        /// could not be captured or reconciled. Never guessed around.
+        case gap
+    }
+
+    /// The smallest suffix/prefix overlap accepted as proof that two reads
+    /// cover the same content. Smaller coincidences (a shared blank line, a
+    /// repeated prompt) are treated as no overlap, because a spurious gap is
+    /// honest while a spurious stitch silently corrupts history. When one
+    /// side is shorter than this, the overlap floor drops to that length: a
+    /// whole-screen match is correct by construction there.
+    static let minimumOverlap = 3
+
+    /// Invariant: `.lines` runs are never adjacent (a stitch merges them)
+    /// and a `.gap` is never first or last, so the cache always ends with
+    /// the live run.
+    private(set) var segments: [Segment] = []
+
+    var isEmpty: Bool {
+        segments.isEmpty
+    }
+
+    /// The lines of the newest contiguous run. The live mirror of the
+    /// Agent's screen always lives here; backfill stitches onto its front
+    /// because a `recent` read ends at the same newest line.
+    var newestLines: [String] {
+        guard case .lines(let lines) = segments.last else { return [] }
+        return lines
+    }
+
+    enum VisibleOutcome: Equatable, Sendable {
+        /// The read carried no new content.
+        case unchanged
+        /// The read's top overlapped the cache's bottom; the newly scrolled
+        /// lines were appended to the newest run.
+        case extended
+        /// No usable overlap (an alternate-screen repaint, or a reconnect
+        /// that scrolled a full screen): the newest run was replaced.
+        case replaced
+    }
+
+    /// Reconciles one `visible` read with the live tail. The visible screen
+    /// is a sliding window: when its top lines match the cache's bottom
+    /// lines the window scrolled and only the fresh lines are appended;
+    /// otherwise the screen repainted and the tail is replaced outright.
+    @discardableResult
+    mutating func applyVisible(_ text: String) -> VisibleOutcome {
+        let read = Self.splitLines(text)
+        guard let newest = newestLinesIfPresent else {
+            // The first install always reports a change: even an empty
+            // screen must paint, or the store never renders and the view
+            // loads forever.
+            segments = [.lines(read)]
+            return .replaced
+        }
+        guard read != newest else { return .unchanged }
+        // A read fully contained at the tail (a shorter screen, or the same
+        // screen while the cache runs deeper) changes nothing. The empty
+        // read is excluded: a cleared screen is a replacement, not a no-op.
+        if !read.isEmpty, read.count <= newest.count, newest.suffix(read.count) == read {
+            return .unchanged
+        }
+        let floor = min(Self.minimumOverlap, read.count, newest.count)
+        if floor >= 1,
+            let overlap = Self.largestOverlap(suffixOf: newest, prefixOf: read, floor: floor)
+        {
+            let fresh = read.suffix(read.count - overlap)
+            guard !fresh.isEmpty else { return .unchanged }
+            segments[segments.count - 1] = .lines(newest + fresh)
+            return .extended
+        }
+        segments[segments.count - 1] = .lines(read)
+        return .replaced
+    }
+
+    struct BackfillOutcome: Equatable, Sendable {
+        /// Lines the read added that the cache did not already hold. Zero
+        /// means the read was fully captured — the capture limit is reached.
+        var newLines: Int
+        /// Whether an explicit gap marker was inserted because the read
+        /// could not be overlap-stitched onto the cache.
+        var insertedGap: Bool
+    }
+
+    /// Reconciles one `recent` read (the server's newest lines, up to its
+    /// cap) with the cache. While the Agent is idle the read's last line is
+    /// the cache's newest line, so the stitch is anchored at the end of the
+    /// newest run: the largest shared suffix proves the read's remaining
+    /// prefix is older content, which is prepended. Failing that, the read
+    /// may still contain the whole newest run (output raced the read): the
+    /// read then supersedes the tail outright. With no shared content at
+    /// all, the read's relation to the cache is unknowable — the old tail
+    /// is sealed, a gap marker records the missing region, and the read
+    /// becomes the new tail.
+    @discardableResult
+    mutating func stitchBackfill(_ text: String) -> BackfillOutcome {
+        let read = Self.splitLines(text)
+        guard !read.isEmpty else {
+            return BackfillOutcome(newLines: 0, insertedGap: false)
+        }
+        guard let newest = newestLinesIfPresent, !newest.isEmpty else {
+            if segments.isEmpty {
+                segments = [.lines(read)]
+            } else {
+                segments[segments.count - 1] = .lines(read)
+            }
+            return BackfillOutcome(newLines: read.count, insertedGap: false)
+        }
+        let floor = min(Self.minimumOverlap, read.count, newest.count)
+        if floor >= 1,
+            let overlap = Self.largestOverlap(suffixOf: read, suffixOf: newest, floor: floor)
+        {
+            let older = read.prefix(read.count - overlap)
+            guard !older.isEmpty else {
+                return BackfillOutcome(newLines: 0, insertedGap: false)
+            }
+            segments[segments.count - 1] = .lines(older + newest)
+            return BackfillOutcome(newLines: older.count, insertedGap: false)
+        }
+        if newest.count >= Self.minimumOverlap,
+            Self.containment(of: newest, in: read) != nil
+        {
+            segments[segments.count - 1] = .lines(read)
+            return BackfillOutcome(
+                newLines: read.count - newest.count, insertedGap: false)
+        }
+        segments.append(.gap)
+        segments.append(.lines(read))
+        return BackfillOutcome(newLines: read.count, insertedGap: true)
+    }
+
+    /// Splits read text into lines, dropping the one empty fragment a
+    /// trailing newline leaves behind. Interior empty lines are content;
+    /// empty text is zero lines (Foundation's split would say one).
+    static func splitLines(_ text: String) -> [String] {
+        guard !text.isEmpty else { return [] }
+        var lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        if text.hasSuffix("\n") {
+            lines.removeLast()
+        }
+        return lines
+    }
+
+    /// `nil` only when the cache is empty; the invariant keeps a trailing
+    /// `.lines` run otherwise, even if it holds zero lines.
+    private var newestLinesIfPresent: [String]? {
+        guard case .lines(let lines) = segments.last else { return nil }
+        return lines
+    }
+
+    /// The largest `k >= floor` such that the two collections share a
+    /// suffix/prefix (or suffix/suffix) of length `k`, searching longest
+    /// first so a genuine deep overlap always wins over a coincidental
+    /// short one.
+    private static func largestOverlap(
+        suffixOf first: [String],
+        prefixOf second: [String],
+        floor: Int
+    ) -> Int? {
+        var candidate = min(first.count, second.count)
+        while candidate >= floor {
+            if first.suffix(candidate) == second.prefix(candidate) {
+                return candidate
+            }
+            candidate -= 1
+        }
+        return nil
+    }
+
+    private static func largestOverlap(
+        suffixOf first: [String],
+        suffixOf second: [String],
+        floor: Int
+    ) -> Int? {
+        var candidate = min(first.count, second.count)
+        while candidate >= floor {
+            if first.suffix(candidate) == second.suffix(candidate) {
+                return candidate
+            }
+            candidate -= 1
+        }
+        return nil
+    }
+
+    /// The rightmost position at which `needle` appears in `haystack` as a
+    /// contiguous run, if any. Rightmost because the newest run sits at the
+    /// end of a `recent` read when content is stable; an earlier duplicate
+    /// of the same lines is history, not the tail.
+    private static func containment(of needle: [String], in haystack: [String]) -> Int? {
+        guard needle.count <= haystack.count else { return nil }
+        var start = haystack.count - needle.count
+        while start >= 0 {
+            if haystack[start..<(start + needle.count)].elementsEqual(needle) {
+                return start
+            }
+            start -= 1
+        }
+        return nil
+    }
+}

--- a/Sources/Heeler/Monitor/AgentMonitorHistory.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorHistory.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-/// Monitor's local scrollback cache: an ordered list of contiguous line runs
-/// separated by explicit gap markers, oldest first. In-memory only.
+/// Monitor's local scrollback cache: captured line runs and explicit gap
+/// markers, ordered oldest first. The final line run is always the live
+/// screen, kept separate from backfilled or sealed history. In-memory only.
 ///
 /// herdr exposes no history cursor (`agent.read` takes a source and a line
 /// count, capped at 1000 lines), so every reconciliation is an
@@ -11,8 +12,8 @@ import Foundation
 /// stitching rules are testable on their own.
 struct AgentMonitorHistory: Equatable, Sendable {
     enum Segment: Equatable, Sendable {
-        /// A contiguous run of captured lines. ANSI state flows within a run;
-        /// runs never sit adjacent to another run (a stitch merges them).
+        /// One contiguous captured run. Adjacent line segments may exist to
+        /// preserve the boundary between backfilled history and live output.
         case lines([String])
         /// An explicit marker that the content between the neighbouring runs
         /// could not be captured or reconciled. Never guessed around.
@@ -27,18 +28,22 @@ struct AgentMonitorHistory: Equatable, Sendable {
     /// whole-screen match is correct by construction there.
     static let minimumOverlap = 3
 
-    /// Invariant: `.lines` runs are never adjacent (a stitch merges them)
-    /// and a `.gap` is never first or last, so the cache always ends with
-    /// the live run.
+    /// The final `.lines` segment is always the live screen. Backfilled and
+    /// sealed live runs remain separate from it, including when they are
+    /// known to be contiguous; only a `.gap` claims unknown continuity.
     private(set) var segments: [Segment] = []
+
+    /// The range reconciled by the most recent backfill. It normally spans
+    /// the current history suffix and live run. After an unstitched read it
+    /// instead points at that read above the gap, so a later, deeper read can
+    /// extend it without moving captured history below the live screen.
+    private var backfillRange: Range<Int>?
 
     var isEmpty: Bool {
         segments.isEmpty
     }
 
-    /// The lines of the newest contiguous run. The live mirror of the
-    /// Agent's screen always lives here; backfill stitches onto its front
-    /// because a `recent` read ends at the same newest line.
+    /// The live mirror of the Agent's screen, always the final segment.
     var newestLines: [String] {
         guard case .lines(let lines) = segments.last else { return [] }
         return lines
@@ -47,18 +52,18 @@ struct AgentMonitorHistory: Equatable, Sendable {
     enum VisibleOutcome: Equatable, Sendable {
         /// The read carried no new content.
         case unchanged
-        /// The read's top overlapped the cache's bottom; the newly scrolled
-        /// lines were appended to the newest run.
+        /// The read's top overlapped the live screen's bottom; newly scrolled
+        /// lines were appended to the live run.
         case extended
         /// No usable overlap (an alternate-screen repaint, or a reconnect
-        /// that scrolled a full screen): the newest run was replaced.
+        /// that scrolled a full screen): a new live run was installed.
         case replaced
     }
 
     /// Reconciles one `visible` read with the live tail. The visible screen
-    /// is a sliding window: when its top lines match the cache's bottom
-    /// lines the window scrolled and only the fresh lines are appended;
-    /// otherwise the screen repainted and the tail is replaced outright.
+    /// is a sliding window: when its top lines match the live run's bottom,
+    /// only fresh lines are appended. Otherwise the old live run is sealed
+    /// as history and the repaint becomes a new live run below a gap.
     @discardableResult
     mutating func applyVisible(_ text: String) -> VisibleOutcome {
         let read = Self.splitLines(text)
@@ -67,12 +72,13 @@ struct AgentMonitorHistory: Equatable, Sendable {
             // screen must paint, or the store never renders and the view
             // loads forever.
             segments = [.lines(read)]
+            backfillRange = 0..<1
             return .replaced
         }
         guard read != newest else { return .unchanged }
         // A read fully contained at the tail (a shorter screen, or the same
-        // screen while the cache runs deeper) changes nothing. The empty
-        // read is excluded: a cleared screen is a replacement, not a no-op.
+        // screen while the live run accumulated scrolling) changes nothing.
+        // The empty read is excluded: a cleared screen is a replacement.
         if !read.isEmpty, read.count <= newest.count, newest.suffix(read.count) == read {
             return .unchanged
         }
@@ -85,13 +91,23 @@ struct AgentMonitorHistory: Equatable, Sendable {
             segments[segments.count - 1] = .lines(newest + fresh)
             return .extended
         }
-        segments[segments.count - 1] = .lines(read)
+
+        // Replacing only the live segment preserves every backfilled and
+        // previously sealed run. There is no content to seal when the old
+        // live screen was empty, so reuse that final slot in that case.
+        if newest.isEmpty {
+            segments[segments.count - 1] = .lines(read)
+        } else {
+            segments.append(.gap)
+            segments.append(.lines(read))
+        }
+        backfillRange = (segments.count - 1)..<segments.count
         return .replaced
     }
 
     struct BackfillOutcome: Equatable, Sendable {
         /// Lines the read added that the cache did not already hold. Zero
-        /// means the read was fully captured — the capture limit is reached.
+        /// means the read was fully captured: the capture limit is reached.
         var newLines: Int
         /// Whether an explicit gap marker was inserted because the read
         /// could not be overlap-stitched onto the cache.
@@ -99,49 +115,50 @@ struct AgentMonitorHistory: Equatable, Sendable {
     }
 
     /// Reconciles one `recent` read (the server's newest lines, up to its
-    /// cap) with the cache. While the Agent is idle the read's last line is
-    /// the cache's newest line, so the stitch is anchored at the end of the
-    /// newest run: the largest shared suffix proves the read's remaining
-    /// prefix is older content, which is prepended. Failing that, the read
-    /// may still contain the whole newest run (output raced the read): the
-    /// read then supersedes the tail outright. With no shared content at
-    /// all, the read's relation to the cache is unknowable — the old tail
-    /// is sealed, a gap marker records the missing region, and the read
-    /// becomes the new tail.
+    /// cap) with the range covered by the preceding backfill. The largest
+    /// shared suffix proves the read's remaining prefix is older content,
+    /// which is kept in a segment above the live screen. With no shared
+    /// content, the read is likewise placed above the live run with explicit
+    /// gaps rather than displacing the live screen or pretending continuity.
     @discardableResult
     mutating func stitchBackfill(_ text: String) -> BackfillOutcome {
         let read = Self.splitLines(text)
         guard !read.isEmpty else {
             return BackfillOutcome(newLines: 0, insertedGap: false)
         }
-        guard let newest = newestLinesIfPresent, !newest.isEmpty else {
-            if segments.isEmpty {
-                segments = [.lines(read)]
-            } else {
-                segments[segments.count - 1] = .lines(read)
-            }
+        guard let newest = newestLinesIfPresent else {
+            segments = [.lines(read)]
+            backfillRange = 0..<1
             return BackfillOutcome(newLines: read.count, insertedGap: false)
         }
-        let floor = min(Self.minimumOverlap, read.count, newest.count)
+        if newest.isEmpty {
+            let liveIndex = segments.count - 1
+            segments.insert(.lines(read), at: liveIndex)
+            backfillRange = liveIndex..<(liveIndex + 2)
+            return BackfillOutcome(newLines: read.count, insertedGap: false)
+        }
+
+        let range = validBackfillRange ?? ((segments.count - 1)..<segments.count)
+        let anchor = lines(in: range)
+        let floor = min(Self.minimumOverlap, read.count, anchor.count)
         if floor >= 1,
-            let overlap = Self.largestOverlap(suffixOf: read, suffixOf: newest, floor: floor)
+            let overlap = Self.largestOverlap(suffixOf: read, suffixOf: anchor, floor: floor)
         {
-            let older = read.prefix(read.count - overlap)
+            let older = Array(read.prefix(read.count - overlap))
             guard !older.isEmpty else {
                 return BackfillOutcome(newLines: 0, insertedGap: false)
             }
-            segments[segments.count - 1] = .lines(older + newest)
+            prepend(older, to: range)
             return BackfillOutcome(newLines: older.count, insertedGap: false)
         }
-        if newest.count >= Self.minimumOverlap,
-            Self.containment(of: newest, in: read) != nil
+        if anchor.count >= Self.minimumOverlap,
+            Self.containment(of: anchor, in: read) != nil
         {
-            segments[segments.count - 1] = .lines(read)
+            replaceBackfillRange(range, with: read)
             return BackfillOutcome(
-                newLines: read.count - newest.count, insertedGap: false)
+                newLines: max(0, read.count - anchor.count), insertedGap: false)
         }
-        segments.append(.gap)
-        segments.append(.lines(read))
+        insertUnstitchedBackfill(read)
         return BackfillOutcome(newLines: read.count, insertedGap: true)
     }
 
@@ -163,6 +180,78 @@ struct AgentMonitorHistory: Equatable, Sendable {
     private var newestLinesIfPresent: [String]? {
         guard case .lines(let lines) = segments.last else { return nil }
         return lines
+    }
+
+    private var validBackfillRange: Range<Int>? {
+        guard
+            let backfillRange,
+            backfillRange.lowerBound >= segments.startIndex,
+            backfillRange.upperBound <= segments.endIndex,
+            !backfillRange.isEmpty,
+            segments[backfillRange].allSatisfy({ segment in
+                if case .lines = segment { return true }
+                return false
+            })
+        else { return nil }
+        return backfillRange
+    }
+
+    private func lines(in range: Range<Int>) -> [String] {
+        range.flatMap { index in
+            guard case .lines(let lines) = segments[index] else { return [] }
+            return lines
+        }
+    }
+
+    private mutating func prepend(_ older: [String], to range: Range<Int>) {
+        guard case .lines(let first) = segments[range.lowerBound] else { return }
+        if range.lowerBound == segments.count - 1 {
+            segments.insert(.lines(older), at: range.lowerBound)
+            backfillRange = range.lowerBound..<(range.upperBound + 1)
+        } else {
+            segments[range.lowerBound] = .lines(older + first)
+            backfillRange = range
+        }
+    }
+
+    private mutating func replaceBackfillRange(
+        _ range: Range<Int>,
+        with read: [String]
+    ) {
+        guard range.upperBound == segments.endIndex else {
+            segments.replaceSubrange(range, with: [.lines(read)])
+            backfillRange = range.lowerBound..<(range.lowerBound + 1)
+            return
+        }
+
+        // A racing `recent` read can contain the previous screen before its
+        // newest lines. Preserve the live/history boundary by treating a
+        // screen-sized suffix as the new live run.
+        let liveCount = min(newestLines.count, read.count)
+        let history = Array(read.dropLast(liveCount))
+        let live = Array(read.suffix(liveCount))
+        let replacement: [Segment]
+        if history.isEmpty {
+            replacement = [.lines(live)]
+        } else {
+            replacement = [.lines(history), .lines(live)]
+        }
+        segments.replaceSubrange(range, with: replacement)
+        backfillRange = range.lowerBound..<(range.lowerBound + replacement.count)
+    }
+
+    private mutating func insertUnstitchedBackfill(_ read: [String]) {
+        let liveIndex = segments.count - 1
+        var insertion: [Segment] = []
+        if liveIndex > 0, segments[liveIndex - 1] != .gap {
+            insertion.append(.gap)
+        }
+        let readOffset = insertion.count
+        insertion.append(.lines(read))
+        insertion.append(.gap)
+        segments.insert(contentsOf: insertion, at: liveIndex)
+        let readIndex = liveIndex + readOffset
+        backfillRange = readIndex..<(readIndex + 1)
     }
 
     /// The largest `k >= floor` such that the two collections share a

--- a/Sources/Heeler/Monitor/AgentMonitorStore.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorStore.swift
@@ -371,6 +371,12 @@ final class AgentMonitorStore {
         let hadContent = !history.isEmpty
         let outcome = history.applyVisible(text)
         guard outcome != .unchanged else { return }
+        if outcome == .replaced, historyState == .exhausted {
+            // Exhaustion describes the backfill window anchored to the old
+            // live run. A repaint invalidates that anchor, so the new live
+            // generation must be allowed to backfill from the top again.
+            historyState = agentStatus == .working ? .unavailable : .idle
+        }
         renderSnapshot()
         contentChangeCount &+= 1
         if hadContent, !isBottomPinned {
@@ -378,28 +384,42 @@ final class AgentMonitorStore {
         }
     }
 
-    /// Renders the whole cache — history runs stitched above the live
-    /// screen, with gap markers spliced between unreconciled regions. Each
-    /// run renders independently, so ANSI state flows within a captured run
-    /// and resets at a gap, which is the honest boundary anyway.
+    /// Renders the whole cache, with history above the live screen and gap
+    /// markers between unreconciled regions. Storage keeps history and live
+    /// runs separate, but adjacent line segments render together so ANSI
+    /// state still flows across every byte-proven boundary. It resets only
+    /// at a gap, which is the honest boundary anyway.
     private func renderSnapshot() {
-        var rendered = AttributedString()
-        var isFirstSegment = true
+        var renderedSegments: [AttributedString] = []
+        var contiguousParts: [String] = []
+
+        func flushContiguousLines() {
+            guard !contiguousParts.isEmpty else { return }
+            renderedSegments.append(
+                ANSISnapshotRenderer.render(contiguousParts.joined(separator: "\n")))
+            contiguousParts.removeAll(keepingCapacity: true)
+        }
+
         for segment in history.segments {
-            if !isFirstSegment {
-                rendered.append(AttributedString("\n"))
-            }
-            isFirstSegment = false
             switch segment {
             case .lines(let lines):
-                rendered.append(
-                    ANSISnapshotRenderer.render(lines.joined(separator: "\n")))
+                contiguousParts.append(lines.joined(separator: "\n"))
             case .gap:
+                flushContiguousLines()
                 var marker = AttributedString(Self.gapMarkerText)
                 marker.foregroundColor = Color.secondary
                 marker.inlinePresentationIntent = .emphasized
-                rendered.append(marker)
+                renderedSegments.append(marker)
             }
+        }
+        flushContiguousLines()
+
+        var rendered = AttributedString()
+        for (index, segment) in renderedSegments.enumerated() {
+            if index > 0 {
+                rendered.append(AttributedString("\n"))
+            }
+            rendered.append(segment)
         }
         snapshot = rendered
     }

--- a/Sources/Heeler/Monitor/AgentMonitorStore.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import SwiftUI
 
 protocol AgentMonitorClock: Sendable {
     func sleep(for duration: Duration) async throws
@@ -11,8 +12,10 @@ struct ContinuousAgentMonitorClock: AgentMonitorClock {
     }
 }
 
-/// Owns Monitor's adaptive live mirror. Status pushes trigger one refresh;
-/// only a Working Agent in a foreground view also receives cadence refreshes.
+/// Owns Monitor's adaptive live mirror and its local scrollback. Status
+/// pushes trigger one refresh; only a Working Agent in a foreground view
+/// also receives cadence refreshes. History is served from the in-memory
+/// cache and backfilled through `agent.read` only while the Agent is idle.
 @MainActor
 @Observable
 final class AgentMonitorStore {
@@ -23,13 +26,37 @@ final class AgentMonitorStore {
         case failed(String)
     }
 
+    /// Where the scrollback stands relative to herdr's capture limit. herdr
+    /// has no history cursor, so "more history" is only ever one `recent`
+    /// read away; the states exist to make that read honest.
+    enum HistoryState: Equatable {
+        /// No load in flight; reaching the top of the cache may fetch more.
+        case idle
+        /// An idle backfill read is in flight — the one loading state in
+        /// Monitor.
+        case loading
+        /// The Agent is working, or herdr answered `agent_not_idle`:
+        /// history is honestly unavailable, never a spinner.
+        case unavailable
+        /// The oldest capturable content is already cached.
+        case exhausted
+        /// The backfill read itself failed; retryable from the marker.
+        case failed(String)
+    }
+
     static let refreshCadence: Duration = .seconds(2)
+    /// herdr caps every read at 1000 lines; ask for the whole window.
+    static let historyLineCount = 1000
+    /// The in-content marker for a region that could not be captured or
+    /// reconciled. Tests assert on this copy.
+    static let gapMarkerText = "— gap: content not captured —"
 
     private(set) var state: State = .idle
     private(set) var snapshot: AttributedString?
     private(set) var capturedAt: Date?
     private(set) var agentStatus: AgentStatus
     private(set) var liveUpdatesAvailable = true
+    private(set) var historyState: HistoryState = .idle
     private(set) var contentChangeCount: UInt64 = 0
     private(set) var isBottomPinned = true
     private(set) var hasNewOutput = false
@@ -39,13 +66,15 @@ final class AgentMonitorStore {
     private let clock: any AgentMonitorClock
     private let statusUpdates: AsyncStream<ConsoleStore.AgentStatusUpdate>?
     private let read: @Sendable (AgentReadParams) async throws -> PaneReadResult
-    @ObservationIgnored private var snapshotText: String?
+    @ObservationIgnored private var history = AgentMonitorHistory()
     @ObservationIgnored private var hasOpened = false
     @ObservationIgnored private var isForeground = true
     @ObservationIgnored private var isMonitorVisible = true
     @ObservationIgnored private var needsRefreshAfterAttach = false
     @ObservationIgnored private var isFetching = false
+    @ObservationIgnored private var isBackfilling = false
     @ObservationIgnored private var fetchWaiters: [CheckedContinuation<Void, Never>] = []
+    @ObservationIgnored private var backfillWaiters: [CheckedContinuation<Void, Never>] = []
     @ObservationIgnored private var pollingTask: Task<Void, Never>?
     @ObservationIgnored private var statusTask: Task<Void, Never>?
 
@@ -70,15 +99,20 @@ final class AgentMonitorStore {
         statusTask?.cancel()
     }
 
-    /// Fetches exactly once for this Monitor instance, then starts the
-    /// status-driven state machine. SwiftUI may re-run its task when Attach
-    /// pops, so the return refresh has its own explicit path.
+    /// Fetches exactly once for this Monitor instance, backfills history
+    /// once when the Agent is not working, then starts the status-driven
+    /// state machine. SwiftUI may re-run its task when Attach pops, so the
+    /// return refresh has its own explicit path.
     func open() async {
         guard !hasOpened else { return }
         hasOpened = true
         consumeStatusUpdates()
         await fetch()
         reconcilePolling()
+        // A cold cache backfills once on open so scrolling up is served
+        // from local lines from the first paint. A Working Agent skips the
+        // read entirely; the top of the cache says why instead.
+        await loadEarlierHistory()
     }
 
     func setForeground(_ isForeground: Bool) {
@@ -93,6 +127,16 @@ final class AgentMonitorStore {
     func agentStatusDidChange(_ status: AgentStatus) async {
         guard agentStatus != status else { return }
         agentStatus = status
+        if status == .working {
+            // History cannot be captured while the Agent works. An
+            // in-flight backfill resolves itself: herdr answers
+            // `agent_not_idle`, which lands as unavailability below.
+            if historyState != .loading, historyState != .exhausted {
+                historyState = .unavailable
+            }
+        } else if historyState == .unavailable {
+            historyState = .idle
+        }
         stopPolling()
         guard hasOpened, isMonitorVisible, liveUpdatesAvailable else { return }
         await waitForCurrentFetch()
@@ -136,6 +180,84 @@ final class AgentMonitorStore {
 
     func retry() async {
         await refresh()
+    }
+
+    /// The view reports the scroll reaching the top of the cache. An idle
+    /// Agent gets one backfill with a visible loading state; a working Agent
+    /// gets the honest unavailability notice instead of a spinner.
+    func topEdgeReached() {
+        guard hasOpened, liveUpdatesAvailable else { return }
+        guard agentStatus != .working else {
+            if historyState != .exhausted {
+                historyState = .unavailable
+            }
+            return
+        }
+        switch historyState {
+        case .idle, .unavailable, .failed:
+            // Set synchronously so a geometry re-fire before the task steps
+            // cannot double-fire the read.
+            historyState = .loading
+            Task { await self.loadEarlierHistory() }
+        case .loading, .exhausted:
+            break
+        }
+    }
+
+    /// One backfill read. herdr exposes no history cursor, so this reads
+    /// the server's newest lines (capped at `historyLineCount`) and
+    /// overlap-stitches them onto the cache; a stitch that finds no shared
+    /// content records an explicit gap instead of guessing. Also the retry
+    /// path for a failed backfill.
+    func loadEarlierHistory() async {
+        guard hasOpened else { return }
+        // Visible reads and backfills share one flight: a top-edge hit
+        // during a cadence poll must not interleave two reads, or the
+        // backfill could stitch against a tail the poll just replaced and
+        // record a spurious gap. The wait runs before the flag is set, so
+        // a fetch holding its own flag never waits back on this one.
+        await waitForCurrentFetch()
+        guard !isBackfilling else { return }
+        guard agentStatus != .working else {
+            if historyState != .exhausted {
+                historyState = .unavailable
+            }
+            return
+        }
+        guard historyState != .exhausted else { return }
+        isBackfilling = true
+        historyState = .loading
+        defer { finishBackfill() }
+        do {
+            let result = try await read(
+                AgentReadParams(
+                    source: .recent,
+                    target: target,
+                    format: .ansi,
+                    lines: Self.historyLineCount,
+                    stripANSI: false))
+            let outcome = history.stitchBackfill(result.text)
+            if outcome.newLines > 0 || outcome.insertedGap {
+                renderSnapshot()
+                contentChangeCount &+= 1
+            }
+            capturedAt = now()
+            // The capture limit is reached when the server had fewer lines
+            // than the cap (that was everything) or when the read added
+            // nothing (the window is already fully cached).
+            let returnedLines = AgentMonitorHistory.splitLines(result.text).count
+            historyState =
+                returnedLines < Self.historyLineCount || outcome.newLines == 0
+                ? .exhausted : .idle
+        } catch let error as HerdrAPIError where error.code == "agent_not_idle" {
+            // History is capturable only while the Agent is idle; a racing
+            // status push makes this honest unavailability, never an error.
+            historyState = .unavailable
+        } catch is CancellationError {
+            historyState = .idle
+        } catch {
+            historyState = .failed(Self.message(for: error))
+        }
     }
 
     private func consumeStatusUpdates() {
@@ -217,6 +339,9 @@ final class AgentMonitorStore {
             state = .loading
         }
         defer { finishFetch() }
+        // The other half of the shared flight: a poll that fires while a
+        // backfill reads waits for it rather than interleaving on the wire.
+        await waitForCurrentBackfill()
 
         do {
             let result = try await read(
@@ -225,7 +350,7 @@ final class AgentMonitorStore {
                     target: target,
                     format: .ansi,
                     stripANSI: false))
-            applySnapshotText(result.text)
+            applyVisibleText(result.text)
             capturedAt = now()
             state = .loaded
         } catch is CancellationError {
@@ -234,21 +359,49 @@ final class AgentMonitorStore {
                 hasOpened = false
             }
         } catch {
-            // #181 owns special `agent_not_idle` handling for history
-            // backfill; visible-screen refreshes surface every error honestly.
+            // Visible-screen refreshes surface every error honestly. The
+            // `agent_not_idle` carve-out lives in the backfill path
+            // (`loadEarlierHistory`), where it means history is unavailable
+            // while the Agent works — never an error.
             state = .failed(Self.message(for: error))
         }
     }
 
-    private func applySnapshotText(_ text: String) {
-        guard snapshotText != text else { return }
-        let hadSnapshot = snapshotText != nil
-        snapshotText = text
-        snapshot = ANSISnapshotRenderer.render(text)
+    private func applyVisibleText(_ text: String) {
+        let hadContent = !history.isEmpty
+        let outcome = history.applyVisible(text)
+        guard outcome != .unchanged else { return }
+        renderSnapshot()
         contentChangeCount &+= 1
-        if hadSnapshot, !isBottomPinned {
+        if hadContent, !isBottomPinned {
             hasNewOutput = true
         }
+    }
+
+    /// Renders the whole cache — history runs stitched above the live
+    /// screen, with gap markers spliced between unreconciled regions. Each
+    /// run renders independently, so ANSI state flows within a captured run
+    /// and resets at a gap, which is the honest boundary anyway.
+    private func renderSnapshot() {
+        var rendered = AttributedString()
+        var isFirstSegment = true
+        for segment in history.segments {
+            if !isFirstSegment {
+                rendered.append(AttributedString("\n"))
+            }
+            isFirstSegment = false
+            switch segment {
+            case .lines(let lines):
+                rendered.append(
+                    ANSISnapshotRenderer.render(lines.joined(separator: "\n")))
+            case .gap:
+                var marker = AttributedString(Self.gapMarkerText)
+                marker.foregroundColor = Color.secondary
+                marker.inlinePresentationIntent = .emphasized
+                rendered.append(marker)
+            }
+        }
+        snapshot = rendered
     }
 
     private func waitForCurrentFetch() async {
@@ -262,6 +415,22 @@ final class AgentMonitorStore {
         isFetching = false
         let waiters = fetchWaiters
         fetchWaiters.removeAll(keepingCapacity: false)
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func waitForCurrentBackfill() async {
+        guard isBackfilling else { return }
+        await withCheckedContinuation { continuation in
+            backfillWaiters.append(continuation)
+        }
+    }
+
+    private func finishBackfill() {
+        isBackfilling = false
+        let waiters = backfillWaiters
+        backfillWaiters.removeAll(keepingCapacity: false)
         for waiter in waiters {
             waiter.resume()
         }

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -148,6 +148,7 @@ struct AgentDetailView: View {
         ScrollViewReader { proxy in
             ScrollView([.horizontal, .vertical]) {
                 VStack(alignment: .leading, spacing: 0) {
+                    historyTopMarker
                     Text(snapshot)
                         .font(.system(.body, design: .monospaced))
                         .textSelection(.enabled)
@@ -164,6 +165,12 @@ struct AgentDetailView: View {
                 geometry.visibleRect.maxY >= geometry.contentSize.height - 24
             } action: { _, isPinned in
                 monitor.setBottomPinned(isPinned)
+            }
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                geometry.visibleRect.minY <= 24
+            } action: { _, isAtTop in
+                guard isAtTop else { return }
+                monitor.topEdgeReached()
             }
             .onChange(of: monitor.contentChangeCount) {
                 guard monitor.isBottomPinned else { return }
@@ -184,6 +191,61 @@ struct AgentDetailView: View {
                 }
             }
         }
+    }
+
+    /// The only place history states are visible: a thin marker above the
+    /// cached content. While the Agent works the notice replaces any
+    /// spinner outright — history is unavailable, never "loading".
+    @ViewBuilder
+    private var historyTopMarker: some View {
+        if monitor.agentStatus == .working, monitor.historyState != .exhausted {
+            historyMarkerLabel(
+                "History unavailable while the Agent works",
+                systemImage: "clock.badge.exclamationmark")
+        } else {
+            switch monitor.historyState {
+            case .loading:
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading earlier history…")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+            case .unavailable:
+                historyMarkerLabel(
+                    "History unavailable while the Agent works",
+                    systemImage: "clock.badge.exclamationmark")
+            case .exhausted:
+                historyMarkerLabel(
+                    "Beginning of captured history",
+                    systemImage: "arrow.up.to.line")
+            case .failed(let message):
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Label(message, systemImage: "exclamationmark.triangle")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 8)
+                    Button("Retry") { Task { await monitor.loadEarlierHistory() } }
+                        .font(.footnote)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal)
+                .padding(.vertical, 10)
+            case .idle:
+                EmptyView()
+            }
+        }
+    }
+
+    private func historyMarkerLabel(_ text: String, systemImage: String) -> some View {
+        Label(text, systemImage: systemImage)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
     }
 
     private var statusHeader: some View {

--- a/Tests/HeelerTests/AgentMonitorHistoryTests.swift
+++ b/Tests/HeelerTests/AgentMonitorHistoryTests.swift
@@ -21,7 +21,12 @@ struct AgentMonitorHistoryTests {
 
         // Scrolled by one: the four-line overlap extends the tail.
         #expect(history.applyVisible("l2\nl3\nl4\nl5\nl6") == .extended)
-        #expect(history.newestLines == ["l1", "l2", "l3", "l4", "l5", "l6"])
+        #expect(history.newestLines == ["l2", "l3", "l4", "l5", "l6"])
+        #expect(
+            history.segments == [
+                .lines(["l1"]),
+                .lines(["l2", "l3", "l4", "l5", "l6"]),
+            ])
 
         // Repaint: no overlap, a new live run is installed.
         #expect(history.applyVisible("n1\nn2\nn3\nn4\nn5") == .replaced)
@@ -177,5 +182,70 @@ struct AgentMonitorHistoryTests {
                 .gap,
                 .lines([]),
             ])
+    }
+
+    @Test func nearDuplicateRuleIsConservativeAndByteExact() {
+        let original = (1...10).map { "line \($0)" }
+        var oneChangedLine = original
+        oneChangedLine[4] = "spinner frame 2"
+        var twoChangedLines = oneChangedLine
+        twoChangedLines[7] = "elapsed 00:02"
+        var threeChangedLines = twoChangedLines
+        threeChangedLines[9] = "tokens 42"
+
+        #expect(AgentMonitorHistory.isNearDuplicate(original, oneChangedLine))
+        #expect(AgentMonitorHistory.isNearDuplicate(original, twoChangedLines))
+        #expect(!AgentMonitorHistory.isNearDuplicate(original, threeChangedLines))
+        #expect(!AgentMonitorHistory.isNearDuplicate(original, Array(original.dropLast())))
+        #expect(
+            !AgentMonitorHistory.isNearDuplicate(
+                ["one", "two", "three", "four"],
+                ["one", "two", "changed", "four"]))
+
+        // Swift String equality treats these canonically equivalent forms
+        // as equal. Repaint dedupe deliberately compares their UTF-8 bytes.
+        let composed = ["header", "café", "three", "four", "five"]
+        let decomposed = ["changed", "cafe\u{301}", "three", "four", "five"]
+        #expect(!AgentMonitorHistory.isNearDuplicate(composed, decomposed))
+    }
+
+    @Test func nearDuplicateRepaintReplacesTheLiveRunInPlace() {
+        var history = AgentMonitorHistory()
+        let first = (1...10).map { "line \($0)" }
+        var repaint = first
+        repaint[5] = "spinner frame 2"
+
+        history.applyVisible(first.joined(separator: "\n"))
+        #expect(history.applyVisible(repaint.joined(separator: "\n")) == .replaced)
+        #expect(history.segments == [.lines(repaint)])
+    }
+
+    @Test func sealedLiveGenerationsAreCappedWithoutDroppingProvenHistory() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("l0\nl1\nl2\nl3\nl4")
+        #expect(history.applyVisible("l1\nl2\nl3\nl4\nl5") == .extended)
+        history.stitchBackfill("h1\nh2\nl0\nl1\nl2\nl3\nl4\nl5")
+
+        let replacementCount = AgentMonitorHistory.maximumSealedLiveGenerations + 3
+        for generation in 1...replacementCount {
+            let screen = (1...5).map { "generation \(generation), line \($0)" }
+            #expect(history.applyVisible(screen.joined(separator: "\n")) == .replaced)
+        }
+
+        var expected: [AgentMonitorHistory.Segment] = [
+            .lines(["h1", "h2", "l0"]),
+            .gap,
+        ]
+        let firstRetainedGeneration =
+            replacementCount - AgentMonitorHistory.maximumSealedLiveGenerations
+        for generation in firstRetainedGeneration..<replacementCount {
+            expected.append(
+                .lines((1...5).map { "generation \(generation), line \($0)" }))
+            expected.append(.gap)
+        }
+        expected.append(
+            .lines((1...5).map { "generation \(replacementCount), line \($0)" }))
+
+        #expect(history.segments == expected)
     }
 }

--- a/Tests/HeelerTests/AgentMonitorHistoryTests.swift
+++ b/Tests/HeelerTests/AgentMonitorHistoryTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@MainActor
+@Suite("Agent Monitor history")
+struct AgentMonitorHistoryTests {
+    @Test func splitLinesDropsOnlyTheTrailingNewlineFragment() {
+        #expect(AgentMonitorHistory.splitLines("") == [])
+        #expect(AgentMonitorHistory.splitLines("a") == ["a"])
+        #expect(AgentMonitorHistory.splitLines("a\n") == ["a"])
+        #expect(AgentMonitorHistory.splitLines("a\n\nb") == ["a", "", "b"])
+        #expect(AgentMonitorHistory.splitLines("\n") == [""])
+    }
+
+    @Test func visibleReadsExtendReplaceAndSettle() {
+        var history = AgentMonitorHistory()
+        #expect(history.applyVisible("l1\nl2\nl3\nl4\nl5") == .replaced)
+        #expect(history.applyVisible("l1\nl2\nl3\nl4\nl5") == .unchanged)
+
+        // Scrolled by one: the four-line overlap extends the tail.
+        #expect(history.applyVisible("l2\nl3\nl4\nl5\nl6") == .extended)
+        #expect(history.newestLines == ["l1", "l2", "l3", "l4", "l5", "l6"])
+
+        // Repaint: no overlap, the tail is replaced.
+        #expect(history.applyVisible("n1\nn2\nn3\nn4\nn5") == .replaced)
+        #expect(history.newestLines == ["n1", "n2", "n3", "n4", "n5"])
+
+        // A cleared screen replaces; re-reading it changes nothing.
+        #expect(history.applyVisible("") == .replaced)
+        #expect(history.newestLines == [])
+        #expect(history.applyVisible("") == .unchanged)
+    }
+
+    @Test func backfillStitchesBySharedSuffix() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("s1\ns2\ns3\ns4")
+
+        let first = history.stitchBackfill("o1\no2\ns1\ns2\ns3\ns4")
+        #expect(first == .init(newLines: 2, insertedGap: false))
+        #expect(history.newestLines == ["o1", "o2", "s1", "s2", "s3", "s4"])
+
+        // The same window again: fully captured, nothing new.
+        let repeatRead = history.stitchBackfill("o1\no2\ns1\ns2\ns3\ns4")
+        #expect(repeatRead == .init(newLines: 0, insertedGap: false))
+
+        // A window contained inside a deeper cache adds nothing either.
+        let contained = history.stitchBackfill("s1\ns2\ns3\ns4")
+        #expect(contained == .init(newLines: 0, insertedGap: false))
+        #expect(history.newestLines == ["o1", "o2", "s1", "s2", "s3", "s4"])
+    }
+
+    @Test func backfillSupersedesTheTailWhenTheWindowContainsIt() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("s1\ns2\ns3\ns4")
+
+        // Output raced the read: the tail sits mid-window, not at its end.
+        // The read is the better truth for the whole region.
+        let outcome = history.stitchBackfill("o1\ns1\ns2\ns3\ns4\nn1\nn2")
+        #expect(outcome == .init(newLines: 3, insertedGap: false))
+        #expect(history.newestLines == ["o1", "s1", "s2", "s3", "s4", "n1", "n2"])
+    }
+
+    @Test func backfillWithoutSharedContentRecordsAGap() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("stale a\nstale b\nstale c")
+
+        let outcome = history.stitchBackfill("fresh 1\nfresh 2\nfresh 3")
+        #expect(outcome == .init(newLines: 3, insertedGap: true))
+        #expect(
+            history.segments == [
+                .lines(["stale a", "stale b", "stale c"]),
+                .gap,
+                .lines(["fresh 1", "fresh 2", "fresh 3"]),
+            ])
+
+        // The next read stitches onto the new tail, below the gap.
+        let second = history.stitchBackfill("older\nfresh 1\nfresh 2\nfresh 3")
+        #expect(second == .init(newLines: 1, insertedGap: false))
+        #expect(
+            history.segments == [
+                .lines(["stale a", "stale b", "stale c"]),
+                .gap,
+                .lines(["older", "fresh 1", "fresh 2", "fresh 3"]),
+            ])
+    }
+
+    @Test func tinyScreensMatchOnTheirWholeLength() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("only line")
+
+        // Below the minimum overlap the floor drops to the screen's length:
+        // a whole-screen match is correct by construction.
+        let outcome = history.stitchBackfill("older 1\nolder 2\nonly line")
+        #expect(outcome == .init(newLines: 2, insertedGap: false))
+        #expect(history.newestLines == ["older 1", "older 2", "only line"])
+    }
+
+    @Test func emptyFirstReadStillInstalls() {
+        var history = AgentMonitorHistory()
+        // The first install must report a change even for empty content, or
+        // the store never renders and the view loads forever.
+        #expect(history.applyVisible("") == .replaced)
+        #expect(history.newestLines == [])
+        #expect(history.applyVisible("") == .unchanged)
+    }
+
+    @Test func coincidentalShortOverlapsDoNotStitch() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("a\nb\nc\nd")
+
+        // Two shared lines at the end are below the minimum overlap: the
+        // read is treated as unrelated content, never stitched history.
+        let short = history.stitchBackfill("x\ny\nc\nd")
+        #expect(short.insertedGap)
+        #expect(
+            history.segments == [
+                .lines(["a", "b", "c", "d"]),
+                .gap,
+                .lines(["x", "y", "c", "d"]),
+            ])
+
+        // The live tail holds the same line: a two-line overlap is a
+        // repaint, not an extension.
+        var visible = AgentMonitorHistory()
+        visible.applyVisible("a\nb\nc\nd")
+        #expect(visible.applyVisible("c\nd\ne") == .replaced)
+        #expect(visible.newestLines == ["c", "d", "e"])
+    }
+
+    @Test func emptyBackfillAddsNothing() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("s1\ns2\ns3")
+
+        #expect(history.stitchBackfill("") == .init(newLines: 0, insertedGap: false))
+        #expect(history.newestLines == ["s1", "s2", "s3"])
+    }
+}

--- a/Tests/HeelerTests/AgentMonitorHistoryTests.swift
+++ b/Tests/HeelerTests/AgentMonitorHistoryTests.swift
@@ -23,7 +23,7 @@ struct AgentMonitorHistoryTests {
         #expect(history.applyVisible("l2\nl3\nl4\nl5\nl6") == .extended)
         #expect(history.newestLines == ["l1", "l2", "l3", "l4", "l5", "l6"])
 
-        // Repaint: no overlap, the tail is replaced.
+        // Repaint: no overlap, a new live run is installed.
         #expect(history.applyVisible("n1\nn2\nn3\nn4\nn5") == .replaced)
         #expect(history.newestLines == ["n1", "n2", "n3", "n4", "n5"])
 
@@ -39,7 +39,11 @@ struct AgentMonitorHistoryTests {
 
         let first = history.stitchBackfill("o1\no2\ns1\ns2\ns3\ns4")
         #expect(first == .init(newLines: 2, insertedGap: false))
-        #expect(history.newestLines == ["o1", "o2", "s1", "s2", "s3", "s4"])
+        #expect(
+            history.segments == [
+                .lines(["o1", "o2"]),
+                .lines(["s1", "s2", "s3", "s4"]),
+            ])
 
         // The same window again: fully captured, nothing new.
         let repeatRead = history.stitchBackfill("o1\no2\ns1\ns2\ns3\ns4")
@@ -48,7 +52,7 @@ struct AgentMonitorHistoryTests {
         // A window contained inside a deeper cache adds nothing either.
         let contained = history.stitchBackfill("s1\ns2\ns3\ns4")
         #expect(contained == .init(newLines: 0, insertedGap: false))
-        #expect(history.newestLines == ["o1", "o2", "s1", "s2", "s3", "s4"])
+        #expect(history.newestLines == ["s1", "s2", "s3", "s4"])
     }
 
     @Test func backfillSupersedesTheTailWhenTheWindowContainsIt() {
@@ -59,7 +63,11 @@ struct AgentMonitorHistoryTests {
         // The read is the better truth for the whole region.
         let outcome = history.stitchBackfill("o1\ns1\ns2\ns3\ns4\nn1\nn2")
         #expect(outcome == .init(newLines: 3, insertedGap: false))
-        #expect(history.newestLines == ["o1", "s1", "s2", "s3", "s4", "n1", "n2"])
+        #expect(
+            history.segments == [
+                .lines(["o1", "s1", "s2"]),
+                .lines(["s3", "s4", "n1", "n2"]),
+            ])
     }
 
     @Test func backfillWithoutSharedContentRecordsAGap() {
@@ -70,19 +78,19 @@ struct AgentMonitorHistoryTests {
         #expect(outcome == .init(newLines: 3, insertedGap: true))
         #expect(
             history.segments == [
-                .lines(["stale a", "stale b", "stale c"]),
-                .gap,
                 .lines(["fresh 1", "fresh 2", "fresh 3"]),
+                .gap,
+                .lines(["stale a", "stale b", "stale c"]),
             ])
 
-        // The next read stitches onto the new tail, below the gap.
+        // The next read extends the backfill run above the live screen.
         let second = history.stitchBackfill("older\nfresh 1\nfresh 2\nfresh 3")
         #expect(second == .init(newLines: 1, insertedGap: false))
         #expect(
             history.segments == [
-                .lines(["stale a", "stale b", "stale c"]),
-                .gap,
                 .lines(["older", "fresh 1", "fresh 2", "fresh 3"]),
+                .gap,
+                .lines(["stale a", "stale b", "stale c"]),
             ])
     }
 
@@ -94,7 +102,11 @@ struct AgentMonitorHistoryTests {
         // a whole-screen match is correct by construction.
         let outcome = history.stitchBackfill("older 1\nolder 2\nonly line")
         #expect(outcome == .init(newLines: 2, insertedGap: false))
-        #expect(history.newestLines == ["older 1", "older 2", "only line"])
+        #expect(
+            history.segments == [
+                .lines(["older 1", "older 2"]),
+                .lines(["only line"]),
+            ])
     }
 
     @Test func emptyFirstReadStillInstalls() {
@@ -116,9 +128,9 @@ struct AgentMonitorHistoryTests {
         #expect(short.insertedGap)
         #expect(
             history.segments == [
-                .lines(["a", "b", "c", "d"]),
-                .gap,
                 .lines(["x", "y", "c", "d"]),
+                .gap,
+                .lines(["a", "b", "c", "d"]),
             ])
 
         // The live tail holds the same line: a two-line overlap is a
@@ -135,5 +147,35 @@ struct AgentMonitorHistoryTests {
 
         #expect(history.stitchBackfill("") == .init(newLines: 0, insertedGap: false))
         #expect(history.newestLines == ["s1", "s2", "s3"])
+    }
+
+    @Test func nonoverlappingRepaintPreservesBackfilledHistory() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("s1\ns2\ns3\ns4")
+        history.stitchBackfill("h1\nh2\nh3\nh4\nh5\nh6\ns1\ns2\ns3\ns4")
+
+        #expect(history.applyVisible("r1\nr2\nr3\nr4") == .replaced)
+        #expect(
+            history.segments == [
+                .lines(["h1", "h2", "h3", "h4", "h5", "h6"]),
+                .lines(["s1", "s2", "s3", "s4"]),
+                .gap,
+                .lines(["r1", "r2", "r3", "r4"]),
+            ])
+    }
+
+    @Test func emptyVisibleReadPreservesCapturedHistory() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("s1\ns2\ns3\ns4")
+        history.stitchBackfill("h1\nh2\nh3\ns1\ns2\ns3\ns4")
+
+        #expect(history.applyVisible("") == .replaced)
+        #expect(
+            history.segments == [
+                .lines(["h1", "h2", "h3"]),
+                .lines(["s1", "s2", "s3", "s4"]),
+                .gap,
+                .lines([]),
+            ])
     }
 }

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -22,15 +22,18 @@ struct AgentMonitorStoreTests {
         }
         await transport.setAgentText("second", target: "w1:p1")
         #expect(await clock.advance() == .seconds(2))
+        let expected = [
+            "first", AgentMonitorStore.gapMarkerText, "second",
+        ].joined(separator: "\n")
         try await waitUntil("one clock tick should perform one refresh") {
-            guard store.snapshot.map({ String($0.characters) }) == "second" else {
+            guard store.snapshot.map({ String($0.characters) }) == expected else {
                 return false
             }
             return await transport.agentReadParams.count == 2
         }
 
         #expect(store.agentStatus == .working)
-        #expect(String(try #require(store.snapshot).characters) == "second")
+        #expect(String(try #require(store.snapshot).characters) == expected)
     }
 
     @Test func idleAndBackgroundStatesDoNotPoll() async throws {
@@ -104,30 +107,42 @@ struct AgentMonitorStoreTests {
 
         await transport.setAgentText("working", target: "w1:p1")
         #expect(await transport.emit(.agentStatusChanged(paneID: "w1:p1", status: .working)))
+        let workingSnapshot = [
+            "idle", AgentMonitorStore.gapMarkerText, "working",
+        ].joined(separator: "\n")
         try await waitUntil("Working should surface and refresh") {
             guard
                 store.agentStatus == .working,
-                store.snapshot.map({ String($0.characters) }) == "working"
+                store.snapshot.map({ String($0.characters) }) == workingSnapshot
             else { return false }
             return await agentReads(transport, source: .visible).count == 2
         }
 
         await transport.setAgentText("done", target: "w1:p1")
         #expect(await transport.emit(.agentStatusChanged(paneID: "w1:p1", status: .done)))
+        let doneSnapshot = [
+            "idle", AgentMonitorStore.gapMarkerText, "working",
+            AgentMonitorStore.gapMarkerText, "done",
+        ].joined(separator: "\n")
         try await waitUntil("Done should surface and refresh") {
             guard
                 store.agentStatus == .done,
-                store.snapshot.map({ String($0.characters) }) == "done"
+                store.snapshot.map({ String($0.characters) }) == doneSnapshot
             else { return false }
             return await agentReads(transport, source: .visible).count == 3
         }
 
         await transport.setAgentText("blocked", target: "w1:p1")
         #expect(await transport.emit(.agentStatusChanged(paneID: "w1:p1", status: .blocked)))
+        let blockedSnapshot = [
+            "idle", AgentMonitorStore.gapMarkerText, "working",
+            AgentMonitorStore.gapMarkerText, "done",
+            AgentMonitorStore.gapMarkerText, "blocked",
+        ].joined(separator: "\n")
         try await waitUntil("Blocked should surface and refresh") {
             guard
                 store.agentStatus == .blocked,
-                store.snapshot.map({ String($0.characters) }) == "blocked"
+                store.snapshot.map({ String($0.characters) }) == blockedSnapshot
             else { return false }
             return await agentReads(transport, source: .visible).count == 4
         }
@@ -322,7 +337,10 @@ struct AgentMonitorStoreTests {
         await store.refreshOnReturn()
 
         let snapshot = try #require(store.snapshot)
-        #expect(String(snapshot.characters) == "after")
+        #expect(
+            String(snapshot.characters)
+                == ["before", AgentMonitorStore.gapMarkerText, "after"]
+                .joined(separator: "\n"))
         #expect(await agentReads(transport, source: .visible).count == 2)
     }
 
@@ -355,7 +373,10 @@ struct AgentMonitorStoreTests {
         await returning.value
 
         let snapshot = try #require(store.snapshot)
-        #expect(String(snapshot.characters) == "after Attach")
+        #expect(
+            String(snapshot.characters)
+                == ["opening", AgentMonitorStore.gapMarkerText, "after Attach"]
+                .joined(separator: "\n"))
         #expect(await agentReads(transport, source: .visible).count == 2)
     }
 
@@ -520,9 +541,9 @@ struct AgentMonitorStoreTests {
         await store.open()
 
         let expected = [
-            "stale a", "stale b", "stale c",
-            AgentMonitorStore.gapMarkerText,
             "fresh 1", "fresh 2", "fresh 3",
+            AgentMonitorStore.gapMarkerText,
+            "stale a", "stale b", "stale c",
         ].joined(separator: "\n")
         #expect(String(try #require(store.snapshot).characters) == expected)
         #expect(store.historyState == .exhausted)
@@ -646,10 +667,54 @@ struct AgentMonitorStoreTests {
         #expect(
             String(try #require(store.snapshot).characters) == "l1\nl2\nl3\nl4\nl5\nl6")
 
-        // A repaint shares no overlap: the tail is replaced, not extended.
+        // A repaint shares no overlap: a new live run is installed.
         await transport.setAgentText("n1\nn2\nn3\nn4\nn5", target: "w1:p1")
         await store.refresh()
-        #expect(String(try #require(store.snapshot).characters) == "n1\nn2\nn3\nn4\nn5")
+        #expect(
+            String(try #require(store.snapshot).characters)
+                == [
+                    "l1", "l2", "l3", "l4", "l5", "l6",
+                    AgentMonitorStore.gapMarkerText,
+                    "n1", "n2", "n3", "n4", "n5",
+                ].joined(separator: "\n"))
+    }
+
+    @Test func liveReplacementResetsExhaustionAndAllowsAnotherBackfill() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("s1\ns2\ns3\ns4", target: "w1:p1")
+        await transport.setAgentHistoryText(
+            "h1\nh2\nh3\nh4\nh5\nh6\ns1\ns2\ns3\ns4", target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+        #expect(store.historyState == .exhausted)
+
+        await transport.setAgentText("r1\nr2\nr3\nr4", target: "w1:p1")
+        await store.refresh()
+
+        #expect(store.historyState == .idle)
+        let preserved = [
+            "h1", "h2", "h3", "h4", "h5", "h6", "s1", "s2", "s3", "s4",
+            AgentMonitorStore.gapMarkerText, "r1", "r2", "r3", "r4",
+        ].joined(separator: "\n")
+        #expect(String(try #require(store.snapshot).characters) == preserved)
+
+        await transport.setAgentHistoryText(
+            "new older 1\nnew older 2\nr1\nr2\nr3\nr4", target: "w1:p1")
+        store.topEdgeReached()
+        try await waitUntil("the replacement should allow a new backfill") {
+            store.historyState == .exhausted
+        }
+
+        #expect(await agentReads(transport, source: .recent).count == 2)
+        #expect(
+            String(try #require(store.snapshot).characters)
+                == [
+                    "h1", "h2", "h3", "h4", "h5", "h6", "s1", "s2", "s3", "s4",
+                    AgentMonitorStore.gapMarkerText, "new older 1", "new older 2", "r1",
+                    "r2", "r3", "r4",
+                ].joined(separator: "\n"))
     }
 
     private func agentReads(

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -42,7 +42,9 @@ struct AgentMonitorStoreTests {
         await idleStore.open()
 
         #expect(await idleClock.pendingSleepCount == 0)
-        #expect(await idleTransport.agentReadParams.count == 1)
+        // One visible snapshot plus the one idle backfill on open (#181).
+        #expect(await agentReads(idleTransport, source: .visible).count == 1)
+        #expect(await agentReads(idleTransport, source: .recent).count == 1)
 
         let workingTransport = ScriptedTransport()
         let workingClock = ManualAgentMonitorClock()
@@ -60,6 +62,7 @@ struct AgentMonitorStoreTests {
             await workingClock.pendingSleepCount == 0
         }
 
+        // A Working Agent never backfills, so its only read is the snapshot.
         #expect(await workingTransport.agentReadParams.count == 1)
     }
 
@@ -106,7 +109,7 @@ struct AgentMonitorStoreTests {
                 store.agentStatus == .working,
                 store.snapshot.map({ String($0.characters) }) == "working"
             else { return false }
-            return await transport.agentReadParams.count == 2
+            return await agentReads(transport, source: .visible).count == 2
         }
 
         await transport.setAgentText("done", target: "w1:p1")
@@ -116,7 +119,7 @@ struct AgentMonitorStoreTests {
                 store.agentStatus == .done,
                 store.snapshot.map({ String($0.characters) }) == "done"
             else { return false }
-            return await transport.agentReadParams.count == 3
+            return await agentReads(transport, source: .visible).count == 3
         }
 
         await transport.setAgentText("blocked", target: "w1:p1")
@@ -126,7 +129,7 @@ struct AgentMonitorStoreTests {
                 store.agentStatus == .blocked,
                 store.snapshot.map({ String($0.characters) }) == "blocked"
             else { return false }
-            return await transport.agentReadParams.count == 4
+            return await agentReads(transport, source: .visible).count == 4
         }
         try await waitUntil("Blocked should cancel the cadence") {
             await clock.pendingSleepCount == 0
@@ -284,13 +287,25 @@ struct AgentMonitorStoreTests {
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "plain red")
         #expect(
-            await transport.agentReadParams == [
+            await agentReads(transport, source: .visible) == [
                 AgentReadParams(
                     source: .visible,
                     target: "w1:p1",
                     format: .ansi,
                     stripANSI: false)
             ])
+        // The idle open also backfills once (#181); the scripted window
+        // equals the screen, so nothing new lands and history is exhausted.
+        #expect(
+            await agentReads(transport, source: .recent) == [
+                AgentReadParams(
+                    source: .recent,
+                    target: "w1:p1",
+                    format: .ansi,
+                    lines: AgentMonitorStore.historyLineCount,
+                    stripANSI: false)
+            ])
+        #expect(store.historyState == .exhausted)
     }
 
     @Test func returningFromAttachRefreshesExactlyOnce() async throws {
@@ -308,12 +323,19 @@ struct AgentMonitorStoreTests {
 
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "after")
-        #expect(await transport.agentReadParams.count == 2)
+        #expect(await agentReads(transport, source: .visible).count == 2)
     }
 
     @Test func returningWhileOpenIsLoadingStillPerformsTheRefresh() async throws {
         let transport = ScriptedTransport()
         await transport.setAgentText("opening", target: "w1:p1")
+        // The open also backfills (#181), and the gated visible read lets
+        // the scripted screen move on before that backfill executes. Pin
+        // the history window to the pre-Attach screen so it stitches to
+        // nothing; the return refresh alone then decides the final screen.
+        // (A window disjoint from the stale tail would honestly record a
+        // gap — correct store behavior, but not what this test is about.)
+        await transport.setAgentHistoryText("opening", target: "w1:p1")
         let gate = ScriptedTransportCallGate()
         await transport.gateNextAgentRead(using: gate)
         let store = AgentMonitorStore(target: "w1:p1") { params in
@@ -334,7 +356,7 @@ struct AgentMonitorStoreTests {
 
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "after Attach")
-        #expect(await transport.agentReadParams.count == 2)
+        #expect(await agentReads(transport, source: .visible).count == 2)
     }
 
     @Test func failedOpenSurfacesTheServerErrorAndRetryRecovers() async throws {
@@ -357,7 +379,7 @@ struct AgentMonitorStoreTests {
         #expect(store.state == .loaded)
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "recovered")
-        #expect(await transport.agentReadParams.count == 2)
+        #expect(await agentReads(transport, source: .visible).count == 2)
     }
 
     @Test func failedReturnKeepsTheLastSnapshotAndItsFreshness() async throws {
@@ -377,6 +399,264 @@ struct AgentMonitorStoreTests {
         #expect(store.capturedAt == capturedAt)
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "known screen")
+    }
+
+    // MARK: History backfill (#181)
+
+    @Test func openWhileIdleBackfillsHistoryAboveTheScreen() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("screen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        await transport.setAgentHistoryText(
+            "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+        await store.open()
+
+        // The window overlaps the screen by its three lines, so only the
+        // older prefix is prepended; a short read ends history immediately.
+        let snapshot = try #require(store.snapshot)
+        #expect(
+            String(snapshot.characters) == "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3")
+        #expect(store.historyState == .exhausted)
+        #expect(await agentReads(transport, source: .visible).count == 1)
+        #expect(await agentReads(transport, source: .recent).count == 1)
+    }
+
+    @Test func openWhileWorkingSkipsBackfillAndTopEdgeStaysHonest() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("live screen", target: "w1:p1")
+        let store = AgentMonitorStore(
+            target: "w1:p1", initialStatus: .working
+        ) { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        #expect(store.historyState == .unavailable)
+        #expect(await transport.agentReadParams.count == 1)
+
+        store.topEdgeReached()
+
+        // Working never spins and never reads: the notice is the answer.
+        #expect(store.historyState == .unavailable)
+        #expect(await transport.agentReadParams.count == 1)
+    }
+
+    @Test func topEdgeWhileIdleShowsLoadingThenStitchesOlderLines() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("screen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        let store = AgentMonitorStore(
+            target: "w1:p1", initialStatus: .working
+        ) { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+        #expect(store.historyState == .unavailable)
+
+        // Going idle refreshes the screen but does not backfill on its own.
+        await store.agentStatusDidChange(.idle)
+        #expect(store.historyState == .idle)
+
+        await transport.setAgentHistoryText(
+            "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        let gate = ScriptedTransportCallGate()
+        await transport.gateNextAgentRead(using: gate)
+        store.topEdgeReached()
+        #expect(store.historyState == .loading)
+        try await waitUntil("the backfill read should be in flight") {
+            await gate.entryCount == 1
+        }
+
+        await gate.open()
+        try await waitUntil("the backfill should land") {
+            store.historyState == .exhausted
+        }
+
+        let snapshot = try #require(store.snapshot)
+        #expect(
+            String(snapshot.characters) == "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3")
+        #expect(await agentReads(transport, source: .recent).count == 1)
+    }
+
+    @Test func repeatBackfillAtTheCaptureLimitEndsHistory() async throws {
+        let transport = ScriptedTransport()
+        let screen = (998...1000).map { "line \($0)" }.joined(separator: "\n")
+        let window = (1...1000).map { "line \($0)" }.joined(separator: "\n")
+        await transport.setAgentText(screen, target: "w1:p1")
+        await transport.setAgentHistoryText(window, target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        // A full-window read that added lines might have more behind it.
+        #expect(store.historyState == .idle)
+        #expect(String(try #require(store.snapshot).characters) == window)
+
+        // The same window comes back: nothing new, so the limit is honest.
+        store.topEdgeReached()
+        try await waitUntil("the confirming read should declare the limit") {
+            store.historyState == .exhausted
+        }
+        #expect(String(try #require(store.snapshot).characters) == window)
+        #expect(await agentReads(transport, source: .recent).count == 2)
+    }
+
+    @Test func unstitchableReadInsertsAnExplicitGapMarker() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("stale a\nstale b\nstale c", target: "w1:p1")
+        // The server's buffer shares not one line with the cache (restarted
+        // pane, cleared scrollback): no overlap, no guessing.
+        await transport.setAgentHistoryText("fresh 1\nfresh 2\nfresh 3", target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        let expected = [
+            "stale a", "stale b", "stale c",
+            AgentMonitorStore.gapMarkerText,
+            "fresh 1", "fresh 2", "fresh 3",
+        ].joined(separator: "\n")
+        #expect(String(try #require(store.snapshot).characters) == expected)
+        #expect(store.historyState == .exhausted)
+    }
+
+    @Test func agentNotIdleSurfacesAsUnavailableNeverAnError() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("live screen", target: "w1:p1")
+        await transport.setAgentHistoryReadFailure(
+            HerdrAPIError(code: "agent_not_idle", message: "agent is working"))
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        // The screen loaded; only history is unavailable, and honestly so.
+        #expect(store.state == .loaded)
+        #expect(store.historyState == .unavailable)
+        #expect(String(try #require(store.snapshot).characters) == "live screen")
+
+        // A later top-edge hit retries the read and lands the same way.
+        store.topEdgeReached()
+        try await waitUntil("the retried read should settle as unavailable") {
+            store.historyState == .unavailable
+        }
+        #expect(store.state == .loaded)
+        #expect(await agentReads(transport, source: .recent).count == 2)
+    }
+
+    @Test func failedBackfillSurfacesARetryableError() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("screen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        await transport.setAgentHistoryReadFailure(TransportError.timedOut)
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        #expect(store.state == .loaded)
+        #expect(store.historyState == .failed("The Host did not answer in time."))
+
+        await transport.setAgentHistoryReadFailure(nil)
+        await transport.setAgentHistoryText(
+            "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        await store.loadEarlierHistory()
+
+        #expect(store.historyState == .exhausted)
+        #expect(
+            String(try #require(store.snapshot).characters)
+                == "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3")
+    }
+
+    @Test func openingOnAnEmptyScreenPaintsTheEmptyState() async throws {
+        let transport = ScriptedTransport()
+        // No scripted text: the visible read answers "". The first install
+        // must still render, or the view loads forever.
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        #expect(store.state == .loaded)
+        let snapshot = try #require(store.snapshot)
+        #expect(snapshot.characters.isEmpty)
+        #expect(store.historyState == .exhausted)
+    }
+
+    @Test func backfillWaitsForAnInFlightVisibleRead() async throws {
+        let transport = ScriptedTransport()
+        let screen = (998...1000).map { "line \($0)" }.joined(separator: "\n")
+        let window = (1...1000).map { "line \($0)" }.joined(separator: "\n")
+        await transport.setAgentText(screen, target: "w1:p1")
+        await transport.setAgentHistoryText(window, target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+        #expect(store.historyState == .idle)
+
+        // A visible read in flight (a cadence poll or pull-to-refresh) holds
+        // the shared flight; the top-edge backfill must queue behind it
+        // rather than interleave and risk a spurious gap.
+        let gate = ScriptedTransportCallGate()
+        await transport.gateNextAgentRead(using: gate)
+        let refreshing = Task { await store.refresh() }
+        try await waitUntil("the visible read should be in flight") {
+            await gate.entryCount == 1
+        }
+        store.topEdgeReached()
+        #expect(store.historyState == .loading)
+        #expect(await agentReads(transport, source: .recent).count == 1)
+
+        await gate.open()
+        await refreshing.value
+        try await waitUntil("the queued backfill should run and exhaust") {
+            store.historyState == .exhausted
+        }
+
+        #expect(await agentReads(transport, source: .recent).count == 2)
+        let snapshot = try #require(store.snapshot)
+        #expect(String(snapshot.characters) == window)
+        #expect(!String(snapshot.characters).contains(AgentMonitorStore.gapMarkerText))
+    }
+
+    @Test func visibleReadsExtendTheLiveTailWhileWorking() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("l1\nl2\nl3\nl4\nl5", target: "w1:p1")
+        let store = AgentMonitorStore(
+            target: "w1:p1", initialStatus: .working
+        ) { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+
+        // A scrolled screen overlaps the cached tail: only fresh lines land.
+        await transport.setAgentText("l2\nl3\nl4\nl5\nl6", target: "w1:p1")
+        await store.refresh()
+        #expect(
+            String(try #require(store.snapshot).characters) == "l1\nl2\nl3\nl4\nl5\nl6")
+
+        // A repaint shares no overlap: the tail is replaced, not extended.
+        await transport.setAgentText("n1\nn2\nn3\nn4\nn5", target: "w1:p1")
+        await store.refresh()
+        #expect(String(try #require(store.snapshot).characters) == "n1\nn2\nn3\nn4\nn5")
+    }
+
+    private func agentReads(
+        _ transport: ScriptedTransport,
+        source: ReadSource
+    ) async -> [AgentReadParams] {
+        await transport.agentReadParams.filter { $0.source == source }
     }
 
     private func waitUntil(

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -735,13 +735,19 @@ struct AgentMonitorStoreTests {
 
         #expect(store.sendError == nil)
         #expect(store.isSendingKey == false)
+        // The refreshed screen shares nothing with the old one, so the
+        // scrollback seals the pre-send screen above a gap (#181) rather
+        // than discarding it.
         let snapshot = try #require(store.snapshot)
-        #expect(String(snapshot.characters) == "after ctrl+c")
+        #expect(
+            String(snapshot.characters)
+                == ["before", AgentMonitorStore.gapMarkerText, "after ctrl+c"]
+                .joined(separator: "\n"))
         #expect(
             await transport.agentSendKeysParams == [
                 AgentSendKeysParams(keys: ["ctrl+c"], target: "w1:p1")
             ])
-        #expect(await transport.agentReadParams.count == 2)
+        #expect(await agentReads(transport, source: .visible).count == 2)
     }
 
     @Test func sendFailureSurfacesWithoutRefreshing() async throws {
@@ -758,7 +764,7 @@ struct AgentMonitorStoreTests {
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "known screen")
         #expect(await transport.agentSendKeysParams.isEmpty)
-        #expect(await transport.agentReadParams.count == 1)
+        #expect(await agentReads(transport, source: .visible).count == 1)
     }
 
     @Test func successfulSendClearsAPriorSendError() async throws {
@@ -776,8 +782,13 @@ struct AgentMonitorStoreTests {
         await store.send(.escape)
 
         #expect(store.sendError == nil)
+        // As above: the unrelated refreshed screen lands below a gap while
+        // the pre-send screen stays in the scrollback (#181).
         let snapshot = try #require(store.snapshot)
-        #expect(String(snapshot.characters) == "dismissed")
+        #expect(
+            String(snapshot.characters)
+                == ["screen", AgentMonitorStore.gapMarkerText, "dismissed"]
+                .joined(separator: "\n"))
         #expect(
             await transport.agentSendKeysParams == [
                 AgentSendKeysParams(keys: ["esc"], target: "w1:p1")

--- a/Tests/HeelerTests/Support/ScriptedTransport.swift
+++ b/Tests/HeelerTests/Support/ScriptedTransport.swift
@@ -58,6 +58,11 @@ final actor ScriptedTransport: Transport {
     private var agentTexts: [String: String] = [:]
     private var agentReadFailure: (any Error)?
     private var nextAgentReadGate: ScriptedTransportCallGate?
+    /// History-source (`recent`/`recent_unwrapped`) read scripting, separate
+    /// from the visible screen: Monitor's backfill tests script a wider
+    /// window than the live tail without disturbing visible-read tests.
+    private var agentHistoryTexts: [String: String] = [:]
+    private var agentHistoryReadFailure: (any Error)?
     private var missingPaneIDs: Set<String> = []
     private var nextStreamID: UInt64 = 0
     private var liveStreamID: UInt64?
@@ -136,6 +141,21 @@ final actor ScriptedTransport: Transport {
     /// Makes every subsequent `readAgent` throw `failure`.
     func setAgentReadFailure(_ failure: (any Error)?) {
         agentReadFailure = failure
+    }
+
+    /// Scripts the text `readAgent` returns for history sources (`recent`,
+    /// `recent_unwrapped`) on `target`; unscripted targets fall back to the
+    /// `setAgentText` value, as a server whose window equals its screen
+    /// would answer.
+    func setAgentHistoryText(_ text: String, target: String) {
+        agentHistoryTexts[target] = text
+    }
+
+    /// Makes every subsequent history-source `readAgent` throw `failure`
+    /// while leaving visible reads untouched — the `agent_not_idle` race
+    /// between the screen and a backfill.
+    func setAgentHistoryReadFailure(_ failure: (any Error)?) {
+        agentHistoryReadFailure = failure
     }
 
     /// Pauses the next Agent read after capturing its response.
@@ -332,8 +352,12 @@ final actor ScriptedTransport: Transport {
 
     func readAgent(_ params: AgentReadParams) async throws -> PaneReadResult {
         agentReadParams.append(params)
-        let responseText = agentTexts[params.target] ?? ""
-        let failure = agentReadFailure
+        let isHistoryRead = params.source != .visible
+        let responseText =
+            isHistoryRead
+            ? (agentHistoryTexts[params.target] ?? agentTexts[params.target] ?? "")
+            : (agentTexts[params.target] ?? "")
+        let failure = isHistoryRead ? (agentHistoryReadFailure ?? agentReadFailure) : agentReadFailure
         let gate = nextAgentReadGate
         nextAgentReadGate = nil
         await gate?.waitUntilOpen()


### PR DESCRIPTION
## Summary

Scrolling up through what the Agent did is instant within an in-memory cache. Hitting the top of the cache while the Agent is idle backfills once through the agent-level read (recent source, up to the server's 1000-line cap) with a visible loading state — the only loading state in the flow. While the Agent works, the top shows an honest "history unavailable while the Agent works" notice (the server's `agent_not_idle` surfaces as unavailability, never an error or spinner). Reads and reconnects reconcile via a pure overlap-stitching module (`AgentMonitorHistory`): a failed stitch inserts an explicit gap marker rather than guessing, coincidental 1-2 line overlaps are refused (minimum overlap 3), and reaching the capture limit shows an end-of-history marker. Backfill and the 2-second live-mirror fetch are mutually single-flight so a race cannot manufacture spurious gaps.

Closes #181 (part of #176).

## Test evidence

Full CI mirror (`scripts/run-ci-ios-tests.sh`) at HEAD b498db8: **exit 0, 866 of 961 tests executed, 95 skipped and proven elsewhere** — including 10 pure stitching fixtures and 12 scripted-Transport store tests (gap markers, exhaustion, agent_not_idle honesty, backfill/fetch serialization, empty-first-screen paint).

One pre-existing test (`returningWhileOpenIsLoadingStillPerformsTheRefresh`) needed its scripting extended: it predated open-time backfill and left the history source unscripted, producing an interleaving impossible against a real server; its assertions are unchanged.

## Merge order

Stacked on #188 (feat/180-monitor-live-mirror). Round merge order: #177 → #178 → #179 → #180 → **#181** → #182 → #183. #182 (parallel sibling off the same base, also touching the Monitor surface and CHANGELOG) merges after this and rebases if needed; #183 rebases last.