### PR TITLE
refactor(monitor): reflow history into accessible segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,9 +94,11 @@ Entries reference the issue that motivated them.
   constrained to the available screen width while captured history remains
   vertically scrollable. (#179)
 
-- Monitor suppresses decoration-only terminal borders and empty background
-  bars from snapshot output, uses a denser readable text treatment, and shows
-  locally sent Composer messages as distinct You cards. (#179; #182)
+- Monitor now presents a stable status summary, a high-contrast snapshot
+  canvas, one scrollable activity surface for Agent output and locally sent
+  messages, a compact Composer, and an explicit path into Attach. Decorative
+  terminal borders and hidden horizontal controls no longer compete with the
+  content. (#179; #182)
 
 - Malformed herdr API error responses that carry an empty id now fail the
   originating request immediately with the server's error instead of hanging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,10 @@ Entries reference the issue that motivated them.
 
 ### Fixed
 
+- Monitor snapshots no longer scroll horizontally. Their text now stays
+  constrained to the available screen width while captured history remains
+  vertically scrollable. (#179)
+
 - Malformed herdr API error responses that carry an empty id now fail the
   originating request immediately with the server's error instead of hanging
   until the request deadline. herdr answers unparseable requests with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@ Entries reference the issue that motivated them.
   constrained to the available screen width while captured history remains
   vertically scrollable. (#179)
 
+- Monitor suppresses decoration-only terminal borders and empty background
+  bars from snapshot output, uses a denser readable text treatment, and shows
+  locally sent Composer messages as distinct You cards. (#179; #182)
+
 - Malformed herdr API error responses that carry an empty id now fail the
   originating request immediately with the server's error instead of hanging
   until the request deadline. herdr answers unparseable requests with

--- a/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
+++ b/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
@@ -10,7 +10,111 @@ enum ANSISnapshotRenderer {
     /// Converts one complete terminal snapshot into display-ready attributed text.
     static func render(_ snapshot: String) -> AttributedString {
         var parser = Parser(snapshot)
-        return parser.render()
+        return cleanTerminalChrome(from: parser.render())
+    }
+
+    private static func cleanTerminalChrome(from rendered: AttributedString) -> AttributedString {
+        var cleaned = rendered
+        let whitespaceBackgroundRanges = cleaned.runs.compactMap { run in
+            cleaned.characters[run.range].allSatisfy(\.isWhitespace) ? run.range : nil
+        }
+        for range in whitespaceBackgroundRanges {
+            cleaned[range].backgroundColor = nil
+        }
+        return removingDecorationOnlyLines(from: cleaned)
+    }
+
+    private static func removingDecorationOnlyLines(
+        from source: AttributedString
+    ) -> AttributedString {
+        var keptLines: [AttributedString] = []
+        var lineStart = source.startIndex
+        var cursor = lineStart
+
+        while cursor < source.endIndex {
+            if source.characters[cursor] == "\n" {
+                appendLine(source[lineStart..<cursor], to: &keptLines)
+                cursor = source.characters.index(after: cursor)
+                lineStart = cursor
+            } else {
+                cursor = source.characters.index(after: cursor)
+            }
+        }
+        appendLine(source[lineStart..<source.endIndex], to: &keptLines)
+
+        var result = AttributedString()
+        for (index, line) in keptLines.enumerated() {
+            if index > 0 {
+                result.append(AttributedString("\n"))
+            }
+            result.append(line)
+        }
+        return result
+    }
+
+    private static func appendLine(
+        _ line: AttributedSubstring,
+        to lines: inout [AttributedString]
+    ) {
+        let visibleCharacters = line.characters.filter { !$0.isWhitespace }
+        let isDecorationOnly = visibleCharacters.count >= 3
+            && visibleCharacters.allSatisfy(isBoxDrawing)
+        guard !isDecorationOnly else { return }
+        lines.append(trimmingDecorativeEdges(from: line))
+    }
+
+    private static func trimmingDecorativeEdges(
+        from line: AttributedSubstring
+    ) -> AttributedString {
+        var start = line.startIndex
+        var end = line.endIndex
+
+        var cursor = end
+        var trailingDecorationCount = 0
+        while cursor > start {
+            let previous = line.characters.index(before: cursor)
+            let character = line.characters[previous]
+            guard character.isWhitespace || isBoxDrawing(character) else { break }
+            if isBoxDrawing(character) {
+                trailingDecorationCount += 1
+            }
+            cursor = previous
+        }
+        if trailingDecorationCount >= 3,
+            containsContent(in: line.characters[start..<cursor])
+        {
+            end = cursor
+        }
+
+        cursor = start
+        var leadingDecorationCount = 0
+        while cursor < end {
+            let character = line.characters[cursor]
+            guard character.isWhitespace || isBoxDrawing(character) else { break }
+            if isBoxDrawing(character) {
+                leadingDecorationCount += 1
+            }
+            cursor = line.characters.index(after: cursor)
+        }
+        if leadingDecorationCount >= 3,
+            containsContent(in: line.characters[cursor..<end])
+        {
+            start = cursor
+        }
+
+        return AttributedString(line[start..<end])
+    }
+
+    private static func containsContent(
+        in characters: AttributedString.CharacterView.SubSequence
+    ) -> Bool {
+        characters.contains { !$0.isWhitespace && !isBoxDrawing($0) }
+    }
+
+    private static func isBoxDrawing(_ character: Character) -> Bool {
+        character.unicodeScalars.allSatisfy { scalar in
+            (0x2500...0x257F).contains(scalar.value)
+        }
     }
 }
 
@@ -48,7 +152,7 @@ extension ANSISnapshotRenderer {
                     appendText(from: textStart, to: index)
                     consumeControlString(after: scalars.index(after: index), bellTerminates: false)
                     textStart = index
-                case 0x00...0x08, 0x0B, 0x0C, 0x0E...0x1F, 0x7F...0x9F:
+                case 0x00...0x08, 0x0B...0x1F, 0x7F...0x9F:
                     appendText(from: textStart, to: index)
                     index = scalars.index(after: index)
                     textStart = index

--- a/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
+++ b/Sources/Heeler/Monitor/ANSISnapshotRenderer.swift
@@ -15,13 +15,41 @@ enum ANSISnapshotRenderer {
 
     private static func cleanTerminalChrome(from rendered: AttributedString) -> AttributedString {
         var cleaned = rendered
-        let whitespaceBackgroundRanges = cleaned.runs.compactMap { run in
-            cleaned.characters[run.range].allSatisfy(\.isWhitespace) ? run.range : nil
+        let whitespaceBackgroundRanges = cleaned.runs.flatMap { run in
+            backgroundPaddingRanges(in: run.range, characters: cleaned.characters)
         }
         for range in whitespaceBackgroundRanges {
             cleaned[range].backgroundColor = nil
         }
         return removingDecorationOnlyLines(from: cleaned)
+    }
+
+    private static func backgroundPaddingRanges(
+        in range: Range<AttributedString.Index>,
+        characters: AttributedString.CharacterView
+    ) -> [Range<AttributedString.Index>] {
+        var start = range.lowerBound
+        while start < range.upperBound, characters[start].isWhitespace {
+            start = characters.index(after: start)
+        }
+
+        guard start < range.upperBound else { return [range] }
+
+        var end = range.upperBound
+        while end > start {
+            let previous = characters.index(before: end)
+            guard characters[previous].isWhitespace else { break }
+            end = previous
+        }
+
+        var ranges: [Range<AttributedString.Index>] = []
+        if range.lowerBound < start {
+            ranges.append(range.lowerBound..<start)
+        }
+        if end < range.upperBound {
+            ranges.append(end..<range.upperBound)
+        }
+        return ranges
     }
 
     private static func removingDecorationOnlyLines(

--- a/Sources/Heeler/Monitor/AgentComposerView.swift
+++ b/Sources/Heeler/Monitor/AgentComposerView.swift
@@ -1,40 +1,25 @@
 import SwiftUI
 
-/// Monitor's native, local-first message surface. It renders optimistic
-/// echoes but never infers structured conversation history from terminal
-/// output (ADR 0012).
+/// Monitor's native, local-first input surface. Optimistic delivery echoes
+/// render in ``AgentSentMessagesView`` beside the snapshot, while this view
+/// keeps the draft and terminal controls reachable in stable bottom chrome.
 struct AgentComposerView: View {
     let store: AgentComposerStore
+    let isControlKeyEnabled: Bool
+    let onControlKey: (MonitorControlKey) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            if !store.messages.isEmpty {
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        LazyVStack(spacing: 10) {
-                            ForEach(store.messages) { message in
-                                messageRow(message)
-                                    .id(message.id)
-                            }
-                        }
-                    }
-                    .defaultScrollAnchor(.bottom)
-                    .onChange(of: store.messages.count) {
-                        guard let latest = store.messages.last else { return }
-                        proxy.scrollTo(latest.id, anchor: .bottom)
-                    }
-                }
-                .frame(maxHeight: 176)
-                .accessibilityLabel("Sent messages")
-            }
+        VStack(alignment: .leading, spacing: 12) {
+            MonitorControlKeyStrip(
+                isEnabled: isControlKeyEnabled,
+                onTap: onControlKey)
 
-            Text("Message")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            Text("Message the Agent")
+                .font(.caption.weight(.semibold))
 
             HStack(alignment: .bottom, spacing: 10) {
                 TextField(
-                    "Message",
+                    "Type a message",
                     text: Binding(
                         get: { store.draft },
                         set: { store.replaceDraft(with: $0) }),
@@ -42,28 +27,64 @@ struct AgentComposerView: View {
                 )
                 .lineLimit(1...5)
                 .textFieldStyle(.plain)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-                .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
-                .accessibilityLabel("Message")
+                .padding(12)
+                .background(
+                    Color(uiColor: .secondarySystemBackground),
+                    in: RoundedRectangle(cornerRadius: 14))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 14)
+                        .stroke(.secondary.opacity(0.18), lineWidth: 1)
+                }
+                .accessibilityLabel("Message the Agent")
 
-                Button("Send", systemImage: "arrow.up.circle.fill") {
+                Button("Send", systemImage: "arrow.up") {
                     Task { await store.send() }
                 }
                 .buttonStyle(.borderedProminent)
+                .buttonBorderShape(.circle)
+                .labelStyle(.iconOnly)
+                .frame(minWidth: 44, minHeight: 44)
                 .disabled(!store.canSend)
                 .accessibilityHint("Delivers the complete draft to the Agent")
             }
         }
-        .padding(.horizontal)
-        .padding(.vertical, 10)
-        .background(.bar)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.regularMaterial)
+        .overlay(alignment: .top) { Divider() }
+    }
+}
+
+struct AgentSentMessagesView: View {
+    let store: AgentComposerStore
+
+    @ViewBuilder
+    var body: some View {
+        if !store.messages.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Label("Sent from this device", systemImage: "iphone")
+                        .font(.subheadline.weight(.semibold))
+                        .accessibilityAddTraits(.isHeader)
+                    Text("Delivery means the Host accepted the message.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                ForEach(store.messages) { message in
+                    messageRow(message)
+                        .id(message.id)
+                }
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Messages sent from this device")
+        }
     }
 
     private func messageRow(_ message: AgentComposerStore.Message) -> some View {
         HStack {
-            Spacer(minLength: 44)
-            VStack(alignment: .leading, spacing: 8) {
+            Spacer(minLength: 48)
+            VStack(alignment: .leading, spacing: 6) {
                 Text("You")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
@@ -73,7 +94,7 @@ struct AgentComposerView: View {
                     .textSelection(.enabled)
 
                 statusLabel(for: message.state)
-                    .font(.footnote)
+                    .font(.caption)
 
                 if case .failed(let detail) = message.state {
                     Text(detail)
@@ -95,8 +116,8 @@ struct AgentComposerView: View {
             }
             .padding(12)
             .background(
-                Color.accentColor.opacity(0.12),
-                in: RoundedRectangle(cornerRadius: 14))
+                Color.accentColor.opacity(0.16),
+                in: RoundedRectangle(cornerRadius: 16))
         }
         .frame(maxWidth: .infinity, alignment: .trailing)
     }

--- a/Sources/Heeler/Monitor/AgentComposerView.swift
+++ b/Sources/Heeler/Monitor/AgentComposerView.swift
@@ -11,7 +11,7 @@ struct AgentComposerView: View {
             if !store.messages.isEmpty {
                 ScrollViewReader { proxy in
                     ScrollView {
-                        LazyVStack(spacing: 8) {
+                        LazyVStack(spacing: 10) {
                             ForEach(store.messages) { message in
                                 messageRow(message)
                                     .id(message.id)
@@ -61,34 +61,44 @@ struct AgentComposerView: View {
     }
 
     private func messageRow(_ message: AgentComposerStore.Message) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(message.text)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .textSelection(.enabled)
-
-            statusLabel(for: message.state)
-                .font(.footnote)
-
-            if case .failed(let detail) = message.state {
-                Text(detail)
-                    .font(.footnote)
+        HStack {
+            Spacer(minLength: 44)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("You")
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
-                HStack(spacing: 8) {
-                    Button("Retry", systemImage: "arrow.clockwise") {
-                        Task { await store.retry(message.id) }
-                    }
-                    .buttonStyle(.borderedProminent)
 
-                    Button("Edit Draft", systemImage: "pencil") {
-                        store.withdrawToDraft(message.id)
+                Text(message.text)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+
+                statusLabel(for: message.state)
+                    .font(.footnote)
+
+                if case .failed(let detail) = message.state {
+                    Text(detail)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    HStack(spacing: 8) {
+                        Button("Retry", systemImage: "arrow.clockwise") {
+                            Task { await store.retry(message.id) }
+                        }
+                        .buttonStyle(.borderedProminent)
+
+                        Button("Edit Draft", systemImage: "pencil") {
+                            store.withdrawToDraft(message.id)
+                        }
+                        .buttonStyle(.bordered)
                     }
-                    .buttonStyle(.bordered)
+                    .controlSize(.small)
                 }
-                .controlSize(.small)
             }
+            .padding(12)
+            .background(
+                Color.accentColor.opacity(0.12),
+                in: RoundedRectangle(cornerRadius: 14))
         }
-        .padding(10)
-        .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
+        .frame(maxWidth: .infinity, alignment: .trailing)
     }
 
     @ViewBuilder

--- a/Sources/Heeler/Monitor/AgentMonitorHistory.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorHistory.swift
@@ -7,7 +7,12 @@ import Foundation
 ///
 /// herdr exposes no history cursor (`agent.read` takes a source and a line
 /// count, capped at 1000 lines), so every reconciliation is an
-/// overlap-stitch against what the cache already holds. This type is the
+/// overlap-stitch against what the cache already holds. Backfill uses
+/// `recent_unwrapped`, while the live screen remains a terminal grid; the
+/// stitcher therefore permits one logical backfill line to match multiple
+/// trailing grid rows after trimming terminal padding. It never rewrites the
+/// captured bytes, and it still records a gap unless a whole boundary or at
+/// least `minimumOverlap` logical lines prove continuity. This type is the
 /// pure line algebra behind that: it performs no I/O, keeps no presentation
 /// state, and is deliberately separate from `AgentMonitorStore` so the
 /// stitching rules are testable on their own.
@@ -136,20 +141,23 @@ struct AgentMonitorHistory: Equatable, Sendable {
     }
 
     struct BackfillOutcome: Equatable, Sendable {
-        /// Lines the read added that the cache did not already hold. Zero
-        /// means the read was fully captured: the capture limit is reached.
+        /// Logical lines the read added that the cache did not already hold.
+        /// Zero means the read was fully captured: the capture limit is
+        /// reached.
         var newLines: Int
         /// Whether an explicit gap marker was inserted because the read
         /// could not be overlap-stitched onto the cache.
         var insertedGap: Bool
     }
 
-    /// Reconciles one `recent` read (the server's newest lines, up to its
-    /// cap) with the range covered by the preceding backfill. The largest
-    /// shared suffix proves the read's remaining prefix is older content,
-    /// which is kept in a segment above the live screen. With no shared
-    /// content, the read is likewise placed above the live run with explicit
-    /// gaps rather than displacing the live screen or pretending continuity.
+    /// Reconciles one `recent_unwrapped` read (the server's newest logical
+    /// lines, up to its cap) with the range covered by the preceding backfill.
+    /// Its largest logical suffix is matched against the cached physical-line
+    /// suffix, allowing several wrapped grid rows to equal one logical line.
+    /// The read's remaining prefix is older content and stays byte-exact in a
+    /// segment above the live screen. With no proven boundary, the read is
+    /// likewise placed above the live run with explicit gaps rather than
+    /// displacing the live screen or pretending continuity.
     @discardableResult
     mutating func stitchBackfill(_ text: String) -> BackfillOutcome {
         let read = Self.splitLines(text)
@@ -170,9 +178,8 @@ struct AgentMonitorHistory: Equatable, Sendable {
 
         let range = validBackfillRange ?? ((segments.count - 1)..<segments.count)
         let anchor = lines(in: range)
-        let floor = min(Self.minimumOverlap, read.count, anchor.count)
-        if floor >= 1,
-            let overlap = Self.largestOverlap(suffixOf: read, suffixOf: anchor, floor: floor)
+        if let overlap = Self.largestReflowedOverlap(
+            unwrappedSuffixOf: read, cachedSuffixOf: anchor)
         {
             let older = Array(read.prefix(read.count - overlap))
             guard !older.isEmpty else {
@@ -418,10 +425,101 @@ struct AgentMonitorHistory: Equatable, Sendable {
         return nil
     }
 
+    /// Returns the number of logical `recent_unwrapped` lines proven to be
+    /// the same boundary as a suffix of the cached grid. Each logical line
+    /// consumes one or more cached rows, so differing terminal widths do not
+    /// manufacture gaps. Trailing spaces and tabs are ignored only for this
+    /// comparison because a visible grid may pad its final row; stored and
+    /// rendered strings remain byte-exact.
+    ///
+    /// A match is accepted when it covers either whole boundary, or when at
+    /// least `minimumOverlap` logical lines agree. This preserves the former
+    /// small-screen behavior without letting one coincidental prompt line
+    /// stitch two otherwise unrelated captures.
+    private static func largestReflowedOverlap(
+        unwrappedSuffixOf read: [String],
+        cachedSuffixOf cached: [String]
+    ) -> Int? {
+        guard !read.isEmpty, !cached.isEmpty else { return nil }
+
+        let logicalLines = read.map(ReconciliationLine.init)
+        let cachedRows = cached.map(ReconciliationLine.init)
+        var cachedEnd = cachedRows.endIndex
+        var overlap = 0
+
+        for logicalLine in logicalLines.reversed() {
+            guard
+                let start = matchingStart(
+                    of: logicalLine,
+                    in: cachedRows,
+                    endingAt: cachedEnd)
+            else { break }
+            overlap += 1
+            cachedEnd = start
+        }
+
+        guard overlap > 0 else { return nil }
+        let coversWholeRead = overlap == read.count
+        let coversWholeCache = cachedEnd == cachedRows.startIndex
+        guard overlap >= minimumOverlap || coversWholeRead || coversWholeCache else {
+            return nil
+        }
+        return overlap
+    }
+
+    private struct ReconciliationLine {
+        let raw: [UInt8]
+        let trimmed: [UInt8]
+
+        init(_ line: String) {
+            raw = Array(line.utf8)
+            var trimmed = raw
+            while let last = trimmed.last, last == 0x20 || last == 0x09 {
+                trimmed.removeLast()
+            }
+            self.trimmed = trimmed
+        }
+    }
+
+    /// Finds the nearest cached row boundary whose concatenated bytes equal one
+    /// unwrapped logical line. Searching backward makes the required suffix
+    /// boundary explicit and keeps older unrelated rows out of the proof.
+    private static func matchingStart(
+        of logicalLine: ReconciliationLine,
+        in cachedRows: [ReconciliationLine],
+        endingAt cachedEnd: Int
+    ) -> Int? {
+        guard cachedEnd > cachedRows.startIndex else { return nil }
+        var combinedRaw: [UInt8] = []
+        var combinedTrimmed: [UInt8] = []
+        var start = cachedEnd
+
+        while start > cachedRows.startIndex {
+            start -= 1
+            combinedRaw.insert(contentsOf: cachedRows[start].raw, at: combinedRaw.startIndex)
+            combinedTrimmed.insert(
+                contentsOf: cachedRows[start].trimmed,
+                at: combinedTrimmed.startIndex)
+            let rawCanMatch = combinedRaw.count <= logicalLine.raw.count
+            let trimmedCanMatch = combinedTrimmed.count <= logicalLine.trimmed.count
+            guard rawCanMatch || trimmedCanMatch else { break }
+            if (rawCanMatch && combinedRaw.elementsEqual(logicalLine.raw))
+                || (trimmedCanMatch
+                    && combinedTrimmed.elementsEqual(logicalLine.trimmed))
+            {
+                // Empty padded rows can yield many equivalent partitions;
+                // the nearest boundary preserves the most evidence for the
+                // preceding logical line and is the conservative choice.
+                return start
+            }
+        }
+        return nil
+    }
+
     /// The rightmost position at which `needle` appears in `haystack` as a
     /// contiguous run, if any. Rightmost because the newest run sits at the
-    /// end of a `recent` read when content is stable; an earlier duplicate
-    /// of the same lines is history, not the tail.
+    /// end of a `recent_unwrapped` read when content is stable; an earlier
+    /// duplicate of the same lines is history, not the tail.
     private static func containment(of needle: [String], in haystack: [String]) -> Int? {
         guard needle.count <= haystack.count else { return nil }
         var start = haystack.count - needle.count

--- a/Sources/Heeler/Monitor/AgentMonitorHistory.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorHistory.swift
@@ -178,22 +178,36 @@ struct AgentMonitorHistory: Equatable, Sendable {
 
         let range = validBackfillRange ?? ((segments.count - 1)..<segments.count)
         let anchor = lines(in: range)
-        if let overlap = Self.largestReflowedOverlap(
+        if let match = Self.largestReflowedOverlap(
             unwrappedSuffixOf: read, cachedSuffixOf: anchor)
         {
-            let older = Array(read.prefix(read.count - overlap))
+            let older = Array(read.prefix(read.count - match.logicalLineCount))
+            if match.usedPartialBoundary {
+                replaceBackfillRange(
+                    range,
+                    with: read,
+                    liveLogicalLineCount: match.logicalLineCount)
+                return BackfillOutcome(
+                    newLines: older.count + 1,
+                    insertedGap: false)
+            }
             guard !older.isEmpty else {
                 return BackfillOutcome(newLines: 0, insertedGap: false)
             }
             prepend(older, to: range)
             return BackfillOutcome(newLines: older.count, insertedGap: false)
         }
-        if anchor.count >= Self.minimumOverlap,
-            Self.containment(of: anchor, in: read) != nil
-        {
-            replaceBackfillRange(range, with: read)
+        if let containment = Self.reflowedContainment(of: anchor, in: read) {
+            replaceBackfillRange(
+                range,
+                with: read,
+                liveLogicalLineCount: containment.logicalRange.count)
             return BackfillOutcome(
-                newLines: max(0, read.count - anchor.count), insertedGap: false)
+                newLines: max(
+                    0,
+                    read.count - containment.logicalRange.count
+                        + (containment.usedPartialBoundary ? 1 : 0)),
+                insertedGap: false)
         }
         insertUnstitchedBackfill(read)
         return BackfillOutcome(newLines: read.count, insertedGap: true)
@@ -353,7 +367,8 @@ struct AgentMonitorHistory: Equatable, Sendable {
 
     private mutating func replaceBackfillRange(
         _ range: Range<Int>,
-        with read: [String]
+        with read: [String],
+        liveLogicalLineCount: Int
     ) {
         guard range.upperBound == segments.endIndex else {
             segments.replaceSubrange(range, with: [.lines(read)])
@@ -361,10 +376,10 @@ struct AgentMonitorHistory: Equatable, Sendable {
             return
         }
 
-        // A racing `recent` read can contain the previous screen before its
-        // newest lines. Preserve the live/history boundary by treating a
-        // screen-sized suffix as the new live run.
-        let liveCount = min(newestLines.count, read.count)
+        // A racing `recent_unwrapped` read can contain the previous screen
+        // before its newest lines. The reflow match supplies the screen's
+        // logical-line span; physical visible-row counts are not comparable.
+        let liveCount = min(liveLogicalLineCount, read.count)
         let history = Array(read.dropLast(liveCount))
         let live = Array(read.suffix(liveCount))
         let replacement: [Segment]
@@ -425,12 +440,23 @@ struct AgentMonitorHistory: Equatable, Sendable {
         return nil
     }
 
-    /// Returns the number of logical `recent_unwrapped` lines proven to be
-    /// the same boundary as a suffix of the cached grid. Each logical line
-    /// consumes one or more cached rows, so differing terminal widths do not
-    /// manufacture gaps. Trailing spaces and tabs are ignored only for this
-    /// comparison because a visible grid may pad its final row; stored and
-    /// rendered strings remain byte-exact.
+    private struct ReflowedMatch {
+        let logicalLineCount: Int
+        let usedPartialBoundary: Bool
+        let coversWholeCache: Bool
+    }
+
+    private struct ReflowedContainment {
+        let logicalRange: Range<Int>
+        let usedPartialBoundary: Bool
+    }
+
+    /// Returns the logical `recent_unwrapped` suffix proven to share the
+    /// cached grid boundary. Each logical line consumes one or more cached
+    /// rows, so differing terminal widths do not manufacture gaps. A cached
+    /// first row may also be the trailing portion of a logical line that
+    /// began above the visible screen; that partial boundary is reported so
+    /// the caller can replace rather than duplicate it.
     ///
     /// A match is accepted when it covers either whole boundary, or when at
     /// least `minimumOverlap` logical lines agree. This preserves the former
@@ -439,32 +465,73 @@ struct AgentMonitorHistory: Equatable, Sendable {
     private static func largestReflowedOverlap(
         unwrappedSuffixOf read: [String],
         cachedSuffixOf cached: [String]
-    ) -> Int? {
+    ) -> ReflowedMatch? {
         guard !read.isEmpty, !cached.isEmpty else { return nil }
 
         let logicalLines = read.map(ReconciliationLine.init)
         let cachedRows = cached.map(ReconciliationLine.init)
-        var cachedEnd = cachedRows.endIndex
-        var overlap = 0
+        guard
+            let match = reflowedSuffixMatch(
+                logicalLines: logicalLines,
+                endingAt: logicalLines.endIndex,
+                cachedRows: cachedRows)
+        else { return nil }
 
-        for logicalLine in logicalLines.reversed() {
+        let coversWholeRead = match.logicalLineCount == read.count
+        guard !match.usedPartialBoundary || match.coversWholeCache else {
+            return nil
+        }
+        guard
+            match.logicalLineCount >= minimumOverlap
+                || coversWholeRead
+                || match.coversWholeCache
+        else { return nil }
+        return match
+    }
+
+    private static func reflowedSuffixMatch(
+        logicalLines: [ReconciliationLine],
+        endingAt logicalEnd: Int,
+        cachedRows: [ReconciliationLine]
+    ) -> ReflowedMatch? {
+        guard logicalEnd > logicalLines.startIndex, !cachedRows.isEmpty else {
+            return nil
+        }
+
+        var cachedEnd = cachedRows.endIndex
+        var logicalIndex = logicalEnd
+        var matchedCount = 0
+        var usedPartialBoundary = false
+
+        while logicalIndex > logicalLines.startIndex, cachedEnd > cachedRows.startIndex {
+            logicalIndex -= 1
+            let logicalLine = logicalLines[logicalIndex]
+            if let start = matchingStart(
+                    of: logicalLine,
+                    in: cachedRows,
+                    endingAt: cachedEnd)
+            {
+                matchedCount += 1
+                cachedEnd = start
+                continue
+            }
             guard
-                let start = matchingStart(
+                !usedPartialBoundary,
+                let start = suffixMatchingStart(
                     of: logicalLine,
                     in: cachedRows,
                     endingAt: cachedEnd)
             else { break }
-            overlap += 1
+            matchedCount += 1
             cachedEnd = start
+            usedPartialBoundary = true
         }
 
-        guard overlap > 0 else { return nil }
-        let coversWholeRead = overlap == read.count
-        let coversWholeCache = cachedEnd == cachedRows.startIndex
-        guard overlap >= minimumOverlap || coversWholeRead || coversWholeCache else {
-            return nil
-        }
-        return overlap
+        guard matchedCount > 0 else { return nil }
+        return ReflowedMatch(
+            logicalLineCount: matchedCount,
+            usedPartialBoundary: usedPartialBoundary,
+            coversWholeCache: cachedEnd == cachedRows.startIndex)
     }
 
     private struct ReconciliationLine {
@@ -516,18 +583,65 @@ struct AgentMonitorHistory: Equatable, Sendable {
         return nil
     }
 
-    /// The rightmost position at which `needle` appears in `haystack` as a
-    /// contiguous run, if any. Rightmost because the newest run sits at the
-    /// end of a `recent_unwrapped` read when content is stable; an earlier
-    /// duplicate of the same lines is history, not the tail.
-    private static func containment(of needle: [String], in haystack: [String]) -> Int? {
-        guard needle.count <= haystack.count else { return nil }
-        var start = haystack.count - needle.count
-        while start >= 0 {
-            if Self.areByteIdentical(haystack[start..<(start + needle.count)], needle) {
-                return start
-            }
+    /// Matches cached continuation rows against the suffix of one logical
+    /// line. The longest suffix wins so every continuation row is absorbed
+    /// before matching proceeds to the preceding logical line.
+    private static func suffixMatchingStart(
+        of logicalLine: ReconciliationLine,
+        in cachedRows: [ReconciliationLine],
+        endingAt cachedEnd: Int
+    ) -> Int? {
+        guard cachedEnd > cachedRows.startIndex else { return nil }
+        var combinedRaw: [UInt8] = []
+        var combinedTrimmed: [UInt8] = []
+        var earliestMatch: Int?
+        var start = cachedEnd
+
+        while start > cachedRows.startIndex {
             start -= 1
+            combinedRaw.insert(contentsOf: cachedRows[start].raw, at: combinedRaw.startIndex)
+            combinedTrimmed.insert(
+                contentsOf: cachedRows[start].trimmed,
+                at: combinedTrimmed.startIndex)
+            let rawCanMatch = combinedRaw.count < logicalLine.raw.count
+            let trimmedCanMatch = combinedTrimmed.count < logicalLine.trimmed.count
+            guard rawCanMatch || trimmedCanMatch else { break }
+            let rawMatches = rawCanMatch && !combinedRaw.isEmpty
+                && logicalLine.raw.suffix(combinedRaw.count).elementsEqual(combinedRaw)
+            let trimmedMatches = trimmedCanMatch && !combinedTrimmed.isEmpty
+                && logicalLine.trimmed.suffix(combinedTrimmed.count)
+                    .elementsEqual(combinedTrimmed)
+            if rawMatches || trimmedMatches {
+                earliestMatch = start
+            }
+        }
+        return earliestMatch
+    }
+
+    /// Finds the rightmost logical-line range that fully contains the cached
+    /// rows using the same reflow and continuation rules as suffix stitching.
+    private static func reflowedContainment(
+        of cached: [String],
+        in read: [String]
+    ) -> ReflowedContainment? {
+        guard !cached.isEmpty, !read.isEmpty else { return nil }
+        let logicalLines = read.map(ReconciliationLine.init)
+        let cachedRows = cached.map(ReconciliationLine.init)
+
+        var logicalEnd = logicalLines.endIndex
+        while logicalEnd > logicalLines.startIndex {
+            if let match = reflowedSuffixMatch(
+                logicalLines: logicalLines,
+                endingAt: logicalEnd,
+                cachedRows: cachedRows),
+                match.coversWholeCache
+            {
+                let lowerBound = logicalEnd - match.logicalLineCount
+                return ReflowedContainment(
+                    logicalRange: lowerBound..<logicalEnd,
+                    usedPartialBoundary: match.usedPartialBoundary)
+            }
+            logicalEnd -= 1
         }
         return nil
     }

--- a/Sources/Heeler/Monitor/AgentMonitorHistory.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorHistory.swift
@@ -182,11 +182,8 @@ struct AgentMonitorHistory: Equatable, Sendable {
             unwrappedSuffixOf: read, cachedSuffixOf: anchor)
         {
             let older = Array(read.prefix(read.count - match.logicalLineCount))
-            if match.usedPartialBoundary {
-                replaceBackfillRange(
-                    range,
-                    with: read,
-                    liveLogicalLineCount: match.logicalLineCount)
+            if let partialPrefix = match.partialPrefix {
+                prepend(older + [partialPrefix], to: range)
                 return BackfillOutcome(
                     newLines: older.count + 1,
                     insertedGap: false)
@@ -197,16 +194,23 @@ struct AgentMonitorHistory: Equatable, Sendable {
             prepend(older, to: range)
             return BackfillOutcome(newLines: older.count, insertedGap: false)
         }
-        if let containment = Self.reflowedContainment(of: anchor, in: read) {
-            replaceBackfillRange(
-                range,
-                with: read,
-                liveLogicalLineCount: containment.logicalRange.count)
+        if anchor.count >= Self.minimumOverlap,
+            let containment = Self.reflowedContainment(of: anchor, in: read)
+        {
+            // The suffix after the contained screen raced ahead of the last
+            // visible read. It cannot be ordered below that exact live screen,
+            // so defer it until the next visible refresh and retain only the
+            // proven older prefix here.
+            var older = Array(read.prefix(containment.logicalRange.lowerBound))
+            if let partialPrefix = containment.partialPrefix {
+                older.append(partialPrefix)
+            }
+            guard !older.isEmpty else {
+                return BackfillOutcome(newLines: 0, insertedGap: false)
+            }
+            prepend(older, to: range)
             return BackfillOutcome(
-                newLines: max(
-                    0,
-                    read.count - containment.logicalRange.count
-                        + (containment.usedPartialBoundary ? 1 : 0)),
+                newLines: older.count,
                 insertedGap: false)
         }
         insertUnstitchedBackfill(read)
@@ -365,33 +369,6 @@ struct AgentMonitorHistory: Equatable, Sendable {
         }
     }
 
-    private mutating func replaceBackfillRange(
-        _ range: Range<Int>,
-        with read: [String],
-        liveLogicalLineCount: Int
-    ) {
-        guard range.upperBound == segments.endIndex else {
-            segments.replaceSubrange(range, with: [.lines(read)])
-            backfillRange = range.lowerBound..<(range.lowerBound + 1)
-            return
-        }
-
-        // A racing `recent_unwrapped` read can contain the previous screen
-        // before its newest lines. The reflow match supplies the screen's
-        // logical-line span; physical visible-row counts are not comparable.
-        let liveCount = min(liveLogicalLineCount, read.count)
-        let history = Array(read.dropLast(liveCount))
-        let live = Array(read.suffix(liveCount))
-        let replacement: [Segment]
-        if history.isEmpty {
-            replacement = [.lines(live)]
-        } else {
-            replacement = [.lines(history), .lines(live)]
-        }
-        segments.replaceSubrange(range, with: replacement)
-        backfillRange = range.lowerBound..<(range.lowerBound + replacement.count)
-    }
-
     private mutating func insertUnstitchedBackfill(_ read: [String]) {
         let liveIndex = segments.count - 1
         var insertion: [Segment] = []
@@ -442,13 +419,13 @@ struct AgentMonitorHistory: Equatable, Sendable {
 
     private struct ReflowedMatch {
         let logicalLineCount: Int
-        let usedPartialBoundary: Bool
+        let partialPrefix: String?
         let coversWholeCache: Bool
     }
 
     private struct ReflowedContainment {
         let logicalRange: Range<Int>
-        let usedPartialBoundary: Bool
+        let partialPrefix: String?
     }
 
     /// Returns the logical `recent_unwrapped` suffix proven to share the
@@ -456,7 +433,8 @@ struct AgentMonitorHistory: Equatable, Sendable {
     /// rows, so differing terminal widths do not manufacture gaps. A cached
     /// first row may also be the trailing portion of a logical line that
     /// began above the visible screen; that partial boundary is reported so
-    /// the caller can replace rather than duplicate it.
+    /// the caller can preserve its missing prefix as history without changing
+    /// the live screen's physical-row geometry.
     ///
     /// A match is accepted when it covers either whole boundary, or when at
     /// least `minimumOverlap` logical lines agree. This preserves the former
@@ -478,7 +456,7 @@ struct AgentMonitorHistory: Equatable, Sendable {
         else { return nil }
 
         let coversWholeRead = match.logicalLineCount == read.count
-        guard !match.usedPartialBoundary || match.coversWholeCache else {
+        guard match.partialPrefix == nil || match.coversWholeCache else {
             return nil
         }
         guard
@@ -501,7 +479,7 @@ struct AgentMonitorHistory: Equatable, Sendable {
         var cachedEnd = cachedRows.endIndex
         var logicalIndex = logicalEnd
         var matchedCount = 0
-        var usedPartialBoundary = false
+        var partialPrefix: String?
 
         while logicalIndex > logicalLines.startIndex, cachedEnd > cachedRows.startIndex {
             logicalIndex -= 1
@@ -516,21 +494,24 @@ struct AgentMonitorHistory: Equatable, Sendable {
                 continue
             }
             guard
-                !usedPartialBoundary,
-                let start = suffixMatchingStart(
+                partialPrefix == nil,
+                let partialMatch = suffixMatchingStart(
                     of: logicalLine,
                     in: cachedRows,
                     endingAt: cachedEnd)
             else { break }
+            // A continuation can only begin at the top of the cached range;
+            // accepting an interior suffix would discard older unmatched rows.
+            guard partialMatch.start == cachedRows.startIndex else { break }
             matchedCount += 1
-            cachedEnd = start
-            usedPartialBoundary = true
+            cachedEnd = partialMatch.start
+            partialPrefix = partialMatch.missingPrefix
         }
 
         guard matchedCount > 0 else { return nil }
         return ReflowedMatch(
             logicalLineCount: matchedCount,
-            usedPartialBoundary: usedPartialBoundary,
+            partialPrefix: partialPrefix,
             coversWholeCache: cachedEnd == cachedRows.startIndex)
     }
 
@@ -586,15 +567,20 @@ struct AgentMonitorHistory: Equatable, Sendable {
     /// Matches cached continuation rows against the suffix of one logical
     /// line. The longest suffix wins so every continuation row is absorbed
     /// before matching proceeds to the preceding logical line.
+    private struct PartialSuffixMatch {
+        let start: Int
+        let missingPrefix: String
+    }
+
     private static func suffixMatchingStart(
         of logicalLine: ReconciliationLine,
         in cachedRows: [ReconciliationLine],
         endingAt cachedEnd: Int
-    ) -> Int? {
+    ) -> PartialSuffixMatch? {
         guard cachedEnd > cachedRows.startIndex else { return nil }
         var combinedRaw: [UInt8] = []
         var combinedTrimmed: [UInt8] = []
-        var earliestMatch: Int?
+        var earliestMatch: PartialSuffixMatch?
         var start = cachedEnd
 
         while start > cachedRows.startIndex {
@@ -611,8 +597,18 @@ struct AgentMonitorHistory: Equatable, Sendable {
             let trimmedMatches = trimmedCanMatch && !combinedTrimmed.isEmpty
                 && logicalLine.trimmed.suffix(combinedTrimmed.count)
                     .elementsEqual(combinedTrimmed)
-            if rawMatches || trimmedMatches {
-                earliestMatch = start
+            if rawMatches {
+                earliestMatch = PartialSuffixMatch(
+                    start: start,
+                    missingPrefix: String(
+                        decoding: logicalLine.raw.dropLast(combinedRaw.count),
+                        as: UTF8.self))
+            } else if trimmedMatches {
+                earliestMatch = PartialSuffixMatch(
+                    start: start,
+                    missingPrefix: String(
+                        decoding: logicalLine.trimmed.dropLast(combinedTrimmed.count),
+                        as: UTF8.self))
             }
         }
         return earliestMatch
@@ -639,7 +635,7 @@ struct AgentMonitorHistory: Equatable, Sendable {
                 let lowerBound = logicalEnd - match.logicalLineCount
                 return ReflowedContainment(
                     logicalRange: lowerBound..<logicalEnd,
-                    usedPartialBoundary: match.usedPartialBoundary)
+                    partialPrefix: match.partialPrefix)
             }
             logicalEnd -= 1
         }

--- a/Sources/Heeler/Monitor/AgentMonitorStore.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorStore.swift
@@ -81,9 +81,13 @@ final class AgentMonitorStore {
 
     private(set) var state: State = .idle
     private(set) var snapshotSegments: [RenderedSegment] = []
-    /// Compatibility view used by state checks and non-UI callers. The
-    /// Monitor view renders `snapshotSegments` so each region is a separate
-    /// accessibility element.
+    var hasSnapshot: Bool { !snapshotSegments.isEmpty }
+    var isSnapshotEmpty: Bool {
+        hasSnapshot && snapshotSegments.allSatisfy { $0.text.characters.isEmpty }
+    }
+    /// Joined compatibility view for tests and diagnostics. Production state
+    /// and view paths use `hasSnapshot`, `isSnapshotEmpty`, and the segments
+    /// directly so they never rebuild this value during body evaluation.
     var snapshot: AttributedString? {
         guard !snapshotSegments.isEmpty else { return nil }
         var joined = AttributedString()
@@ -293,10 +297,10 @@ final class AgentMonitorStore {
                 contentChangeCount &+= 1
             }
             capturedAt = now()
-            // `recent_unwrapped` counts logical lines. The capture limit is
-            // reached when the server had fewer logical lines than the cap
-            // (that was everything) or when the read added nothing (the
-            // logical-line window is already fully cached).
+            // We assume the `recent_unwrapped` response line count uses the
+            // same unit as the request cap; this has not been verified live.
+            // Independently, adding nothing proves this returned window is
+            // already fully cached.
             let returnedLines = AgentMonitorHistory.splitLines(result.text).count
             historyState =
                 returnedLines < Self.historyLineCount || outcome.newLines == 0
@@ -408,7 +412,7 @@ final class AgentMonitorStore {
     private func fetch() async {
         guard !isFetching else { return }
         isFetching = true
-        if snapshot == nil {
+        if !hasSnapshot {
             state = .loading
         }
         defer { finishFetch() }
@@ -427,8 +431,8 @@ final class AgentMonitorStore {
             capturedAt = now()
             state = .loaded
         } catch is CancellationError {
-            state = snapshot == nil ? .idle : .loaded
-            if snapshot == nil {
+            state = hasSnapshot ? .loaded : .idle
+            if !hasSnapshot {
                 hasOpened = false
             }
         } catch {
@@ -471,24 +475,24 @@ final class AgentMonitorStore {
             guard !contiguousParts.isEmpty else { return }
             let combined = ANSISnapshotRenderer.render(
                 contiguousParts.joined(separator: "\n"))
-            var renderedPrefixParts: [String] = []
-            var previousBoundary = combined.startIndex
+            var cursor = combined.startIndex
 
-            for part in contiguousParts {
-                renderedPrefixParts.append(part)
-                let prefixCharacterCount = ANSISnapshotRenderer.render(
-                    renderedPrefixParts.joined(separator: "\n")
-                ).characters.count
-                let boundedCount = min(prefixCharacterCount, combined.characters.count)
-                let boundary = combined.characters.index(
-                    combined.startIndex, offsetBy: boundedCount)
-                var contentStart = previousBoundary
-                if contentStart < boundary, combined.characters[contentStart] == "\n" {
+            for (index, part) in contiguousParts.enumerated() {
+                var contentStart = cursor
+                if index > 0,
+                    contentStart < combined.endIndex,
+                    combined.characters[contentStart] == "\n"
+                {
                     contentStart = combined.characters.index(after: contentStart)
                 }
+                let characterCount = ANSISnapshotRenderer.render(part).characters.count
+                let boundary = combined.characters.index(
+                    contentStart,
+                    offsetBy: characterCount,
+                    limitedBy: combined.endIndex) ?? combined.endIndex
                 rendered.append(
                     (.content, AttributedString(combined[contentStart..<boundary])))
-                previousBoundary = boundary
+                cursor = boundary
             }
             contiguousParts.removeAll(keepingCapacity: true)
         }

--- a/Sources/Heeler/Monitor/AgentMonitorStore.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorStore.swift
@@ -476,16 +476,24 @@ final class AgentMonitorStore {
             let combined = ANSISnapshotRenderer.render(
                 contiguousParts.joined(separator: "\n"))
             var cursor = combined.startIndex
+            var hasKeptLines = false
+            var emittedPart = false
 
-            for (index, part) in contiguousParts.enumerated() {
+            for part in contiguousParts {
+                let renderedPart = ANSISnapshotRenderer.render(part)
+                let keptLineCount = Self.keptRenderedLineCount(
+                    in: part,
+                    renderedPart: renderedPart)
+                guard keptLineCount > 0 else { continue }
+
                 var contentStart = cursor
-                if index > 0,
+                if hasKeptLines,
                     contentStart < combined.endIndex,
                     combined.characters[contentStart] == "\n"
                 {
                     contentStart = combined.characters.index(after: contentStart)
                 }
-                let characterCount = ANSISnapshotRenderer.render(part).characters.count
+                let characterCount = renderedPart.characters.count
                 let boundary = combined.characters.index(
                     contentStart,
                     offsetBy: characterCount,
@@ -493,6 +501,13 @@ final class AgentMonitorStore {
                 rendered.append(
                     (.content, AttributedString(combined[contentStart..<boundary])))
                 cursor = boundary
+                hasKeptLines = true
+                emittedPart = true
+            }
+            if !emittedPart {
+                // An all-decoration capture still represents a loaded, empty
+                // snapshot rather than returning to the loading state.
+                rendered.append((.content, combined))
             }
             contiguousParts.removeAll(keepingCapacity: true)
         }
@@ -554,6 +569,34 @@ final class AgentMonitorStore {
             start = end
         }
         return parts
+    }
+
+    /// Appending a printable sentinel turns the renderer's retained logical
+    /// lines into separators we can count, including a retained blank line
+    /// whose independently rendered attributed string is empty. Decoration-
+    /// only lines contribute no separator and therefore cannot shift the next
+    /// accessibility slice.
+    private static func keptRenderedLineCount(
+        in part: String,
+        renderedPart: AttributedString
+    ) -> Int {
+        let sentinel: Character = "\u{E000}"
+        let probe = ANSISnapshotRenderer.render(part + "\n" + String(sentinel))
+        guard probe.characters.last == sentinel else {
+            guard !renderedPart.characters.isEmpty else {
+                return part.isEmpty ? 1 : 0
+            }
+            return renderedPart.characters.reduce(into: 1) { count, character in
+                if character == "\n" {
+                    count += 1
+                }
+            }
+        }
+        return probe.characters.dropLast().reduce(into: 0) { count, character in
+            if character == "\n" {
+                count += 1
+            }
+        }
     }
 
     private func waitForCurrentFetch() async {

--- a/Sources/Heeler/Monitor/AgentMonitorStore.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorStore.swift
@@ -21,6 +21,28 @@ struct ContinuousAgentMonitorClock: AgentMonitorClock {
 @MainActor
 @Observable
 final class AgentMonitorStore {
+    struct RenderedSegment: Identifiable, Equatable {
+        enum Kind: Hashable, Sendable {
+            case content
+            case gap
+        }
+
+        struct ID: Hashable, Sendable {
+            let kind: Kind
+            /// Counted from the live tail so prepending older history does
+            /// not change the identity of existing rendered regions.
+            let offsetFromNewest: Int
+        }
+
+        let id: ID
+        let kind: Kind
+        let text: AttributedString
+
+        var accessibilityLabel: String? {
+            kind == .gap ? "Content not captured" : nil
+        }
+    }
+
     enum State: Equatable {
         case idle
         case loading
@@ -29,8 +51,9 @@ final class AgentMonitorStore {
     }
 
     /// Where the scrollback stands relative to herdr's capture limit. herdr
-    /// has no history cursor, so "more history" is only ever one `recent`
-    /// read away; the states exist to make that read honest.
+    /// has no history cursor, so "more history" is only ever one
+    /// `recent_unwrapped` read away; the states exist to make that read
+    /// honest.
     enum HistoryState: Equatable {
         /// No load in flight; reaching the top of the cache may fetch more.
         case idle
@@ -49,12 +72,29 @@ final class AgentMonitorStore {
     static let refreshCadence: Duration = .seconds(2)
     /// herdr caps every read at 1000 lines; ask for the whole window.
     static let historyLineCount = 1000
+    /// Bounds one VoiceOver utterance while keeping enough terminal context
+    /// in each independently navigable content element.
+    static let maximumAccessibleSegmentLines = 40
     /// The in-content marker for a region that could not be captured or
     /// reconciled. Tests assert on this copy.
     static let gapMarkerText = "— gap: content not captured —"
 
     private(set) var state: State = .idle
-    private(set) var snapshot: AttributedString?
+    private(set) var snapshotSegments: [RenderedSegment] = []
+    /// Compatibility view used by state checks and non-UI callers. The
+    /// Monitor view renders `snapshotSegments` so each region is a separate
+    /// accessibility element.
+    var snapshot: AttributedString? {
+        guard !snapshotSegments.isEmpty else { return nil }
+        var joined = AttributedString()
+        for (index, segment) in snapshotSegments.enumerated() {
+            if index > 0 {
+                joined.append(AttributedString("\n"))
+            }
+            joined.append(segment.text)
+        }
+        return joined
+    }
     private(set) var capturedAt: Date?
     private(set) var agentStatus: AgentStatus
     private(set) var liveUpdatesAvailable = true
@@ -216,7 +256,7 @@ final class AgentMonitorStore {
     }
 
     /// One backfill read. herdr exposes no history cursor, so this reads
-    /// the server's newest lines (capped at `historyLineCount`) and
+    /// the server's newest logical lines (capped at `historyLineCount`) and
     /// overlap-stitches them onto the cache; a stitch that finds no shared
     /// content records an explicit gap instead of guessing. Also the retry
     /// path for a failed backfill.
@@ -242,7 +282,7 @@ final class AgentMonitorStore {
         do {
             let result = try await read(
                 AgentReadParams(
-                    source: .recent,
+                    source: .recentUnwrapped,
                     target: target,
                     format: .ansi,
                     lines: Self.historyLineCount,
@@ -253,9 +293,10 @@ final class AgentMonitorStore {
                 contentChangeCount &+= 1
             }
             capturedAt = now()
-            // The capture limit is reached when the server had fewer lines
-            // than the cap (that was everything) or when the read added
-            // nothing (the window is already fully cached).
+            // `recent_unwrapped` counts logical lines. The capture limit is
+            // reached when the server had fewer logical lines than the cap
+            // (that was everything) or when the read added nothing (the
+            // logical-line window is already fully cached).
             let returnedLines = AgentMonitorHistory.splitLines(result.text).count
             historyState =
                 returnedLines < Self.historyLineCount || outcome.newLines == 0
@@ -418,42 +459,97 @@ final class AgentMonitorStore {
 
     /// Renders the whole cache, with history above the live screen and gap
     /// markers between unreconciled regions. Storage keeps history and live
-    /// runs separate, but adjacent line segments render together so ANSI
-    /// state still flows across every byte-proven boundary. It resets only
-    /// at a gap, which is the honest boundary anyway.
+    /// runs as separate accessibility segments, but adjacent line runs first
+    /// render together and are sliced afterward so ANSI state still flows
+    /// across every byte-proven boundary. It resets only at a gap, which is
+    /// the honest boundary anyway.
     private func renderSnapshot() {
-        var renderedSegments: [AttributedString] = []
+        var rendered: [(kind: RenderedSegment.Kind, text: AttributedString)] = []
         var contiguousParts: [String] = []
 
         func flushContiguousLines() {
             guard !contiguousParts.isEmpty else { return }
-            renderedSegments.append(
-                ANSISnapshotRenderer.render(contiguousParts.joined(separator: "\n")))
+            let combined = ANSISnapshotRenderer.render(
+                contiguousParts.joined(separator: "\n"))
+            var renderedPrefixParts: [String] = []
+            var previousBoundary = combined.startIndex
+
+            for part in contiguousParts {
+                renderedPrefixParts.append(part)
+                let prefixCharacterCount = ANSISnapshotRenderer.render(
+                    renderedPrefixParts.joined(separator: "\n")
+                ).characters.count
+                let boundedCount = min(prefixCharacterCount, combined.characters.count)
+                let boundary = combined.characters.index(
+                    combined.startIndex, offsetBy: boundedCount)
+                var contentStart = previousBoundary
+                if contentStart < boundary, combined.characters[contentStart] == "\n" {
+                    contentStart = combined.characters.index(after: contentStart)
+                }
+                rendered.append(
+                    (.content, AttributedString(combined[contentStart..<boundary])))
+                previousBoundary = boundary
+            }
             contiguousParts.removeAll(keepingCapacity: true)
         }
 
         for segment in history.segments {
             switch segment {
             case .lines(let lines):
-                contiguousParts.append(lines.joined(separator: "\n"))
+                contiguousParts.append(contentsOf: Self.accessibleParts(for: lines))
             case .gap:
                 flushContiguousLines()
                 var marker = AttributedString(Self.gapMarkerText)
                 marker.foregroundColor = Color.secondary
                 marker.inlinePresentationIntent = .emphasized
-                renderedSegments.append(marker)
+                rendered.append((.gap, marker))
             }
         }
         flushContiguousLines()
 
-        var rendered = AttributedString()
-        for (index, segment) in renderedSegments.enumerated() {
-            if index > 0 {
-                rendered.append(AttributedString("\n"))
+        var contentOffset = 0
+        var gapOffset = 0
+        var identified: [RenderedSegment] = []
+        identified.reserveCapacity(rendered.count)
+        for segment in rendered.reversed() {
+            let offset: Int
+            switch segment.kind {
+            case .content:
+                offset = contentOffset
+                contentOffset += 1
+            case .gap:
+                offset = gapOffset
+                gapOffset += 1
             }
-            rendered.append(segment)
+            identified.append(
+                RenderedSegment(
+                    id: .init(kind: segment.kind, offsetFromNewest: offset),
+                    kind: segment.kind,
+                    text: segment.text))
         }
-        snapshot = rendered
+        snapshotSegments = Array(identified.reversed())
+    }
+
+    /// Chunks from the newest end. Prepending older history then changes only
+    /// the oldest chunk, while the IDs of all existing tail chunks remain
+    /// stable because rendered IDs are also counted from newest.
+    private static func accessibleParts(for lines: [String]) -> [String] {
+        guard !lines.isEmpty else { return [""] }
+        let firstChunkCount = lines.count % maximumAccessibleSegmentLines
+        var start = lines.startIndex
+        var parts: [String] = []
+
+        if firstChunkCount > 0 {
+            let end = start + firstChunkCount
+            parts.append(lines[start..<end].joined(separator: "\n"))
+            start = end
+        }
+        while start < lines.endIndex {
+            let end = min(start + maximumAccessibleSegmentLines, lines.endIndex)
+            parts.append(lines[start..<end].joined(separator: "\n"))
+            start = end
+        }
+        return parts
     }
 
     private func waitForCurrentFetch() async {

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -172,7 +172,7 @@ struct AgentDetailView: View {
 
     private func snapshotScrollView(_ snapshot: AttributedString) -> some View {
         ScrollViewReader { proxy in
-            ScrollView([.horizontal, .vertical]) {
+            ScrollView(.vertical) {
                 VStack(alignment: .leading, spacing: 0) {
                     historyTopMarker
                     Text(snapshot)

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -75,116 +75,154 @@ struct AgentDetailView: View {
         VStack(spacing: 0) {
             monitorSurface
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-            Divider()
-            AgentComposerView(store: composer)
+            AgentComposerView(
+                store: composer,
+                isControlKeyEnabled: !monitor.isSendingKey
+            ) { key in
+                Task { await monitor.send(key) }
+            }
         }
-            .navigationTitle(title)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    Button("Attach", systemImage: "terminal") {
-                        monitor.attachDidOpen()
-                        isShowingAttach = true
-                    }
-                }
+        .background(Color(uiColor: .systemGroupedBackground))
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationDestination(isPresented: $isShowingAttach) {
+            AgentAttachView(
+                agent: agent,
+                console: console,
+                terminal: terminal,
+                hosts: hosts,
+                activity: activity,
+                keyboardHandoff: keyboardHandoff,
+                keyboardInset: keyboardInset,
+                isOnStage: isOnStage,
+                onSwitch: onSwitch,
+                onClosed: onClosed,
+                attachStore: attach)
+        }
+        .onChange(of: isShowingAttach) { wasShowing, isShowing in
+            guard wasShowing, !isShowing else { return }
+            Task {
+                await attach.leave().value
+                await monitor.refreshOnReturn()
             }
-            .navigationDestination(isPresented: $isShowingAttach) {
-                AgentAttachView(
-                    agent: agent,
-                    console: console,
-                    terminal: terminal,
-                    hosts: hosts,
-                    activity: activity,
-                    keyboardHandoff: keyboardHandoff,
-                    keyboardInset: keyboardInset,
-                    isOnStage: isOnStage,
-                    onSwitch: onSwitch,
-                    onClosed: onClosed,
-                    attachStore: attach)
-            }
-            .onChange(of: isShowingAttach) { wasShowing, isShowing in
-                guard wasShowing, !isShowing else { return }
-                Task {
-                    await attach.leave().value
-                    await monitor.refreshOnReturn()
-                }
-            }
-            .task {
-                composer.open()
-                await monitor.open()
-            }
-            .onChange(of: scenePhase, initial: true) { _, phase in
-                monitor.setForeground(phase == .active)
-            }
+        }
+        .task {
+            composer.open()
+            await monitor.open()
+        }
+        .onChange(of: scenePhase, initial: true) { _, phase in
+            monitor.setForeground(phase == .active)
+        }
     }
 
     @ViewBuilder
     private var monitorSurface: some View {
-        if let snapshot = monitor.snapshot {
-            VStack(spacing: 0) {
-                statusHeader
-                Divider()
+        VStack(spacing: 0) {
+            monitorHeader
+            if let snapshot = monitor.snapshot {
                 if snapshot.characters.isEmpty {
-                    ScrollView {
-                        ContentUnavailableView(
-                            "No Output", systemImage: "rectangle.dashed",
-                            description: Text("The Agent's latest screen is empty."))
-                            .frame(maxWidth: .infinity, minHeight: 360)
+                    ScrollView(.vertical) {
+                        VStack(spacing: 16) {
+                            ContentUnavailableView {
+                                Label("No Agent output", systemImage: "rectangle.dashed")
+                            } description: {
+                                Text("The latest snapshot is empty. Refresh to check again.")
+                            } actions: {
+                                Button("Refresh", systemImage: "arrow.clockwise") {
+                                    Task { await monitor.refresh() }
+                                }
+                                .buttonStyle(.bordered)
+                            }
+
+                            AgentSentMessagesView(store: composer)
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, minHeight: 360)
                     }
                     .refreshable { await monitor.refresh() }
                 } else {
                     snapshotScrollView(snapshot)
                 }
-                if let sendError = monitor.sendError {
-                    Text(sendError)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal)
-                        .padding(.top, 8)
-                }
-                MonitorControlKeyStrip(isEnabled: !monitor.isSendingKey) { key in
-                    Task { await monitor.send(key) }
-                }
-            }
-        } else {
-            switch monitor.state {
-            case .failed(let message):
-                ContentUnavailableView {
-                    Label("Couldn't Load Screen", systemImage: "exclamationmark.triangle")
-                } description: {
-                    VStack(spacing: 8) {
-                        Text(message)
-                        if !monitor.liveUpdatesAvailable {
-                            liveUpdatesUnavailableLabel
+            } else {
+                switch monitor.state {
+                case .failed(let message):
+                    ScrollView(.vertical) {
+                        VStack(spacing: 16) {
+                            ContentUnavailableView {
+                                Label(
+                                    "Unable to load Agent output",
+                                    systemImage: "exclamationmark.triangle")
+                            } description: {
+                                Text(message)
+                            } actions: {
+                                Button("Try again", systemImage: "arrow.clockwise") {
+                                    Task { await monitor.retry() }
+                                }
+                                .buttonStyle(.borderedProminent)
+                            }
+
+                            AgentSentMessagesView(store: composer)
                         }
+                        .padding()
+                        .frame(maxWidth: .infinity, minHeight: 360)
                     }
-                } actions: {
-                    Button("Retry") { Task { await monitor.retry() } }
-                        .buttonStyle(.borderedProminent)
-                }
-            case .idle, .loading, .loaded:
-                ProgressView("Loading latest screen…")
+                case .idle, .loading, .loaded:
+                    VStack(spacing: 12) {
+                        ProgressView()
+                        Text("Loading Agent output…")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
             }
         }
+        .background(Color(uiColor: .systemGroupedBackground))
     }
 
     private func snapshotScrollView(_ snapshot: AttributedString) -> some View {
         ScrollViewReader { proxy in
             ScrollView(.vertical) {
-                VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: 12) {
                     historyTopMarker
+                    Text("Agent output")
+                        .font(.subheadline.weight(.semibold))
+                        .accessibilityAddTraits(.isHeader)
                     Text(snapshot)
                         .font(.system(.callout, design: .monospaced))
                         .lineSpacing(3)
+                        .foregroundStyle(.white)
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .topLeading)
-                        .padding()
+                        .padding(16)
+                        .background(
+                            Color.black.opacity(0.94),
+                            in: RoundedRectangle(cornerRadius: 16))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 16)
+                                .stroke(.white.opacity(0.12), lineWidth: 1)
+                        }
+                        .environment(\.colorScheme, .dark)
+
+                    if let sendError = monitor.sendError {
+                        Label(sendError, systemImage: "exclamationmark.triangle")
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(12)
+                            .background(
+                                Color.red.opacity(0.08),
+                                in: RoundedRectangle(cornerRadius: 12))
+                    }
+
+                    AgentSentMessagesView(store: composer)
+
                     Color.clear
                         .frame(height: 1)
                         .id(Self.outputBottomID)
                 }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
             }
             .defaultScrollAnchor(.bottom, for: .initialOffset)
             .refreshable { await monitor.refresh() }
@@ -203,18 +241,19 @@ struct AgentDetailView: View {
                 guard monitor.isBottomPinned else { return }
                 proxy.scrollTo(Self.outputBottomID, anchor: .bottom)
             }
+            .onChange(of: composer.messages.count) {
+                guard monitor.isBottomPinned else { return }
+                proxy.scrollTo(Self.outputBottomID, anchor: .bottom)
+            }
             .overlay(alignment: .bottomTrailing) {
                 if monitor.hasNewOutput {
-                    Button("New Output", systemImage: "arrow.down") {
+                    Button("Jump to latest", systemImage: "arrow.down") {
                         monitor.jumpToLatestOutput()
-                        withAnimation(.snappy) {
-                            proxy.scrollTo(Self.outputBottomID, anchor: .bottom)
-                        }
+                        proxy.scrollTo(Self.outputBottomID, anchor: .bottom)
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
-                    .padding()
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .padding(20)
                 }
             }
         }
@@ -239,8 +278,9 @@ struct AgentDetailView: View {
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
             case .unavailable:
                 historyMarkerLabel(
                     "History unavailable while the Agent works",
@@ -259,8 +299,8 @@ struct AgentDetailView: View {
                         .font(.footnote)
                 }
                 .frame(maxWidth: .infinity)
-                .padding(.horizontal)
-                .padding(.vertical, 10)
+                .padding(12)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
             case .idle:
                 EmptyView()
             }
@@ -271,42 +311,96 @@ struct AgentDetailView: View {
         Label(text, systemImage: systemImage)
             .font(.footnote)
             .foregroundStyle(.secondary)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
     }
 
-    private var statusHeader: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 8) {
-                Text("Agent output")
-                    .font(.subheadline.weight(.semibold))
-                AgentStatusBadge(status: monitor.agentStatus)
-                Spacer(minLength: 8)
-                if let capturedAt = monitor.capturedAt {
-                    Label(
-                        "Updated \(capturedAt.formatted(date: .omitted, time: .standard))",
-                        systemImage: "clock")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
+    private var monitorHeader: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .center, spacing: 12) {
+                    monitorIdentity
+                    Spacer(minLength: 12)
+                    attachButton
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    monitorIdentity
+                    attachButton
                 }
             }
+
             if !monitor.liveUpdatesAvailable {
                 liveUpdatesUnavailableLabel
             }
-            if case .failed(let message) = monitor.state {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Label(message, systemImage: "exclamationmark.triangle")
+            if monitor.snapshot != nil, case .failed(let message) = monitor.state {
+                HStack(alignment: .center, spacing: 8) {
+                    Label(
+                        "Refresh failed. Showing the last snapshot. \(message)",
+                        systemImage: "exclamationmark.triangle")
                         .font(.footnote)
-                        .foregroundStyle(.secondary)
                     Spacer(minLength: 8)
-                    Button("Retry") { Task { await monitor.retry() } }
+                    Button("Try again") { Task { await monitor.retry() } }
                         .font(.footnote)
                 }
+                .padding(12)
+                .background(
+                    Color.orange.opacity(0.12),
+                    in: RoundedRectangle(cornerRadius: 12))
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal)
-        .padding(.vertical, 10)
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color(uiColor: .secondarySystemGroupedBackground))
+    }
+
+    private var monitorIdentity: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Monitor")
+                .font(.headline)
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 8) {
+                    AgentStatusBadge(status: monitor.agentStatus)
+                    snapshotFreshness
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    AgentStatusBadge(status: monitor.agentStatus)
+                    snapshotFreshness
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var snapshotFreshness: some View {
+        if let capturedAt = monitor.capturedAt {
+            Label(
+                "Updated \(capturedAt.formatted(date: .omitted, time: .shortened))",
+                systemImage: "clock")
+                .font(.caption)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+        } else {
+            Text("Waiting for the first snapshot")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var attachButton: some View {
+        Button("Attach", systemImage: "terminal") {
+            monitor.attachDidOpen()
+            isShowingAttach = true
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.regular)
+        .frame(minHeight: 44)
+        .accessibilityHint("Opens the live terminal")
     }
 
     private var title: String {
@@ -315,10 +409,12 @@ struct AgentDetailView: View {
 
     private var liveUpdatesUnavailableLabel: some View {
         Label(
-            "Live updates unavailable. Pull to refresh.",
+            "Updates are paused. Pull down to refresh.",
             systemImage: "wifi.slash")
             .font(.footnote)
-            .foregroundStyle(.secondary)
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
     }
 
     private static let outputBottomID = "agent-monitor-output-bottom"

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -119,8 +119,8 @@ struct AgentDetailView: View {
     private var monitorSurface: some View {
         VStack(spacing: 0) {
             monitorHeader
-            if let snapshot = monitor.snapshot {
-                if snapshot.characters.isEmpty {
+            if monitor.hasSnapshot {
+                if monitor.isSnapshotEmpty {
                     ScrollView(.vertical) {
                         VStack(spacing: 16) {
                             ContentUnavailableView {
@@ -141,7 +141,7 @@ struct AgentDetailView: View {
                     }
                     .refreshable { await monitor.refresh() }
                 } else {
-                    snapshotScrollView(snapshot)
+                    snapshotScrollView()
                 }
             } else {
                 switch monitor.state {
@@ -180,7 +180,7 @@ struct AgentDetailView: View {
         .background(Color(uiColor: .systemGroupedBackground))
     }
 
-    private func snapshotScrollView(_: AttributedString) -> some View {
+    private func snapshotScrollView() -> some View {
         ScrollViewReader { proxy in
             ScrollView(.vertical) {
                 VStack(alignment: .leading, spacing: 12) {
@@ -188,7 +188,7 @@ struct AgentDetailView: View {
                     Text("Agent output")
                         .font(.subheadline.weight(.semibold))
                         .accessibilityAddTraits(.isHeader)
-                    VStack(alignment: .leading, spacing: 0) {
+                    VStack(alignment: .leading, spacing: 3) {
                         ForEach(monitor.snapshotSegments) { segment in
                             if let accessibilityLabel = segment.accessibilityLabel {
                                 Text(segment.text)
@@ -345,7 +345,7 @@ struct AgentDetailView: View {
             if !monitor.liveUpdatesAvailable {
                 liveUpdatesUnavailableLabel
             }
-            if monitor.snapshot != nil, case .failed(let message) = monitor.state {
+            if monitor.hasSnapshot, case .failed(let message) = monitor.state {
                 HStack(alignment: .center, spacing: 8) {
                     Label(
                         "Refresh failed. Showing the last snapshot. \(message)",

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -180,7 +180,7 @@ struct AgentDetailView: View {
         .background(Color(uiColor: .systemGroupedBackground))
     }
 
-    private func snapshotScrollView(_ snapshot: AttributedString) -> some View {
+    private func snapshotScrollView(_: AttributedString) -> some View {
         ScrollViewReader { proxy in
             ScrollView(.vertical) {
                 VStack(alignment: .leading, spacing: 12) {
@@ -188,7 +188,18 @@ struct AgentDetailView: View {
                     Text("Agent output")
                         .font(.subheadline.weight(.semibold))
                         .accessibilityAddTraits(.isHeader)
-                    Text(snapshot)
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(monitor.snapshotSegments) { segment in
+                            if let accessibilityLabel = segment.accessibilityLabel {
+                                Text(segment.text)
+                                    .accessibilityElement(children: .ignore)
+                                    .accessibilityLabel(accessibilityLabel)
+                            } else {
+                                Text(segment.text)
+                                    .accessibilityElement(children: .combine)
+                            }
+                        }
+                    }
                         .font(.system(.callout, design: .monospaced))
                         .lineSpacing(3)
                         .foregroundStyle(.white)

--- a/Sources/Heeler/Monitor/AgentMonitorView.swift
+++ b/Sources/Heeler/Monitor/AgentMonitorView.swift
@@ -176,7 +176,8 @@ struct AgentDetailView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     historyTopMarker
                     Text(snapshot)
-                        .font(.system(.body, design: .monospaced))
+                        .font(.system(.callout, design: .monospaced))
+                        .lineSpacing(3)
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .topLeading)
                         .padding()
@@ -276,7 +277,9 @@ struct AgentDetailView: View {
 
     private var statusHeader: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
+            HStack(spacing: 8) {
+                Text("Agent output")
+                    .font(.subheadline.weight(.semibold))
                 AgentStatusBadge(status: monitor.agentStatus)
                 Spacer(minLength: 8)
                 if let capturedAt = monitor.capturedAt {

--- a/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
+++ b/Sources/Heeler/Monitor/MonitorControlKeyStrip.swift
@@ -1,35 +1,51 @@
 import SwiftUI
 
-/// Monitor's horizontal control-key strip (#183): Enter, Esc, Ctrl+C, and
-/// the four arrows. Self-contained so package #180 can attach elsewhere
-/// without reshaping the rest of the Monitor surface. Spellings live on
+/// Monitor's compact control-key row (#183). The three prompt actions stay
+/// one tap away; directional keys live behind an explicit menu so narrow
+/// layouts never hide controls offscreen. Spellings live on
 /// ``MonitorControlKey``; this view only presents the buttons.
 struct MonitorControlKeyStrip: View {
     let isEnabled: Bool
     let onTap: (MonitorControlKey) -> Void
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                ForEach(MonitorControlKey.allCases) { key in
+        HStack(spacing: 8) {
+            ForEach(Self.quickKeys) { key in
+                Button {
+                    onTap(key)
+                } label: {
+                    keyLabel(key)
+                        .font(.callout.weight(.medium))
+                        .frame(minWidth: 44, minHeight: 44)
+                        .padding(.horizontal, 4)
+                }
+                .buttonStyle(.bordered)
+                .disabled(!isEnabled)
+                .accessibilityLabel(key.accessibilityLabel)
+            }
+
+            Spacer(minLength: 0)
+
+            Menu {
+                ForEach(Self.arrowKeys) { key in
                     Button {
                         onTap(key)
                     } label: {
-                        keyLabel(key)
-                            .font(.callout.weight(.medium))
-                            .frame(minWidth: 44, minHeight: 36)
-                            .padding(.horizontal, 4)
+                        Label(key.accessibilityLabel, systemImage: key.systemImage ?? "arrow.up")
                     }
-                    .buttonStyle(.bordered)
                     .disabled(!isEnabled)
-                    .accessibilityLabel(key.accessibilityLabel)
                 }
+            } label: {
+                Image(systemName: "arrow.up.and.down.and.arrow.left.and.right")
+                    .font(.callout.weight(.medium))
+                    .frame(minWidth: 44, minHeight: 44)
             }
-            .padding(.horizontal, 1)
+            .buttonStyle(.bordered)
+            .disabled(!isEnabled)
+            .accessibilityLabel("Directional keys")
+            .accessibilityHint("Shows directional keys")
         }
-        .padding(.horizontal)
-        .padding(.vertical, 8)
-        .background(.bar)
+        .dynamicTypeSize(...DynamicTypeSize.large)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Control keys")
     }
@@ -42,4 +58,12 @@ struct MonitorControlKeyStrip: View {
             Text(label)
         }
     }
+
+    private static let quickKeys: [MonitorControlKey] = [
+        .enter, .escape, .interrupt,
+    ]
+
+    private static let arrowKeys: [MonitorControlKey] = [
+        .up, .down, .left, .right,
+    ]
 }

--- a/Tests/HeelerTests/ANSISnapshotRendererTests.swift
+++ b/Tests/HeelerTests/ANSISnapshotRendererTests.swift
@@ -290,6 +290,28 @@ struct ANSISnapshotRendererTests {
         #expect(rendered.runs.first?.backgroundColor == nil)
     }
 
+    @Test func removesBackgroundColorFromRunPadding() {
+        let rendered = ANSISnapshotRenderer.render(
+            "\u{1B}[48;5;232m    message    \u{1B}[0m")
+        let runs = rendered.runs.map { run in
+            (
+                text: String(rendered.characters[run.range]),
+                background: run.backgroundColor
+            )
+        }
+
+        #expect(String(rendered.characters) == "    message    ")
+        #expect(runs.count == 3)
+        #expect(runs[0].text == "    ")
+        #expect(runs[0].background == nil)
+        #expect(runs[1].text == "message")
+        #expect(
+            runs[1].background
+                == Color(red: 8.0 / 255.0, green: 8.0 / 255.0, blue: 8.0 / 255.0))
+        #expect(runs[2].text == "    ")
+        #expect(runs[2].background == nil)
+    }
+
     private func assertFixture(_ fixture: Fixture) {
         let rendered = ANSISnapshotRenderer.render(String(decoding: fixture.bytes, as: UTF8.self))
         #expect(String(rendered.characters) == fixture.text, "\(fixture.name): text")

--- a/Tests/HeelerTests/ANSISnapshotRendererTests.swift
+++ b/Tests/HeelerTests/ANSISnapshotRendererTests.swift
@@ -246,7 +246,7 @@ struct ANSISnapshotRendererTests {
         fixtures.forEach(assertFixture)
     }
 
-    @Test func preservesBoxDrawingMultibyteTextAndLineStructure() {
+    @Test func filtersDecorativeBoxLinesAndPreservesMultibyteContent() {
         let fixture = Fixture(
             name: "box drawing CJK emoji and newlines",
             bytes: [
@@ -256,14 +256,38 @@ struct ANSISnapshotRendererTests {
                 0x1B, 0x5B, 0x30, 0x6D, 0xE2, 0x94, 0x82, 0x0A,
                 0xE2, 0x94, 0x94, 0xE2, 0x94, 0x80, 0xE2, 0x94, 0x98,
             ],
-            text: "┌─┐\n│你🐝│\n└─┘",
+            text: "│你🐝│",
             runs: [
-                ExpectedRun(text: "┌─┐\n│"),
+                ExpectedRun(text: "│"),
                 ExpectedRun(text: "你🐝", foreground: RGB(0x00, 0x80, 0x00)),
-                ExpectedRun(text: "│\n└─┘"),
+                ExpectedRun(text: "│"),
             ])
 
         assertFixture(fixture)
+    }
+
+    @Test func removesDecorationOnlyBoxDrawingLines() {
+        let rendered = ANSISnapshotRenderer.render(
+            "before\r\n────────────────\r\n│ useful content │\r\n└──────────────┘\r\nafter")
+
+        #expect(String(rendered.characters) == "before\n│ useful content │\nafter")
+    }
+
+    @Test func trimsLongDecorativeEdgesFromContentLines() {
+        let rendered = ANSISnapshotRenderer.render(
+            "──── heading\r\n─ Worked for 1m 33s ─────────────\r\n│ useful content │")
+
+        #expect(
+            String(rendered.characters)
+                == "heading\n─ Worked for 1m 33s\n│ useful content │")
+    }
+
+    @Test func removesBackgroundColorFromWhitespaceOnlyRuns() {
+        let rendered = ANSISnapshotRenderer.render(
+            "\u{1B}[48;5;232m        \u{1B}[0m\nmessage")
+
+        #expect(String(rendered.characters) == "        \nmessage")
+        #expect(rendered.runs.first?.backgroundColor == nil)
     }
 
     private func assertFixture(_ fixture: Fixture) {

--- a/Tests/HeelerTests/AgentMonitorHistoryTests.swift
+++ b/Tests/HeelerTests/AgentMonitorHistoryTests.swift
@@ -139,6 +139,63 @@ struct AgentMonitorHistoryTests {
             ])
     }
 
+    @Test func wrappedBackfillContainmentReflowsMidWindow() {
+        var history = AgentMonitorHistory()
+        history.applyVisible(
+            "screen one wra\nps across rows\nscreen two\nscreen three")
+
+        let outcome = history.stitchBackfill(
+            [
+                "older",
+                "screen one wraps across rows",
+                "screen two",
+                "screen three",
+                "newer one",
+                "newer two",
+            ].joined(separator: "\n"))
+
+        #expect(outcome == .init(newLines: 3, insertedGap: false))
+        #expect(
+            history.segments == [
+                .lines(["older", "screen one wraps across rows", "screen two"]),
+                .lines(["screen three", "newer one", "newer two"]),
+            ])
+    }
+
+    @Test func visibleTopContinuationIsAbsorbedWithoutDuplication() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("continuation\nsecond logical line\nthird logical line")
+
+        let outcome = history.stitchBackfill(
+            [
+                "older",
+                "full logical line continuation",
+                "second logical line",
+                "third logical line",
+            ].joined(separator: "\n"))
+
+        #expect(outcome == .init(newLines: 2, insertedGap: false))
+        #expect(
+            history.segments == [
+                .lines(["older"]),
+                .lines([
+                    "full logical line continuation",
+                    "second logical line",
+                    "third logical line",
+                ]),
+            ])
+    }
+
+    @Test func tinyContinuationScreenDoesNotCreateAGap() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("continuation")
+
+        let outcome = history.stitchBackfill("full logical line continuation")
+
+        #expect(outcome == .init(newLines: 1, insertedGap: false))
+        #expect(history.segments == [.lines(["full logical line continuation"])])
+    }
+
     @Test func backfillWithoutSharedContentRecordsAGap() {
         var history = AgentMonitorHistory()
         history.applyVisible("stale a\nstale b\nstale c")

--- a/Tests/HeelerTests/AgentMonitorHistoryTests.swift
+++ b/Tests/HeelerTests/AgentMonitorHistoryTests.swift
@@ -124,18 +124,19 @@ struct AgentMonitorHistoryTests {
             ])
     }
 
-    @Test func backfillSupersedesTheTailWhenTheWindowContainsIt() {
+    @Test func backfillContainmentPreservesExactLiveTail() {
         var history = AgentMonitorHistory()
         history.applyVisible("s1\ns2\ns3\ns4")
 
-        // Output raced the read: the tail sits mid-window, not at its end.
-        // The read is the better truth for the whole region.
+        // Output raced the read: the cached screen sits mid-window. Only the
+        // older prefix can be placed without replacing exact live geometry;
+        // a subsequent visible read will reconcile the newer tail.
         let outcome = history.stitchBackfill("o1\ns1\ns2\ns3\ns4\nn1\nn2")
-        #expect(outcome == .init(newLines: 3, insertedGap: false))
+        #expect(outcome == .init(newLines: 1, insertedGap: false))
         #expect(
             history.segments == [
-                .lines(["o1", "s1", "s2"]),
-                .lines(["s3", "s4", "n1", "n2"]),
+                .lines(["o1"]),
+                .lines(["s1", "s2", "s3", "s4"]),
             ])
     }
 
@@ -154,11 +155,16 @@ struct AgentMonitorHistoryTests {
                 "newer two",
             ].joined(separator: "\n"))
 
-        #expect(outcome == .init(newLines: 3, insertedGap: false))
+        #expect(outcome == .init(newLines: 1, insertedGap: false))
         #expect(
             history.segments == [
-                .lines(["older", "screen one wraps across rows", "screen two"]),
-                .lines(["screen three", "newer one", "newer two"]),
+                .lines(["older"]),
+                .lines([
+                    "screen one wra",
+                    "ps across rows",
+                    "screen two",
+                    "screen three",
+                ]),
             ])
     }
 
@@ -177,13 +183,17 @@ struct AgentMonitorHistoryTests {
         #expect(outcome == .init(newLines: 2, insertedGap: false))
         #expect(
             history.segments == [
-                .lines(["older"]),
+                .lines(["older", "full logical line "]),
                 .lines([
-                    "full logical line continuation",
+                    "continuation",
                     "second logical line",
                     "third logical line",
                 ]),
             ])
+        #expect(
+            history.applyVisible("continuation\nsecond logical line\nthird logical line")
+                == .unchanged)
+        #expect(!history.segments.contains(.gap))
     }
 
     @Test func tinyContinuationScreenDoesNotCreateAGap() {
@@ -193,7 +203,50 @@ struct AgentMonitorHistoryTests {
         let outcome = history.stitchBackfill("full logical line continuation")
 
         #expect(outcome == .init(newLines: 1, insertedGap: false))
-        #expect(history.segments == [.lines(["full logical line continuation"])])
+        #expect(
+            history.segments == [
+                .lines(["full logical line "]),
+                .lines(["continuation"]),
+            ])
+    }
+
+    @Test func largeWrappedScreenRemainsStableAfterPartialBoundaryStitch() {
+        var history = AgentMonitorHistory()
+        let visible = [
+            "continuation", "second logical line", "third logical line",
+            "fourth logical line", "fifth logical line",
+        ].joined(separator: "\n")
+        history.applyVisible(visible)
+
+        let outcome = history.stitchBackfill(
+            [
+                "older",
+                "full logical line continuation",
+                "second logical line",
+                "third logical line",
+                "fourth logical line",
+                "fifth logical line",
+            ].joined(separator: "\n"))
+
+        #expect(outcome == .init(newLines: 2, insertedGap: false))
+        #expect(history.applyVisible(visible) == .unchanged)
+        #expect(!history.segments.contains(.gap))
+        #expect(history.newestLines == AgentMonitorHistory.splitLines(visible))
+    }
+
+    @Test func shortBlankContainmentDoesNotResplitTheLiveScreen() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("\n\n")
+
+        let outcome = history.stitchBackfill("older\n\n\nnewer")
+
+        #expect(outcome == .init(newLines: 4, insertedGap: true))
+        #expect(
+            history.segments == [
+                .lines(["older", "", "", "newer"]),
+                .gap,
+                .lines(["", ""]),
+            ])
     }
 
     @Test func backfillWithoutSharedContentRecordsAGap() {

--- a/Tests/HeelerTests/AgentMonitorHistoryTests.swift
+++ b/Tests/HeelerTests/AgentMonitorHistoryTests.swift
@@ -60,6 +60,70 @@ struct AgentMonitorHistoryTests {
         #expect(history.newestLines == ["s1", "s2", "s3", "s4"])
     }
 
+    @Test func unwrappedBackfillStitchesToWrappedVisibleRows() {
+        var history = AgentMonitorHistory()
+        history.applyVisible(
+            [
+                "first logical line wra   ",
+                "ps across rows",
+                "second logical line",
+                "third logical line",
+            ].joined(separator: "\n"))
+
+        let outcome = history.stitchBackfill(
+            [
+                "older logical line",
+                "first logical line wraps across rows",
+                "second logical line",
+                "third logical line",
+            ].joined(separator: "\n"))
+
+        #expect(outcome == .init(newLines: 1, insertedGap: false))
+        #expect(
+            history.segments == [
+                .lines(["older logical line"]),
+                .lines([
+                    "first logical line wra   ",
+                    "ps across rows",
+                    "second logical line",
+                    "third logical line",
+                ]),
+            ])
+    }
+
+    @Test func wrapWidthDifferenceDeduplicatesTheWholeBoundary() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("abcdefgh\nijklmnop\nqrstuvwx")
+
+        let outcome = history.stitchBackfill("abcdefghijklmnop\nqrstuvwx")
+
+        #expect(outcome == .init(newLines: 0, insertedGap: false))
+        #expect(
+            history.segments == [
+                .lines(["abcdefgh", "ijklmnop", "qrstuvwx"])
+            ])
+    }
+
+    @Test func disjointUnwrappedBackfillStillRecordsAGap() {
+        var history = AgentMonitorHistory()
+        history.applyVisible("cached line wraps\nhere\nand ends")
+
+        let outcome = history.stitchBackfill(
+            "different logical line\nanother logical line\nnewest logical line")
+
+        #expect(outcome == .init(newLines: 3, insertedGap: true))
+        #expect(
+            history.segments == [
+                .lines([
+                    "different logical line",
+                    "another logical line",
+                    "newest logical line",
+                ]),
+                .gap,
+                .lines(["cached line wraps", "here", "and ends"]),
+            ])
+    }
+
     @Test func backfillSupersedesTheTailWhenTheWindowContainsIt() {
         var history = AgentMonitorHistory()
         history.applyVisible("s1\ns2\ns3\ns4")

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -300,6 +300,8 @@ struct AgentMonitorStoreTests {
 
         #expect(store.state == .loaded)
         #expect(store.capturedAt == capturedAt)
+        #expect(store.hasSnapshot)
+        #expect(!store.isSnapshotEmpty)
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "plain red")
         #expect(
@@ -392,6 +394,7 @@ struct AgentMonitorStoreTests {
         await store.open()
 
         #expect(store.state == .failed("herdr rejected the snapshot: agent is working"))
+        #expect(!store.hasSnapshot)
         #expect(store.snapshot == nil)
 
         await transport.setAgentReadFailure(nil)
@@ -399,6 +402,8 @@ struct AgentMonitorStoreTests {
         await store.retry()
 
         #expect(store.state == .loaded)
+        #expect(store.hasSnapshot)
+        #expect(!store.isSnapshotEmpty)
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == "recovered")
         #expect(await agentReads(transport, source: .visible).count == 2)
@@ -572,7 +577,7 @@ struct AgentMonitorStoreTests {
         #expect(gap.accessibilityLabel == "Content not captured")
     }
 
-    @Test func renderedSegmentIDsSurviveHistoryPrepending() async throws {
+    @Test func renderedTailSegmentIDSurvivesHistoryPrepending() async throws {
         let transport = ScriptedTransport()
         await transport.setAgentText("screen 1\nscreen 2\nscreen 3", target: "w1:p1")
         let store = AgentMonitorStore(
@@ -697,6 +702,8 @@ struct AgentMonitorStoreTests {
         await store.open()
 
         #expect(store.state == .loaded)
+        #expect(store.hasSnapshot)
+        #expect(store.isSnapshotEmpty)
         let snapshot = try #require(store.snapshot)
         #expect(snapshot.characters.isEmpty)
         #expect(store.historyState == .exhausted)

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -619,6 +619,33 @@ struct AgentMonitorStoreTests {
                 == Color(red: 128.0 / 255.0, green: 0, blue: 0))
     }
 
+    @Test func decorationOnlyAccessibilityChunkDoesNotShiftFollowingSlices() async throws {
+        let transport = ScriptedTransport()
+        let visibleLines = ["screen 1", "screen 2", "screen 3"]
+        let olderLines = (1...40).map { "older \($0)" }
+        await transport.setAgentText(
+            visibleLines.joined(separator: "\n"), target: "w1:p1")
+        await transport.setAgentHistoryText(
+            (["────"] + olderLines + visibleLines).joined(separator: "\n"),
+            target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        #expect(store.snapshotSegments.map(\.kind) == [.content, .content])
+        #expect(
+            store.snapshotSegments.map { String($0.text.characters) }
+                == [
+                    olderLines.joined(separator: "\n"),
+                    visibleLines.joined(separator: "\n"),
+                ])
+        #expect(
+            String(try #require(store.snapshot).characters)
+                == (olderLines + visibleLines).joined(separator: "\n"))
+    }
+
     @Test func largeHistoryUsesBoundedAccessibilitySegments() async throws {
         let transport = ScriptedTransport()
         let allLines = (1...85).map { "line \($0)" }

--- a/Tests/HeelerTests/AgentMonitorStoreTests.swift
+++ b/Tests/HeelerTests/AgentMonitorStoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import Testing
 
 @testable import Heeler
@@ -47,7 +48,7 @@ struct AgentMonitorStoreTests {
         #expect(await idleClock.pendingSleepCount == 0)
         // One visible snapshot plus the one idle backfill on open (#181).
         #expect(await agentReads(idleTransport, source: .visible).count == 1)
-        #expect(await agentReads(idleTransport, source: .recent).count == 1)
+        #expect(await agentReads(idleTransport, source: .recentUnwrapped).count == 1)
 
         let workingTransport = ScriptedTransport()
         let workingClock = ManualAgentMonitorClock()
@@ -312,9 +313,9 @@ struct AgentMonitorStoreTests {
         // The idle open also backfills once (#181); the scripted window
         // equals the screen, so nothing new lands and history is exhausted.
         #expect(
-            await agentReads(transport, source: .recent) == [
+            await agentReads(transport, source: .recentUnwrapped) == [
                 AgentReadParams(
-                    source: .recent,
+                    source: .recentUnwrapped,
                     target: "w1:p1",
                     format: .ansi,
                     lines: AgentMonitorStore.historyLineCount,
@@ -443,7 +444,7 @@ struct AgentMonitorStoreTests {
             String(snapshot.characters) == "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3")
         #expect(store.historyState == .exhausted)
         #expect(await agentReads(transport, source: .visible).count == 1)
-        #expect(await agentReads(transport, source: .recent).count == 1)
+        #expect(await agentReads(transport, source: .recentUnwrapped).count == 1)
     }
 
     @Test func openWhileWorkingSkipsBackfillAndTopEdgeStaysHonest() async throws {
@@ -500,7 +501,7 @@ struct AgentMonitorStoreTests {
         let snapshot = try #require(store.snapshot)
         #expect(
             String(snapshot.characters) == "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3")
-        #expect(await agentReads(transport, source: .recent).count == 1)
+        #expect(await agentReads(transport, source: .recentUnwrapped).count == 1)
     }
 
     @Test func repeatBackfillAtTheCaptureLimitEndsHistory() async throws {
@@ -525,7 +526,7 @@ struct AgentMonitorStoreTests {
             store.historyState == .exhausted
         }
         #expect(String(try #require(store.snapshot).characters) == window)
-        #expect(await agentReads(transport, source: .recent).count == 2)
+        #expect(await agentReads(transport, source: .recentUnwrapped).count == 2)
     }
 
     @Test func unstitchableReadInsertsAnExplicitGapMarker() async throws {
@@ -547,6 +548,93 @@ struct AgentMonitorStoreTests {
         ].joined(separator: "\n")
         #expect(String(try #require(store.snapshot).characters) == expected)
         #expect(store.historyState == .exhausted)
+    }
+
+    @Test func renderedSnapshotSeparatesContentAndGapAccessibility() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("older screen", target: "w1:p1")
+        let store = AgentMonitorStore(
+            target: "w1:p1", initialStatus: .working
+        ) { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+
+        await transport.setAgentText("live screen", target: "w1:p1")
+        await store.refresh()
+
+        #expect(store.snapshotSegments.map(\.kind) == [.content, .gap, .content])
+        #expect(
+            store.snapshotSegments.map { String($0.text.characters) }
+                == ["older screen", AgentMonitorStore.gapMarkerText, "live screen"])
+        let gap = try #require(store.snapshotSegments.first { $0.kind == .gap })
+        #expect(String(gap.text.characters) == AgentMonitorStore.gapMarkerText)
+        #expect(gap.accessibilityLabel == "Content not captured")
+    }
+
+    @Test func renderedSegmentIDsSurviveHistoryPrepending() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("screen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        let store = AgentMonitorStore(
+            target: "w1:p1", initialStatus: .working
+        ) { params in
+            try await transport.readAgent(params)
+        }
+        await store.open()
+        let initialIDs = store.snapshotSegments.map(\.id)
+
+        await store.agentStatusDidChange(.idle)
+        await transport.setAgentHistoryText(
+            "older 1\nolder 2\nscreen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        await store.loadEarlierHistory()
+
+        #expect(store.snapshotSegments.map(\.kind) == [.content, .content])
+        #expect(store.snapshotSegments.last?.id == initialIDs.first)
+        #expect(
+            store.snapshotSegments.map { String($0.text.characters) }
+                == ["older 1\nolder 2", "screen 1\nscreen 2\nscreen 3"])
+    }
+
+    @Test func contiguousHistoryAndLiveShareANSIState() async throws {
+        let transport = ScriptedTransport()
+        await transport.setAgentText("screen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        await transport.setAgentHistoryText(
+            "\u{1B}[31molder\nscreen 1\nscreen 2\nscreen 3", target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        let content = try #require(store.snapshotSegments.last)
+        #expect(store.snapshotSegments.count == 2)
+        #expect(content.kind == .content)
+        #expect(
+            content.text.runs.last?.foregroundColor
+                == Color(red: 128.0 / 255.0, green: 0, blue: 0))
+    }
+
+    @Test func largeHistoryUsesBoundedAccessibilitySegments() async throws {
+        let transport = ScriptedTransport()
+        let allLines = (1...85).map { "line \($0)" }
+        await transport.setAgentText(
+            allLines.suffix(3).joined(separator: "\n"), target: "w1:p1")
+        await transport.setAgentHistoryText(
+            allLines.joined(separator: "\n"), target: "w1:p1")
+        let store = AgentMonitorStore(target: "w1:p1") { params in
+            try await transport.readAgent(params)
+        }
+
+        await store.open()
+
+        #expect(store.snapshotSegments.count == 4)
+        #expect(store.snapshotSegments.allSatisfy { $0.kind == .content })
+        for segment in store.snapshotSegments {
+            let lineCount = String(segment.text.characters).split(
+                separator: "\n", omittingEmptySubsequences: false
+            ).count
+            #expect(lineCount <= AgentMonitorStore.maximumAccessibleSegmentLines)
+        }
     }
 
     @Test func agentNotIdleSurfacesAsUnavailableNeverAnError() async throws {
@@ -571,7 +659,7 @@ struct AgentMonitorStoreTests {
             store.historyState == .unavailable
         }
         #expect(store.state == .loaded)
-        #expect(await agentReads(transport, source: .recent).count == 2)
+        #expect(await agentReads(transport, source: .recentUnwrapped).count == 2)
     }
 
     @Test func failedBackfillSurfacesARetryableError() async throws {
@@ -637,7 +725,7 @@ struct AgentMonitorStoreTests {
         }
         store.topEdgeReached()
         #expect(store.historyState == .loading)
-        #expect(await agentReads(transport, source: .recent).count == 1)
+        #expect(await agentReads(transport, source: .recentUnwrapped).count == 1)
 
         await gate.open()
         await refreshing.value
@@ -645,7 +733,7 @@ struct AgentMonitorStoreTests {
             store.historyState == .exhausted
         }
 
-        #expect(await agentReads(transport, source: .recent).count == 2)
+        #expect(await agentReads(transport, source: .recentUnwrapped).count == 2)
         let snapshot = try #require(store.snapshot)
         #expect(String(snapshot.characters) == window)
         #expect(!String(snapshot.characters).contains(AgentMonitorStore.gapMarkerText))
@@ -707,7 +795,7 @@ struct AgentMonitorStoreTests {
             store.historyState == .exhausted
         }
 
-        #expect(await agentReads(transport, source: .recent).count == 2)
+        #expect(await agentReads(transport, source: .recentUnwrapped).count == 2)
         #expect(
             String(try #require(store.snapshot).characters)
                 == [

--- a/Tests/HeelerTests/HeelerSSHSessionE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHSessionE2ETests.swift
@@ -262,11 +262,11 @@ struct HeelerSSHSessionE2ETests {
         }
     }
 
-    /// Same phase-gate sequence as cancellation: force the deadline past while
-    /// allocation is held so cleanup is always uncertain, then hold cleanup past
-    /// its two-second budget so invalidation is deterministic.
-    @Test("deadline completes promptly and invalidates uncertain cleanup")
-    func deadlineInvalidatesUncertainCleanup() async throws {
+    /// Inject timeout only after allocation, then hold cleanup past its
+    /// two-second budget. This keeps setup scheduling outside the failure
+    /// trigger while exercising the real allocated-channel cleanup path.
+    @Test("allocated exec timeout completes promptly and invalidates uncertain cleanup")
+    func allocatedExecTimeoutInvalidatesUncertainCleanup() async throws {
         let environment = try #require(HeelerSSHTestEnvironment.current)
         let connection = try await environment.connect()
 
@@ -275,21 +275,20 @@ struct HeelerSSHSessionE2ETests {
             let cleanup = SessionPhaseGate()
             await connection.holdNextExecChannelAllocationForTesting {
                 await allocated.waitUntilReleased()
+                throw SSHError.timedOut
             }
             await connection.holdNextExecCleanupForTesting {
                 await cleanup.waitUntilReleased()
             }
 
             let command = Task {
-                try await connection.execute("sleep 30", timeout: .milliseconds(150))
+                try await connection.execute("sleep 30", timeout: .seconds(40))
             }
-            try await waitUntilPhase("deadline should allocate its channel") {
+            try await waitUntilPhase("timeout should allocate its channel") {
                 await allocated.hasEntered
             }
-            // Let the 150ms execute budget expire while allocation is held.
-            try await Task.sleep(for: .milliseconds(200))
             await allocated.release()
-            try await waitUntilPhase("deadline should enter catch cleanup") {
+            try await waitUntilPhase("timeout should enter catch cleanup") {
                 await cleanup.hasEntered
             }
             try await Task.sleep(for: .milliseconds(2_100))


### PR DESCRIPTION
Part of the Monitor conversational refactor round (refs #179). This PR owns history reflow and snapshot structure: findings #3 and #8 of the interface review.

## Changes

- **Unwrapped history reads**: backfill switches from `recent` (hard-wrapped grid rows) to `recent_unwrapped` logical lines, so history reflows naturally at display width instead of shattering at the pane's 80-column wraps. The visible screen stays a `visible` grid read.
- **Reflow-aware overlap stitching**: `AgentMonitorHistory` reconciles unwrapped logical lines against wrapped cached rows by concatenation matching with strict conservatism (whole-boundary or >=3-line continuity proof; genuine non-overlap still records the honest gap marker per ADR 0012). The live segment always keeps exact visible-read geometry; a logical line whose tail rows are on screen contributes only its missing prefix to history — no duplication, no spurious gaps on the follow-up read.
- **Segmented snapshot for VoiceOver**: the monolithic up-to-1000-line snapshot becomes an ordered list of rendered segments (content chunks bounded at 40 lines, gap markers as their own labeled rows, "Content not captured"), each its own accessibility element. ANSI continuity is preserved by rendering contiguous runs whole and slicing, in O(total length); scroll anchoring, bottom-pinning, and new-output behavior are unchanged.

## Merge order

Last of three PRs sharing base d041e9f: merge after #192 (ansi-fidelity) and #191 (conversational chrome), then rebase this branch on main to resolve the expected overlap in `AgentMonitorView.snapshotScrollView` and `AgentMonitorStore` before merging.

## Test evidence

`xcodebuild test -only-testing:HeelerTests/AgentMonitorHistoryTests -only-testing:HeelerTests/AgentMonitorStoreTests` on iPhone 17 simulator: **54 tests in 2 suites passed** (wrapped/unwrapped stitch vectors, partial-boundary regression with follow-up visible read, containment threshold, decoration-chunk slicing, segment shape/ID/gap-label coverage).

Review: three internal rounds (round 1 sent back on a containment-path spurious-gap violation and two hot-path performance regressions; round 2's fix introduced a live-segment geometry regression, fixed in round 3 by preserving live rows outright — the reviewer replayed all vectors by hand each round).

Known trades (reviewed, accepted): a mid-window containment defers raced-ahead lines to the next visible refresh; cross-segment text selection is lost to the accessibility split; the `recent_unwrapped` line-count unit is an explicitly flagged unverified assumption in code comments.

CHANGELOG entry for the round lands as a follow-up after all three PRs merge.