### PR TITLE
feat(monitor): adaptive ansi rendering fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,9 +94,11 @@ Entries reference the issue that motivated them.
   constrained to the available screen width while captured history remains
   vertically scrollable. (#179)
 
-- Monitor suppresses decoration-only terminal borders and empty background
-  bars from snapshot output, uses a denser readable text treatment, and shows
-  locally sent Composer messages as distinct You cards. (#179; #182)
+- Monitor now presents a stable status summary, a high-contrast snapshot
+  canvas, one scrollable activity surface for Agent output and locally sent
+  messages, a compact Composer, and an explicit path into Attach. Decorative
+  terminal borders and hidden horizontal controls no longer compete with the
+  content. (#179; #182)
 
 - Malformed herdr API error responses that carry an empty id now fail the
   originating request immediately with the server's error instead of hanging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ Entries reference the issue that motivated them.
 
 ### Fixed
 
+- Monitor snapshots no longer scroll horizontally. Their text now stays
+  constrained to the available screen width while captured history remains
+  vertically scrollable. (#179)
+
 - Malformed herdr API error responses that carry an empty id now fail the
   originating request immediately with the server's error instead of hanging
   until the request deadline. herdr answers unparseable requests with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@ Entries reference the issue that motivated them.
   constrained to the available screen width while captured history remains
   vertically scrollable. (#179)
 
+- Monitor suppresses decoration-only terminal borders and empty background
+  bars from snapshot output, uses a denser readable text treatment, and shows
+  locally sent Composer messages as distinct You cards. (#179; #182)
+
 - Malformed herdr API error responses that carry an empty id now fail the
   originating request immediately with the server's error instead of hanging
   until the request deadline. herdr answers unparseable requests with

--- a/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
+++ b/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
@@ -418,13 +418,26 @@ extension ANSISnapshotRenderer {
             guard start < end else { return }
             var run = AttributedString(String(scalars[start..<end]))
 
-            if let foreground = style.foreground?.color {
+            var foreground = style.foreground?.color
+            var background = style.background?.color
+            if style.reversed {
+                // Reverse video swaps the effective colors. An unset side falls
+                // back to the default label-on-surface pair, so a bare SGR 7
+                // still reads as a visible highlight in both appearances.
+                let swappedForeground = background
+                    ?? Color(uiColor: .secondarySystemGroupedBackground)
+                let swappedBackground = foreground ?? Color(uiColor: .label)
+                foreground = swappedForeground
+                background = swappedBackground
+            }
+
+            if let foreground {
                 run.foregroundColor = style.dim
                     ? foreground.opacity(0.5) : foreground
             } else if style.dim {
                 run.foregroundColor = Color.primary.opacity(0.5)
             }
-            if let background = style.background?.color {
+            if let background {
                 run.backgroundColor = background
             }
 
@@ -582,6 +595,8 @@ extension ANSISnapshotRenderer {
                     style.italic = true
                 case 4:
                     style.underline = true
+                case 7:
+                    style.reversed = true
                 case 22:
                     style.bold = false
                     style.dim = false
@@ -589,6 +604,8 @@ extension ANSISnapshotRenderer {
                     style.italic = false
                 case 24:
                     style.underline = false
+                case 27:
+                    style.reversed = false
                 case 30...37:
                     style.foreground = Self.ansiColors[parameter - 30]
                 case 38:
@@ -730,5 +747,6 @@ extension ANSISnapshotRenderer {
         var dim = false
         var italic = false
         var underline = false
+        var reversed = false
     }
 }

--- a/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
+++ b/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
@@ -10,7 +10,111 @@ enum ANSISnapshotRenderer {
     /// Converts one complete terminal snapshot into display-ready attributed text.
     static func render(_ snapshot: String) -> AttributedString {
         var parser = Parser(snapshot)
-        return parser.render()
+        return cleanTerminalChrome(from: parser.render())
+    }
+
+    private static func cleanTerminalChrome(from rendered: AttributedString) -> AttributedString {
+        var cleaned = rendered
+        let whitespaceBackgroundRanges = cleaned.runs.compactMap { run in
+            cleaned.characters[run.range].allSatisfy(\.isWhitespace) ? run.range : nil
+        }
+        for range in whitespaceBackgroundRanges {
+            cleaned[range].backgroundColor = nil
+        }
+        return removingDecorationOnlyLines(from: cleaned)
+    }
+
+    private static func removingDecorationOnlyLines(
+        from source: AttributedString
+    ) -> AttributedString {
+        var keptLines: [AttributedString] = []
+        var lineStart = source.startIndex
+        var cursor = lineStart
+
+        while cursor < source.endIndex {
+            if source.characters[cursor] == "\n" {
+                appendLine(source[lineStart..<cursor], to: &keptLines)
+                cursor = source.characters.index(after: cursor)
+                lineStart = cursor
+            } else {
+                cursor = source.characters.index(after: cursor)
+            }
+        }
+        appendLine(source[lineStart..<source.endIndex], to: &keptLines)
+
+        var result = AttributedString()
+        for (index, line) in keptLines.enumerated() {
+            if index > 0 {
+                result.append(AttributedString("\n"))
+            }
+            result.append(line)
+        }
+        return result
+    }
+
+    private static func appendLine(
+        _ line: AttributedSubstring,
+        to lines: inout [AttributedString]
+    ) {
+        let visibleCharacters = line.characters.filter { !$0.isWhitespace }
+        let isDecorationOnly = visibleCharacters.count >= 3
+            && visibleCharacters.allSatisfy(isBoxDrawing)
+        guard !isDecorationOnly else { return }
+        lines.append(trimmingDecorativeEdges(from: line))
+    }
+
+    private static func trimmingDecorativeEdges(
+        from line: AttributedSubstring
+    ) -> AttributedString {
+        var start = line.startIndex
+        var end = line.endIndex
+
+        var cursor = end
+        var trailingDecorationCount = 0
+        while cursor > start {
+            let previous = line.characters.index(before: cursor)
+            let character = line.characters[previous]
+            guard character.isWhitespace || isBoxDrawing(character) else { break }
+            if isBoxDrawing(character) {
+                trailingDecorationCount += 1
+            }
+            cursor = previous
+        }
+        if trailingDecorationCount >= 3,
+            containsContent(in: line.characters[start..<cursor])
+        {
+            end = cursor
+        }
+
+        cursor = start
+        var leadingDecorationCount = 0
+        while cursor < end {
+            let character = line.characters[cursor]
+            guard character.isWhitespace || isBoxDrawing(character) else { break }
+            if isBoxDrawing(character) {
+                leadingDecorationCount += 1
+            }
+            cursor = line.characters.index(after: cursor)
+        }
+        if leadingDecorationCount >= 3,
+            containsContent(in: line.characters[cursor..<end])
+        {
+            start = cursor
+        }
+
+        return AttributedString(line[start..<end])
+    }
+
+    private static func containsContent(
+        in characters: AttributedString.CharacterView.SubSequence
+    ) -> Bool {
+        characters.contains { !$0.isWhitespace && !isBoxDrawing($0) }
+    }
+
+    private static func isBoxDrawing(_ character: Character) -> Bool {
+        character.unicodeScalars.allSatisfy { scalar in
+            (0x2500...0x257F).contains(scalar.value)
+        }
     }
 }
 
@@ -48,7 +152,7 @@ extension ANSISnapshotRenderer {
                     appendText(from: textStart, to: index)
                     consumeControlString(after: scalars.index(after: index), bellTerminates: false)
                     textStart = index
-                case 0x00...0x08, 0x0B, 0x0C, 0x0E...0x1F, 0x7F...0x9F:
+                case 0x00...0x08, 0x0B...0x1F, 0x7F...0x9F:
                     appendText(from: textStart, to: index)
                     index = scalars.index(after: index)
                     textStart = index

--- a/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
+++ b/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
@@ -15,13 +15,41 @@ enum ANSISnapshotRenderer {
 
     private static func cleanTerminalChrome(from rendered: AttributedString) -> AttributedString {
         var cleaned = rendered
-        let whitespaceBackgroundRanges = cleaned.runs.compactMap { run in
-            cleaned.characters[run.range].allSatisfy(\.isWhitespace) ? run.range : nil
+        let whitespaceBackgroundRanges = cleaned.runs.flatMap { run in
+            backgroundPaddingRanges(in: run.range, characters: cleaned.characters)
         }
         for range in whitespaceBackgroundRanges {
             cleaned[range].backgroundColor = nil
         }
         return removingDecorationOnlyLines(from: cleaned)
+    }
+
+    private static func backgroundPaddingRanges(
+        in range: Range<AttributedString.Index>,
+        characters: AttributedString.CharacterView
+    ) -> [Range<AttributedString.Index>] {
+        var start = range.lowerBound
+        while start < range.upperBound, characters[start].isWhitespace {
+            start = characters.index(after: start)
+        }
+
+        guard start < range.upperBound else { return [range] }
+
+        var end = range.upperBound
+        while end > start {
+            let previous = characters.index(before: end)
+            guard characters[previous].isWhitespace else { break }
+            end = previous
+        }
+
+        var ranges: [Range<AttributedString.Index>] = []
+        if range.lowerBound < start {
+            ranges.append(range.lowerBound..<start)
+        }
+        if end < range.upperBound {
+            ranges.append(end..<range.upperBound)
+        }
+        return ranges
     }
 
     private static func removingDecorationOnlyLines(

--- a/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
+++ b/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
@@ -27,7 +27,7 @@ enum ANSISnapshotRenderer {
         for range in whitespaceBackgroundRanges {
             cleaned[range].backgroundColor = nil
         }
-        return removingDecorationOnlyLines(from: cleaned)
+        return removingTrailingChromeBlock(from: cleaned)
     }
 
     private static func backgroundPaddingRanges(
@@ -58,26 +58,37 @@ enum ANSISnapshotRenderer {
         return ranges
     }
 
-    private static func removingDecorationOnlyLines(
+    /// Removes only the trailing chrome block of the snapshot: the agent
+    /// TUI's own input-box frame (a wide box-drawing frame at the very end
+    /// whose interior is empty or a bare prompt) plus one immediately
+    /// following status/hint line. Monitor renders its own Composer directly
+    /// below the snapshot, so a dead input box on top of it is the single
+    /// worst "fake terminal" artifact. Interior box-drawing content — tables,
+    /// framed boxes mid-snapshot — is always kept: losing chrome is cosmetic,
+    /// losing content is a correctness bug, so whenever detection is unsure
+    /// this returns the snapshot untouched.
+    private static func removingTrailingChromeBlock(
         from source: AttributedString
     ) -> AttributedString {
-        var keptLines: [AttributedString] = []
+        var lines: [AttributedString] = []
         var lineStart = source.startIndex
         var cursor = lineStart
 
         while cursor < source.endIndex {
             if source.characters[cursor] == "\n" {
-                appendLine(source[lineStart..<cursor], to: &keptLines)
+                lines.append(AttributedString(source[lineStart..<cursor]))
                 cursor = source.characters.index(after: cursor)
                 lineStart = cursor
             } else {
                 cursor = source.characters.index(after: cursor)
             }
         }
-        appendLine(source[lineStart..<source.endIndex], to: &keptLines)
+        lines.append(AttributedString(source[lineStart..<source.endIndex]))
+
+        guard let chromeStart = trailingChromeStartIndex(in: lines) else { return source }
 
         var result = AttributedString()
-        for (index, line) in keptLines.enumerated() {
+        for (index, line) in lines[..<chromeStart].enumerated() {
             if index > 0 {
                 result.append(AttributedString("\n"))
             }
@@ -86,63 +97,93 @@ enum ANSISnapshotRenderer {
         return result
     }
 
-    private static func appendLine(
-        _ line: AttributedSubstring,
-        to lines: inout [AttributedString]
-    ) {
-        let visibleCharacters = line.characters.filter { !$0.isWhitespace }
-        let isDecorationOnly = visibleCharacters.count >= 3
-            && visibleCharacters.allSatisfy(isBoxDrawing)
-        guard !isDecorationOnly else { return }
-        lines.append(trimmingDecorativeEdges(from: line))
+    /// The smallest box width considered chrome. Agent input boxes span the
+    /// pane; narrower decorations are treated as content.
+    private static let minimumFrameWidth = 20
+
+    private static let topBorderCorners: Set<Character> = ["╭", "┌", "┏"]
+    private static let bottomBorderCorners: Set<Character> = ["╰", "└", "┗"]
+    private static let barePrompts: Set<String> = [">", "❯"]
+
+    private static func trailingChromeStartIndex(in lines: [AttributedString]) -> Int? {
+        var end = lines.count
+        while end > 0, isBlank(lines[end - 1]) {
+            end -= 1
+        }
+        guard end >= 3 else { return nil }
+
+        // The TUI draws at most one status/hint line below the input box.
+        var bottom = end - 1
+        if !isBorderLine(lines[bottom], openedBy: bottomBorderCorners) {
+            guard isHintLine(lines[bottom]),
+                isBorderLine(lines[bottom - 1], openedBy: bottomBorderCorners)
+            else { return nil }
+            bottom -= 1
+        }
+
+        var interiorStart = bottom - 1
+        while interiorStart >= 0, isFrameInteriorLine(lines[interiorStart]) {
+            // A frame holding real content is content, not chrome.
+            guard frameInteriorIsBarePrompt(lines[interiorStart]) else { return nil }
+            interiorStart -= 1
+        }
+        // Require at least one interior line and a matching top border.
+        guard interiorStart < bottom - 1,
+            interiorStart >= 0,
+            isBorderLine(lines[interiorStart], openedBy: topBorderCorners)
+        else { return nil }
+        return interiorStart
     }
 
-    private static func trimmingDecorativeEdges(
-        from line: AttributedSubstring
-    ) -> AttributedString {
-        var start = line.startIndex
-        var end = line.endIndex
-
-        var cursor = end
-        var trailingDecorationCount = 0
-        while cursor > start {
-            let previous = line.characters.index(before: cursor)
-            let character = line.characters[previous]
-            guard character.isWhitespace || isBoxDrawing(character) else { break }
-            if isBoxDrawing(character) {
-                trailingDecorationCount += 1
-            }
-            cursor = previous
-        }
-        if trailingDecorationCount >= 3,
-            containsContent(in: line.characters[start..<cursor])
-        {
-            end = cursor
-        }
-
-        cursor = start
-        var leadingDecorationCount = 0
-        while cursor < end {
-            let character = line.characters[cursor]
-            guard character.isWhitespace || isBoxDrawing(character) else { break }
-            if isBoxDrawing(character) {
-                leadingDecorationCount += 1
-            }
-            cursor = line.characters.index(after: cursor)
-        }
-        if leadingDecorationCount >= 3,
-            containsContent(in: line.characters[cursor..<end])
-        {
-            start = cursor
-        }
-
-        return AttributedString(line[start..<end])
-    }
-
-    private static func containsContent(
-        in characters: AttributedString.CharacterView.SubSequence
+    private static func isBorderLine(
+        _ line: AttributedString,
+        openedBy corners: Set<Character>
     ) -> Bool {
-        characters.contains { !$0.isWhitespace && !isBoxDrawing($0) }
+        let trimmed = String(line.characters).trimmingCharacters(in: .whitespaces)
+        guard trimmed.count >= minimumFrameWidth,
+            let first = trimmed.first,
+            corners.contains(first)
+        else { return false }
+        return trimmed.allSatisfy(isBoxDrawing)
+    }
+
+    private static func isFrameInteriorLine(_ line: AttributedString) -> Bool {
+        let trimmed = String(line.characters).trimmingCharacters(in: .whitespaces)
+        guard let first = trimmed.first,
+            let last = trimmed.last,
+            isVerticalBorder(first),
+            isVerticalBorder(last)
+        else { return false }
+        return true
+    }
+
+    private static func frameInteriorIsBarePrompt(_ line: AttributedString) -> Bool {
+        var content = String(line.characters).trimmingCharacters(in: .whitespaces)
+        // The vertical borders were verified by `isFrameInteriorLine`.
+        guard content.count >= 2 else { return false }
+        content.removeFirst()
+        content.removeLast()
+        let trimmed = content.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty || barePrompts.contains(trimmed)
+    }
+
+    /// The status/hint line a TUI draws under its input box: indented, never
+    /// starting at column 0 like real content.
+    private static func isHintLine(_ line: AttributedString) -> Bool {
+        let text = String(line.characters)
+        guard let first = text.first, first.isWhitespace else { return false }
+        return text.contains { !$0.isWhitespace }
+    }
+
+    private static func isBlank(_ line: AttributedString) -> Bool {
+        line.characters.allSatisfy { $0.isWhitespace }
+    }
+
+    private static func isVerticalBorder(_ character: Character) -> Bool {
+        guard character.unicodeScalars.count == 1,
+            let scalar = character.unicodeScalars.first
+        else { return false }
+        return [0x2502, 0x2503, 0x2506, 0x2507, 0x250A, 0x250B].contains(scalar.value)
     }
 
     private static func isBoxDrawing(_ character: Character) -> Bool {

--- a/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
+++ b/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
@@ -9,9 +9,11 @@ import UIKit
 /// sequence. It has no I/O or terminal state beyond the supplied snapshot.
 ///
 /// Monitor shows snapshots on the grouped list surface in both light and dark
-/// appearance, so emitted colors adapt: every foreground is guaranteed to
-/// reach WCAG 4.5:1 against `UIColor.secondarySystemGroupedBackground`
-/// resolved in the matching appearance.
+/// appearance, so emitted colors adapt. Every foreground reaches WCAG 4.5:1
+/// against its effective background — the run's own background when one is
+/// set, else the snapshot surface — and every background reaches 4.5:1
+/// against the appearance's label color, so ambient text on colored
+/// backgrounds (diff hunks, selection bars) stays legible.
 enum ANSISnapshotRenderer {
     /// Converts one complete terminal snapshot into display-ready attributed text.
     static func render(_ snapshot: String) -> AttributedString {
@@ -214,23 +216,19 @@ extension ANSISnapshotRenderer {
             self.blue = min(0xFF, max(0, blue))
         }
 
-        init(_ uiColor: UIColor) {
+        /// Fails when the color cannot be converted to sRGB; callers must
+        /// substitute a documented fallback rather than render silent black.
+        init?(_ uiColor: UIColor) {
             var red: CGFloat = 0
             var green: CGFloat = 0
             var blue: CGFloat = 0
             var alpha: CGFloat = 0
-            uiColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+            guard uiColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+            else { return nil }
             self.init(
                 red: Int((red * 255).rounded()),
                 green: Int((green * 255).rounded()),
                 blue: Int((blue * 255).rounded()))
-        }
-
-        var color: Color {
-            Color(
-                red: Double(red) / 255,
-                green: Double(green) / 255,
-                blue: Double(blue) / 255)
         }
 
         var uiColor: UIColor {
@@ -245,8 +243,7 @@ extension ANSISnapshotRenderer {
     /// WCAG contrast math and the legibility clamp, expressed as pure
     /// functions so tests can assert the contrast contract directly.
     enum Contrast {
-        /// The WCAG AA ratio every emitted foreground must reach against the
-        /// snapshot surface.
+        /// The WCAG AA ratio every emitted color pair must reach.
         static let minimumForegroundRatio = 4.5
 
         /// The ratio the clamp searches for. The small margin absorbs 8-bit
@@ -275,41 +272,59 @@ extension ANSISnapshotRenderer {
             return (lighter + 0.05) / (darker + 0.05)
         }
 
-        /// Returns `color` unchanged when it already contrasts with `surface`;
-        /// otherwise adjusts its lightness — hue and saturation preserved —
-        /// until it does. Light surfaces push colors darker, dark surfaces
-        /// push them lighter.
-        static func legible(_ color: RGB, on surface: RGB, appearance: Appearance) -> RGB {
-            guard ratio(of: color, to: surface) < minimumForegroundRatio else { return color }
+        /// Returns `color` unchanged when it already contrasts with
+        /// `reference`; otherwise adjusts its lightness — hue and saturation
+        /// preserved — until it does, moving away from the reference's
+        /// lightness to stay as close to the source as possible.
+        ///
+        /// The guarantee rests on one fact: against any reference, at least
+        /// one lightness extreme (0.0 or 1.0) reaches 4.5:1 — the worst case
+        /// is a mid-luminance reference, where black or white still passes.
+        /// The references used here (label colors, the snapshot surface, and
+        /// already-clamped backgrounds) all satisfy it. If the direction away
+        /// from the reference cannot reach the minimum — possible with a
+        /// mid-luminance reference — the other direction is used.
+        static func legible(_ color: RGB, on reference: RGB) -> RGB {
+            guard ratio(of: color, to: reference) < minimumForegroundRatio else { return color }
 
             let hsl = HSL(color)
-            // Contrast against a fixed surface is monotonic in lightness, so a
-            // binary search finds the value closest to the original that passes.
-            var passing = appearance == .light ? 0.0 : 1.0
+            let darken = relativeLuminance(of: color) < relativeLuminance(of: reference)
+            let primary = clamped(hsl, on: reference, darken: darken)
+            guard ratio(of: primary, to: reference) < minimumForegroundRatio else {
+                return primary
+            }
+            return clamped(hsl, on: reference, darken: !darken)
+        }
+
+        /// Binary-searches the lightness value closest to the original that
+        /// reaches `clampTargetRatio` against `reference`. Contrast against a
+        /// fixed reference is monotonic in lightness, so the search
+        /// converges; if even the endpoint misses the target it is returned
+        /// as the best effort.
+        private static func clamped(_ hsl: HSL, on reference: RGB, darken: Bool) -> RGB {
+            var passing = darken ? 0.0 : 1.0
             var failing = hsl.lightness
             for _ in 0..<32 {
                 let middle = (passing + failing) / 2
-                if ratio(of: hsl.withLightness(middle).rgb, to: surface) >= clampTargetRatio {
+                if ratio(of: hsl.withLightness(middle).rgb, to: reference) >= clampTargetRatio {
                     passing = middle
                 } else {
                     failing = middle
                 }
             }
-
-            var result = hsl.withLightness(passing).rgb
-            var attempts = 0
-            while ratio(of: result, to: surface) < minimumForegroundRatio, attempts < 8 {
-                passing += appearance == .light ? -0.004 : 0.004
-                result = hsl.withLightness(min(1, max(0, passing))).rgb
-                attempts += 1
-            }
-            return result
+            return hsl.withLightness(passing).rgb
         }
 
         private struct HSL {
             var hue: Double
             var saturation: Double
             var lightness: Double
+
+            init(hue: Double, saturation: Double, lightness: Double) {
+                self.hue = hue
+                self.saturation = saturation
+                self.lightness = lightness
+            }
 
             init(_ rgb: RGB) {
                 let red = Double(rgb.red) / 255
@@ -319,14 +334,14 @@ extension ANSISnapshotRenderer {
                 let minimum = min(red, green, blue)
                 let delta = maximum - minimum
 
-                lightness = (maximum + minimum) / 2
+                let lightness = (maximum + minimum) / 2
                 guard delta > 0 else {
-                    hue = 0
-                    saturation = 0
+                    self.init(hue: 0, saturation: 0, lightness: lightness)
                     return
                 }
 
-                saturation = delta / (1 - abs(2 * lightness - 1))
+                let saturation = delta / (1 - abs(2 * lightness - 1))
+                let hue: Double
                 switch maximum {
                 case red:
                     hue = 60 * ((green - blue) / delta).truncatingRemainder(dividingBy: 6)
@@ -335,9 +350,10 @@ extension ANSISnapshotRenderer {
                 default:
                     hue = 60 * ((red - green) / delta + 4)
                 }
-                if hue < 0 {
-                    hue += 360
-                }
+                self.init(
+                    hue: hue < 0 ? hue + 360 : hue,
+                    saturation: saturation,
+                    lightness: lightness)
             }
 
             func withLightness(_ lightness: Double) -> HSL {
@@ -367,42 +383,88 @@ extension ANSISnapshotRenderer {
         }
     }
 
-    /// The surface Monitor renders snapshots on, resolved per appearance. It
-    /// is the reference every emitted foreground is clamped against.
+    /// The surface Monitor renders snapshots on, resolved once per
+    /// appearance. It is the reference for foregrounds with no explicit
+    /// background.
     static func surfaceColor(for appearance: Appearance) -> RGB {
-        let style: UIUserInterfaceStyle = appearance == .dark ? .dark : .light
-        let resolved = UIColor.secondarySystemGroupedBackground.resolvedColor(
-            with: UITraitCollection(userInterfaceStyle: style))
-        return RGB(resolved)
+        resolvedSurface.resolve(appearance)
     }
 
-    /// A color with one value per appearance, each pre-clamped for legibility
-    /// on the matching surface, bridged into a single dynamic `Color`.
-    private struct AdaptiveColor {
+    /// The appearance's default text color, resolved once per appearance.
+    /// Backgrounds are clamped against it so ambient label-colored text on
+    /// colored backgrounds (diff hunks, selection bars) stays legible.
+    static func labelColor(for appearance: Appearance) -> RGB {
+        resolvedLabel.resolve(appearance)
+    }
+
+    private static let resolvedSurface = DynamicColor(
+        light: resolveSystemColor(
+            UIColor.secondarySystemGroupedBackground, for: .light,
+            fallback: RGB(red: 0xFF, green: 0xFF, blue: 0xFF)),
+        dark: resolveSystemColor(
+            UIColor.secondarySystemGroupedBackground, for: .dark,
+            fallback: RGB(red: 0x1C, green: 0x1C, blue: 0x1E)))
+    private static let resolvedLabel = DynamicColor(
+        light: resolveSystemColor(
+            UIColor.label, for: .light,
+            fallback: RGB(red: 0x00, green: 0x00, blue: 0x00)),
+        dark: resolveSystemColor(
+            UIColor.label, for: .dark,
+            fallback: RGB(red: 0xFF, green: 0xFF, blue: 0xFF)))
+
+    /// Resolves a system color in one appearance. The fallback is the value
+    /// iOS documents for that color in that appearance, used only when the
+    /// color cannot be converted to sRGB.
+    private static func resolveSystemColor(
+        _ uiColor: UIColor,
+        for appearance: Appearance,
+        fallback: RGB
+    ) -> RGB {
+        let style: UIUserInterfaceStyle = appearance == .dark ? .dark : .light
+        let resolved = uiColor.resolvedColor(with: UITraitCollection(userInterfaceStyle: style))
+        return RGB(resolved) ?? fallback
+    }
+
+    /// A pair of per-appearance sRGB values with a dynamic `Color` bridge.
+    private struct DynamicColor {
         let light: RGB
         let dark: RGB
 
-        init(light: RGB, dark: RGB) {
-            self.light = Contrast.legible(
-                light,
-                on: ANSISnapshotRenderer.surfaceColor(for: .light),
-                appearance: .light)
-            self.dark = Contrast.legible(
-                dark,
-                on: ANSISnapshotRenderer.surfaceColor(for: .dark),
-                appearance: .dark)
-        }
-
-        /// A single source color (256-color cube, grayscale ramp, truecolor),
-        /// clamped per appearance.
-        init(source color: RGB) {
-            self.init(light: color, dark: color)
+        func resolve(_ appearance: Appearance) -> RGB {
+            appearance == .dark ? dark : light
         }
 
         var color: Color {
             Color(uiColor: UIColor { traits in
-                (traits.userInterfaceStyle == .dark ? dark : light).uiColor
+                resolve(traits.userInterfaceStyle == .dark ? .dark : .light).uiColor
             })
+        }
+    }
+
+    /// A terminal-requested color: per-appearance source values plus the two
+    /// precomputed clamp results for the two roles it can play.
+    private struct ANSIColor {
+        /// The requested color, per appearance.
+        let source: DynamicColor
+        /// Foreground role with no explicit background: clamped against the
+        /// snapshot surface.
+        let onSurface: DynamicColor
+        /// Background role: clamped so the appearance's label text stays
+        /// legible on it.
+        let asBackground: DynamicColor
+
+        init(source: DynamicColor) {
+            self.source = source
+            onSurface = DynamicColor(
+                light: Contrast.legible(
+                    source.light, on: ANSISnapshotRenderer.resolvedSurface.light),
+                dark: Contrast.legible(
+                    source.dark, on: ANSISnapshotRenderer.resolvedSurface.dark))
+            asBackground = DynamicColor(
+                light: Contrast.legible(
+                    source.light, on: ANSISnapshotRenderer.resolvedLabel.light),
+                dark: Contrast.legible(
+                    source.dark, on: ANSISnapshotRenderer.resolvedLabel.dark))
         }
     }
 
@@ -459,27 +521,58 @@ extension ANSISnapshotRenderer {
             guard start < end else { return }
             var run = AttributedString(String(scalars[start..<end]))
 
-            var foreground = style.foreground?.color
-            var background = style.background?.color
-            if style.reversed {
-                // Reverse video swaps the effective colors. An unset side falls
-                // back to the default label-on-surface pair, so a bare SGR 7
-                // still reads as a visible highlight in both appearances.
-                let swappedForeground = background
-                    ?? Color(uiColor: .secondarySystemGroupedBackground)
-                let swappedBackground = foreground ?? Color(uiColor: .label)
-                foreground = swappedForeground
-                background = swappedBackground
+            // Reverse video swaps the effective colors first; the usual
+            // foreground/background rules then apply to the swapped pair.
+            // Unset sides fall back to the default label-on-surface pair, so
+            // a bare SGR 7 still reads as a visible highlight.
+            let foregroundSource = style.reversed ? style.background : style.foreground
+            let backgroundSource = style.reversed ? style.foreground : style.background
+
+            // A background is clamped so the appearance's label text stays
+            // legible on it; the system fallback (label fill for reverse
+            // video) needs no clamp.
+            let background: DynamicColor? = backgroundSource?.asBackground
+                ?? (style.reversed ? ANSISnapshotRenderer.resolvedLabel : nil)
+
+            let foreground: DynamicColor?
+            if let foregroundSource {
+                if let background, backgroundSource != nil {
+                    // Explicit foreground on an explicit background: clamped
+                    // against it here, once per appearance, so the dynamic
+                    // provider stays trivial. Every other pairing uses a
+                    // precomputed variant.
+                    foreground = DynamicColor(
+                        light: Contrast.legible(
+                            foregroundSource.source.light, on: background.light),
+                        dark: Contrast.legible(
+                            foregroundSource.source.dark, on: background.dark))
+                } else if background != nil {
+                    // Reversed with no explicit background: the fill is the
+                    // label color, which this variant is clamped against.
+                    foreground = foregroundSource.asBackground
+                } else {
+                    foreground = foregroundSource.onSurface
+                }
+            } else if style.reversed, let background {
+                // Reversed with no explicit foreground: surface-colored text
+                // on the fill.
+                foreground = DynamicColor(
+                    light: Contrast.legible(
+                        ANSISnapshotRenderer.resolvedSurface.light, on: background.light),
+                    dark: Contrast.legible(
+                        ANSISnapshotRenderer.resolvedSurface.dark, on: background.dark))
+            } else {
+                foreground = nil
             }
 
             if let foreground {
                 run.foregroundColor = style.dim
-                    ? foreground.opacity(0.5) : foreground
+                    ? foreground.color.opacity(0.5) : foreground.color
             } else if style.dim {
                 run.foregroundColor = Color.primary.opacity(0.5)
             }
             if let background {
-                run.backgroundColor = background
+                run.backgroundColor = background.color
             }
 
             var emphasis: InlinePresentationIntent = []
@@ -675,7 +768,7 @@ extension ANSISnapshotRenderer {
         private mutating func applyExtendedColor(
             _ parameters: [Int],
             at introducerIndex: Int,
-            to keyPath: WritableKeyPath<SGRState, AdaptiveColor?>
+            to keyPath: WritableKeyPath<SGRState, ANSIColor?>
         ) -> Int {
             let modeIndex = introducerIndex + 1
             guard modeIndex < parameters.count else { return parameters.count }
@@ -693,11 +786,12 @@ extension ANSISnapshotRenderer {
                 guard blueIndex < parameters.count else { return parameters.count }
                 let components = parameters[(modeIndex + 1)...blueIndex]
                 if components.allSatisfy({ (0...255).contains($0) }) {
-                    style[keyPath: keyPath] = AdaptiveColor(
-                        source: RGB(
-                            red: components[components.startIndex],
-                            green: components[components.index(after: components.startIndex)],
-                            blue: components[blueIndex]))
+                    let rgb = RGB(
+                        red: components[components.startIndex],
+                        green: components[components.index(after: components.startIndex)],
+                        blue: components[blueIndex])
+                    style[keyPath: keyPath] = ANSIColor(
+                        source: DynamicColor(light: rgb, dark: rgb))
                 }
                 return blueIndex
             default:
@@ -705,85 +799,99 @@ extension ANSISnapshotRenderer {
             }
         }
 
-        private static func color256(_ index: Int) -> AdaptiveColor? {
+        private static func color256(_ index: Int) -> ANSIColor? {
             guard (0...255).contains(index) else { return nil }
-            if index < ansiColors.count {
-                return ansiColors[index]
-            }
-            if index < 232 {
-                let cubeIndex = index - 16
-                return AdaptiveColor(
-                    source: RGB(
-                        red: cubeComponent(cubeIndex / 36),
-                        green: cubeComponent((cubeIndex / 6) % 6),
-                        blue: cubeComponent(cubeIndex % 6)))
-            }
-            let gray = 8 + (index - 232) * 10
-            return AdaptiveColor(source: RGB(red: gray, green: gray, blue: gray))
+            return ansiColors[index]
         }
 
         private static func cubeComponent(_ index: Int) -> Int {
             index == 0 ? 0 : 55 + index * 40
         }
 
-        // Per-appearance values chosen for legibility on
-        // `secondarySystemGroupedBackground`; `AdaptiveColor` still clamps
-        // them, so the WCAG floor holds even if a value is edited later.
-        private static let ansiColors: [AdaptiveColor] = [
-            AdaptiveColor(
+        private static func sourceColor(for index: Int) -> DynamicColor {
+            if index < basePalette.count {
+                return basePalette[index]
+            }
+            let rgb: RGB
+            if index < 232 {
+                let cubeIndex = index - 16
+                rgb = RGB(
+                    red: cubeComponent(cubeIndex / 36),
+                    green: cubeComponent((cubeIndex / 6) % 6),
+                    blue: cubeComponent(cubeIndex % 6))
+            } else {
+                let gray = 8 + (index - 232) * 10
+                rgb = RGB(red: gray, green: gray, blue: gray)
+            }
+            return DynamicColor(light: rgb, dark: rgb)
+        }
+
+        // All 256 xterm entries with their precomputed clamp results, built
+        // once: the base 16 carry hand-picked per-appearance sources, the
+        // cube/grayscale entries share one source across appearances.
+        private static let ansiColors: [ANSIColor] = (0...255).map { index in
+            ANSIColor(source: sourceColor(for: index))
+        }
+
+        // Per-appearance sources chosen for legibility of the foreground role
+        // on `secondarySystemGroupedBackground`; the background role is
+        // derived by the `ANSIColor` clamp, so the WCAG floor holds even if a
+        // value is edited later.
+        private static let basePalette: [DynamicColor] = [
+            DynamicColor(
                 light: RGB(red: 0x1C, green: 0x1C, blue: 0x1E),
                 dark: RGB(red: 0x8C, green: 0x8C, blue: 0x8C)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0xA3, green: 0x15, blue: 0x15),
                 dark: RGB(red: 0xF9, green: 0x75, blue: 0x83)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0x0A, green: 0x6E, blue: 0x0A),
                 dark: RGB(red: 0x56, green: 0xD3, blue: 0x64)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0x6D, green: 0x6D, blue: 0x00),
                 dark: RGB(red: 0xE5, green: 0xE5, blue: 0x10)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0x04, green: 0x51, blue: 0xA5),
                 dark: RGB(red: 0x57, green: 0x9B, blue: 0xD5)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0x8A, green: 0x0A, blue: 0x8A),
                 dark: RGB(red: 0xD6, green: 0x70, blue: 0xD6)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0x00, green: 0x76, blue: 0x76),
                 dark: RGB(red: 0x39, green: 0xC5, blue: 0xCF)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0x59, green: 0x59, blue: 0x59),
                 dark: RGB(red: 0xC0, green: 0xC0, blue: 0xC0)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0x6E, green: 0x6E, blue: 0x6E),
                 dark: RGB(red: 0xA0, green: 0xA0, blue: 0xA0)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0xD7, green: 0x00, blue: 0x00),
                 dark: RGB(red: 0xFF, green: 0x7B, blue: 0x72)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0x00, green: 0x7A, blue: 0x00),
                 dark: RGB(red: 0x7C, green: 0xE3, blue: 0x8B)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0x71, green: 0x71, blue: 0x00),
                 dark: RGB(red: 0xF2, green: 0xF9, blue: 0x7C)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0x10, green: 0x59, blue: 0xD0),
                 dark: RGB(red: 0x6C, green: 0xB6, blue: 0xFF)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0xBC, green: 0x05, blue: 0xBC),
                 dark: RGB(red: 0xF9, green: 0x82, blue: 0xF9)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0x00, green: 0x7A, blue: 0x7A),
                 dark: RGB(red: 0x66, green: 0xE0, blue: 0xE0)),
-            AdaptiveColor(
+            DynamicColor(
                 light: RGB(red: 0x00, green: 0x00, blue: 0x00),
                 dark: RGB(red: 0xFF, green: 0xFF, blue: 0xFF)),
         ]
     }
 
     private struct SGRState {
-        var foreground: AdaptiveColor?
-        var background: AdaptiveColor?
+        var foreground: ANSIColor?
+        var background: ANSIColor?
         var bold = false
         var dim = false
         var italic = false

--- a/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
+++ b/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
@@ -1,11 +1,17 @@
 import Foundation
 import SwiftUI
+import UIKit
 
 /// Renders the ANSI-formatted text returned by herdr reads for Monitor.
 ///
 /// The renderer preserves printable text and line structure, applies the SGR
 /// subset Monitor understands, and removes every other terminal control
 /// sequence. It has no I/O or terminal state beyond the supplied snapshot.
+///
+/// Monitor shows snapshots on the grouped list surface in both light and dark
+/// appearance, so emitted colors adapt: every foreground is guaranteed to
+/// reach WCAG 4.5:1 against `UIColor.secondarySystemGroupedBackground`
+/// resolved in the matching appearance.
 enum ANSISnapshotRenderer {
     /// Converts one complete terminal snapshot into display-ready attributed text.
     static func render(_ snapshot: String) -> AttributedString {
@@ -147,6 +153,218 @@ enum ANSISnapshotRenderer {
 }
 
 extension ANSISnapshotRenderer {
+    /// The appearance a snapshot is rendered for. Adaptive colors carry one
+    /// value per appearance.
+    enum Appearance {
+        case light
+        case dark
+    }
+
+    /// An 8-bit sRGB color. This is the currency of the contrast machinery;
+    /// dynamic resolution happens only at the `Color`/`UIColor` boundary.
+    struct RGB: Sendable, Equatable {
+        let red: Int
+        let green: Int
+        let blue: Int
+
+        init(red: Int, green: Int, blue: Int) {
+            self.red = min(0xFF, max(0, red))
+            self.green = min(0xFF, max(0, green))
+            self.blue = min(0xFF, max(0, blue))
+        }
+
+        init(_ uiColor: UIColor) {
+            var red: CGFloat = 0
+            var green: CGFloat = 0
+            var blue: CGFloat = 0
+            var alpha: CGFloat = 0
+            uiColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+            self.init(
+                red: Int((red * 255).rounded()),
+                green: Int((green * 255).rounded()),
+                blue: Int((blue * 255).rounded()))
+        }
+
+        var color: Color {
+            Color(
+                red: Double(red) / 255,
+                green: Double(green) / 255,
+                blue: Double(blue) / 255)
+        }
+
+        var uiColor: UIColor {
+            UIColor(
+                red: CGFloat(red) / 255,
+                green: CGFloat(green) / 255,
+                blue: CGFloat(blue) / 255,
+                alpha: 1)
+        }
+    }
+
+    /// WCAG contrast math and the legibility clamp, expressed as pure
+    /// functions so tests can assert the contrast contract directly.
+    enum Contrast {
+        /// The WCAG AA ratio every emitted foreground must reach against the
+        /// snapshot surface.
+        static let minimumForegroundRatio = 4.5
+
+        /// The ratio the clamp searches for. The small margin absorbs 8-bit
+        /// quantization so the rounded result still clears the minimum.
+        private static let clampTargetRatio = minimumForegroundRatio + 0.1
+
+        /// WCAG relative luminance of an opaque sRGB color.
+        static func relativeLuminance(of color: RGB) -> Double {
+            func linear(_ channel: Int) -> Double {
+                let value = Double(channel) / 255
+                return value <= 0.03928
+                    ? value / 12.92
+                    : pow((value + 0.055) / 1.055, 2.4)
+            }
+            return 0.2126 * linear(color.red)
+                + 0.7152 * linear(color.green)
+                + 0.0722 * linear(color.blue)
+        }
+
+        /// WCAG contrast ratio between two colors, in 1...21.
+        static func ratio(of first: RGB, to second: RGB) -> Double {
+            let firstLuminance = relativeLuminance(of: first)
+            let secondLuminance = relativeLuminance(of: second)
+            let lighter = max(firstLuminance, secondLuminance)
+            let darker = min(firstLuminance, secondLuminance)
+            return (lighter + 0.05) / (darker + 0.05)
+        }
+
+        /// Returns `color` unchanged when it already contrasts with `surface`;
+        /// otherwise adjusts its lightness — hue and saturation preserved —
+        /// until it does. Light surfaces push colors darker, dark surfaces
+        /// push them lighter.
+        static func legible(_ color: RGB, on surface: RGB, appearance: Appearance) -> RGB {
+            guard ratio(of: color, to: surface) < minimumForegroundRatio else { return color }
+
+            let hsl = HSL(color)
+            // Contrast against a fixed surface is monotonic in lightness, so a
+            // binary search finds the value closest to the original that passes.
+            var passing = appearance == .light ? 0.0 : 1.0
+            var failing = hsl.lightness
+            for _ in 0..<32 {
+                let middle = (passing + failing) / 2
+                if ratio(of: hsl.withLightness(middle).rgb, to: surface) >= clampTargetRatio {
+                    passing = middle
+                } else {
+                    failing = middle
+                }
+            }
+
+            var result = hsl.withLightness(passing).rgb
+            var attempts = 0
+            while ratio(of: result, to: surface) < minimumForegroundRatio, attempts < 8 {
+                passing += appearance == .light ? -0.004 : 0.004
+                result = hsl.withLightness(min(1, max(0, passing))).rgb
+                attempts += 1
+            }
+            return result
+        }
+
+        private struct HSL {
+            var hue: Double
+            var saturation: Double
+            var lightness: Double
+
+            init(_ rgb: RGB) {
+                let red = Double(rgb.red) / 255
+                let green = Double(rgb.green) / 255
+                let blue = Double(rgb.blue) / 255
+                let maximum = max(red, green, blue)
+                let minimum = min(red, green, blue)
+                let delta = maximum - minimum
+
+                lightness = (maximum + minimum) / 2
+                guard delta > 0 else {
+                    hue = 0
+                    saturation = 0
+                    return
+                }
+
+                saturation = delta / (1 - abs(2 * lightness - 1))
+                switch maximum {
+                case red:
+                    hue = 60 * ((green - blue) / delta).truncatingRemainder(dividingBy: 6)
+                case green:
+                    hue = 60 * ((blue - red) / delta + 2)
+                default:
+                    hue = 60 * ((red - green) / delta + 4)
+                }
+                if hue < 0 {
+                    hue += 360
+                }
+            }
+
+            func withLightness(_ lightness: Double) -> HSL {
+                HSL(hue: hue, saturation: saturation, lightness: lightness)
+            }
+
+            var rgb: RGB {
+                let chroma = (1 - abs(2 * lightness - 1)) * saturation
+                let x = chroma * (1 - abs((hue / 60).truncatingRemainder(dividingBy: 2) - 1))
+                let offset = lightness - chroma / 2
+                let red: Double
+                let green: Double
+                let blue: Double
+                switch hue {
+                case 0..<60: (red, green, blue) = (chroma, x, 0)
+                case 60..<120: (red, green, blue) = (x, chroma, 0)
+                case 120..<180: (red, green, blue) = (0, chroma, x)
+                case 180..<240: (red, green, blue) = (0, x, chroma)
+                case 240..<300: (red, green, blue) = (x, 0, chroma)
+                default: (red, green, blue) = (chroma, 0, x)
+                }
+                return RGB(
+                    red: Int(((red + offset) * 255).rounded()),
+                    green: Int(((green + offset) * 255).rounded()),
+                    blue: Int(((blue + offset) * 255).rounded()))
+            }
+        }
+    }
+
+    /// The surface Monitor renders snapshots on, resolved per appearance. It
+    /// is the reference every emitted foreground is clamped against.
+    static func surfaceColor(for appearance: Appearance) -> RGB {
+        let style: UIUserInterfaceStyle = appearance == .dark ? .dark : .light
+        let resolved = UIColor.secondarySystemGroupedBackground.resolvedColor(
+            with: UITraitCollection(userInterfaceStyle: style))
+        return RGB(resolved)
+    }
+
+    /// A color with one value per appearance, each pre-clamped for legibility
+    /// on the matching surface, bridged into a single dynamic `Color`.
+    private struct AdaptiveColor {
+        let light: RGB
+        let dark: RGB
+
+        init(light: RGB, dark: RGB) {
+            self.light = Contrast.legible(
+                light,
+                on: ANSISnapshotRenderer.surfaceColor(for: .light),
+                appearance: .light)
+            self.dark = Contrast.legible(
+                dark,
+                on: ANSISnapshotRenderer.surfaceColor(for: .dark),
+                appearance: .dark)
+        }
+
+        /// A single source color (256-color cube, grayscale ramp, truecolor),
+        /// clamped per appearance.
+        init(source color: RGB) {
+            self.init(light: color, dark: color)
+        }
+
+        var color: Color {
+            Color(uiColor: UIColor { traits in
+                (traits.userInterfaceStyle == .dark ? dark : light).uiColor
+            })
+        }
+    }
+
     private struct Parser {
         private let scalars: String.UnicodeScalarView
         private var index: String.UnicodeScalarView.Index
@@ -200,14 +418,14 @@ extension ANSISnapshotRenderer {
             guard start < end else { return }
             var run = AttributedString(String(scalars[start..<end]))
 
-            if let foreground = style.foreground {
+            if let foreground = style.foreground?.color {
                 run.foregroundColor = style.dim
-                    ? foreground.color.opacity(0.5) : foreground.color
+                    ? foreground.opacity(0.5) : foreground
             } else if style.dim {
                 run.foregroundColor = Color.primary.opacity(0.5)
             }
-            if let background = style.background {
-                run.backgroundColor = background.color
+            if let background = style.background?.color {
+                run.backgroundColor = background
             }
 
             var emphasis: InlinePresentationIntent = []
@@ -399,7 +617,7 @@ extension ANSISnapshotRenderer {
         private mutating func applyExtendedColor(
             _ parameters: [Int],
             at introducerIndex: Int,
-            to keyPath: WritableKeyPath<SGRState, RGB?>
+            to keyPath: WritableKeyPath<SGRState, AdaptiveColor?>
         ) -> Int {
             let modeIndex = introducerIndex + 1
             guard modeIndex < parameters.count else { return parameters.count }
@@ -417,10 +635,11 @@ extension ANSISnapshotRenderer {
                 guard blueIndex < parameters.count else { return parameters.count }
                 let components = parameters[(modeIndex + 1)...blueIndex]
                 if components.allSatisfy({ (0...255).contains($0) }) {
-                    style[keyPath: keyPath] = RGB(
-                        red: components[components.startIndex],
-                        green: components[components.index(after: components.startIndex)],
-                        blue: components[blueIndex])
+                    style[keyPath: keyPath] = AdaptiveColor(
+                        source: RGB(
+                            red: components[components.startIndex],
+                            green: components[components.index(after: components.startIndex)],
+                            blue: components[blueIndex]))
                 }
                 return blueIndex
             default:
@@ -428,65 +647,88 @@ extension ANSISnapshotRenderer {
             }
         }
 
-        private static func color256(_ index: Int) -> RGB? {
+        private static func color256(_ index: Int) -> AdaptiveColor? {
             guard (0...255).contains(index) else { return nil }
             if index < ansiColors.count {
                 return ansiColors[index]
             }
             if index < 232 {
                 let cubeIndex = index - 16
-                return RGB(
-                    red: cubeComponent(cubeIndex / 36),
-                    green: cubeComponent((cubeIndex / 6) % 6),
-                    blue: cubeComponent(cubeIndex % 6))
+                return AdaptiveColor(
+                    source: RGB(
+                        red: cubeComponent(cubeIndex / 36),
+                        green: cubeComponent((cubeIndex / 6) % 6),
+                        blue: cubeComponent(cubeIndex % 6)))
             }
             let gray = 8 + (index - 232) * 10
-            return RGB(red: gray, green: gray, blue: gray)
+            return AdaptiveColor(source: RGB(red: gray, green: gray, blue: gray))
         }
 
         private static func cubeComponent(_ index: Int) -> Int {
             index == 0 ? 0 : 55 + index * 40
         }
 
-        private static let ansiColors: [RGB] = [
-            RGB(red: 0x00, green: 0x00, blue: 0x00),
-            RGB(red: 0x80, green: 0x00, blue: 0x00),
-            RGB(red: 0x00, green: 0x80, blue: 0x00),
-            RGB(red: 0x80, green: 0x80, blue: 0x00),
-            RGB(red: 0x00, green: 0x00, blue: 0x80),
-            RGB(red: 0x80, green: 0x00, blue: 0x80),
-            RGB(red: 0x00, green: 0x80, blue: 0x80),
-            RGB(red: 0xC0, green: 0xC0, blue: 0xC0),
-            RGB(red: 0x80, green: 0x80, blue: 0x80),
-            RGB(red: 0xFF, green: 0x00, blue: 0x00),
-            RGB(red: 0x00, green: 0xFF, blue: 0x00),
-            RGB(red: 0xFF, green: 0xFF, blue: 0x00),
-            RGB(red: 0x00, green: 0x00, blue: 0xFF),
-            RGB(red: 0xFF, green: 0x00, blue: 0xFF),
-            RGB(red: 0x00, green: 0xFF, blue: 0xFF),
-            RGB(red: 0xFF, green: 0xFF, blue: 0xFF),
+        // Per-appearance values chosen for legibility on
+        // `secondarySystemGroupedBackground`; `AdaptiveColor` still clamps
+        // them, so the WCAG floor holds even if a value is edited later.
+        private static let ansiColors: [AdaptiveColor] = [
+            AdaptiveColor(
+                light: RGB(red: 0x1C, green: 0x1C, blue: 0x1E),
+                dark: RGB(red: 0x8C, green: 0x8C, blue: 0x8C)),
+            AdaptiveColor(
+                light: RGB(red: 0xA3, green: 0x15, blue: 0x15),
+                dark: RGB(red: 0xF9, green: 0x75, blue: 0x83)),
+            AdaptiveColor(
+                light: RGB(red: 0x0A, green: 0x6E, blue: 0x0A),
+                dark: RGB(red: 0x56, green: 0xD3, blue: 0x64)),
+            AdaptiveColor(
+                light: RGB(red: 0x6D, green: 0x6D, blue: 0x00),
+                dark: RGB(red: 0xE5, green: 0xE5, blue: 0x10)),
+            AdaptiveColor(
+                light: RGB(red: 0x04, green: 0x51, blue: 0xA5),
+                dark: RGB(red: 0x57, green: 0x9B, blue: 0xD5)),
+            AdaptiveColor(
+                light: RGB(red: 0x8A, green: 0x0A, blue: 0x8A),
+                dark: RGB(red: 0xD6, green: 0x70, blue: 0xD6)),
+            AdaptiveColor(
+                light: RGB(red: 0x00, green: 0x76, blue: 0x76),
+                dark: RGB(red: 0x39, green: 0xC5, blue: 0xCF)),
+            AdaptiveColor(
+                light: RGB(red: 0x59, green: 0x59, blue: 0x59),
+                dark: RGB(red: 0xC0, green: 0xC0, blue: 0xC0)),
+            AdaptiveColor(
+                light: RGB(red: 0x6E, green: 0x6E, blue: 0x6E),
+                dark: RGB(red: 0xA0, green: 0xA0, blue: 0xA0)),
+            AdaptiveColor(
+                light: RGB(red: 0xD7, green: 0x00, blue: 0x00),
+                dark: RGB(red: 0xFF, green: 0x7B, blue: 0x72)),
+            AdaptiveColor(
+                light: RGB(red: 0x00, green: 0x7A, blue: 0x00),
+                dark: RGB(red: 0x7C, green: 0xE3, blue: 0x8B)),
+            AdaptiveColor(
+                light: RGB(red: 0x71, green: 0x71, blue: 0x00),
+                dark: RGB(red: 0xF2, green: 0xF9, blue: 0x7C)),
+            AdaptiveColor(
+                light: RGB(red: 0x10, green: 0x59, blue: 0xD0),
+                dark: RGB(red: 0x6C, green: 0xB6, blue: 0xFF)),
+            AdaptiveColor(
+                light: RGB(red: 0xBC, green: 0x05, blue: 0xBC),
+                dark: RGB(red: 0xF9, green: 0x82, blue: 0xF9)),
+            AdaptiveColor(
+                light: RGB(red: 0x00, green: 0x7A, blue: 0x7A),
+                dark: RGB(red: 0x66, green: 0xE0, blue: 0xE0)),
+            AdaptiveColor(
+                light: RGB(red: 0x00, green: 0x00, blue: 0x00),
+                dark: RGB(red: 0xFF, green: 0xFF, blue: 0xFF)),
         ]
     }
 
     private struct SGRState {
-        var foreground: RGB?
-        var background: RGB?
+        var foreground: AdaptiveColor?
+        var background: AdaptiveColor?
         var bold = false
         var dim = false
         var italic = false
         var underline = false
-    }
-
-    private struct RGB {
-        let red: Int
-        let green: Int
-        let blue: Int
-
-        var color: Color {
-            Color(
-                red: Double(red) / 255,
-                green: Double(green) / 255,
-                blue: Double(blue) / 255)
-        }
     }
 }

--- a/Sources/Heeler/Monitor/AgentComposerView.swift
+++ b/Sources/Heeler/Monitor/AgentComposerView.swift
@@ -1,40 +1,25 @@
 import SwiftUI
 
-/// Monitor's native, local-first message surface. It renders optimistic
-/// echoes but never infers structured conversation history from terminal
-/// output (ADR 0012).
+/// Monitor's native, local-first input surface. Optimistic delivery echoes
+/// render in ``AgentSentMessagesView`` beside the snapshot, while this view
+/// keeps the draft and terminal controls reachable in stable bottom chrome.
 struct AgentComposerView: View {
     let store: AgentComposerStore
+    let isControlKeyEnabled: Bool
+    let onControlKey: (MonitorControlKey) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            if !store.messages.isEmpty {
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        LazyVStack(spacing: 10) {
-                            ForEach(store.messages) { message in
-                                messageRow(message)
-                                    .id(message.id)
-                            }
-                        }
-                    }
-                    .defaultScrollAnchor(.bottom)
-                    .onChange(of: store.messages.count) {
-                        guard let latest = store.messages.last else { return }
-                        proxy.scrollTo(latest.id, anchor: .bottom)
-                    }
-                }
-                .frame(maxHeight: 176)
-                .accessibilityLabel("Sent messages")
-            }
+        VStack(alignment: .leading, spacing: 12) {
+            MonitorControlKeyStrip(
+                isEnabled: isControlKeyEnabled,
+                onTap: onControlKey)
 
-            Text("Message")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            Text("Message the Agent")
+                .font(.caption.weight(.semibold))
 
             HStack(alignment: .bottom, spacing: 10) {
                 TextField(
-                    "Message",
+                    "Type a message",
                     text: Binding(
                         get: { store.draft },
                         set: { store.replaceDraft(with: $0) }),
@@ -42,28 +27,64 @@ struct AgentComposerView: View {
                 )
                 .lineLimit(1...5)
                 .textFieldStyle(.plain)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-                .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
-                .accessibilityLabel("Message")
+                .padding(12)
+                .background(
+                    Color(uiColor: .secondarySystemBackground),
+                    in: RoundedRectangle(cornerRadius: 14))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 14)
+                        .stroke(.secondary.opacity(0.18), lineWidth: 1)
+                }
+                .accessibilityLabel("Message the Agent")
 
-                Button("Send", systemImage: "arrow.up.circle.fill") {
+                Button("Send", systemImage: "arrow.up") {
                     Task { await store.send() }
                 }
                 .buttonStyle(.borderedProminent)
+                .buttonBorderShape(.circle)
+                .labelStyle(.iconOnly)
+                .frame(minWidth: 44, minHeight: 44)
                 .disabled(!store.canSend)
                 .accessibilityHint("Delivers the complete draft to the Agent")
             }
         }
-        .padding(.horizontal)
-        .padding(.vertical, 10)
-        .background(.bar)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.regularMaterial)
+        .overlay(alignment: .top) { Divider() }
+    }
+}
+
+struct AgentSentMessagesView: View {
+    let store: AgentComposerStore
+
+    @ViewBuilder
+    var body: some View {
+        if !store.messages.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Label("Sent from this device", systemImage: "iphone")
+                        .font(.subheadline.weight(.semibold))
+                        .accessibilityAddTraits(.isHeader)
+                    Text("Delivery means the Host accepted the message.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                ForEach(store.messages) { message in
+                    messageRow(message)
+                        .id(message.id)
+                }
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Messages sent from this device")
+        }
     }
 
     private func messageRow(_ message: AgentComposerStore.Message) -> some View {
         HStack {
-            Spacer(minLength: 44)
-            VStack(alignment: .leading, spacing: 8) {
+            Spacer(minLength: 48)
+            VStack(alignment: .leading, spacing: 6) {
                 Text("You")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
@@ -73,7 +94,7 @@ struct AgentComposerView: View {
                     .textSelection(.enabled)
 
                 statusLabel(for: message.state)
-                    .font(.footnote)
+                    .font(.caption)
 
                 if case .failed(let detail) = message.state {
                     Text(detail)
@@ -95,8 +116,8 @@ struct AgentComposerView: View {
             }
             .padding(12)
             .background(
-                Color.accentColor.opacity(0.12),
-                in: RoundedRectangle(cornerRadius: 14))
+                Color.accentColor.opacity(0.16),
+                in: RoundedRectangle(cornerRadius: 16))
         }
         .frame(maxWidth: .infinity, alignment: .trailing)
     }

--- a/Sources/Heeler/Monitor/AgentComposerView.swift
+++ b/Sources/Heeler/Monitor/AgentComposerView.swift
@@ -11,7 +11,7 @@ struct AgentComposerView: View {
             if !store.messages.isEmpty {
                 ScrollViewReader { proxy in
                     ScrollView {
-                        LazyVStack(spacing: 8) {
+                        LazyVStack(spacing: 10) {
                             ForEach(store.messages) { message in
                                 messageRow(message)
                                     .id(message.id)
@@ -61,34 +61,44 @@ struct AgentComposerView: View {
     }
 
     private func messageRow(_ message: AgentComposerStore.Message) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(message.text)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .textSelection(.enabled)
-
-            statusLabel(for: message.state)
-                .font(.footnote)
-
-            if case .failed(let detail) = message.state {
-                Text(detail)
-                    .font(.footnote)
+        HStack {
+            Spacer(minLength: 44)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("You")
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
-                HStack(spacing: 8) {
-                    Button("Retry", systemImage: "arrow.clockwise") {
-                        Task { await store.retry(message.id) }
-                    }
-                    .buttonStyle(.borderedProminent)
 
-                    Button("Edit Draft", systemImage: "pencil") {
-                        store.withdrawToDraft(message.id)
+                Text(message.text)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+
+                statusLabel(for: message.state)
+                    .font(.footnote)
+
+                if case .failed(let detail) = message.state {
+                    Text(detail)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    HStack(spacing: 8) {
+                        Button("Retry", systemImage: "arrow.clockwise") {
+                            Task { await store.retry(message.id) }
+                        }
+                        .buttonStyle(.borderedProminent)
+
+                        Button("Edit Draft", systemImage: "pencil") {
+                            store.withdrawToDraft(message.id)
+                        }
+                        .buttonStyle(.bordered)
                     }
-                    .buttonStyle(.bordered)
+                    .controlSize(.small)
                 }
-                .controlSize(.small)
             }
+            .padding(12)
+            .background(
+                Color.accentColor.opacity(0.12),
+                in: RoundedRectangle(cornerRadius: 14))
         }
-        .padding(10)
-        .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
+        .frame(maxWidth: .infinity, alignment: .trailing)
     }
 
     @ViewBuilder

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -172,7 +172,7 @@ struct AgentDetailView: View {
 
     private func snapshotScrollView(_ snapshot: AttributedString) -> some View {
         ScrollViewReader { proxy in
-            ScrollView([.horizontal, .vertical]) {
+            ScrollView(.vertical) {
                 VStack(alignment: .leading, spacing: 0) {
                     historyTopMarker
                     Text(snapshot)

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -75,116 +75,154 @@ struct AgentDetailView: View {
         VStack(spacing: 0) {
             monitorSurface
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            Divider()
-            AgentComposerView(store: composer)
+            AgentComposerView(
+                store: composer,
+                isControlKeyEnabled: !monitor.isSendingKey
+            ) { key in
+                Task { await monitor.send(key) }
+            }
         }
-            .navigationTitle(title)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    Button("Attach", systemImage: "terminal") {
-                        monitor.attachDidOpen()
-                        isShowingAttach = true
-                    }
-                }
+        .background(Color(uiColor: .systemGroupedBackground))
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationDestination(isPresented: $isShowingAttach) {
+            AgentAttachView(
+                agent: agent,
+                console: console,
+                terminal: terminal,
+                hosts: hosts,
+                activity: activity,
+                keyboardHandoff: keyboardHandoff,
+                keyboardInset: keyboardInset,
+                isOnStage: isOnStage,
+                onSwitch: onSwitch,
+                onClosed: onClosed,
+                attachStore: attach)
+        }
+        .onChange(of: isShowingAttach) { wasShowing, isShowing in
+            guard wasShowing, !isShowing else { return }
+            Task {
+                await attach.leave().value
+                await monitor.refreshOnReturn()
             }
-            .navigationDestination(isPresented: $isShowingAttach) {
-                AgentAttachView(
-                    agent: agent,
-                    console: console,
-                    terminal: terminal,
-                    hosts: hosts,
-                    activity: activity,
-                    keyboardHandoff: keyboardHandoff,
-                    keyboardInset: keyboardInset,
-                    isOnStage: isOnStage,
-                    onSwitch: onSwitch,
-                    onClosed: onClosed,
-                    attachStore: attach)
-            }
-            .onChange(of: isShowingAttach) { wasShowing, isShowing in
-                guard wasShowing, !isShowing else { return }
-                Task {
-                    await attach.leave().value
-                    await monitor.refreshOnReturn()
-                }
-            }
-            .task {
-                composer.open()
-                await monitor.open()
-            }
-            .onChange(of: scenePhase, initial: true) { _, phase in
-                monitor.setForeground(phase == .active)
-            }
+        }
+        .task {
+            composer.open()
+            await monitor.open()
+        }
+        .onChange(of: scenePhase, initial: true) { _, phase in
+            monitor.setForeground(phase == .active)
+        }
     }
 
     @ViewBuilder
     private var monitorSurface: some View {
-        if let snapshot = monitor.snapshot {
-            VStack(spacing: 0) {
-                statusHeader
-                Divider()
+        VStack(spacing: 0) {
+            monitorHeader
+            if let snapshot = monitor.snapshot {
                 if snapshot.characters.isEmpty {
-                    ScrollView {
-                        ContentUnavailableView(
-                            "No Output", systemImage: "rectangle.dashed",
-                            description: Text("The Agent's latest screen is empty."))
-                            .frame(maxWidth: .infinity, minHeight: 360)
+                    ScrollView(.vertical) {
+                        VStack(spacing: 16) {
+                            ContentUnavailableView {
+                                Label("No Agent output", systemImage: "rectangle.dashed")
+                            } description: {
+                                Text("The latest snapshot is empty. Refresh to check again.")
+                            } actions: {
+                                Button("Refresh", systemImage: "arrow.clockwise") {
+                                    Task { await monitor.refresh() }
+                                }
+                                .buttonStyle(.bordered)
+                            }
+
+                            AgentSentMessagesView(store: composer)
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, minHeight: 360)
                     }
                     .refreshable { await monitor.refresh() }
                 } else {
                     snapshotScrollView(snapshot)
                 }
-                if let sendError = monitor.sendError {
-                    Text(sendError)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal)
-                        .padding(.top, 8)
-                }
-                MonitorControlKeyStrip(isEnabled: !monitor.isSendingKey) { key in
-                    Task { await monitor.send(key) }
-                }
-            }
-        } else {
-            switch monitor.state {
-            case .failed(let message):
-                ContentUnavailableView {
-                    Label("Couldn't Load Screen", systemImage: "exclamationmark.triangle")
-                } description: {
-                    VStack(spacing: 8) {
-                        Text(message)
-                        if !monitor.liveUpdatesAvailable {
-                            liveUpdatesUnavailableLabel
+            } else {
+                switch monitor.state {
+                case .failed(let message):
+                    ScrollView(.vertical) {
+                        VStack(spacing: 16) {
+                            ContentUnavailableView {
+                                Label(
+                                    "Unable to load Agent output",
+                                    systemImage: "exclamationmark.triangle")
+                            } description: {
+                                Text(message)
+                            } actions: {
+                                Button("Try again", systemImage: "arrow.clockwise") {
+                                    Task { await monitor.retry() }
+                                }
+                                .buttonStyle(.borderedProminent)
+                            }
+
+                            AgentSentMessagesView(store: composer)
                         }
+                        .padding()
+                        .frame(maxWidth: .infinity, minHeight: 360)
                     }
-                } actions: {
-                    Button("Retry") { Task { await monitor.retry() } }
-                        .buttonStyle(.borderedProminent)
-                }
-            case .idle, .loading, .loaded:
-                ProgressView("Loading latest screen…")
+                case .idle, .loading, .loaded:
+                    VStack(spacing: 12) {
+                        ProgressView()
+                        Text("Loading Agent output…")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
             }
         }
+        .background(Color(uiColor: .systemGroupedBackground))
     }
 
     private func snapshotScrollView(_ snapshot: AttributedString) -> some View {
         ScrollViewReader { proxy in
             ScrollView(.vertical) {
-                VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: 12) {
                     historyTopMarker
+                    Text("Agent output")
+                        .font(.subheadline.weight(.semibold))
+                        .accessibilityAddTraits(.isHeader)
                     Text(snapshot)
                         .font(.system(.callout, design: .monospaced))
                         .lineSpacing(3)
+                        .foregroundStyle(.white)
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .topLeading)
-                        .padding()
+                        .padding(16)
+                        .background(
+                            Color.black.opacity(0.94),
+                            in: RoundedRectangle(cornerRadius: 16))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 16)
+                                .stroke(.white.opacity(0.12), lineWidth: 1)
+                        }
+                        .environment(\.colorScheme, .dark)
+
+                    if let sendError = monitor.sendError {
+                        Label(sendError, systemImage: "exclamationmark.triangle")
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(12)
+                            .background(
+                                Color.red.opacity(0.08),
+                                in: RoundedRectangle(cornerRadius: 12))
+                    }
+
+                    AgentSentMessagesView(store: composer)
+
                     Color.clear
                         .frame(height: 1)
                         .id(Self.outputBottomID)
                 }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
             }
             .defaultScrollAnchor(.bottom, for: .initialOffset)
             .refreshable { await monitor.refresh() }
@@ -203,18 +241,19 @@ struct AgentDetailView: View {
                 guard monitor.isBottomPinned else { return }
                 proxy.scrollTo(Self.outputBottomID, anchor: .bottom)
             }
+            .onChange(of: composer.messages.count) {
+                guard monitor.isBottomPinned else { return }
+                proxy.scrollTo(Self.outputBottomID, anchor: .bottom)
+            }
             .overlay(alignment: .bottomTrailing) {
                 if monitor.hasNewOutput {
-                    Button("New Output", systemImage: "arrow.down") {
+                    Button("Jump to latest", systemImage: "arrow.down") {
                         monitor.jumpToLatestOutput()
-                        withAnimation(.snappy) {
-                            proxy.scrollTo(Self.outputBottomID, anchor: .bottom)
-                        }
+                        proxy.scrollTo(Self.outputBottomID, anchor: .bottom)
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
-                    .padding()
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .padding(20)
                 }
             }
         }
@@ -239,8 +278,9 @@ struct AgentDetailView: View {
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
             case .unavailable:
                 historyMarkerLabel(
                     "History unavailable while the Agent works",
@@ -259,8 +299,8 @@ struct AgentDetailView: View {
                         .font(.footnote)
                 }
                 .frame(maxWidth: .infinity)
-                .padding(.horizontal)
-                .padding(.vertical, 10)
+                .padding(12)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
             case .idle:
                 EmptyView()
             }
@@ -271,42 +311,96 @@ struct AgentDetailView: View {
         Label(text, systemImage: systemImage)
             .font(.footnote)
             .foregroundStyle(.secondary)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
     }
 
-    private var statusHeader: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 8) {
-                Text("Agent output")
-                    .font(.subheadline.weight(.semibold))
-                AgentStatusBadge(status: monitor.agentStatus)
-                Spacer(minLength: 8)
-                if let capturedAt = monitor.capturedAt {
-                    Label(
-                        "Updated \(capturedAt.formatted(date: .omitted, time: .standard))",
-                        systemImage: "clock")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
+    private var monitorHeader: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .center, spacing: 12) {
+                    monitorIdentity
+                    Spacer(minLength: 12)
+                    attachButton
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    monitorIdentity
+                    attachButton
                 }
             }
+
             if !monitor.liveUpdatesAvailable {
                 liveUpdatesUnavailableLabel
             }
-            if case .failed(let message) = monitor.state {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Label(message, systemImage: "exclamationmark.triangle")
+            if monitor.snapshot != nil, case .failed(let message) = monitor.state {
+                HStack(alignment: .center, spacing: 8) {
+                    Label(
+                        "Refresh failed. Showing the last snapshot. \(message)",
+                        systemImage: "exclamationmark.triangle")
                         .font(.footnote)
-                        .foregroundStyle(.secondary)
                     Spacer(minLength: 8)
-                    Button("Retry") { Task { await monitor.retry() } }
+                    Button("Try again") { Task { await monitor.retry() } }
                         .font(.footnote)
                 }
+                .padding(12)
+                .background(
+                    Color.orange.opacity(0.12),
+                    in: RoundedRectangle(cornerRadius: 12))
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal)
-        .padding(.vertical, 10)
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color(uiColor: .secondarySystemGroupedBackground))
+    }
+
+    private var monitorIdentity: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Monitor")
+                .font(.headline)
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 8) {
+                    AgentStatusBadge(status: monitor.agentStatus)
+                    snapshotFreshness
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    AgentStatusBadge(status: monitor.agentStatus)
+                    snapshotFreshness
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var snapshotFreshness: some View {
+        if let capturedAt = monitor.capturedAt {
+            Label(
+                "Updated \(capturedAt.formatted(date: .omitted, time: .shortened))",
+                systemImage: "clock")
+                .font(.caption)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+        } else {
+            Text("Waiting for the first snapshot")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var attachButton: some View {
+        Button("Attach", systemImage: "terminal") {
+            monitor.attachDidOpen()
+            isShowingAttach = true
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.regular)
+        .frame(minHeight: 44)
+        .accessibilityHint("Opens the live terminal")
     }
 
     private var title: String {
@@ -315,10 +409,12 @@ struct AgentDetailView: View {
 
     private var liveUpdatesUnavailableLabel: some View {
         Label(
-            "Live updates unavailable. Pull to refresh.",
+            "Updates are paused. Pull down to refresh.",
             systemImage: "wifi.slash")
             .font(.footnote)
-            .foregroundStyle(.secondary)
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
     }
 
     private static let outputBottomID = "agent-monitor-output-bottom"

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -176,7 +176,8 @@ struct AgentDetailView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     historyTopMarker
                     Text(snapshot)
-                        .font(.system(.body, design: .monospaced))
+                        .font(.system(.callout, design: .monospaced))
+                        .lineSpacing(3)
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .topLeading)
                         .padding()
@@ -276,7 +277,9 @@ struct AgentDetailView: View {
 
     private var statusHeader: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
+            HStack(spacing: 8) {
+                Text("Agent output")
+                    .font(.subheadline.weight(.semibold))
                 AgentStatusBadge(status: monitor.agentStatus)
                 Spacer(minLength: 8)
                 if let capturedAt = monitor.capturedAt {

--- a/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
+++ b/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
@@ -1,35 +1,51 @@
 import SwiftUI
 
-/// Monitor's horizontal control-key strip (#183): Enter, Esc, Ctrl+C, and
-/// the four arrows. Self-contained so package #180 can attach elsewhere
-/// without reshaping the rest of the Monitor surface. Spellings live on
+/// Monitor's compact control-key row (#183). The three prompt actions stay
+/// one tap away; directional keys live behind an explicit menu so narrow
+/// layouts never hide controls offscreen. Spellings live on
 /// ``MonitorControlKey``; this view only presents the buttons.
 struct MonitorControlKeyStrip: View {
     let isEnabled: Bool
     let onTap: (MonitorControlKey) -> Void
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                ForEach(MonitorControlKey.allCases) { key in
+        HStack(spacing: 8) {
+            ForEach(Self.quickKeys) { key in
+                Button {
+                    onTap(key)
+                } label: {
+                    keyLabel(key)
+                        .font(.callout.weight(.medium))
+                        .frame(minWidth: 44, minHeight: 44)
+                        .padding(.horizontal, 4)
+                }
+                .buttonStyle(.bordered)
+                .disabled(!isEnabled)
+                .accessibilityLabel(key.accessibilityLabel)
+            }
+
+            Spacer(minLength: 0)
+
+            Menu {
+                ForEach(Self.arrowKeys) { key in
                     Button {
                         onTap(key)
                     } label: {
-                        keyLabel(key)
-                            .font(.callout.weight(.medium))
-                            .frame(minWidth: 44, minHeight: 36)
-                            .padding(.horizontal, 4)
+                        Label(key.accessibilityLabel, systemImage: key.systemImage ?? "arrow.up")
                     }
-                    .buttonStyle(.bordered)
                     .disabled(!isEnabled)
-                    .accessibilityLabel(key.accessibilityLabel)
                 }
+            } label: {
+                Image(systemName: "arrow.up.and.down.and.arrow.left.and.right")
+                    .font(.callout.weight(.medium))
+                    .frame(minWidth: 44, minHeight: 44)
             }
-            .padding(.horizontal, 1)
+            .buttonStyle(.bordered)
+            .disabled(!isEnabled)
+            .accessibilityLabel("Directional keys")
+            .accessibilityHint("Shows directional keys")
         }
-        .padding(.horizontal)
-        .padding(.vertical, 8)
-        .background(.bar)
+        .dynamicTypeSize(...DynamicTypeSize.large)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Control keys")
     }
@@ -42,4 +58,12 @@ struct MonitorControlKeyStrip: View {
             Text(label)
         }
     }
+
+    private static let quickKeys: [MonitorControlKey] = [
+        .enter, .escape, .interrupt,
+    ]
+
+    private static let arrowKeys: [MonitorControlKey] = [
+        .up, .down, .left, .right,
+    ]
 }

--- a/Tests/HeelerTests/ANSISnapshotRendererTests.swift
+++ b/Tests/HeelerTests/ANSISnapshotRendererTests.swift
@@ -290,6 +290,28 @@ struct ANSISnapshotRendererTests {
         #expect(rendered.runs.first?.backgroundColor == nil)
     }
 
+    @Test func removesBackgroundColorFromRunPadding() {
+        let rendered = ANSISnapshotRenderer.render(
+            "\u{1B}[48;5;232m    message    \u{1B}[0m")
+        let runs = rendered.runs.map { run in
+            (
+                text: String(rendered.characters[run.range]),
+                background: run.backgroundColor
+            )
+        }
+
+        #expect(String(rendered.characters) == "    message    ")
+        #expect(runs.count == 3)
+        #expect(runs[0].text == "    ")
+        #expect(runs[0].background == nil)
+        #expect(runs[1].text == "message")
+        #expect(
+            runs[1].background
+                == Color(red: 8.0 / 255.0, green: 8.0 / 255.0, blue: 8.0 / 255.0))
+        #expect(runs[2].text == "    ")
+        #expect(runs[2].background == nil)
+    }
+
     private func assertFixture(_ fixture: Fixture) {
         let rendered = ANSISnapshotRenderer.render(String(decoding: fixture.bytes, as: UTF8.self))
         #expect(String(rendered.characters) == fixture.text, "\(fixture.name): text")

--- a/Tests/HeelerTests/ANSISnapshotRendererTests.swift
+++ b/Tests/HeelerTests/ANSISnapshotRendererTests.swift
@@ -36,12 +36,20 @@ struct ANSISnapshotRendererTests {
         }
     }
 
-    /// How a run's color should resolve in one appearance: an exact 8-bit
-    /// value, or a clamped value that only has to satisfy the contrast
-    /// contract against the snapshot surface.
+    private typealias Resolved = (red: Int, green: Int, blue: Int, alpha: Double)
+
+    /// How a run's color should resolve in one appearance.
     private enum ColorExpectation: Sendable {
+        /// An exact 8-bit value.
         case exact(RGB)
-        case clamped
+        /// Clamped for legibility against the snapshot surface (a foreground
+        /// with no explicit background).
+        case clampedOnSurface
+        /// Clamped for legibility against the run's own resolved background.
+        case onExplicitBackground
+        /// Clamped so the appearance's label text stays legible on it (a
+        /// background).
+        case underLabelText
     }
 
     private struct ExpectedColor: Sendable {
@@ -55,11 +63,16 @@ struct ANSISnapshotRendererTests {
         static func adaptive(light: ColorExpectation, dark: ColorExpectation) -> ExpectedColor {
             ExpectedColor(light: light, dark: dark)
         }
+
+        static let onExplicitBackground = ExpectedColor(
+            light: .onExplicitBackground, dark: .onExplicitBackground)
+        static let underLabelText = ExpectedColor(
+            light: .underLabelText, dark: .underLabelText)
     }
 
-    // Mirrors the renderer's base palette; every value clears WCAG 4.5:1 on
-    // `secondarySystemGroupedBackground` in its appearance, so the renderer's
-    // clamp must leave them untouched.
+    // Mirrors the renderer's base palette sources; every value clears WCAG
+    // 4.5:1 on `secondarySystemGroupedBackground` in its appearance, so a
+    // foreground with no explicit background resolves to exactly these.
     private static let palette: [(light: RGB, dark: RGB)] = [
         (RGB(0x1C, 0x1C, 0x1E), RGB(0x8C, 0x8C, 0x8C)),
         (RGB(0xA3, 0x15, 0x15), RGB(0xF9, 0x75, 0x83)),
@@ -94,8 +107,8 @@ struct ANSISnapshotRendererTests {
                     ExpectedRun(text: "plain "),
                     ExpectedRun(
                         text: "red on blue",
-                        foreground: paletteColor(1),
-                        background: paletteColor(4)),
+                        foreground: .onExplicitBackground,
+                        background: .underLabelText),
                     ExpectedRun(text: " plain"),
                 ]),
             Fixture(
@@ -105,8 +118,8 @@ struct ANSISnapshotRendererTests {
                 runs: [
                     ExpectedRun(
                         text: "bright",
-                        foreground: paletteColor(14),
-                        background: paletteColor(9)),
+                        foreground: .onExplicitBackground,
+                        background: .underLabelText),
                     ExpectedRun(text: "reset"),
                 ]),
             Fixture(
@@ -147,9 +160,52 @@ struct ANSISnapshotRendererTests {
                     text: "X",
                     runs: [
                         ExpectedRun(
-                            text: "X", foreground: paletteColor(index),
-                            background: paletteColor(index))
+                            text: "X", foreground: .onExplicitBackground,
+                            background: .underLabelText)
                     ]))
+        }
+    }
+
+    @Test func everyBaseSlotForegroundResolvesToPaletteAndMeetsContract() {
+        for index in 0..<16 {
+            let foregroundCode = index < 8 ? 30 + index : 90 + index - 8
+            let rendered = ANSISnapshotRenderer.render("\u{1B}[\(foregroundCode)mX")
+            let foreground = rendered.runs.first?.foregroundColor
+            let slot = Self.palette[index]
+
+            let light = resolve(foreground, style: .light)
+            #expect(
+                light?.red == slot.light.red && light?.green == slot.light.green
+                    && light?.blue == slot.light.blue,
+                "slot \(index): light foreground")
+            let dark = resolve(foreground, style: .dark)
+            #expect(
+                dark?.red == slot.dark.red && dark?.green == slot.dark.green
+                    && dark?.blue == slot.dark.blue,
+                "slot \(index): dark foreground")
+            assertRatio(
+                light, reference: ANSISnapshotRenderer.surfaceColor(for: .light),
+                label: "slot \(index) light foreground")
+            assertRatio(
+                dark, reference: ANSISnapshotRenderer.surfaceColor(for: .dark),
+                label: "slot \(index) dark foreground")
+        }
+    }
+
+    @Test func everyBaseSlotBackgroundKeepsLabelTextLegibleInBothAppearances() {
+        for index in 0..<16 {
+            let backgroundCode = index < 8 ? 40 + index : 100 + index - 8
+            let rendered = ANSISnapshotRenderer.render("\u{1B}[\(backgroundCode)mX")
+            let background = rendered.runs.first?.backgroundColor
+
+            assertRatio(
+                resolve(background, style: .light),
+                reference: ANSISnapshotRenderer.labelColor(for: .light),
+                label: "slot \(index) light background")
+            assertRatio(
+                resolve(background, style: .dark),
+                reference: ANSISnapshotRenderer.labelColor(for: .dark),
+                label: "slot \(index) dark background")
         }
     }
 
@@ -162,8 +218,8 @@ struct ANSISnapshotRendererTests {
                 runs: [
                     ExpectedRun(
                         text: "ansi",
-                        foreground: paletteColor(1),
-                        background: paletteColor(14))
+                        foreground: .onExplicitBackground,
+                        background: .underLabelText)
                 ]),
             Fixture(
                 name: "256-color cube",
@@ -172,10 +228,8 @@ struct ANSISnapshotRendererTests {
                 runs: [
                     ExpectedRun(
                         text: "cube",
-                        foreground: .adaptive(
-                            light: .exact(RGB(0x00, 0x00, 0xFF)), dark: .clamped),
-                        background: .adaptive(
-                            light: .clamped, dark: .exact(RGB(0xFF, 0x87, 0x00))))
+                        foreground: .onExplicitBackground,
+                        background: .underLabelText)
                 ]),
             Fixture(
                 name: "256-color grayscale",
@@ -184,68 +238,106 @@ struct ANSISnapshotRendererTests {
                 runs: [
                     ExpectedRun(
                         text: "gray",
-                        foreground: .adaptive(
-                            light: .exact(RGB(0x08, 0x08, 0x08)), dark: .clamped),
-                        background: .adaptive(
-                            light: .clamped, dark: .exact(RGB(0xEE, 0xEE, 0xEE))))
+                        foreground: .onExplicitBackground,
+                        background: .underLabelText)
                 ]),
         ]
 
         fixtures.forEach(assertFixture)
     }
 
-    @Test func rendersTruecolorFixtures() {
-        let fixture = Fixture(
-            name: "truecolor foreground and background",
-            bytes: bytes("\u{1B}[38;2;12;34;56;48;2;210;180;140mrgb"),
-            text: "rgb",
-            runs: [
-                ExpectedRun(
-                    text: "rgb",
-                    foreground: .adaptive(
-                        light: .exact(RGB(12, 34, 56)), dark: .clamped),
-                    background: .adaptive(
-                        light: .clamped, dark: .exact(RGB(210, 180, 140))))
-            ])
+    @Test func extendedColorForegroundWithoutBackgroundKeepsSourceWhenLegible() {
+        let fixtures = [
+            Fixture(
+                name: "cube blue",
+                bytes: bytes("\u{1B}[38;5;21mX"),
+                text: "X",
+                runs: [
+                    ExpectedRun(
+                        text: "X",
+                        foreground: .adaptive(
+                            light: .exact(RGB(0x00, 0x00, 0xFF)),
+                            dark: .clampedOnSurface))
+                ]),
+            Fixture(
+                name: "cube orange",
+                bytes: bytes("\u{1B}[38;5;208mX"),
+                text: "X",
+                runs: [
+                    ExpectedRun(
+                        text: "X",
+                        foreground: .adaptive(
+                            light: .clampedOnSurface,
+                            dark: .exact(RGB(0xFF, 0x87, 0x00))))
+                ]),
+            Fixture(
+                name: "dark gray",
+                bytes: bytes("\u{1B}[38;5;232mX"),
+                text: "X",
+                runs: [
+                    ExpectedRun(
+                        text: "X",
+                        foreground: .adaptive(
+                            light: .exact(RGB(0x08, 0x08, 0x08)),
+                            dark: .clampedOnSurface))
+                ]),
+            Fixture(
+                name: "light gray",
+                bytes: bytes("\u{1B}[38;5;255mX"),
+                text: "X",
+                runs: [
+                    ExpectedRun(
+                        text: "X",
+                        foreground: .adaptive(
+                            light: .clampedOnSurface,
+                            dark: .exact(RGB(0xEE, 0xEE, 0xEE))))
+                ]),
+            Fixture(
+                name: "truecolor dark blue",
+                bytes: bytes("\u{1B}[38;2;12;34;56mX"),
+                text: "X",
+                runs: [
+                    ExpectedRun(
+                        text: "X",
+                        foreground: .adaptive(
+                            light: .exact(RGB(12, 34, 56)),
+                            dark: .clampedOnSurface))
+                ]),
+            Fixture(
+                name: "truecolor tan",
+                bytes: bytes("\u{1B}[38;2;210;180;140mX"),
+                text: "X",
+                runs: [
+                    ExpectedRun(
+                        text: "X",
+                        foreground: .adaptive(
+                            light: .clampedOnSurface,
+                            dark: .exact(RGB(210, 180, 140))))
+                ]),
+        ]
 
-        assertFixture(fixture)
+        fixtures.forEach(assertFixture)
     }
 
-    @Test func everyBaseSlotForegroundMeetsContrastContractInBothAppearances() {
-        for index in 0..<16 {
-            let foregroundCode = index < 8 ? 30 + index : 90 + index - 8
-            let rendered = ANSISnapshotRenderer.render("\u{1B}[\(foregroundCode)mX")
-            let foreground = rendered.runs.first?.foregroundColor
-            #expect(foreground != nil, "slot \(index): expected a foreground")
-            assertContrast(
-                resolve(foreground, style: .light), style: .light,
-                label: "slot \(index) foreground")
-            assertContrast(
-                resolve(foreground, style: .dark), style: .dark,
-                label: "slot \(index) foreground")
-        }
-    }
-
-    @Test func extendedColorForegroundsMeetContrastContractInBothAppearances() {
+    @Test func explicitForegroundOnExplicitBackgroundMeetsContrastContract() {
         let samples = [
-            "cube blue": "\u{1B}[38;5;21mX",
-            "cube orange": "\u{1B}[38;5;208mX",
-            "cube yellow": "\u{1B}[38;5;226mX",
-            "dark gray": "\u{1B}[38;5;232mX",
-            "light gray": "\u{1B}[38;5;255mX",
-            "truecolor green": "\u{1B}[38;2;0;255;0mX",
-            "truecolor dark blue": "\u{1B}[38;2;12;34;56mX",
+            "red on blue": "\u{1B}[31;44mX",
+            "bright cyan on bright red": "\u{1B}[96;101mX",
+            "cube blue on cube orange": "\u{1B}[38;5;21;48;5;208mX",
+            "gray on gray": "\u{1B}[38;5;232;48;5;255mX",
+            "truecolor on truecolor": "\u{1B}[38;2;12;34;56;48;2;210;180;140mX",
         ]
         for (name, sample) in samples {
             let rendered = ANSISnapshotRenderer.render(sample)
-            let foreground = rendered.runs.first?.foregroundColor
-            #expect(foreground != nil, "\(name): expected a foreground")
-            assertContrast(
-                resolve(foreground, style: .light), style: .light,
-                label: "\(name) foreground")
-            assertContrast(
-                resolve(foreground, style: .dark), style: .dark,
-                label: "\(name) foreground")
+            let run = rendered.runs.first
+            assertPairRatio(
+                resolve(run?.foregroundColor, style: .light),
+                resolve(run?.backgroundColor, style: .light),
+                label: "\(name) light")
+            assertPairRatio(
+                resolve(run?.foregroundColor, style: .dark),
+                resolve(run?.backgroundColor, style: .dark),
+                label: "\(name) dark")
         }
     }
 
@@ -268,20 +360,15 @@ struct ANSISnapshotRendererTests {
         let maroon = ANSISnapshotRenderer.RGB(red: 0x80, green: 0, blue: 0)
         let silver = ANSISnapshotRenderer.RGB(red: 0xC0, green: 0xC0, blue: 0xC0)
 
-        #expect(
-            ANSISnapshotRenderer.Contrast.legible(maroon, on: white, appearance: .light)
-                == maroon)
-        #expect(
-            ANSISnapshotRenderer.Contrast.legible(silver, on: darkSurface, appearance: .dark)
-                == silver)
+        #expect(ANSISnapshotRenderer.Contrast.legible(maroon, on: white) == maroon)
+        #expect(ANSISnapshotRenderer.Contrast.legible(silver, on: darkSurface) == silver)
     }
 
     @Test func legibleClampDarkensOnLightSurfacePreservingHue() {
         let white = ANSISnapshotRenderer.RGB(red: 255, green: 255, blue: 255)
         let yellow = ANSISnapshotRenderer.RGB(red: 255, green: 255, blue: 0)
 
-        let clamped = ANSISnapshotRenderer.Contrast.legible(
-            yellow, on: white, appearance: .light)
+        let clamped = ANSISnapshotRenderer.Contrast.legible(yellow, on: white)
 
         #expect(ANSISnapshotRenderer.Contrast.ratio(of: clamped, to: white) >= 4.5)
         #expect(clamped.red < yellow.red)
@@ -293,8 +380,7 @@ struct ANSISnapshotRendererTests {
         let darkSurface = ANSISnapshotRenderer.RGB(red: 28, green: 28, blue: 30)
         let navy = ANSISnapshotRenderer.RGB(red: 0, green: 0, blue: 0x80)
 
-        let clamped = ANSISnapshotRenderer.Contrast.legible(
-            navy, on: darkSurface, appearance: .dark)
+        let clamped = ANSISnapshotRenderer.Contrast.legible(navy, on: darkSurface)
 
         #expect(ANSISnapshotRenderer.Contrast.ratio(of: clamped, to: darkSurface) >= 4.5)
         #expect(clamped.blue > navy.blue)
@@ -306,26 +392,49 @@ struct ANSISnapshotRendererTests {
         let darkSurface = ANSISnapshotRenderer.RGB(red: 28, green: 28, blue: 30)
         let darkGray = ANSISnapshotRenderer.RGB(red: 8, green: 8, blue: 8)
 
-        let clamped = ANSISnapshotRenderer.Contrast.legible(
-            darkGray, on: darkSurface, appearance: .dark)
+        let clamped = ANSISnapshotRenderer.Contrast.legible(darkGray, on: darkSurface)
 
         #expect(ANSISnapshotRenderer.Contrast.ratio(of: clamped, to: darkSurface) >= 4.5)
         #expect(clamped.red == clamped.green)
         #expect(clamped.green == clamped.blue)
     }
 
+    @Test func legibleClampHandlesMidLuminanceReference() {
+        let reference = ANSISnapshotRenderer.RGB(red: 0x77, green: 0x77, blue: 0x77)
+        // Slightly lighter than the reference: the primary direction (away
+        // from the reference) cannot reach 4.5:1 here, so the clamp must
+        // fall back to the other direction.
+        let color = ANSISnapshotRenderer.RGB(red: 0x80, green: 0x80, blue: 0x80)
+
+        let clamped = ANSISnapshotRenderer.Contrast.legible(color, on: reference)
+
+        #expect(ANSISnapshotRenderer.Contrast.ratio(of: clamped, to: reference) >= 4.5)
+    }
+
     @Test func reverseVideoSwapsExplicitForegroundAndBackground() {
-        assertFixture(
-            Fixture(
-                name: "reverse video with explicit colors",
-                bytes: bytes("\u{1B}[31;44;7mX"),
-                text: "X",
-                runs: [
-                    ExpectedRun(
-                        text: "X",
-                        foreground: paletteColor(4),
-                        background: paletteColor(1))
-                ]))
+        let rendered = ANSISnapshotRenderer.render("\u{1B}[31;44;7mX")
+        let run = rendered.runs.first
+
+        #expect(run?.foregroundColor != nil)
+        #expect(run?.backgroundColor != nil)
+        // The swapped pair must stay legible in both appearances, and the
+        // fill must keep label text legible.
+        assertPairRatio(
+            resolve(run?.foregroundColor, style: .light),
+            resolve(run?.backgroundColor, style: .light),
+            label: "reverse video light pair")
+        assertPairRatio(
+            resolve(run?.foregroundColor, style: .dark),
+            resolve(run?.backgroundColor, style: .dark),
+            label: "reverse video dark pair")
+        assertRatio(
+            resolve(run?.backgroundColor, style: .light),
+            reference: ANSISnapshotRenderer.labelColor(for: .light),
+            label: "reverse video light fill")
+        assertRatio(
+            resolve(run?.backgroundColor, style: .dark),
+            reference: ANSISnapshotRenderer.labelColor(for: .dark),
+            label: "reverse video dark fill")
     }
 
     @Test func reverseVideoWithoutColorsUsesLegibleHighlightPair() {
@@ -334,42 +443,46 @@ struct ANSISnapshotRendererTests {
 
         #expect(run?.backgroundColor != nil)
         #expect(run?.foregroundColor != nil)
-        for style in [UIUserInterfaceStyle.light, UIUserInterfaceStyle.dark] {
-            let foreground = resolve(run?.foregroundColor, style: style)
-            let background = resolve(run?.backgroundColor, style: style)
-            guard let foreground, let background else {
-                Issue.record("reverse video: expected both colors to resolve")
-                return
-            }
-            let ratio = ANSISnapshotRenderer.Contrast.ratio(
-                of: ANSISnapshotRenderer.RGB(
-                    red: foreground.red, green: foreground.green, blue: foreground.blue),
-                to: ANSISnapshotRenderer.RGB(
-                    red: background.red, green: background.green, blue: background.blue))
-            #expect(
-                ratio >= ANSISnapshotRenderer.Contrast.minimumForegroundRatio,
-                "reverse video highlight contrast \(ratio) below 4.5")
-        }
+        assertPairRatio(
+            resolve(run?.foregroundColor, style: .light),
+            resolve(run?.backgroundColor, style: .light),
+            label: "reverse video light pair")
+        assertPairRatio(
+            resolve(run?.foregroundColor, style: .dark),
+            resolve(run?.backgroundColor, style: .dark),
+            label: "reverse video dark pair")
     }
 
     @Test func reverseVideoWithForegroundOnlyFillsSurfaceText() {
         let rendered = ANSISnapshotRenderer.render("\u{1B}[31;7mX")
         let run = rendered.runs.first
 
-        assertColor(
-            run?.backgroundColor,
-            matches: paletteColor(1),
-            opacity: 1,
-            label: "reverse video background")
-        // The text takes the surface color so it stays legible on the fill.
+        // The text takes the surface color, clamped against the fill: exactly
+        // white on the light fill, exactly black on the dark one.
         let lightForeground = resolve(run?.foregroundColor, style: .light)
         #expect(lightForeground?.red == 255)
         #expect(lightForeground?.green == 255)
         #expect(lightForeground?.blue == 255)
         let darkForeground = resolve(run?.foregroundColor, style: .dark)
-        #expect(darkForeground?.red == 28)
-        #expect(darkForeground?.green == 28)
-        #expect(darkForeground?.blue == 30)
+        #expect(darkForeground?.red == 0)
+        #expect(darkForeground?.green == 0)
+        #expect(darkForeground?.blue == 0)
+        assertPairRatio(
+            lightForeground,
+            resolve(run?.backgroundColor, style: .light),
+            label: "reverse video light pair")
+        assertPairRatio(
+            darkForeground,
+            resolve(run?.backgroundColor, style: .dark),
+            label: "reverse video dark pair")
+        assertRatio(
+            resolve(run?.backgroundColor, style: .light),
+            reference: ANSISnapshotRenderer.labelColor(for: .light),
+            label: "reverse video light fill")
+        assertRatio(
+            resolve(run?.backgroundColor, style: .dark),
+            reference: ANSISnapshotRenderer.labelColor(for: .dark),
+            label: "reverse video dark fill")
     }
 
     @Test func reverseVideoOffAndResetClearReversal() {
@@ -598,12 +711,15 @@ struct ANSISnapshotRendererTests {
         #expect(runs[0].text == "    ")
         #expect(runs[0].background == nil)
         #expect(runs[1].text == "message")
-        // RGB(8, 8, 8) contrasts with the light surface, so it survives
-        // unclamped there.
-        let lightBackground = resolve(runs[1].background, style: .light)
-        #expect(lightBackground?.red == 8)
-        #expect(lightBackground?.green == 8)
-        #expect(lightBackground?.blue == 8)
+        // The surviving background is clamped so label text stays legible.
+        assertRatio(
+            resolve(runs[1].background, style: .light),
+            reference: ANSISnapshotRenderer.labelColor(for: .light),
+            label: "message background light")
+        assertRatio(
+            resolve(runs[1].background, style: .dark),
+            reference: ANSISnapshotRenderer.labelColor(for: .dark),
+            label: "message background dark")
         #expect(runs[2].text == "    ")
         #expect(runs[2].background == nil)
     }
@@ -625,16 +741,24 @@ struct ANSISnapshotRendererTests {
 
         for (actual, expected) in zip(actualRuns, fixture.runs) {
             #expect(actual.text == expected.text, "\(fixture.name): run text")
-            assertColor(
-                actual.foreground,
-                matches: expected.foreground,
-                opacity: expected.foregroundOpacity,
-                label: "\(fixture.name): \(expected.text) foreground")
-            assertColor(
-                actual.background,
-                matches: expected.background,
-                opacity: 1,
-                label: "\(fixture.name): \(expected.text) background")
+            for style in [UIUserInterfaceStyle.light, UIUserInterfaceStyle.dark] {
+                let foreground = resolve(actual.foreground, style: style)
+                let background = resolve(actual.background, style: style)
+                assertResolved(
+                    foreground,
+                    matches: expected.foreground,
+                    opacity: expected.foregroundOpacity,
+                    partner: background,
+                    style: style,
+                    label: "\(fixture.name): \(expected.text) foreground")
+                assertResolved(
+                    background,
+                    matches: expected.background,
+                    opacity: 1,
+                    partner: foreground,
+                    style: style,
+                    label: "\(fixture.name): \(expected.text) background")
+            }
 
             var expectedEmphasis: InlinePresentationIntent = []
             if expected.bold {
@@ -652,68 +776,98 @@ struct ANSISnapshotRendererTests {
         }
     }
 
-    private func assertColor(
-        _ actual: Color?,
+    private func assertResolved(
+        _ resolved: Resolved?,
         matches expected: ExpectedColor?,
         opacity: Double,
+        partner: Resolved?,
+        style: UIUserInterfaceStyle,
         label: String
     ) {
-        for style in [UIUserInterfaceStyle.light, UIUserInterfaceStyle.dark] {
-            let resolved = resolve(actual, style: style)
-            let appearance = style == .dark ? "dark" : "light"
-
-            guard let expected else {
-                if opacity < 1 {
-                    // Dim default foreground: Color.primary at half opacity.
-                    let channel = style == .dark ? 255 : 0
-                    #expect(
-                        resolved?.red == channel && resolved?.green == channel
-                            && resolved?.blue == channel
-                            && abs((resolved?.alpha ?? 0) - opacity) < 0.01,
-                        "\(label): dim default in \(appearance)")
-                } else {
-                    #expect(resolved == nil, "\(label): expected no color in \(appearance)")
-                }
-                continue
-            }
-
-            switch style == .dark ? expected.dark : expected.light {
-            case .exact(let rgb):
+        let appearance = style == .dark ? "dark" : "light"
+        guard let expected else {
+            if opacity < 1 {
+                // Dim default foreground: Color.primary at half opacity.
+                let channel = style == .dark ? 255 : 0
                 #expect(
-                    resolved?.red == rgb.red && resolved?.green == rgb.green
-                        && resolved?.blue == rgb.blue
+                    resolved?.red == channel && resolved?.green == channel
+                        && resolved?.blue == channel
                         && abs((resolved?.alpha ?? 0) - opacity) < 0.01,
-                    "\(label): expected \(rgb) in \(appearance), got \(String(describing: resolved))")
-            case .clamped:
-                assertContrast(resolved, style: style, label: label)
+                    "\(label): dim default in \(appearance)")
+            } else {
+                #expect(resolved == nil, "\(label): expected no color in \(appearance)")
             }
+            return
+        }
+
+        switch style == .dark ? expected.dark : expected.light {
+        case .exact(let rgb):
+            #expect(
+                resolved?.red == rgb.red && resolved?.green == rgb.green
+                    && resolved?.blue == rgb.blue
+                    && abs((resolved?.alpha ?? 0) - opacity) < 0.01,
+                "\(label): expected \(rgb) in \(appearance), got \(String(describing: resolved))")
+        case .clampedOnSurface:
+            assertRatio(
+                resolved,
+                reference: ANSISnapshotRenderer.surfaceColor(
+                    for: style == .dark ? .dark : .light),
+                label: label)
+        case .onExplicitBackground:
+            guard let partner else {
+                Issue.record("\(label): expected a resolved background partner")
+                return
+            }
+            assertPairRatio(resolved, partner, label: label)
+        case .underLabelText:
+            assertRatio(
+                resolved,
+                reference: ANSISnapshotRenderer.labelColor(
+                    for: style == .dark ? .dark : .light),
+                label: label)
         }
     }
 
-    private func assertContrast(
-        _ resolved: (red: Int, green: Int, blue: Int, alpha: Double)?,
-        style: UIUserInterfaceStyle,
+    private func assertRatio(
+        _ resolved: Resolved?,
+        reference: ANSISnapshotRenderer.RGB,
         label: String
     ) {
         guard let resolved else {
             Issue.record("\(label): expected a resolved color")
             return
         }
-        let surface = ANSISnapshotRenderer.surfaceColor(
-            for: style == .dark ? .dark : .light)
-        let ratio = ANSISnapshotRenderer.Contrast.ratio(
-            of: ANSISnapshotRenderer.RGB(
-                red: resolved.red, green: resolved.green, blue: resolved.blue),
-            to: surface)
+        let ratio = ANSISnapshotRenderer.Contrast.ratio(of: rgb(resolved), to: reference)
         #expect(
             ratio >= ANSISnapshotRenderer.Contrast.minimumForegroundRatio,
-            "\(label): contrast \(ratio) below 4.5 in \(style == .dark ? "dark" : "light")")
+            "\(label): contrast \(ratio) below 4.5")
+    }
+
+    private func assertPairRatio(
+        _ foreground: Resolved?,
+        _ background: Resolved?,
+        label: String
+    ) {
+        guard let foreground, let background else {
+            Issue.record("\(label): expected both colors to resolve")
+            return
+        }
+        let ratio = ANSISnapshotRenderer.Contrast.ratio(
+            of: rgb(foreground), to: rgb(background))
+        #expect(
+            ratio >= ANSISnapshotRenderer.Contrast.minimumForegroundRatio,
+            "\(label): contrast \(ratio) below 4.5")
+    }
+
+    private func rgb(_ resolved: Resolved) -> ANSISnapshotRenderer.RGB {
+        ANSISnapshotRenderer.RGB(
+            red: resolved.red, green: resolved.green, blue: resolved.blue)
     }
 
     private func resolve(
         _ color: Color?,
         style: UIUserInterfaceStyle
-    ) -> (red: Int, green: Int, blue: Int, alpha: Double)? {
+    ) -> Resolved? {
         guard let color else { return nil }
         let resolved = UIColor(color).resolvedColor(
             with: UITraitCollection(userInterfaceStyle: style))

--- a/Tests/HeelerTests/ANSISnapshotRendererTests.swift
+++ b/Tests/HeelerTests/ANSISnapshotRendererTests.swift
@@ -246,7 +246,7 @@ struct ANSISnapshotRendererTests {
         fixtures.forEach(assertFixture)
     }
 
-    @Test func preservesBoxDrawingMultibyteTextAndLineStructure() {
+    @Test func filtersDecorativeBoxLinesAndPreservesMultibyteContent() {
         let fixture = Fixture(
             name: "box drawing CJK emoji and newlines",
             bytes: [
@@ -256,14 +256,38 @@ struct ANSISnapshotRendererTests {
                 0x1B, 0x5B, 0x30, 0x6D, 0xE2, 0x94, 0x82, 0x0A,
                 0xE2, 0x94, 0x94, 0xE2, 0x94, 0x80, 0xE2, 0x94, 0x98,
             ],
-            text: "┌─┐\n│你🐝│\n└─┘",
+            text: "│你🐝│",
             runs: [
-                ExpectedRun(text: "┌─┐\n│"),
+                ExpectedRun(text: "│"),
                 ExpectedRun(text: "你🐝", foreground: RGB(0x00, 0x80, 0x00)),
-                ExpectedRun(text: "│\n└─┘"),
+                ExpectedRun(text: "│"),
             ])
 
         assertFixture(fixture)
+    }
+
+    @Test func removesDecorationOnlyBoxDrawingLines() {
+        let rendered = ANSISnapshotRenderer.render(
+            "before\r\n────────────────\r\n│ useful content │\r\n└──────────────┘\r\nafter")
+
+        #expect(String(rendered.characters) == "before\n│ useful content │\nafter")
+    }
+
+    @Test func trimsLongDecorativeEdgesFromContentLines() {
+        let rendered = ANSISnapshotRenderer.render(
+            "──── heading\r\n─ Worked for 1m 33s ─────────────\r\n│ useful content │")
+
+        #expect(
+            String(rendered.characters)
+                == "heading\n─ Worked for 1m 33s\n│ useful content │")
+    }
+
+    @Test func removesBackgroundColorFromWhitespaceOnlyRuns() {
+        let rendered = ANSISnapshotRenderer.render(
+            "\u{1B}[48;5;232m        \u{1B}[0m\nmessage")
+
+        #expect(String(rendered.characters) == "        \nmessage")
+        #expect(rendered.runs.first?.backgroundColor == nil)
     }
 
     private func assertFixture(_ fixture: Fixture) {

--- a/Tests/HeelerTests/ANSISnapshotRendererTests.swift
+++ b/Tests/HeelerTests/ANSISnapshotRendererTests.swift
@@ -314,6 +314,89 @@ struct ANSISnapshotRendererTests {
         #expect(clamped.green == clamped.blue)
     }
 
+    @Test func reverseVideoSwapsExplicitForegroundAndBackground() {
+        assertFixture(
+            Fixture(
+                name: "reverse video with explicit colors",
+                bytes: bytes("\u{1B}[31;44;7mX"),
+                text: "X",
+                runs: [
+                    ExpectedRun(
+                        text: "X",
+                        foreground: paletteColor(4),
+                        background: paletteColor(1))
+                ]))
+    }
+
+    @Test func reverseVideoWithoutColorsUsesLegibleHighlightPair() {
+        let rendered = ANSISnapshotRenderer.render("\u{1B}[7mX")
+        let run = rendered.runs.first
+
+        #expect(run?.backgroundColor != nil)
+        #expect(run?.foregroundColor != nil)
+        for style in [UIUserInterfaceStyle.light, UIUserInterfaceStyle.dark] {
+            let foreground = resolve(run?.foregroundColor, style: style)
+            let background = resolve(run?.backgroundColor, style: style)
+            guard let foreground, let background else {
+                Issue.record("reverse video: expected both colors to resolve")
+                return
+            }
+            let ratio = ANSISnapshotRenderer.Contrast.ratio(
+                of: ANSISnapshotRenderer.RGB(
+                    red: foreground.red, green: foreground.green, blue: foreground.blue),
+                to: ANSISnapshotRenderer.RGB(
+                    red: background.red, green: background.green, blue: background.blue))
+            #expect(
+                ratio >= ANSISnapshotRenderer.Contrast.minimumForegroundRatio,
+                "reverse video highlight contrast \(ratio) below 4.5")
+        }
+    }
+
+    @Test func reverseVideoWithForegroundOnlyFillsSurfaceText() {
+        let rendered = ANSISnapshotRenderer.render("\u{1B}[31;7mX")
+        let run = rendered.runs.first
+
+        assertColor(
+            run?.backgroundColor,
+            matches: paletteColor(1),
+            opacity: 1,
+            label: "reverse video background")
+        // The text takes the surface color so it stays legible on the fill.
+        let lightForeground = resolve(run?.foregroundColor, style: .light)
+        #expect(lightForeground?.red == 255)
+        #expect(lightForeground?.green == 255)
+        #expect(lightForeground?.blue == 255)
+        let darkForeground = resolve(run?.foregroundColor, style: .dark)
+        #expect(darkForeground?.red == 28)
+        #expect(darkForeground?.green == 28)
+        #expect(darkForeground?.blue == 30)
+    }
+
+    @Test func reverseVideoOffAndResetClearReversal() {
+        let rendered = ANSISnapshotRenderer.render(
+            "\u{1B}[7mA\u{1B}[27mB\u{1B}[7mC\u{1B}[0mD")
+        let runs = rendered.runs.map { run in
+            (
+                text: String(rendered.characters[run.range]),
+                foreground: run.foregroundColor,
+                background: run.backgroundColor
+            )
+        }
+
+        #expect(String(rendered.characters) == "ABCD")
+        #expect(runs.count == 4)
+        #expect(runs[0].text == "A")
+        #expect(runs[0].background != nil)
+        #expect(runs[1].text == "B")
+        #expect(runs[1].background == nil)
+        #expect(runs[1].foreground == nil)
+        #expect(runs[2].text == "C")
+        #expect(runs[2].background != nil)
+        #expect(runs[3].text == "D")
+        #expect(runs[3].background == nil)
+        #expect(runs[3].foreground == nil)
+    }
+
     @Test func stripsUnsupportedMalformedAndTruncatedSequences() {
         let fixtures = [
             Fixture(

--- a/Tests/HeelerTests/ANSISnapshotRendererTests.swift
+++ b/Tests/HeelerTests/ANSISnapshotRendererTests.swift
@@ -469,7 +469,7 @@ struct ANSISnapshotRendererTests {
         fixtures.forEach(assertFixture)
     }
 
-    @Test func filtersDecorativeBoxLinesAndPreservesMultibyteContent() {
+    @Test func preservesFramedMultibyteContent() {
         let fixture = Fixture(
             name: "box drawing CJK emoji and newlines",
             bytes: [
@@ -479,30 +479,100 @@ struct ANSISnapshotRendererTests {
                 0x1B, 0x5B, 0x30, 0x6D, 0xE2, 0x94, 0x82, 0x0A,
                 0xE2, 0x94, 0x94, 0xE2, 0x94, 0x80, 0xE2, 0x94, 0x98,
             ],
-            text: "│你🐝│",
+            text: "┌──┐\n│你🐝│\n└──┘",
             runs: [
-                ExpectedRun(text: "│"),
+                ExpectedRun(text: "┌──┐\n│"),
                 ExpectedRun(text: "你🐝", foreground: paletteColor(2)),
-                ExpectedRun(text: "│"),
+                ExpectedRun(text: "│\n└──┘"),
             ])
 
         assertFixture(fixture)
     }
 
-    @Test func removesDecorationOnlyBoxDrawingLines() {
+    @Test func preservesSeparatorAndFrameLinesAroundContent() {
         let rendered = ANSISnapshotRenderer.render(
             "before\r\n────────────────\r\n│ useful content │\r\n└──────────────┘\r\nafter")
 
-        #expect(String(rendered.characters) == "before\n│ useful content │\nafter")
+        #expect(
+            String(rendered.characters)
+                == "before\n────────────────\n│ useful content │\n└──────────────┘\nafter")
     }
 
-    @Test func trimsLongDecorativeEdgesFromContentLines() {
+    @Test func preservesDecorativeEdgesOnContentLines() {
         let rendered = ANSISnapshotRenderer.render(
             "──── heading\r\n─ Worked for 1m 33s ─────────────\r\n│ useful content │")
 
         #expect(
             String(rendered.characters)
-                == "heading\n─ Worked for 1m 33s\n│ useful content │")
+                == "──── heading\n─ Worked for 1m 33s ─────────────\n│ useful content │")
+    }
+
+    @Test func preservesMarkdownTableIncludingSeparatorRow() {
+        // The table ends the snapshot on a bottom border, exactly like a
+        // chrome frame would; its content rows must protect it.
+        let snapshot = """
+            Results:
+            │ name        │ score     │
+            ├─────────────┼───────────┤
+            │ bee         │ 10        │
+            └─────────────┴───────────┘
+            """
+
+        let rendered = ANSISnapshotRenderer.render(snapshot)
+
+        #expect(String(rendered.characters) == snapshot)
+    }
+
+    @Test func removesTrailingEmptyInputBoxFrameAndHintLine() {
+        let rendered = ANSISnapshotRenderer.render(
+            """
+            ⏺ Worked for 1m 33s
+            ╭──────────────────────────╮
+            │ >                        │
+            ╰──────────────────────────╯
+              ⏵⏵ accept edits on (shift+tab to cycle)
+
+            """)
+
+        #expect(String(rendered.characters) == "⏺ Worked for 1m 33s")
+    }
+
+    @Test func removesTrailingInputBoxFrameWithoutHintLine() {
+        let rendered = ANSISnapshotRenderer.render(
+            """
+            ⏺ Worked for 1m 33s
+            ╭──────────────────────────╮
+            │ >                        │
+            ╰──────────────────────────╯
+            """)
+
+        #expect(String(rendered.characters) == "⏺ Worked for 1m 33s")
+    }
+
+    @Test func preservesEmptyFrameFollowedByMoreContent() {
+        let snapshot = """
+            ╭──────────────────────────╮
+            │                          │
+            ╰──────────────────────────╯
+            still working
+            """
+
+        let rendered = ANSISnapshotRenderer.render(snapshot)
+
+        #expect(String(rendered.characters) == snapshot)
+    }
+
+    @Test func preservesTrailingFrameWithRealContentInside() {
+        let snapshot = """
+            Here you go:
+            ╭──────────────────────────╮
+            │ remember to buy milk     │
+            ╰──────────────────────────╯
+            """
+
+        let rendered = ANSISnapshotRenderer.render(snapshot)
+
+        #expect(String(rendered.characters) == snapshot)
     }
 
     @Test func removesBackgroundColorFromWhitespaceOnlyRuns() {

--- a/Tests/HeelerTests/ANSISnapshotRendererTests.swift
+++ b/Tests/HeelerTests/ANSISnapshotRendererTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import Testing
+import UIKit
 
 @testable import Heeler
 
@@ -15,9 +16,9 @@ struct ANSISnapshotRendererTests {
 
     private struct ExpectedRun: Sendable {
         let text: String
-        var foreground: RGB?
+        var foreground: ExpectedColor?
         var foregroundOpacity = 1.0
-        var background: RGB?
+        var background: ExpectedColor?
         var bold = false
         var italic = false
         var underline = false
@@ -33,13 +34,54 @@ struct ANSISnapshotRendererTests {
             self.green = green
             self.blue = blue
         }
+    }
 
-        var color: Color {
-            Color(
-                red: Double(red) / 255,
-                green: Double(green) / 255,
-                blue: Double(blue) / 255)
+    /// How a run's color should resolve in one appearance: an exact 8-bit
+    /// value, or a clamped value that only has to satisfy the contrast
+    /// contract against the snapshot surface.
+    private enum ColorExpectation: Sendable {
+        case exact(RGB)
+        case clamped
+    }
+
+    private struct ExpectedColor: Sendable {
+        let light: ColorExpectation
+        let dark: ColorExpectation
+
+        static func exact(_ light: RGB, _ dark: RGB) -> ExpectedColor {
+            ExpectedColor(light: .exact(light), dark: .exact(dark))
         }
+
+        static func adaptive(light: ColorExpectation, dark: ColorExpectation) -> ExpectedColor {
+            ExpectedColor(light: light, dark: dark)
+        }
+    }
+
+    // Mirrors the renderer's base palette; every value clears WCAG 4.5:1 on
+    // `secondarySystemGroupedBackground` in its appearance, so the renderer's
+    // clamp must leave them untouched.
+    private static let palette: [(light: RGB, dark: RGB)] = [
+        (RGB(0x1C, 0x1C, 0x1E), RGB(0x8C, 0x8C, 0x8C)),
+        (RGB(0xA3, 0x15, 0x15), RGB(0xF9, 0x75, 0x83)),
+        (RGB(0x0A, 0x6E, 0x0A), RGB(0x56, 0xD3, 0x64)),
+        (RGB(0x6D, 0x6D, 0x00), RGB(0xE5, 0xE5, 0x10)),
+        (RGB(0x04, 0x51, 0xA5), RGB(0x57, 0x9B, 0xD5)),
+        (RGB(0x8A, 0x0A, 0x8A), RGB(0xD6, 0x70, 0xD6)),
+        (RGB(0x00, 0x76, 0x76), RGB(0x39, 0xC5, 0xCF)),
+        (RGB(0x59, 0x59, 0x59), RGB(0xC0, 0xC0, 0xC0)),
+        (RGB(0x6E, 0x6E, 0x6E), RGB(0xA0, 0xA0, 0xA0)),
+        (RGB(0xD7, 0x00, 0x00), RGB(0xFF, 0x7B, 0x72)),
+        (RGB(0x00, 0x7A, 0x00), RGB(0x7C, 0xE3, 0x8B)),
+        (RGB(0x71, 0x71, 0x00), RGB(0xF2, 0xF9, 0x7C)),
+        (RGB(0x10, 0x59, 0xD0), RGB(0x6C, 0xB6, 0xFF)),
+        (RGB(0xBC, 0x05, 0xBC), RGB(0xF9, 0x82, 0xF9)),
+        (RGB(0x00, 0x7A, 0x7A), RGB(0x66, 0xE0, 0xE0)),
+        (RGB(0x00, 0x00, 0x00), RGB(0xFF, 0xFF, 0xFF)),
+    ]
+
+    private func paletteColor(_ index: Int) -> ExpectedColor {
+        let slot = Self.palette[index]
+        return .exact(slot.light, slot.dark)
     }
 
     @Test func rendersSixteenColorAndTextAttributeFixtures() {
@@ -52,8 +94,8 @@ struct ANSISnapshotRendererTests {
                     ExpectedRun(text: "plain "),
                     ExpectedRun(
                         text: "red on blue",
-                        foreground: RGB(0x80, 0x00, 0x00),
-                        background: RGB(0x00, 0x00, 0x80)),
+                        foreground: paletteColor(1),
+                        background: paletteColor(4)),
                     ExpectedRun(text: " plain"),
                 ]),
             Fixture(
@@ -63,8 +105,8 @@ struct ANSISnapshotRendererTests {
                 runs: [
                     ExpectedRun(
                         text: "bright",
-                        foreground: RGB(0x00, 0xFF, 0xFF),
-                        background: RGB(0xFF, 0x00, 0x00)),
+                        foreground: paletteColor(14),
+                        background: paletteColor(9)),
                     ExpectedRun(text: "reset"),
                 ]),
             Fixture(
@@ -74,7 +116,7 @@ struct ANSISnapshotRendererTests {
                 runs: [
                     ExpectedRun(
                         text: "styled",
-                        foreground: RGB(0x00, 0x80, 0x00),
+                        foreground: paletteColor(2),
                         foregroundOpacity: 0.5,
                         bold: true,
                         italic: true,
@@ -95,17 +137,6 @@ struct ANSISnapshotRendererTests {
     }
 
     @Test func rendersEverySixteenColorSlot() {
-        let expected = [
-            RGB(0x00, 0x00, 0x00), RGB(0x80, 0x00, 0x00),
-            RGB(0x00, 0x80, 0x00), RGB(0x80, 0x80, 0x00),
-            RGB(0x00, 0x00, 0x80), RGB(0x80, 0x00, 0x80),
-            RGB(0x00, 0x80, 0x80), RGB(0xC0, 0xC0, 0xC0),
-            RGB(0x80, 0x80, 0x80), RGB(0xFF, 0x00, 0x00),
-            RGB(0x00, 0xFF, 0x00), RGB(0xFF, 0xFF, 0x00),
-            RGB(0x00, 0x00, 0xFF), RGB(0xFF, 0x00, 0xFF),
-            RGB(0x00, 0xFF, 0xFF), RGB(0xFF, 0xFF, 0xFF),
-        ]
-
         for index in 0..<16 {
             let foregroundCode = index < 8 ? 30 + index : 90 + index - 8
             let backgroundCode = index < 8 ? 40 + index : 100 + index - 8
@@ -116,8 +147,8 @@ struct ANSISnapshotRendererTests {
                     text: "X",
                     runs: [
                         ExpectedRun(
-                            text: "X", foreground: expected[index],
-                            background: expected[index])
+                            text: "X", foreground: paletteColor(index),
+                            background: paletteColor(index))
                     ]))
         }
     }
@@ -131,8 +162,8 @@ struct ANSISnapshotRendererTests {
                 runs: [
                     ExpectedRun(
                         text: "ansi",
-                        foreground: RGB(0x80, 0x00, 0x00),
-                        background: RGB(0x00, 0xFF, 0xFF))
+                        foreground: paletteColor(1),
+                        background: paletteColor(14))
                 ]),
             Fixture(
                 name: "256-color cube",
@@ -141,8 +172,10 @@ struct ANSISnapshotRendererTests {
                 runs: [
                     ExpectedRun(
                         text: "cube",
-                        foreground: RGB(0x00, 0x00, 0xFF),
-                        background: RGB(0xFF, 0x87, 0x00))
+                        foreground: .adaptive(
+                            light: .exact(RGB(0x00, 0x00, 0xFF)), dark: .clamped),
+                        background: .adaptive(
+                            light: .clamped, dark: .exact(RGB(0xFF, 0x87, 0x00))))
                 ]),
             Fixture(
                 name: "256-color grayscale",
@@ -151,8 +184,10 @@ struct ANSISnapshotRendererTests {
                 runs: [
                     ExpectedRun(
                         text: "gray",
-                        foreground: RGB(0x08, 0x08, 0x08),
-                        background: RGB(0xEE, 0xEE, 0xEE))
+                        foreground: .adaptive(
+                            light: .exact(RGB(0x08, 0x08, 0x08)), dark: .clamped),
+                        background: .adaptive(
+                            light: .clamped, dark: .exact(RGB(0xEE, 0xEE, 0xEE))))
                 ]),
         ]
 
@@ -167,11 +202,116 @@ struct ANSISnapshotRendererTests {
             runs: [
                 ExpectedRun(
                     text: "rgb",
-                    foreground: RGB(12, 34, 56),
-                    background: RGB(210, 180, 140))
+                    foreground: .adaptive(
+                        light: .exact(RGB(12, 34, 56)), dark: .clamped),
+                    background: .adaptive(
+                        light: .clamped, dark: .exact(RGB(210, 180, 140))))
             ])
 
         assertFixture(fixture)
+    }
+
+    @Test func everyBaseSlotForegroundMeetsContrastContractInBothAppearances() {
+        for index in 0..<16 {
+            let foregroundCode = index < 8 ? 30 + index : 90 + index - 8
+            let rendered = ANSISnapshotRenderer.render("\u{1B}[\(foregroundCode)mX")
+            let foreground = rendered.runs.first?.foregroundColor
+            #expect(foreground != nil, "slot \(index): expected a foreground")
+            assertContrast(
+                resolve(foreground, style: .light), style: .light,
+                label: "slot \(index) foreground")
+            assertContrast(
+                resolve(foreground, style: .dark), style: .dark,
+                label: "slot \(index) foreground")
+        }
+    }
+
+    @Test func extendedColorForegroundsMeetContrastContractInBothAppearances() {
+        let samples = [
+            "cube blue": "\u{1B}[38;5;21mX",
+            "cube orange": "\u{1B}[38;5;208mX",
+            "cube yellow": "\u{1B}[38;5;226mX",
+            "dark gray": "\u{1B}[38;5;232mX",
+            "light gray": "\u{1B}[38;5;255mX",
+            "truecolor green": "\u{1B}[38;2;0;255;0mX",
+            "truecolor dark blue": "\u{1B}[38;2;12;34;56mX",
+        ]
+        for (name, sample) in samples {
+            let rendered = ANSISnapshotRenderer.render(sample)
+            let foreground = rendered.runs.first?.foregroundColor
+            #expect(foreground != nil, "\(name): expected a foreground")
+            assertContrast(
+                resolve(foreground, style: .light), style: .light,
+                label: "\(name) foreground")
+            assertContrast(
+                resolve(foreground, style: .dark), style: .dark,
+                label: "\(name) foreground")
+        }
+    }
+
+    @Test func contrastRatioMatchesWCAGReferenceValues() {
+        let black = ANSISnapshotRenderer.RGB(red: 0, green: 0, blue: 0)
+        let white = ANSISnapshotRenderer.RGB(red: 255, green: 255, blue: 255)
+        let gray = ANSISnapshotRenderer.RGB(red: 0x76, green: 0x76, blue: 0x76)
+
+        #expect(abs(ANSISnapshotRenderer.Contrast.ratio(of: black, to: white) - 21) < 0.001)
+        #expect(abs(ANSISnapshotRenderer.Contrast.ratio(of: gray, to: gray) - 1) < 0.001)
+        // #767676 is the canonical lightest gray passing 4.5:1 on white.
+        #expect(abs(ANSISnapshotRenderer.Contrast.ratio(of: gray, to: white) - 4.542) < 0.01)
+        #expect(abs(ANSISnapshotRenderer.Contrast.relativeLuminance(of: white) - 1) < 0.001)
+        #expect(abs(ANSISnapshotRenderer.Contrast.relativeLuminance(of: black)) < 0.001)
+    }
+
+    @Test func legibleClampLeavesContrastingColorsUntouched() {
+        let white = ANSISnapshotRenderer.RGB(red: 255, green: 255, blue: 255)
+        let darkSurface = ANSISnapshotRenderer.RGB(red: 28, green: 28, blue: 30)
+        let maroon = ANSISnapshotRenderer.RGB(red: 0x80, green: 0, blue: 0)
+        let silver = ANSISnapshotRenderer.RGB(red: 0xC0, green: 0xC0, blue: 0xC0)
+
+        #expect(
+            ANSISnapshotRenderer.Contrast.legible(maroon, on: white, appearance: .light)
+                == maroon)
+        #expect(
+            ANSISnapshotRenderer.Contrast.legible(silver, on: darkSurface, appearance: .dark)
+                == silver)
+    }
+
+    @Test func legibleClampDarkensOnLightSurfacePreservingHue() {
+        let white = ANSISnapshotRenderer.RGB(red: 255, green: 255, blue: 255)
+        let yellow = ANSISnapshotRenderer.RGB(red: 255, green: 255, blue: 0)
+
+        let clamped = ANSISnapshotRenderer.Contrast.legible(
+            yellow, on: white, appearance: .light)
+
+        #expect(ANSISnapshotRenderer.Contrast.ratio(of: clamped, to: white) >= 4.5)
+        #expect(clamped.red < yellow.red)
+        #expect(clamped.red >= clamped.blue)
+        #expect(clamped.green >= clamped.blue)
+    }
+
+    @Test func legibleClampLightensOnDarkSurfacePreservingHue() {
+        let darkSurface = ANSISnapshotRenderer.RGB(red: 28, green: 28, blue: 30)
+        let navy = ANSISnapshotRenderer.RGB(red: 0, green: 0, blue: 0x80)
+
+        let clamped = ANSISnapshotRenderer.Contrast.legible(
+            navy, on: darkSurface, appearance: .dark)
+
+        #expect(ANSISnapshotRenderer.Contrast.ratio(of: clamped, to: darkSurface) >= 4.5)
+        #expect(clamped.blue > navy.blue)
+        #expect(clamped.blue > clamped.red)
+        #expect(clamped.blue > clamped.green)
+    }
+
+    @Test func legibleClampKeepsGrayscaleNeutral() {
+        let darkSurface = ANSISnapshotRenderer.RGB(red: 28, green: 28, blue: 30)
+        let darkGray = ANSISnapshotRenderer.RGB(red: 8, green: 8, blue: 8)
+
+        let clamped = ANSISnapshotRenderer.Contrast.legible(
+            darkGray, on: darkSurface, appearance: .dark)
+
+        #expect(ANSISnapshotRenderer.Contrast.ratio(of: clamped, to: darkSurface) >= 4.5)
+        #expect(clamped.red == clamped.green)
+        #expect(clamped.green == clamped.blue)
     }
 
     @Test func stripsUnsupportedMalformedAndTruncatedSequences() {
@@ -259,7 +399,7 @@ struct ANSISnapshotRendererTests {
             text: "│你🐝│",
             runs: [
                 ExpectedRun(text: "│"),
-                ExpectedRun(text: "你🐝", foreground: RGB(0x00, 0x80, 0x00)),
+                ExpectedRun(text: "你🐝", foreground: paletteColor(2)),
                 ExpectedRun(text: "│"),
             ])
 
@@ -305,9 +445,12 @@ struct ANSISnapshotRendererTests {
         #expect(runs[0].text == "    ")
         #expect(runs[0].background == nil)
         #expect(runs[1].text == "message")
-        #expect(
-            runs[1].background
-                == Color(red: 8.0 / 255.0, green: 8.0 / 255.0, blue: 8.0 / 255.0))
+        // RGB(8, 8, 8) contrasts with the light surface, so it survives
+        // unclamped there.
+        let lightBackground = resolve(runs[1].background, style: .light)
+        #expect(lightBackground?.red == 8)
+        #expect(lightBackground?.green == 8)
+        #expect(lightBackground?.blue == 8)
         #expect(runs[2].text == "    ")
         #expect(runs[2].background == nil)
     }
@@ -329,15 +472,16 @@ struct ANSISnapshotRendererTests {
 
         for (actual, expected) in zip(actualRuns, fixture.runs) {
             #expect(actual.text == expected.text, "\(fixture.name): run text")
-            let expectedForeground = expected.foreground.map {
-                expected.foregroundOpacity < 1 ? $0.color.opacity(0.5) : $0.color
-            } ?? (expected.foregroundOpacity < 1 ? Color.primary.opacity(0.5) : nil)
-            #expect(
-                actual.foreground == expectedForeground,
-                "\(fixture.name): \(expected.text) foreground")
-            #expect(
-                actual.background == expected.background?.color,
-                "\(fixture.name): \(expected.text) background")
+            assertColor(
+                actual.foreground,
+                matches: expected.foreground,
+                opacity: expected.foregroundOpacity,
+                label: "\(fixture.name): \(expected.text) foreground")
+            assertColor(
+                actual.background,
+                matches: expected.background,
+                opacity: 1,
+                label: "\(fixture.name): \(expected.text) background")
 
             var expectedEmphasis: InlinePresentationIntent = []
             if expected.bold {
@@ -353,6 +497,84 @@ struct ANSISnapshotRendererTests {
                 actual.underline == (expected.underline ? .single : nil),
                 "\(fixture.name): \(expected.text) underline")
         }
+    }
+
+    private func assertColor(
+        _ actual: Color?,
+        matches expected: ExpectedColor?,
+        opacity: Double,
+        label: String
+    ) {
+        for style in [UIUserInterfaceStyle.light, UIUserInterfaceStyle.dark] {
+            let resolved = resolve(actual, style: style)
+            let appearance = style == .dark ? "dark" : "light"
+
+            guard let expected else {
+                if opacity < 1 {
+                    // Dim default foreground: Color.primary at half opacity.
+                    let channel = style == .dark ? 255 : 0
+                    #expect(
+                        resolved?.red == channel && resolved?.green == channel
+                            && resolved?.blue == channel
+                            && abs((resolved?.alpha ?? 0) - opacity) < 0.01,
+                        "\(label): dim default in \(appearance)")
+                } else {
+                    #expect(resolved == nil, "\(label): expected no color in \(appearance)")
+                }
+                continue
+            }
+
+            switch style == .dark ? expected.dark : expected.light {
+            case .exact(let rgb):
+                #expect(
+                    resolved?.red == rgb.red && resolved?.green == rgb.green
+                        && resolved?.blue == rgb.blue
+                        && abs((resolved?.alpha ?? 0) - opacity) < 0.01,
+                    "\(label): expected \(rgb) in \(appearance), got \(String(describing: resolved))")
+            case .clamped:
+                assertContrast(resolved, style: style, label: label)
+            }
+        }
+    }
+
+    private func assertContrast(
+        _ resolved: (red: Int, green: Int, blue: Int, alpha: Double)?,
+        style: UIUserInterfaceStyle,
+        label: String
+    ) {
+        guard let resolved else {
+            Issue.record("\(label): expected a resolved color")
+            return
+        }
+        let surface = ANSISnapshotRenderer.surfaceColor(
+            for: style == .dark ? .dark : .light)
+        let ratio = ANSISnapshotRenderer.Contrast.ratio(
+            of: ANSISnapshotRenderer.RGB(
+                red: resolved.red, green: resolved.green, blue: resolved.blue),
+            to: surface)
+        #expect(
+            ratio >= ANSISnapshotRenderer.Contrast.minimumForegroundRatio,
+            "\(label): contrast \(ratio) below 4.5 in \(style == .dark ? "dark" : "light")")
+    }
+
+    private func resolve(
+        _ color: Color?,
+        style: UIUserInterfaceStyle
+    ) -> (red: Int, green: Int, blue: Int, alpha: Double)? {
+        guard let color else { return nil }
+        let resolved = UIColor(color).resolvedColor(
+            with: UITraitCollection(userInterfaceStyle: style))
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        resolved.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return (
+            Int((red * 255).rounded()),
+            Int((green * 255).rounded()),
+            Int((blue * 255).rounded()),
+            Double(alpha)
+        )
     }
 
     private func bytes(_ string: String) -> [UInt8] {

--- a/Tests/HeelerTests/ANSISnapshotRendererTests.swift
+++ b/Tests/HeelerTests/ANSISnapshotRendererTests.swift
@@ -592,11 +592,11 @@ struct ANSISnapshotRendererTests {
                 0x1B, 0x5B, 0x30, 0x6D, 0xE2, 0x94, 0x82, 0x0A,
                 0xE2, 0x94, 0x94, 0xE2, 0x94, 0x80, 0xE2, 0x94, 0x98,
             ],
-            text: "┌──┐\n│你🐝│\n└──┘",
+            text: "┌─┐\n│你🐝│\n└─┘",
             runs: [
-                ExpectedRun(text: "┌──┐\n│"),
+                ExpectedRun(text: "┌─┐\n│"),
                 ExpectedRun(text: "你🐝", foreground: paletteColor(2)),
-                ExpectedRun(text: "│\n└──┘"),
+                ExpectedRun(text: "│\n└─┘"),
             ])
 
         assertFixture(fixture)

--- a/Tests/HeelerTests/HeelerSSHSessionE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHSessionE2ETests.swift
@@ -262,11 +262,11 @@ struct HeelerSSHSessionE2ETests {
         }
     }
 
-    /// Same phase-gate sequence as cancellation: force the deadline past while
-    /// allocation is held so cleanup is always uncertain, then hold cleanup past
-    /// its two-second budget so invalidation is deterministic.
-    @Test("deadline completes promptly and invalidates uncertain cleanup")
-    func deadlineInvalidatesUncertainCleanup() async throws {
+    /// Inject timeout only after allocation, then hold cleanup past its
+    /// two-second budget. This keeps setup scheduling outside the failure
+    /// trigger while exercising the real allocated-channel cleanup path.
+    @Test("allocated exec timeout completes promptly and invalidates uncertain cleanup")
+    func allocatedExecTimeoutInvalidatesUncertainCleanup() async throws {
         let environment = try #require(HeelerSSHTestEnvironment.current)
         let connection = try await environment.connect()
 
@@ -275,21 +275,20 @@ struct HeelerSSHSessionE2ETests {
             let cleanup = SessionPhaseGate()
             await connection.holdNextExecChannelAllocationForTesting {
                 await allocated.waitUntilReleased()
+                throw SSHError.timedOut
             }
             await connection.holdNextExecCleanupForTesting {
                 await cleanup.waitUntilReleased()
             }
 
             let command = Task {
-                try await connection.execute("sleep 30", timeout: .milliseconds(150))
+                try await connection.execute("sleep 30", timeout: .seconds(40))
             }
-            try await waitUntilPhase("deadline should allocate its channel") {
+            try await waitUntilPhase("timeout should allocate its channel") {
                 await allocated.hasEntered
             }
-            // Let the 150ms execute budget expire while allocation is held.
-            try await Task.sleep(for: .milliseconds(200))
             await allocated.release()
-            try await waitUntilPhase("deadline should enter catch cleanup") {
+            try await waitUntilPhase("timeout should enter catch cleanup") {
                 await cleanup.hasEntered
             }
             try await Task.sleep(for: .milliseconds(2_100))


### PR DESCRIPTION
Part of the Monitor conversational refactor round (refs #179). This PR owns rendering fidelity: findings #1, #2, #5, #6 of the interface review.

## Changes

- **Adaptive ANSI palette**: the 16 base slots, 256-color cube, grayscale ramp, and truecolor values become dynamic per-appearance colors clamped for legibility. Foregrounds are clamped against their effective background (explicit background when set, else the surface); backgrounds are clamped against the appearance's label color, so label text on ANSI backgrounds stays readable. Independent numeric sweeps (512 fg-on-bg pairs, 32,768 generalized cases) show zero pairs under 4.5:1 in either appearance.
- **Reverse video (SGR 7/27)**: swap-then-clamp; a bare `\e[7m` renders as a label-color fill with surface-color text. Previously the selected item in an agent's confirmation dialog was invisible in Monitor.
- **Scoped-down decoration stripping**: the blanket "delete any 3+ box-drawing run" heuristic is gone — markdown tables and framed content survive byte-for-byte. Only a conservative trailing chrome block (the agent TUI's own empty input-box frame plus its indented hint line) is removed, since Monitor renders its real composer directly below.

Known trades (reviewed, accepted): far-travel clamps can collapse a foreground's hue on extreme pairs; black-vs-white ANSI backgrounds converge visually under the label clamp; dim (SGR 2) applies 50% opacity after clamping by design.

## Merge order

First of three PRs sharing base d041e9f: merge before the conversational-chrome PR (#191), whose light-mode presentation depends on this palette.

## Test evidence

`xcodebuild test -only-testing:HeelerTests/ANSISnapshotRendererTests` on iPhone 17 simulator: **28 tests passed** (palette contrast contracts resolved in both appearances, reverse-video vectors, chrome-stripping vectors a–d). Two internal review rounds plus one validation round (a fixture typo surfaced on first run — expectation did not match its own input bytes — fixed in `1f8f8ff`).

CHANGELOG entry for the round lands as a follow-up after all three PRs merge.