### PR TITLE
feat(monitor): conversational chrome for the agent monitor

### DIFF
--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -284,7 +284,9 @@ final class ConsoleStore {
         let store = AgentComposerStore(
             target: agent.agent.paneID,
             initialStatus: agent.agent.status,
-            statusUpdates: agentStatusUpdates(for: agent.id)
+            statusUpdates: agentStatusUpdates(for: agent.id),
+            // Late-bound Host stager (same seam Attach uses; ADR 0006).
+            stageImage: imageStager(for: hostID)
         ) { [weak self] params in
             guard let self else { throw TransportError.cancelled }
             return try await self.promptAgent(params, on: hostID)

--- a/Sources/Heeler/Images/ImagePreparer.swift
+++ b/Sources/Heeler/Images/ImagePreparer.swift
@@ -49,6 +49,26 @@ struct DataImageSelection: ImageSelection {
     }
 }
 
+/// Image pick from the system document browser (Files). Holds a security-scoped
+/// URL long enough to read bytes, then the existing preparer owns the copy.
+struct FileURLImageSelection: ImageSelection {
+    let url: URL
+
+    func loadData() async throws -> Data {
+        let accessing = url.startAccessingSecurityScopedResource()
+        defer {
+            if accessing {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+        do {
+            return try Data(contentsOf: url)
+        } catch {
+            throw ImagePreparationError.selectionUnavailable
+        }
+    }
+}
+
 protocol ImagePreparing: Sendable {
     func prepare(_ selection: any ImageSelection) async throws -> PreparedImage
 }

--- a/Sources/Heeler/Monitor/AgentComposerStore.swift
+++ b/Sources/Heeler/Monitor/AgentComposerStore.swift
@@ -321,11 +321,12 @@ final class AgentComposerStore: ComposerDraftOperations {
             let image = try await preparer.prepare(selection)
             unclaimedImage = image
             try Task.checkCancellation()
+            // Stale paths leave `stageTask` alone: it holds the newer
+            // operation's handle. Any future cancellation entry point must
+            // reset `stageTask` itself; nilling here would abandon the live
+            // task and allow concurrent double-staging.
             guard operationID == stageOperationID else {
                 try? image.remove()
-                // Drop the busy claim so a future cancel/invalidate path
-                // cannot leave Files permanently disabled.
-                stageTask = nil
                 return
             }
             preparedImage = image
@@ -335,10 +336,7 @@ final class AgentComposerStore: ComposerDraftOperations {
                 image,
                 ImageStageProgressReporter { _ in })
             try Task.checkCancellation()
-            guard operationID == stageOperationID else {
-                stageTask = nil
-                return
-            }
+            guard operationID == stageOperationID else { return }
 
             stageTask = nil
             discardPreparedImage()
@@ -353,10 +351,8 @@ final class AgentComposerStore: ComposerDraftOperations {
     }
 
     private func finishStage(error: any Error, operationID: UInt64) {
-        guard operationID == stageOperationID else {
-            stageTask = nil
-            return
-        }
+        // Stale: do not touch `stageTask` (see runStageAndInsert contract).
+        guard operationID == stageOperationID else { return }
         stageTask = nil
         if Self.isCancellation(error) {
             discardPreparedImage()

--- a/Sources/Heeler/Monitor/AgentComposerStore.swift
+++ b/Sources/Heeler/Monitor/AgentComposerStore.swift
@@ -46,46 +46,113 @@ final class AgentComposerStore: ComposerDraftOperations {
         let pending: [Message]
     }
 
+    /// Image file staging for the Composer Files control. Staging never
+    /// submits; success only inserts the remote path into the local draft.
+    enum FileStageState: Equatable {
+        case idle
+        case staging
+        case failed(String)
+    }
+
     private(set) var messages: [Message] = []
     private(set) var draft = ""
+    private(set) var fileStageState: FileStageState = .idle
 
     private let target: String
     private var agentStatus: AgentStatus
     private var statusRevision: UInt64 = 0
     private let now: @Sendable () -> Date
     private let statusUpdates: AsyncStream<ConsoleStore.AgentStatusUpdate>?
+    private let preparer: any ImagePreparing
+    private let stageImage: ImageStager?
     private let prompt: @Sendable (AgentPromptParams) async throws -> Agent
     @ObservationIgnored private var hasOpened = false
     @ObservationIgnored private var statusTask: Task<Void, Never>?
+    @ObservationIgnored private var stageTask: Task<Void, Never>?
+    @ObservationIgnored private var stageOperationID: UInt64 = 0
+    @ObservationIgnored private var preparedImage: PreparedImage?
 
     init(
         target: String,
         initialStatus: AgentStatus = .idle,
         now: @escaping @Sendable () -> Date = { Date() },
         statusUpdates: AsyncStream<ConsoleStore.AgentStatusUpdate>? = nil,
+        preparer: any ImagePreparing = ImagePreparer(),
+        stageImage: ImageStager? = nil,
         prompt: @escaping @Sendable (AgentPromptParams) async throws -> Agent
     ) {
         self.target = target
         agentStatus = initialStatus
         self.now = now
         self.statusUpdates = statusUpdates
+        self.preparer = preparer
+        self.stageImage = stageImage
         self.prompt = prompt
     }
 
     deinit {
         statusTask?.cancel()
+        stageTask?.cancel()
     }
 
     var canSend: Bool {
         draft.contains(where: { !$0.isWhitespace })
     }
 
+    var isStagingFile: Bool {
+        if case .staging = fileStageState { true } else { false }
+    }
+
+    var fileStageFailureMessage: String? {
+        if case .failed(let message) = fileStageState { message } else { nil }
+    }
+
+    /// Files is available when a Host stager is wired and no stage is running.
+    /// Draft edits do not depend on agent status, so this is independent of
+    /// control-key enablement.
+    var canStageFile: Bool {
+        stageImage != nil && !isStagingFile
+    }
+
     func replaceDraft(with text: String) {
         draft = text
     }
 
+    /// Inserts `text` into the local draft without submitting.
+    ///
+    /// Separator rule: empty `text` is a no-op. When the draft is non-empty
+    /// and does not already end in whitespace, a single space is inserted
+    /// before `text` so paste, snippet, and staged-path insertions do not
+    /// glue onto the preceding token. Callers that want a trailing separator
+    /// (staged paths) include it in `text`.
     func insertIntoDraft(_ text: String) {
-        draft.append(text)
+        guard !text.isEmpty else { return }
+        if draft.isEmpty || draft.last?.isWhitespace == true {
+            draft.append(text)
+        } else {
+            draft.append(" ")
+            draft.append(text)
+        }
+    }
+
+    /// Prepares and stages one image over the Host SFTP seam, then inserts
+    /// the remote path into the draft (with a trailing space) without
+    /// submitting. Failures keep the draft intact and surface recovery copy.
+    func stageAndInsertImage(_ selection: any ImageSelection) {
+        guard let stageImage, stageTask == nil else { return }
+        discardPreparedImage()
+        stageOperationID &+= 1
+        let operationID = stageOperationID
+        fileStageState = .staging
+        stageTask = Task {
+            await self.runStageAndInsert(
+                selection, stageImage: stageImage, operationID: operationID)
+        }
+    }
+
+    func dismissFileStageFailure() {
+        guard case .failed = fileStageState else { return }
+        fileStageState = .idle
     }
 
     /// Starts consuming Console's existing per-Agent status fan-out. This
@@ -238,6 +305,85 @@ final class AgentComposerStore: ComposerDraftOperations {
             error.connectionGuidance
         default:
             "The message could not be sent. Check the connection and retry."
+        }
+    }
+
+    private func runStageAndInsert(
+        _ selection: any ImageSelection,
+        stageImage: @escaping ImageStager,
+        operationID: UInt64
+    ) async {
+        var unclaimedImage: PreparedImage?
+        do {
+            let image = try await preparer.prepare(selection)
+            unclaimedImage = image
+            try Task.checkCancellation()
+            guard operationID == stageOperationID else {
+                try? image.remove()
+                return
+            }
+            preparedImage = image
+            unclaimedImage = nil
+
+            let staged = try await stageImage(
+                image,
+                ImageStageProgressReporter { _ in })
+            try Task.checkCancellation()
+            guard operationID == stageOperationID else { return }
+
+            stageTask = nil
+            discardPreparedImage()
+            fileStageState = .idle
+            // Trailing space matches Attach path insertion so the user can
+            // keep typing after the path without gluing tokens together.
+            insertIntoDraft(staged.path + " ")
+        } catch {
+            try? unclaimedImage?.remove()
+            finishStage(error: error, operationID: operationID)
+        }
+    }
+
+    private func finishStage(error: any Error, operationID: UInt64) {
+        guard operationID == stageOperationID else { return }
+        stageTask = nil
+        if Self.isCancellation(error) {
+            discardPreparedImage()
+            fileStageState = .idle
+            return
+        }
+        discardPreparedImage()
+        fileStageState = .failed(Self.fileStageMessage(for: error))
+    }
+
+    private func discardPreparedImage() {
+        try? preparedImage?.remove()
+        preparedImage = nil
+    }
+
+    private static func isCancellation(_ error: any Error) -> Bool {
+        error is CancellationError || (error as? ImageStagingError) == .cancelled
+    }
+
+    private static func fileStageMessage(for error: any Error) -> String {
+        switch error {
+        case TransportError.sshUnreachable:
+            "The Host is not connected. Reconnect, then choose the image again."
+        case ImageStagingError.sftpUnavailable:
+            "SFTP is unavailable on this Host. Enable its SSH SFTP subsystem, then try again."
+        case let staging as ImageStagingError where staging.isRetryable:
+            "Image upload failed. Choose the image again to retry."
+        case ImagePreparationError.selectionUnavailable:
+            "The selected photo is no longer available. Choose another image."
+        case ImagePreparationError.sourceTooLarge:
+            "The selected image is too large to decode safely. Choose a smaller image."
+        case ImagePreparationError.invalidImage:
+            "The selected item is not a readable image. Choose a different file."
+        case ImagePreparationError.unableToProduceBoundedOutput:
+            "The image could not be reduced below the 16 MiB upload limit. Choose a smaller image."
+        case ImagePreparationError.localStorageFailed:
+            "herdr could not prepare the image in protected local storage. Try again."
+        default:
+            "Image upload failed. Choose the image again to retry."
         }
     }
 }

--- a/Sources/Heeler/Monitor/AgentComposerStore.swift
+++ b/Sources/Heeler/Monitor/AgentComposerStore.swift
@@ -17,6 +17,9 @@ final class AgentComposerStore: ComposerDraftOperations {
     struct Message: Identifiable, Equatable {
         let id: UUID
         let text: String
+        /// Wall-clock time this message was (last) submitted. Used to decide
+        /// whether the snapshot already reflects it (capture-anchored timeline).
+        fileprivate(set) var sentAt: Date
         fileprivate var agentWasWorkingAtSend: Bool
         fileprivate var statusRevisionAtSend: UInt64
         fileprivate var observedWorkingAfterSend: Bool
@@ -36,12 +39,20 @@ final class AgentComposerStore: ComposerDraftOperations {
         case done
     }
 
+    /// Capture-anchored split of local echoes: reflected messages already
+    /// appear inside the agent snapshot; pending ones still need bubbles.
+    struct MessagePartition: Equatable {
+        let reflected: [Message]
+        let pending: [Message]
+    }
+
     private(set) var messages: [Message] = []
     private(set) var draft = ""
 
     private let target: String
     private var agentStatus: AgentStatus
     private var statusRevision: UInt64 = 0
+    private let now: @Sendable () -> Date
     private let statusUpdates: AsyncStream<ConsoleStore.AgentStatusUpdate>?
     private let prompt: @Sendable (AgentPromptParams) async throws -> Agent
     @ObservationIgnored private var hasOpened = false
@@ -50,11 +61,13 @@ final class AgentComposerStore: ComposerDraftOperations {
     init(
         target: String,
         initialStatus: AgentStatus = .idle,
+        now: @escaping @Sendable () -> Date = { Date() },
         statusUpdates: AsyncStream<ConsoleStore.AgentStatusUpdate>? = nil,
         prompt: @escaping @Sendable (AgentPromptParams) async throws -> Agent
     ) {
         self.target = target
         agentStatus = initialStatus
+        self.now = now
         self.statusUpdates = statusUpdates
         self.prompt = prompt
     }
@@ -94,7 +107,9 @@ final class AgentComposerStore: ComposerDraftOperations {
     func send() async {
         guard canSend else { return }
         let message = Message(
-            id: UUID(), text: draft,
+            id: UUID(),
+            text: draft,
+            sentAt: now(),
             agentWasWorkingAtSend: agentStatus == .working,
             statusRevisionAtSend: statusRevision,
             observedWorkingAfterSend: false,
@@ -107,11 +122,35 @@ final class AgentComposerStore: ComposerDraftOperations {
     func retry(_ id: Message.ID) async {
         guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
         guard case .failed = messages[index].state else { return }
+        messages[index].sentAt = now()
         messages[index].agentWasWorkingAtSend = agentStatus == .working
         messages[index].statusRevisionAtSend = statusRevision
         messages[index].observedWorkingAfterSend = false
         messages[index].state = .sending
         await deliver(id)
+    }
+
+    /// Splits local echoes relative to the current snapshot capture time.
+    /// A delivered message is **reflected** when `sentAt < capturedAt` (already
+    /// visible in agent output); everything else stays **pending**.
+    func partitionMessages(capturedAt: Date?) -> MessagePartition {
+        var reflected: [Message] = []
+        var pending: [Message] = []
+        for message in messages {
+            if Self.isReflected(message, capturedAt: capturedAt) {
+                reflected.append(message)
+            } else {
+                pending.append(message)
+            }
+        }
+        return MessagePartition(reflected: reflected, pending: pending)
+    }
+
+    /// Pure helper for tests and ``partitionMessages(capturedAt:)``.
+    static func isReflected(_ message: Message, capturedAt: Date?) -> Bool {
+        guard case .delivered = message.state else { return false }
+        guard let capturedAt else { return false }
+        return message.sentAt < capturedAt
     }
 
     /// Removes a failed echo and restores all of its text to the draft. If

--- a/Sources/Heeler/Monitor/AgentComposerStore.swift
+++ b/Sources/Heeler/Monitor/AgentComposerStore.swift
@@ -120,18 +120,21 @@ final class AgentComposerStore: ComposerDraftOperations {
 
     /// Inserts `text` into the local draft without submitting.
     ///
-    /// Separator rule: empty `text` is a no-op. When the draft is non-empty
-    /// and does not already end in whitespace, a single space is inserted
-    /// before `text` so paste, snippet, and staged-path insertions do not
-    /// glue onto the preceding token. Callers that want a trailing separator
-    /// (staged paths) include it in `text`.
+    /// Separator rule: leading whitespace on `text` is stripped so clipboard
+    /// paste cannot double-separate against the draft tail. Empty / pure-
+    /// whitespace `text` is a no-op. When the draft is non-empty and does not
+    /// already end in whitespace, a single space is inserted before the
+    /// remainder so paste, snippet, and staged-path insertions do not glue
+    /// onto the preceding token. Callers that want a trailing separator
+    /// (staged paths) include it in `text` (trailing whitespace is kept).
     func insertIntoDraft(_ text: String) {
-        guard !text.isEmpty else { return }
+        let insertion = text.drop(while: \.isWhitespace)
+        guard !insertion.isEmpty else { return }
         if draft.isEmpty || draft.last?.isWhitespace == true {
-            draft.append(text)
+            draft.append(contentsOf: insertion)
         } else {
             draft.append(" ")
-            draft.append(text)
+            draft.append(contentsOf: insertion)
         }
     }
 
@@ -144,8 +147,8 @@ final class AgentComposerStore: ComposerDraftOperations {
         stageOperationID &+= 1
         let operationID = stageOperationID
         fileStageState = .staging
-        stageTask = Task {
-            await self.runStageAndInsert(
+        stageTask = Task { [weak self] in
+            await self?.runStageAndInsert(
                 selection, stageImage: stageImage, operationID: operationID)
         }
     }
@@ -320,6 +323,9 @@ final class AgentComposerStore: ComposerDraftOperations {
             try Task.checkCancellation()
             guard operationID == stageOperationID else {
                 try? image.remove()
+                // Drop the busy claim so a future cancel/invalidate path
+                // cannot leave Files permanently disabled.
+                stageTask = nil
                 return
             }
             preparedImage = image
@@ -329,7 +335,10 @@ final class AgentComposerStore: ComposerDraftOperations {
                 image,
                 ImageStageProgressReporter { _ in })
             try Task.checkCancellation()
-            guard operationID == stageOperationID else { return }
+            guard operationID == stageOperationID else {
+                stageTask = nil
+                return
+            }
 
             stageTask = nil
             discardPreparedImage()
@@ -344,7 +353,10 @@ final class AgentComposerStore: ComposerDraftOperations {
     }
 
     private func finishStage(error: any Error, operationID: UInt64) {
-        guard operationID == stageOperationID else { return }
+        guard operationID == stageOperationID else {
+            stageTask = nil
+            return
+        }
         stageTask = nil
         if Self.isCancellation(error) {
             discardPreparedImage()
@@ -372,8 +384,10 @@ final class AgentComposerStore: ComposerDraftOperations {
             "SFTP is unavailable on this Host. Enable its SSH SFTP subsystem, then try again."
         case let staging as ImageStagingError where staging.isRetryable:
             "Image upload failed. Choose the image again to retry."
+        case is ImageStagingError:
+            "Couldn't attach this image. Try a different image."
         case ImagePreparationError.selectionUnavailable:
-            "The selected photo is no longer available. Choose another image."
+            "The selected file is no longer available. Choose another image."
         case ImagePreparationError.sourceTooLarge:
             "The selected image is too large to decode safely. Choose a smaller image."
         case ImagePreparationError.invalidImage:
@@ -383,7 +397,7 @@ final class AgentComposerStore: ComposerDraftOperations {
         case ImagePreparationError.localStorageFailed:
             "herdr could not prepare the image in protected local storage. Try again."
         default:
-            "Image upload failed. Choose the image again to retry."
+            "Couldn't attach this image. Try a different image."
         }
     }
 }

--- a/Sources/Heeler/Monitor/AgentComposerView.swift
+++ b/Sources/Heeler/Monitor/AgentComposerView.swift
@@ -29,7 +29,7 @@ struct AgentComposerView: View {
                     }
                     .font(.footnote)
                 }
-                .accessibilityElement(children: .combine)
+                .accessibilityElement(children: .contain)
             }
 
             Text("Message the Agent")

--- a/Sources/Heeler/Monitor/AgentComposerView.swift
+++ b/Sources/Heeler/Monitor/AgentComposerView.swift
@@ -85,6 +85,8 @@ struct AgentSentMessagesView: View {
                         Text(Self.reflectedSummaryLabel(count: partition.reflected.count))
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                            .contentShape(Rectangle())
                     }
                 }
 

--- a/Sources/Heeler/Monitor/AgentComposerView.swift
+++ b/Sources/Heeler/Monitor/AgentComposerView.swift
@@ -11,8 +11,26 @@ struct AgentComposerView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             MonitorControlKeyStrip(
-                isEnabled: isControlKeyEnabled,
-                onTap: onControlKey)
+                isControlKeyEnabled: isControlKeyEnabled,
+                isFileStaging: store.isStagingFile,
+                canStageFile: store.canStageFile,
+                onControlKey: onControlKey,
+                onPaste: { store.insertIntoDraft($0) },
+                onImageSelected: { store.stageAndInsertImage($0) })
+
+            if let failure = store.fileStageFailureMessage {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Label(failure, systemImage: "exclamationmark.triangle")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Button("Dismiss") {
+                        store.dismissFileStageFailure()
+                    }
+                    .font(.footnote)
+                }
+                .accessibilityElement(children: .combine)
+            }
 
             Text("Message the Agent")
                 .font(.caption.weight(.semibold))

--- a/Sources/Heeler/Monitor/AgentComposerView.swift
+++ b/Sources/Heeler/Monitor/AgentComposerView.swift
@@ -57,9 +57,13 @@ struct AgentComposerView: View {
 
 struct AgentSentMessagesView: View {
     let store: AgentComposerStore
+    /// Snapshot capture time from the monitor store; anchors the reflected /
+    /// pending split so delivered-and-older echoes do not double-print.
+    let capturedAt: Date?
 
     @ViewBuilder
     var body: some View {
+        let partition = store.partitionMessages(capturedAt: capturedAt)
         if !store.messages.isEmpty {
             VStack(alignment: .leading, spacing: 10) {
                 VStack(alignment: .leading, spacing: 3) {
@@ -71,7 +75,20 @@ struct AgentSentMessagesView: View {
                         .foregroundStyle(.secondary)
                 }
 
-                ForEach(store.messages) { message in
+                if !partition.reflected.isEmpty {
+                    DisclosureGroup {
+                        ForEach(partition.reflected) { message in
+                            messageRow(message)
+                                .id(message.id)
+                        }
+                    } label: {
+                        Text(Self.reflectedSummaryLabel(count: partition.reflected.count))
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                ForEach(partition.pending) { message in
                     messageRow(message)
                         .id(message.id)
                 }
@@ -79,6 +96,12 @@ struct AgentSentMessagesView: View {
             .accessibilityElement(children: .contain)
             .accessibilityLabel("Messages sent from this device")
         }
+    }
+
+    private static func reflectedSummaryLabel(count: Int) -> String {
+        count == 1
+            ? "1 earlier message"
+            : "\(count) earlier messages"
     }
 
     private func messageRow(_ message: AgentComposerStore.Message) -> some View {

--- a/Sources/Heeler/Monitor/AgentMonitorStore.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorStore.swift
@@ -495,7 +495,7 @@ final class AgentMonitorStore {
         case TransportError.timedOut:
             "The Host did not answer in time."
         case let error as HerdrAPIError:
-            "herdr rejected the snapshot: \(error.message)"
+            "Couldn't refresh the screen. \(error.message)"
         case let error as TransportError:
             error.connectionGuidance
         default:
@@ -510,7 +510,7 @@ final class AgentMonitorStore {
         case TransportError.timedOut:
             "The Host did not answer in time."
         case let error as HerdrAPIError:
-            "herdr rejected the key: \(error.message)"
+            "Couldn't send the key. \(error.message)"
         case let error as TransportError:
             error.connectionGuidance
         default:

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -134,7 +134,7 @@ struct AgentDetailView: View {
                                 .buttonStyle(.bordered)
                             }
 
-                            AgentSentMessagesView(store: composer)
+                            AgentSentMessagesView(store: composer, capturedAt: monitor.capturedAt)
                         }
                         .padding()
                         .frame(maxWidth: .infinity, minHeight: 360)
@@ -161,7 +161,7 @@ struct AgentDetailView: View {
                                 .buttonStyle(.borderedProminent)
                             }
 
-                            AgentSentMessagesView(store: composer)
+                            AgentSentMessagesView(store: composer, capturedAt: monitor.capturedAt)
                         }
                         .padding()
                         .frame(maxWidth: .infinity, minHeight: 360)
@@ -191,18 +191,12 @@ struct AgentDetailView: View {
                     Text(snapshot)
                         .font(.system(.callout, design: .monospaced))
                         .lineSpacing(3)
-                        .foregroundStyle(.white)
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .topLeading)
                         .padding(16)
                         .background(
-                            Color.black.opacity(0.94),
+                            Color(uiColor: .secondarySystemGroupedBackground),
                             in: RoundedRectangle(cornerRadius: 16))
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 16)
-                                .stroke(.white.opacity(0.12), lineWidth: 1)
-                        }
-                        .environment(\.colorScheme, .dark)
 
                     if let sendError = monitor.sendError {
                         Label(sendError, systemImage: "exclamationmark.triangle")
@@ -215,7 +209,7 @@ struct AgentDetailView: View {
                                 in: RoundedRectangle(cornerRadius: 12))
                     }
 
-                    AgentSentMessagesView(store: composer)
+                    AgentSentMessagesView(store: composer, capturedAt: monitor.capturedAt)
 
                     Color.clear
                         .frame(height: 1)

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -134,7 +134,9 @@ struct AgentDetailView: View {
                                 .buttonStyle(.bordered)
                             }
 
-                            AgentSentMessagesView(store: composer, capturedAt: monitor.capturedAt)
+                            // Empty snapshots still stamp capturedAt, but nothing is
+                            // on screen — do not collapse delivered echoes as "earlier".
+                            AgentSentMessagesView(store: composer, capturedAt: nil)
                         }
                         .padding()
                         .frame(maxWidth: .infinity, minHeight: 360)

--- a/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
+++ b/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 
-/// Monitor's compact control-key row (#183). The three prompt actions stay
-/// one tap away; directional keys live behind an explicit menu so narrow
-/// layouts never hide controls offscreen. Spellings live on
+/// Monitor's compact control-key row (#183). Enter, Esc, and Ctrl+C stay one
+/// tap away; arrows live behind a menu. Spellings live on
 /// ``MonitorControlKey``; this view only presents the buttons.
 ///
-/// Scales with Dynamic Type: a single HStack when width allows, otherwise a
-/// horizontally scrollable strip so every target stays ≥44pt.
+/// Layout prefers a single HStack. When Dynamic Type or a narrow width does
+/// not fit, a horizontally scrollable strip (with indicators) keeps every
+/// target ≥44pt without clipping keys offscreen.
 struct MonitorControlKeyStrip: View {
     let isEnabled: Bool
     let onTap: (MonitorControlKey) -> Void
@@ -19,7 +19,7 @@ struct MonitorControlKeyStrip: View {
                 directionalMenu
             }
 
-            ScrollView(.horizontal, showsIndicators: false) {
+            ScrollView(.horizontal, showsIndicators: true) {
                 HStack(spacing: 8) {
                     quickKeyButtons
                     directionalMenu

--- a/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
+++ b/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
@@ -4,50 +4,68 @@ import SwiftUI
 /// one tap away; directional keys live behind an explicit menu so narrow
 /// layouts never hide controls offscreen. Spellings live on
 /// ``MonitorControlKey``; this view only presents the buttons.
+///
+/// Scales with Dynamic Type: a single HStack when width allows, otherwise a
+/// horizontally scrollable strip so every target stays ≥44pt.
 struct MonitorControlKeyStrip: View {
     let isEnabled: Bool
     let onTap: (MonitorControlKey) -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
-            ForEach(Self.quickKeys) { key in
-                Button {
-                    onTap(key)
-                } label: {
-                    keyLabel(key)
-                        .font(.callout.weight(.medium))
-                        .frame(minWidth: 44, minHeight: 44)
-                        .padding(.horizontal, 4)
-                }
-                .buttonStyle(.bordered)
-                .disabled(!isEnabled)
-                .accessibilityLabel(key.accessibilityLabel)
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 8) {
+                quickKeyButtons
+                Spacer(minLength: 0)
+                directionalMenu
             }
 
-            Spacer(minLength: 0)
-
-            Menu {
-                ForEach(Self.arrowKeys) { key in
-                    Button {
-                        onTap(key)
-                    } label: {
-                        Label(key.accessibilityLabel, systemImage: key.systemImage ?? "arrow.up")
-                    }
-                    .disabled(!isEnabled)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    quickKeyButtons
+                    directionalMenu
                 }
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Control keys")
+    }
+
+    @ViewBuilder
+    private var quickKeyButtons: some View {
+        ForEach(Self.quickKeys) { key in
+            Button {
+                onTap(key)
             } label: {
-                Image(systemName: "arrow.up.and.down.and.arrow.left.and.right")
+                keyLabel(key)
                     .font(.callout.weight(.medium))
                     .frame(minWidth: 44, minHeight: 44)
+                    .padding(.horizontal, 4)
             }
             .buttonStyle(.bordered)
             .disabled(!isEnabled)
-            .accessibilityLabel("Directional keys")
-            .accessibilityHint("Shows directional keys")
+            .accessibilityLabel(key.accessibilityLabel)
         }
-        .dynamicTypeSize(...DynamicTypeSize.large)
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Control keys")
+    }
+
+    private var directionalMenu: some View {
+        Menu {
+            ForEach(Self.arrowKeys) { key in
+                Button {
+                    onTap(key)
+                } label: {
+                    Label(key.accessibilityLabel, systemImage: key.systemImage ?? "arrow.up")
+                }
+                .disabled(!isEnabled)
+            }
+        } label: {
+            Image(systemName: "arrow.up.and.down.and.arrow.left.and.right")
+                .font(.callout.weight(.medium))
+                .frame(minWidth: 44, minHeight: 44)
+        }
+        .buttonStyle(.bordered)
+        .disabled(!isEnabled)
+        .accessibilityLabel("Directional keys")
+        .accessibilityHint("Shows directional keys")
     }
 
     @ViewBuilder

--- a/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
+++ b/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
@@ -1,5 +1,5 @@
-import PhotosUI
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Monitor's compact control-key row (#183) plus pinned draft accessories.
 /// Enter, Esc, and Ctrl+C stay one tap away; arrows live behind a menu.
@@ -18,7 +18,7 @@ struct MonitorControlKeyStrip: View {
     let onPaste: (String) -> Void
     let onImageSelected: (any ImageSelection) -> Void
 
-    @State private var selectedPhoto: PhotosPickerItem?
+    @State private var isPresentingFileImporter = false
 
     var body: some View {
         ViewThatFits(in: .horizontal) {
@@ -43,10 +43,15 @@ struct MonitorControlKeyStrip: View {
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Control keys")
-        .onChange(of: selectedPhoto) { _, item in
-            guard let item else { return }
-            selectedPhoto = nil
-            onImageSelected(PhotosPickerImageSelection(item: item))
+        .fileImporter(
+            isPresented: $isPresentingFileImporter,
+            allowedContentTypes: [.image],
+            allowsMultipleSelection: false
+        ) { result in
+            guard case .success(let urls) = result, let url = urls.first else {
+                return
+            }
+            onImageSelected(FileURLImageSelection(url: url))
         }
     }
 
@@ -57,7 +62,9 @@ struct MonitorControlKeyStrip: View {
     }
 
     private var filesButton: some View {
-        PhotosPicker(selection: $selectedPhoto, matching: .images) {
+        Button {
+            isPresentingFileImporter = true
+        } label: {
             Group {
                 if isFileStaging {
                     ProgressView()

--- a/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
+++ b/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
@@ -1,40 +1,106 @@
+import PhotosUI
 import SwiftUI
 
-/// Monitor's compact control-key row (#183). Enter, Esc, and Ctrl+C stay one
-/// tap away; arrows live behind a menu. Spellings live on
-/// ``MonitorControlKey``; this view only presents the buttons.
+/// Monitor's compact control-key row (#183) plus pinned draft accessories.
+/// Enter, Esc, and Ctrl+C stay one tap away; arrows live behind a menu.
+/// Files and Paste pin at the leading edge and never scroll away.
 ///
 /// Layout prefers a single HStack. When Dynamic Type or a narrow width does
-/// not fit, a horizontally scrollable strip (with indicators) keeps every
-/// target ≥44pt without clipping keys offscreen.
+/// not fit, Files and Paste stay outside a horizontally scrollable region so
+/// they remain visible while quick keys (and the arrows menu) may scroll.
 struct MonitorControlKeyStrip: View {
-    let isEnabled: Bool
-    let onTap: (MonitorControlKey) -> Void
+    /// Gates only the remote control keys (Enter / Esc / Ctrl+C / arrows).
+    /// Paste and Files edit local draft state and stay enabled independently.
+    let isControlKeyEnabled: Bool
+    let isFileStaging: Bool
+    let canStageFile: Bool
+    let onControlKey: (MonitorControlKey) -> Void
+    let onPaste: (String) -> Void
+    let onImageSelected: (any ImageSelection) -> Void
+
+    @State private var selectedPhoto: PhotosPickerItem?
 
     var body: some View {
         ViewThatFits(in: .horizontal) {
             HStack(spacing: 8) {
+                pinnedAccessories
+                accessoryDivider
                 quickKeyButtons
                 Spacer(minLength: 0)
                 directionalMenu
             }
 
-            ScrollView(.horizontal, showsIndicators: true) {
-                HStack(spacing: 8) {
-                    quickKeyButtons
-                    directionalMenu
+            HStack(spacing: 8) {
+                pinnedAccessories
+                accessoryDivider
+                ScrollView(.horizontal, showsIndicators: true) {
+                    HStack(spacing: 8) {
+                        quickKeyButtons
+                        directionalMenu
+                    }
                 }
             }
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Control keys")
+        .onChange(of: selectedPhoto) { _, item in
+            guard let item else { return }
+            selectedPhoto = nil
+            onImageSelected(PhotosPickerImageSelection(item: item))
+        }
+    }
+
+    @ViewBuilder
+    private var pinnedAccessories: some View {
+        filesButton
+        pasteButton
+    }
+
+    private var filesButton: some View {
+        PhotosPicker(selection: $selectedPhoto, matching: .images) {
+            Group {
+                if isFileStaging {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Text("Files")
+                        .font(.callout.weight(.medium))
+                }
+            }
+            .frame(minWidth: 44, minHeight: 44)
+            .padding(.horizontal, 4)
+        }
+        .buttonStyle(.bordered)
+        .disabled(!canStageFile || isFileStaging)
+        .accessibilityLabel("Attach file")
+        .accessibilityValue(isFileStaging ? "Uploading" : "")
+        .accessibilityHint("Stages an image on the Host and inserts its path into the draft")
+    }
+
+    private var pasteButton: some View {
+        PasteButton(payloadType: String.self) { strings in
+            guard let text = strings.first, !text.isEmpty else { return }
+            onPaste(text)
+        }
+        .labelStyle(.titleOnly)
+        .buttonStyle(.bordered)
+        .frame(minWidth: 44, minHeight: 44)
+        .accessibilityLabel("Paste")
+        .accessibilityHint("Inserts clipboard text into the draft without sending")
+    }
+
+    private var accessoryDivider: some View {
+        Rectangle()
+            .fill(.secondary.opacity(0.35))
+            .frame(width: 1, height: 28)
+            .accessibilityHidden(true)
     }
 
     @ViewBuilder
     private var quickKeyButtons: some View {
         ForEach(Self.quickKeys) { key in
             Button {
-                onTap(key)
+                onControlKey(key)
             } label: {
                 keyLabel(key)
                     .font(.callout.weight(.medium))
@@ -42,7 +108,7 @@ struct MonitorControlKeyStrip: View {
                     .padding(.horizontal, 4)
             }
             .buttonStyle(.bordered)
-            .disabled(!isEnabled)
+            .disabled(!isControlKeyEnabled)
             .accessibilityLabel(key.accessibilityLabel)
         }
     }
@@ -51,11 +117,11 @@ struct MonitorControlKeyStrip: View {
         Menu {
             ForEach(Self.arrowKeys) { key in
                 Button {
-                    onTap(key)
+                    onControlKey(key)
                 } label: {
                     Label(key.accessibilityLabel, systemImage: key.systemImage ?? "arrow.up")
                 }
-                .disabled(!isEnabled)
+                .disabled(!isControlKeyEnabled)
             }
         } label: {
             Image(systemName: "arrow.up.and.down.and.arrow.left.and.right")
@@ -63,7 +129,7 @@ struct MonitorControlKeyStrip: View {
                 .frame(minWidth: 44, minHeight: 44)
         }
         .buttonStyle(.bordered)
-        .disabled(!isEnabled)
+        .disabled(!isControlKeyEnabled)
         .accessibilityLabel("Directional keys")
         .accessibilityHint("Shows directional keys")
     }

--- a/Tests/HeelerTests/AgentComposerStoreTests.swift
+++ b/Tests/HeelerTests/AgentComposerStoreTests.swift
@@ -274,6 +274,172 @@ struct AgentComposerStoreTests {
         #expect(replacementStore.draft == "Keep this local draft")
     }
 
+    // MARK: - Draft insertion (Paste / Files / future accessories)
+
+    @Test func insertIntoDraftSeparatesFromNonWhitespaceTail() {
+        let store = AgentComposerStore(target: "w1:p1") { _ in
+            throw TransportError.cancelled
+        }
+        store.replaceDraft(with: "hello")
+        store.insertIntoDraft("world")
+        #expect(store.draft == "hello world")
+    }
+
+    @Test func insertIntoDraftDoesNotDoubleWhitespace() {
+        let store = AgentComposerStore(target: "w1:p1") { _ in
+            throw TransportError.cancelled
+        }
+        store.replaceDraft(with: "hello ")
+        store.insertIntoDraft("world")
+        #expect(store.draft == "hello world")
+
+        store.replaceDraft(with: "line\n")
+        store.insertIntoDraft("next")
+        #expect(store.draft == "line\nnext")
+    }
+
+    @Test func insertIntoDraftEmptyTextIsNoOp() {
+        let store = AgentComposerStore(target: "w1:p1") { _ in
+            throw TransportError.cancelled
+        }
+        store.replaceDraft(with: "keep")
+        store.insertIntoDraft("")
+        #expect(store.draft == "keep")
+    }
+
+    @Test func insertIntoDraftPopulatesEmptyDraftWithoutLeadingSpace() {
+        let store = AgentComposerStore(target: "w1:p1") { _ in
+            throw TransportError.cancelled
+        }
+        store.insertIntoDraft("pasted")
+        #expect(store.draft == "pasted")
+    }
+
+    // MARK: - Files stage → insert (scripted stager seam)
+
+    @Test func stageAndInsertImageAppendsRemotePathWithoutSubmitting() async throws {
+        let transport = ScriptedTransport()
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("composer-stage-\(UUID().uuidString).jpg")
+        try Data(repeating: 0x41, count: 64).write(to: fileURL)
+        let prepared = PreparedImage(
+            fileURL: fileURL,
+            format: .jpeg,
+            pixelWidth: 16,
+            pixelHeight: 16,
+            byteCount: 64)
+        await transport.configureImageStaging(outcomes: [
+            .success(try StagedImage(path: "/tmp/staged/composer.jpg"))
+        ])
+        let store = AgentComposerStore(
+            target: "w1:p1",
+            preparer: ScriptedComposerImagePreparer(prepared: prepared),
+            stageImage: { image, reporter in
+                try await transport.stageImage(image) { progress in
+                    await reporter.report(progress)
+                }
+            }
+        ) { _ in
+            throw TransportError.cancelled
+        }
+        store.replaceDraft(with: "See")
+
+        store.stageAndInsertImage(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("staging should complete") {
+            store.fileStageState == .idle && store.draft.contains("/tmp/staged/composer.jpg")
+        }
+
+        #expect(store.draft == "See /tmp/staged/composer.jpg ")
+        #expect(store.messages.isEmpty)
+        #expect(await transport.agentPromptParams.isEmpty)
+        #expect(await transport.stageRequests.count == 1)
+        #expect(!FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
+    @Test func stageFailureKeepsDraftAndSurfacesRecoveryCopy() async throws {
+        let transport = ScriptedTransport()
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("composer-fail-\(UUID().uuidString).jpg")
+        try Data(repeating: 0x42, count: 64).write(to: fileURL)
+        let prepared = PreparedImage(
+            fileURL: fileURL,
+            format: .jpeg,
+            pixelWidth: 16,
+            pixelHeight: 16,
+            byteCount: 64)
+        await transport.configureImageStaging(outcomes: [
+            .failure(ImageStagingError.transferFailed)
+        ])
+        let store = AgentComposerStore(
+            target: "w1:p1",
+            preparer: ScriptedComposerImagePreparer(prepared: prepared),
+            stageImage: { image, reporter in
+                try await transport.stageImage(image) { progress in
+                    await reporter.report(progress)
+                }
+            }
+        ) { _ in
+            throw TransportError.cancelled
+        }
+        store.replaceDraft(with: "Do not lose me")
+
+        store.stageAndInsertImage(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("staging should fail") {
+            if case .failed = store.fileStageState { true } else { false }
+        }
+
+        #expect(store.draft == "Do not lose me")
+        #expect(store.messages.isEmpty)
+        #expect(await transport.agentPromptParams.isEmpty)
+        #expect(
+            store.fileStageFailureMessage
+                == "Image upload failed. Choose the image again to retry.")
+        store.dismissFileStageFailure()
+        #expect(store.fileStageState == .idle)
+    }
+
+    @Test func stagingExposesInProgressStateWhileGateIsHeld() async throws {
+        let transport = ScriptedTransport()
+        let stageGate = ScriptedTransportCallGate()
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("composer-gate-\(UUID().uuidString).jpg")
+        try Data(repeating: 0x43, count: 64).write(to: fileURL)
+        let prepared = PreparedImage(
+            fileURL: fileURL,
+            format: .jpeg,
+            pixelWidth: 16,
+            pixelHeight: 16,
+            byteCount: 64)
+        await transport.configureImageStaging(
+            outcomes: [.success(try StagedImage(path: "/tmp/staged/gated.jpg"))],
+            gate: stageGate)
+        let store = AgentComposerStore(
+            target: "w1:p1",
+            preparer: ScriptedComposerImagePreparer(prepared: prepared),
+            stageImage: { image, reporter in
+                try await transport.stageImage(image) { progress in
+                    await reporter.report(progress)
+                }
+            }
+        ) { _ in
+            throw TransportError.cancelled
+        }
+
+        store.stageAndInsertImage(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("staging should be in progress") {
+            store.isStagingFile && await stageGate.entryCount == 1
+        }
+        #expect(!store.canStageFile)
+        #expect(store.draft.isEmpty)
+
+        await stageGate.open()
+        try await waitUntil("staging should finish") {
+            store.fileStageState == .idle
+        }
+        #expect(store.draft == "/tmp/staged/gated.jpg ")
+        #expect(store.canStageFile)
+    }
+
     // MARK: - Capture-anchored message partition
 
     @Test func partitionKeepsAllMessagesPendingWhenCapturedAtIsNil() async {
@@ -467,5 +633,18 @@ struct AgentComposerStoreTests {
                 status: status, workspaceID: "w1", tabID: "w1:t1", paneID: "w1:p1",
                 cwd: "/work", revision: 1),
             workspaceLabel: "Project", repoName: "Project")
+    }
+}
+
+/// Scripted preparer for Composer Files tests; skips Photos decoding.
+private actor ScriptedComposerImagePreparer: ImagePreparing {
+    let prepared: PreparedImage
+
+    init(prepared: PreparedImage) {
+        self.prepared = prepared
+    }
+
+    func prepare(_ selection: any ImageSelection) async throws -> PreparedImage {
+        prepared
     }
 }

--- a/Tests/HeelerTests/AgentComposerStoreTests.swift
+++ b/Tests/HeelerTests/AgentComposerStoreTests.swift
@@ -274,6 +274,126 @@ struct AgentComposerStoreTests {
         #expect(replacementStore.draft == "Keep this local draft")
     }
 
+    // MARK: - Capture-anchored message partition
+
+    @Test func partitionKeepsAllMessagesPendingWhenCapturedAtIsNil() async {
+        let transport = ScriptedTransport()
+        let sentAt = Date(timeIntervalSince1970: 1_700_000_100)
+        let store = AgentComposerStore(target: "w1:p1", now: { sentAt }) { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Hello")
+        await store.send()
+
+        let partition = store.partitionMessages(capturedAt: nil)
+        #expect(partition.reflected.isEmpty)
+        #expect(partition.pending.map(\.text) == ["Hello"])
+        #expect(partition.pending.map(\.state) == [.delivered(.acknowledged)])
+    }
+
+    @Test func partitionReflectsDeliveredMessagesOlderThanSnapshot() async {
+        let transport = ScriptedTransport()
+        let sentAt = Date(timeIntervalSince1970: 1_700_000_100)
+        let store = AgentComposerStore(target: "w1:p1", now: { sentAt }) { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Already on screen")
+        await store.send()
+
+        let capturedAt = Date(timeIntervalSince1970: 1_700_000_200)
+        let partition = store.partitionMessages(capturedAt: capturedAt)
+        #expect(partition.reflected.map(\.text) == ["Already on screen"])
+        #expect(partition.pending.isEmpty)
+    }
+
+    @Test func partitionKeepsExactlyEqualTimestampsPending() async {
+        let transport = ScriptedTransport()
+        let boundary = Date(timeIntervalSince1970: 1_700_000_150)
+        let store = AgentComposerStore(target: "w1:p1", now: { boundary }) { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Same instant")
+        await store.send()
+
+        let partition = store.partitionMessages(capturedAt: boundary)
+        #expect(partition.reflected.isEmpty)
+        #expect(partition.pending.map(\.text) == ["Same instant"])
+    }
+
+    @Test func partitionNeverCollapsesFailedOrSendingMessages() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentPromptFailure(TransportError.timedOut)
+        let oldSend = Date(timeIntervalSince1970: 1_700_000_050)
+        let store = AgentComposerStore(target: "w1:p1", now: { oldSend }) { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Will fail")
+        await store.send()
+        #expect(store.messages.first?.state == .failed(
+            "The Host did not answer. Check the connection and retry."))
+
+        let capturedAt = Date(timeIntervalSince1970: 1_700_000_200)
+        let failedPartition = store.partitionMessages(capturedAt: capturedAt)
+        #expect(failedPartition.reflected.isEmpty)
+        #expect(failedPartition.pending.map(\.text) == ["Will fail"])
+
+        // In-flight send also stays pending even when older than capture.
+        await transport.setAgentPromptFailure(nil)
+        let promptGate = ScriptedTransportCallGate()
+        await transport.gateNextAgentPrompt(using: promptGate)
+        store.replaceDraft(with: "In flight")
+        let send = Task { await store.send() }
+        try await waitUntil("second send should be in flight") {
+            await promptGate.entryCount == 1
+        }
+        #expect(store.messages.map(\.state).contains(.sending))
+
+        let midPartition = store.partitionMessages(capturedAt: capturedAt)
+        #expect(midPartition.reflected.isEmpty)
+        #expect(midPartition.pending.map(\.text) == ["Will fail", "In flight"])
+
+        await promptGate.open()
+        await send.value
+    }
+
+    @Test func partitionSplitsMixedMessagesAroundCaptureBoundary() async throws {
+        let transport = ScriptedTransport()
+        let clock = MutableDateClock(Date(timeIntervalSince1970: 1_700_000_100))
+        let store = AgentComposerStore(target: "w1:p1", now: { clock.now }) { params in
+            try await transport.promptAgent(params)
+        }
+
+        store.replaceDraft(with: "Older delivered")
+        await store.send()
+
+        clock.advance(by: 50)
+        store.replaceDraft(with: "Newer delivered")
+        await store.send()
+
+        // Capture sits strictly after the first send only.
+        let capturedAt = Date(timeIntervalSince1970: 1_700_000_120)
+        let partition = store.partitionMessages(capturedAt: capturedAt)
+        #expect(partition.reflected.map(\.text) == ["Older delivered"])
+        #expect(partition.pending.map(\.text) == ["Newer delivered"])
+        let older = try #require(store.messages.first)
+        let newer = try #require(store.messages.last)
+        #expect(AgentComposerStore.isReflected(older, capturedAt: capturedAt))
+        #expect(!AgentComposerStore.isReflected(newer, capturedAt: capturedAt))
+    }
+
+    /// Mutable wall clock for scripting `now` across multiple sends in one test.
+    private final class MutableDateClock: @unchecked Sendable {
+        private(set) var now: Date
+
+        init(_ now: Date) {
+            self.now = now
+        }
+
+        func advance(by seconds: TimeInterval) {
+            now = now.addingTimeInterval(seconds)
+        }
+    }
+
     private func waitUntil(
         _ comment: Comment,
         timeout: Duration = .seconds(2),

--- a/Tests/HeelerTests/AgentComposerStoreTests.swift
+++ b/Tests/HeelerTests/AgentComposerStoreTests.swift
@@ -291,6 +291,57 @@ struct AgentComposerStoreTests {
         #expect(partition.pending.map(\.state) == [.delivered(.acknowledged)])
     }
 
+    /// Empty snapshots still receive a `capturedAt` stamp in the monitor store,
+    /// but the empty-output UI path must pass `nil` so delivered echoes stay
+    /// full bubbles rather than "N earlier messages" with nothing on screen.
+    @Test func partitionKeepsDeliveredPendingWhenEmptySnapshotSuppressesCapture() async throws {
+        let transport = ScriptedTransport()
+        let sentAt = Date(timeIntervalSince1970: 1_700_000_100)
+        // A successful empty read would stamp a later capture; the empty branch
+        // deliberately ignores it.
+        let emptyReadCapturedAt = Date(timeIntervalSince1970: 1_700_000_300)
+        let store = AgentComposerStore(target: "w1:p1", now: { sentAt }) { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Never shown in empty output")
+        await store.send()
+
+        let message = try #require(store.messages.first)
+        #expect(AgentComposerStore.isReflected(message, capturedAt: emptyReadCapturedAt))
+        let emptyBranchPartition = store.partitionMessages(capturedAt: nil)
+        #expect(emptyBranchPartition.reflected.isEmpty)
+        #expect(emptyBranchPartition.pending.map(\.text) == ["Never shown in empty output"])
+    }
+
+    @Test func retryRefreshesSentAtSoMessageDoesNotCollapseAgainstPriorCapture() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentPromptFailure(TransportError.timedOut)
+        let clock = MutableDateClock(Date(timeIntervalSince1970: 1_700_000_050))
+        let store = AgentComposerStore(target: "w1:p1", now: { clock.now }) { params in
+            try await transport.promptAgent(params)
+        }
+        store.replaceDraft(with: "Retry me")
+        await store.send()
+        let failed = try #require(store.messages.first)
+        #expect(failed.sentAt == Date(timeIntervalSince1970: 1_700_000_050))
+        #expect(
+            failed.state
+                == .failed("The Host did not answer. Check the connection and retry."))
+
+        let captureBetweenAttempts = Date(timeIntervalSince1970: 1_700_000_100)
+        await transport.setAgentPromptFailure(nil)
+        clock.advance(by: 100)
+        await store.retry(failed.id)
+
+        let retried = try #require(store.messages.first)
+        #expect(retried.sentAt == Date(timeIntervalSince1970: 1_700_000_150))
+        #expect(retried.state == .delivered(.acknowledged))
+        // Without refreshing sentAt, the original 050 would collapse under 100.
+        let partition = store.partitionMessages(capturedAt: captureBetweenAttempts)
+        #expect(partition.reflected.isEmpty)
+        #expect(partition.pending.map(\.text) == ["Retry me"])
+    }
+
     @Test func partitionReflectsDeliveredMessagesOlderThanSnapshot() async {
         let transport = ScriptedTransport()
         let sentAt = Date(timeIntervalSince1970: 1_700_000_100)

--- a/Tests/HeelerTests/AgentComposerStoreTests.swift
+++ b/Tests/HeelerTests/AgentComposerStoreTests.swift
@@ -315,6 +315,25 @@ struct AgentComposerStoreTests {
         #expect(store.draft == "pasted")
     }
 
+    @Test func insertIntoDraftStripsLeadingWhitespaceFromInsertion() {
+        let store = AgentComposerStore(target: "w1:p1") { _ in
+            throw TransportError.cancelled
+        }
+        // Clipboard often carries a leading space or newline; do not double
+        // separate against a draft that already ends in whitespace.
+        store.replaceDraft(with: "hello ")
+        store.insertIntoDraft("  world")
+        #expect(store.draft == "hello world")
+
+        store.replaceDraft(with: "hello")
+        store.insertIntoDraft("\nworld")
+        #expect(store.draft == "hello world")
+
+        store.replaceDraft(with: "keep")
+        store.insertIntoDraft("   \n\t")
+        #expect(store.draft == "keep")
+    }
+
     // MARK: - Files stage → insert (scripted stager seam)
 
     @Test func stageAndInsertImageAppendsRemotePathWithoutSubmitting() async throws {
@@ -396,6 +415,45 @@ struct AgentComposerStoreTests {
                 == "Image upload failed. Choose the image again to retry.")
         store.dismissFileStageFailure()
         #expect(store.fileStageState == .idle)
+    }
+
+    @Test func nonRetryableStageFailureDoesNotInviteRetry() async throws {
+        let transport = ScriptedTransport()
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("composer-nonretry-\(UUID().uuidString).jpg")
+        try Data(repeating: 0x44, count: 64).write(to: fileURL)
+        let prepared = PreparedImage(
+            fileURL: fileURL,
+            format: .jpeg,
+            pixelWidth: 16,
+            pixelHeight: 16,
+            byteCount: 64)
+        await transport.configureImageStaging(outcomes: [
+            .failure(ImageStagingError.invalidRemotePath)
+        ])
+        let store = AgentComposerStore(
+            target: "w1:p1",
+            preparer: ScriptedComposerImagePreparer(prepared: prepared),
+            stageImage: { image, reporter in
+                try await transport.stageImage(image) { progress in
+                    await reporter.report(progress)
+                }
+            }
+        ) { _ in
+            throw TransportError.cancelled
+        }
+        store.replaceDraft(with: "Keep me")
+
+        store.stageAndInsertImage(DataImageSelection(data: Data([0x01])))
+        try await waitUntil("non-retryable staging should fail") {
+            if case .failed = store.fileStageState { true } else { false }
+        }
+
+        #expect(store.draft == "Keep me")
+        #expect(
+            store.fileStageFailureMessage
+                == "Couldn't attach this image. Try a different image.")
+        #expect(store.fileStageFailureMessage?.localizedCaseInsensitiveContains("retry") != true)
     }
 
     @Test func stagingExposesInProgressStateWhileGateIsHeld() async throws {

--- a/Tests/HeelerTests/AgentComposerStoreTests.swift
+++ b/Tests/HeelerTests/AgentComposerStoreTests.swift
@@ -485,7 +485,8 @@ struct AgentComposerStoreTests {
 
         store.stageAndInsertImage(DataImageSelection(data: Data([0x01])))
         try await waitUntil("staging should be in progress") {
-            store.isStagingFile && await stageGate.entryCount == 1
+            let entryCount = await stageGate.entryCount
+            return store.isStagingFile && entryCount == 1
         }
         #expect(!store.canStageFile)
         #expect(store.draft.isEmpty)

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -390,7 +390,7 @@ struct AgentMonitorStoreTests {
 
         await store.open()
 
-        #expect(store.state == .failed("herdr rejected the snapshot: agent is working"))
+        #expect(store.state == .failed("Couldn't refresh the screen. agent is working"))
         #expect(store.snapshot == nil)
 
         await transport.setAgentReadFailure(nil)
@@ -760,7 +760,7 @@ struct AgentMonitorStoreTests {
             HerdrAPIError(code: "invalid_key", message: "unsupported key foo"))
         await store.send(.enter)
 
-        #expect(store.sendError == "herdr rejected the key: unsupported key foo")
+        #expect(store.sendError == "Couldn't send the key. unsupported key foo")
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "known screen")
         #expect(await transport.agentSendKeysParams.isEmpty)


### PR DESCRIPTION
Part of the Monitor conversational refactor round (refs #179). This PR owns the view chrome: findings #4, #7, #9, #10 of the interface review, plus the composer accessories requested mid-round.

## Changes

- **De-terminal the snapshot surface**: the snapshot card drops the forced-dark black card, white stroke, and forced white text for an adaptive `secondarySystemGroupedBackground` surface with `.primary` text, reading as the agent's side of the conversation opposite the trailing accent bubbles.
- **Capture-anchored sent-message timeline**: `Message` gains `sentAt` (injectable clock); delivered messages older than the snapshot's `capturedAt` collapse into a compact expandable "N earlier messages" row, so the timeline no longer double-prints messages already visible inside the agent output. The empty-snapshot branch passes `capturedAt: nil` so messages never collapse against output that was never shown.
- **Dynamic Type**: the control-key strip's `...large` cap is removed; `ViewThatFits` falls back to a horizontally scrollable strip with indicators, all targets stay >=44pt.
- **Error copy**: "herdr rejected the snapshot/key: ..." becomes "Couldn't refresh the screen. ..." / "Couldn't send the key. ...".
- **Composer accessories (Files + Paste)**: pinned at the leading edge of the strip's first row in both layout branches (outside the scroll region at accessibility sizes). Paste is the system `PasteButton` inserting into the draft without submitting (ADR 0009), with boundary-whitespace normalization. Files opens `.fileImporter` restricted to images and stages the pick through the existing SFTP image pipeline (ADR 0006, zero transport growth), inserting the remote path into the draft; staging shows in-progress state and calm, retryability-aware failure copy.

## Merge order

One of three PRs sharing base d041e9f. Merge **after** the ansi-fidelity PR #192 (adaptive ANSI palette — light-mode ANSI colors on this branch alone are an acknowledged interim state) and **before** the history-reflow PR, which will be rebased on top.

## Test evidence

`xcodebuild test -only-testing:HeelerTests/AgentComposerStoreTests -only-testing:HeelerTests/AgentMonitorStoreTests` on iPhone 17 simulator: **55 tests in 2 suites passed** (partition/retry coverage, insert separators, scripted stage success/failure/in-progress, non-retryable copy).

Review: two rounds on the chrome package, two on the accessories package, one validation round (a test-only actor-isolation compile error surfaced and was fixed in `318046f`).

Follow-ups noted during review (out of scope here): unify staging error copy with `ImageAttachStore.failure(for:)`; surface `.fileImporter` failures; visual QA of PasteButton `.bordered` styling and AX5 pinned-width behavior; CHANGELOG entry for the round lands after all three PRs merge.