### PR TITLE
feat(composer): add attachment actions and terminal chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Entries reference the issue that motivated them.
 
 ### Added
 
+- Agent detail now places a plus menu to the left of Send. It can add an image
+  from Photos or a file up to 64 MiB from Files, stages the selection privately
+  on the Host over SFTP, and inserts the resulting path into the local draft
+  without submitting it. Links and the former title-bar Agent actions now live
+  in the same menu, leaving the navigation title uncluttered. (#182)
+
 - Agent detail now combines the complete live libghostty terminal with a local
   Composer. The terminal preserves TUI rendering, scrollback, and PTY resize,
   including touch scrolling in alternate-screen TUIs, but no longer accepts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Entries reference the issue that motivated them.
   without submitting it. Discovered Links appear beside the plus menu, while
   the former title-bar Agent actions live inside it. Agent detail keeps only an
   omits Agent detail's title bar so terminal output uses the full area below
-  the system status bar, while preserving edge-swipe navigation. (#182)
+  the system status bar, while preserving edge-swipe navigation and matching
+  status-bar contrast to the terminal theme. (#182)
 
 - Agent detail now combines the complete live libghostty terminal with a local
   Composer. The terminal preserves TUI rendering, scrollback, and PTY resize,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Entries reference the issue that motivated them.
   on the Host over SFTP, and inserts the resulting path into the local draft
   without submitting it. Discovered Links appear beside the plus menu, while
   the former title-bar Agent actions live inside it. Agent detail keeps only an
-  icon-only system Back control above the terminal, preserving edge-swipe
-  navigation without covering terminal content. (#182)
+  icon-only system Back control over a transparent navigation bar, preserving
+  edge-swipe navigation while terminal output extends beneath it. (#182)
 
 - Agent detail now combines the complete live libghostty terminal with a local
   Composer. The terminal preserves TUI rendering, scrollback, and PTY resize,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ Entries reference the issue that motivated them.
   on the Host over SFTP, and inserts the resulting path into the local draft
   without submitting it. Discovered Links appear beside the plus menu, while
   the former title-bar Agent actions live inside it. Agent detail keeps only an
-  icon-only system Back control over a transparent navigation bar, preserving
-  edge-swipe navigation while terminal output extends beneath it and the
-  system status bar remains opaque. (#182)
+  icon-only system Back control over a translucent navigation bar, preserving
+  edge-swipe navigation while terminal output remains subtly visible beneath
+  it and stays below the system status bar. (#182)
 
 - Agent detail now combines the complete live libghostty terminal with a local
   Composer. The terminal preserves TUI rendering, scrollback, and PTY resize,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,8 @@ Entries reference the issue that motivated them.
   on the Host over SFTP, and inserts the resulting path into the local draft
   without submitting it. Discovered Links appear beside the plus menu, while
   the former title-bar Agent actions live inside it. Agent detail keeps only an
-  icon-only system Back control over a translucent navigation bar, preserving
-  edge-swipe navigation while terminal output remains subtly visible beneath
-  it and stays below the system status bar. (#182)
+  omits Agent detail's title bar so terminal output uses the full area below
+  the system status bar, while preserving edge-swipe navigation. (#182)
 
 - Agent detail now combines the complete live libghostty terminal with a local
   Composer. The terminal preserves TUI rendering, scrollback, and PTY resize,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Entries reference the issue that motivated them.
   without submitting it. Discovered Links appear beside the plus menu, while
   the former title-bar Agent actions live inside it. Agent detail keeps only an
   icon-only system Back control over a transparent navigation bar, preserving
-  edge-swipe navigation while terminal output extends beneath it. (#182)
+  edge-swipe navigation while terminal output extends beneath it and the
+  system status bar remains opaque. (#182)
 
 - Agent detail now combines the complete live libghostty terminal with a local
   Composer. The terminal preserves TUI rendering, scrollback, and PTY resize,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ Entries reference the issue that motivated them.
   from Photos or a file up to 64 MiB from Files, stages the selection privately
   on the Host over SFTP, and inserts the resulting path into the local draft
   without submitting it. Discovered Links appear beside the plus menu, while
-  the former title-bar Agent actions live inside it. Agent detail keeps only an
-  omits Agent detail's title bar so terminal output uses the full area below
-  the system status bar, while preserving edge-swipe navigation and matching
-  status-bar contrast to the terminal theme. (#182)
+  the former title-bar Agent actions live inside it. Agent detail omits the
+  visible title bar so terminal output uses the full area below the system
+  status bar, while preserving edge-swipe navigation and matching status-bar
+  contrast to the terminal theme. (#182)
 
 - Agent detail now combines the complete live libghostty terminal with a local
   Composer. The terminal preserves TUI rendering, scrollback, and PTY resize,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ Entries reference the issue that motivated them.
   from Photos or a file up to 64 MiB from Files, stages the selection privately
   on the Host over SFTP, and inserts the resulting path into the local draft
   without submitting it. Discovered Links appear beside the plus menu, while
-  the former title-bar Agent actions live inside it. Agent detail removes its
-  navigation bar entirely so the terminal gets the full screen height, while
-  retaining the native edge-swipe return gesture. (#182)
+  the former title-bar Agent actions live inside it. Agent detail keeps only an
+  icon-only system Back control above the terminal, preserving edge-swipe
+  navigation without covering terminal content. (#182)
 
 - Agent detail now combines the complete live libghostty terminal with a local
   Composer. The terminal preserves TUI rendering, scrollback, and PTY resize,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ Entries reference the issue that motivated them.
   from Photos or a file up to 64 MiB from Files, stages the selection privately
   on the Host over SFTP, and inserts the resulting path into the local draft
   without submitting it. Discovered Links appear beside the plus menu, while
-  the former title-bar Agent actions live inside it, leaving the navigation
-  title uncluttered. (#182)
+  the former title-bar Agent actions live inside it. Agent detail removes its
+  navigation bar entirely so the terminal gets the full screen height, while
+  retaining the native edge-swipe return gesture. (#182)
 
 - Agent detail now combines the complete live libghostty terminal with a local
   Composer. The terminal preserves TUI rendering, scrollback, and PTY resize,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ Entries reference the issue that motivated them.
 - Agent detail now places a plus menu to the left of Send. It can add an image
   from Photos or a file up to 64 MiB from Files, stages the selection privately
   on the Host over SFTP, and inserts the resulting path into the local draft
-  without submitting it. Links and the former title-bar Agent actions now live
-  in the same menu, leaving the navigation title uncluttered. (#182)
+  without submitting it. Discovered Links appear beside the plus menu, while
+  the former title-bar Agent actions live inside it, leaving the navigation
+  title uncluttered. (#182)
 
 - Agent detail now combines the complete live libghostty terminal with a local
   Composer. The terminal preserves TUI rendering, scrollback, and PTY resize,

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		14F3A10674FAF72C63042108 /* PairingConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEAD52089A35D4B2D47AF25 /* PairingConnector.swift */; };
 		1566E45603CB8F83337BD9C3 /* TerminalAppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4273AC6F39EB1E015820E614 /* TerminalAppearanceSettingsView.swift */; };
 		1706E607DD6100E20479457C /* GhosttyTerminal in Frameworks */ = {isa = PBXBuildFile; productRef = 19D717C20DA226346335AFF6 /* GhosttyTerminal */; };
+		179292D9C3E605BC46282FE0 /* ComposerAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4616CECA2722086A6B8B490 /* ComposerAttachmentTests.swift */; };
 		17F313D8AE9647F8F5D4DBFD /* AgentAttachStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F8ED10B8A8A33D307789E6 /* AgentAttachStore.swift */; };
 		1AD6824BFB55CB50607AD702 /* FakeTransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696C6905D9D6EEFF77A64E2E /* FakeTransportConnector.swift */; };
 		1ADE76974DEBFD636189EE45 /* NotificationRelayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6876069E2B641D09FF1520E6 /* NotificationRelayEndpoint.swift */; };
@@ -47,6 +48,7 @@
 		2D7DC2A884FB9BA311D265A6 /* SkillProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176C059114F4646026196943 /* SkillProbeTests.swift */; };
 		2E612B94231EF97A285C83D5 /* SSHSourcePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CFDDFD7A676ECD4EF29BDE /* SSHSourcePolicyTests.swift */; };
 		2E82149F859FCBF05F9E999B /* HerdrSocketLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F09325DE68693680E5A3BB /* HerdrSocketLocationTests.swift */; };
+		31D859C60649F69B3D2DA506 /* FileAttachStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603B3391236DA4AE48C3E39F /* FileAttachStore.swift */; };
 		31E4ADB22D4D655E7CFDB749 /* TerminalInputControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05AD61D4FA60884234EA856C /* TerminalInputControllerTests.swift */; };
 		3286D6FBB12157F2A19A82CE /* AgentNotificationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB37CBDC9DE0CE539FC476A0 /* AgentNotificationRenderer.swift */; };
 		35205050C9CB8E473D8A28C0 /* Base64URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32413805C1AA874DBEE37547 /* Base64URL.swift */; };
@@ -84,6 +86,7 @@
 		541F71DBCA922E84DCA98D5E /* AgentNotificationRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F3B82DFAD293C0EE344804 /* AgentNotificationRouting.swift */; };
 		54D3A4F4FBF8F3F6C154BACE /* AppActivityCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B72AE2059C59D8A59C9B2A /* AppActivityCoordinator.swift */; };
 		55C7DF5052817C34AFF088C2 /* TerminalTextSelectionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19FF62E7BD9DC71E1172A472 /* TerminalTextSelectionPresenter.swift */; };
+		5789049E3BA965EB057C4577 /* FilePreparerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C833B5BA50276247A54258B /* FilePreparerTests.swift */; };
 		5B0522DF97BC46599DDE4E93 /* TransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A41E40939438986DE30402 /* TransportConnector.swift */; };
 		5B137E763FFACD1AFE5C7E30 /* AgentNotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7EC7BEC9AACD2DAF634B2C /* AgentNotificationRouter.swift */; };
 		5DBC04E1863A4740B3C84F3B /* DemoScreenshotMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0A5D6A13F3F940E50EDCFD /* DemoScreenshotMode.swift */; };
@@ -208,6 +211,7 @@
 		D6620368048468EFA09B4142 /* HostOnboardingStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D961656A6D8B4F3964740BD /* HostOnboardingStoreTests.swift */; };
 		D868123FC703E505D48AFD85 /* HostOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC1C5701C464ADBBAE0525D /* HostOnboardingView.swift */; };
 		D8742E32B3BA3A76771BC2B7 /* JSONValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A3266F97C243598703DB0A /* JSONValue.swift */; };
+		D8CEC323008C54CD8042970F /* FilePreparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321E267EE49BFE4A60F3B7CB /* FilePreparer.swift */; };
 		D8E9ECA03166EA6AA2BAE712 /* SSHCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA0D80E59E5C49E5F164DB4 /* SSHCredentials.swift */; };
 		D8FA3A3189491AC2A765C6BC /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC80D00F652CB84103C246F /* SettingsView.swift */; };
 		D909BD8D7C3DFCD776AAA781 /* AgentSkill.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9FD6FF5FE83C022600169BE /* AgentSkill.swift */; };
@@ -294,6 +298,7 @@
 		0A319930B80D42FB33DC8E42 /* AgentNotificationBannerStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationBannerStoreTests.swift; sourceTree = "<group>"; };
 		0AEC3D31861DABF40C05EE8D /* HostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStore.swift; sourceTree = "<group>"; };
 		0B248F9372687FDBE3AD24A1 /* AppForegroundRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppForegroundRecoveryTests.swift; sourceTree = "<group>"; };
+		0C833B5BA50276247A54258B /* FilePreparerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreparerTests.swift; sourceTree = "<group>"; };
 		0DAC3DCDEF81B14A2019DDBE /* TerminalStatusDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalStatusDialog.swift; sourceTree = "<group>"; };
 		0DBBD602AA4969937A9306C3 /* HostCredentialsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostCredentialsProvider.swift; sourceTree = "<group>"; };
 		0E38A3F2A443D311C8FCC218 /* NotificationConfigFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationConfigFile.swift; sourceTree = "<group>"; };
@@ -322,6 +327,7 @@
 		2D6996CA1550E32EE6AC3669 /* GitBranchName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitBranchName.swift; sourceTree = "<group>"; };
 		31B3368D352EFC805C2534F9 /* RealSSHFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealSSHFixture.swift; sourceTree = "<group>"; };
 		31F09325DE68693680E5A3BB /* HerdrSocketLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrSocketLocationTests.swift; sourceTree = "<group>"; };
+		321E267EE49BFE4A60F3B7CB /* FilePreparer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreparer.swift; sourceTree = "<group>"; };
 		32413805C1AA874DBEE37547 /* Base64URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64URL.swift; sourceTree = "<group>"; };
 		32AE04F29C794799B45E5C68 /* Host.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Host.swift; sourceTree = "<group>"; };
 		33EF900D8EF7982B54965402 /* HostFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostFormView.swift; sourceTree = "<group>"; };
@@ -363,6 +369,7 @@
 		5B48DF894D26308FA815E656 /* HeelerSSHDirectStreamLocalE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHDirectStreamLocalE2ETests.swift; sourceTree = "<group>"; };
 		5BA0D80E59E5C49E5F164DB4 /* SSHCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHCredentials.swift; sourceTree = "<group>"; };
 		5CB08528C0328AA9AFE358CE /* TerminalFontSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalFontSettings.swift; sourceTree = "<group>"; };
+		603B3391236DA4AE48C3E39F /* FileAttachStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileAttachStore.swift; sourceTree = "<group>"; };
 		60A3266F97C243598703DB0A /* JSONValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValue.swift; sourceTree = "<group>"; };
 		6137F891C34AE9E7951804F7 /* SolvingOrbView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolvingOrbView.swift; sourceTree = "<group>"; };
 		61DA61C2FD4220803AE6D533 /* PairingCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCode.swift; sourceTree = "<group>"; };
@@ -501,6 +508,7 @@
 		F261A0911D08819AFC013F1E /* JSONValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueTests.swift; sourceTree = "<group>"; };
 		F3A63EFEB7D00E59949CF331 /* HostDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostDraft.swift; sourceTree = "<group>"; };
 		F44E8A7E5D2D96096928B69C /* WeakNetworkProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakNetworkProxy.swift; sourceTree = "<group>"; };
+		F4616CECA2722086A6B8B490 /* ComposerAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerAttachmentTests.swift; sourceTree = "<group>"; };
 		F4926339DC2CC7D0D6B58069 /* Notices */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Notices; path = Sources/Heeler/Resources/Notices; sourceTree = SOURCE_ROOT; };
 		F61A04DBA56C56925B594FF1 /* NotificationEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationEnvelope.swift; sourceTree = "<group>"; };
 		F63F7D63E32AA0C85E9F8FBC /* PushRegistrationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRegistrationStore.swift; sourceTree = "<group>"; };
@@ -557,6 +565,7 @@
 				93417EFE29FA2DC3DD3FAF9F /* AsyncDeadlineTests.swift */,
 				8C5A562F5A01AE08691B8479 /* AttachTerminalStoreTests.swift */,
 				414B652A16576BEDEE9AE000 /* ClosePaneStoreTests.swift */,
+				F4616CECA2722086A6B8B490 /* ComposerAttachmentTests.swift */,
 				86F44B0C95580FC88ED880FD /* ConsoleDetailPresentationTests.swift */,
 				00807A3942817BEE9800534F /* ConsoleStoreTests.swift */,
 				7374E36C37E07625B05361AE /* ContentViewActivityDriverTests.swift */,
@@ -566,6 +575,7 @@
 				FE302F516B139F4BADCEC6CB /* EventsSessionBufferingTests.swift */,
 				823B2239BDC425FCE456B625 /* EventsSessionKeepaliveTests.swift */,
 				39AD641EA732307D72698216 /* EventsSessionSubscriptionsTests.swift */,
+				0C833B5BA50276247A54258B /* FilePreparerTests.swift */,
 				D5C058D102046A707547A0FD /* GeneratedWireTypesTests.swift */,
 				233075006FC2C8907BBFF40F /* GitBranchNameTests.swift */,
 				5B48DF894D26308FA815E656 /* HeelerSSHDirectStreamLocalE2ETests.swift */,
@@ -733,6 +743,7 @@
 				4F710C63524E24B79F95A898 /* HeelerApp.swift */,
 				5880878B95ED812C768FF824 /* Console */,
 				19B18CBCC288113F74374B8D /* Demo */,
+				FEC0B219712E060EDE656B53 /* Files */,
 				4892D7AF177E633F713692C3 /* Hosts */,
 				767FC01958BC8BD821273A6E /* Images */,
 				26FDCBEEFC6493DEB4A081E9 /* Notifications */,
@@ -988,6 +999,15 @@
 			path = Generated;
 			sourceTree = "<group>";
 		};
+		FEC0B219712E060EDE656B53 /* Files */ = {
+			isa = PBXGroup;
+			children = (
+				603B3391236DA4AE48C3E39F /* FileAttachStore.swift */,
+				321E267EE49BFE4A60F3B7CB /* FilePreparer.swift */,
+			);
+			path = Files;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1165,6 +1185,8 @@
 				7BD7F228AC8A9EDA13A63C2C /* DeviceKey.swift in Sources */,
 				63ADBED637BEA84B045BE9FC /* DeviceKeyStore.swift in Sources */,
 				469C32C1704BA67A19BB3AA9 /* EventsSession.swift in Sources */,
+				31D859C60649F69B3D2DA506 /* FileAttachStore.swift in Sources */,
+				D8CEC323008C54CD8042970F /* FilePreparer.swift in Sources */,
 				84C252AF6731EA693B93494A /* GitBranchName.swift in Sources */,
 				6C33AC12CE7ACC5730240A75 /* HeelerApp.swift in Sources */,
 				22A39C0FD2A18C6655D14F53 /* HeelerSSHHostKeyVerifier.swift in Sources */,
@@ -1291,6 +1313,7 @@
 				E40D1C6F825ABCD68AA5F196 /* AttachTerminalStoreTests.swift in Sources */,
 				5150B659FACE9AFD9ECF9F6D /* AuthorizedKeysTestLock.swift in Sources */,
 				61F58007C6B81F14D2F6B58B /* ClosePaneStoreTests.swift in Sources */,
+				179292D9C3E605BC46282FE0 /* ComposerAttachmentTests.swift in Sources */,
 				7A73A34256C7B55060AAE9DE /* ConsoleDetailPresentationTests.swift in Sources */,
 				AA6498ABD1E1782C0B5D8F5B /* ConsoleStoreTests.swift in Sources */,
 				8B171AB6CB0C087D059631C4 /* ContentViewActivityDriverTests.swift in Sources */,
@@ -1302,6 +1325,7 @@
 				FEC497C4A95E5F4D945EF3BA /* EventsSessionSubscriptionsTests.swift in Sources */,
 				E7CE4737CFB94163D9EEC8F2 /* FakePairingConnector.swift in Sources */,
 				1AD6824BFB55CB50607AD702 /* FakeTransportConnector.swift in Sources */,
+				5789049E3BA965EB057C4577 /* FilePreparerTests.swift in Sources */,
 				297F2EB19960A01651FDA05C /* GeneratedWireTypesTests.swift in Sources */,
 				745597578F4E92FCC065823A /* GitBranchNameTests.swift in Sources */,
 				4D0A9B8F7343093907B24788 /* HeelerSSHDirectStreamLocalE2ETests.swift in Sources */,

--- a/Sources/Heeler/Console/AgentAttachStore.swift
+++ b/Sources/Heeler/Console/AgentAttachStore.swift
@@ -40,6 +40,7 @@ final class AgentAttachStore {
     private(set) var terminal: AttachTerminalStore
     let input: TerminalInputController
     let image: ImageAttachStore
+    let file: FileAttachStore?
     let close: ClosePaneStore
     private(set) var attachLinkOpenFailure: AttachLinkOpenFailure?
 
@@ -71,6 +72,8 @@ final class AgentAttachStore {
         isOnStage: @escaping () -> Bool,
         runTerminal: @escaping TerminalSessionRunner,
         stageImage: @escaping ImageStager,
+        stageFile: FileStager? = nil,
+        composer: (any ComposerDraftOperations)? = nil,
         closePane: @escaping () async throws -> Void
     ) {
         let input = TerminalInputController()
@@ -83,7 +86,17 @@ final class AgentAttachStore {
         self.linkIndex = linkIndex
         terminal = Self.makeTerminal(
             target: target, input: input, runTerminal: runTerminal, linkIndex: linkIndex)
-        image = ImageAttachStore(stageImage: stageImage, input: input)
+        image = ImageAttachStore(
+            stageImage: stageImage,
+            input: input,
+            composer: composer)
+        if let stageFile, let composer {
+            file = FileAttachStore(
+                stageFile: stageFile,
+                composer: composer)
+        } else {
+            file = nil
+        }
         close = ClosePaneStore(paneTitle: paneTitle, close: closePane)
     }
 
@@ -121,8 +134,16 @@ final class AgentAttachStore {
         image.state
     }
 
+    var fileState: FileAttachState? {
+        file?.state
+    }
+
     var canSelectImage: Bool {
-        terminal.status == .live && image.canSelectImage
+        image.canSelectImage && file?.state.isBusy != true
+    }
+
+    var canSelectFile: Bool {
+        file?.canSelectFile == true && !image.state.isBusy
     }
 
     var isLocalInputEnabled: Bool {
@@ -220,7 +241,15 @@ final class AgentAttachStore {
     }
 
     func selectImage(_ selection: any ImageSelection) {
+        guard canSelectImage else { return }
+        file?.dismissResult()
         image.select(selection)
+    }
+
+    func selectFile(_ url: URL) {
+        guard canSelectFile else { return }
+        image.dismissResult()
+        file?.select(url)
     }
 
     func cancelImage() {
@@ -241,6 +270,26 @@ final class AgentAttachStore {
 
     func insertImagePath() {
         image.insertPath()
+    }
+
+    func cancelFile() {
+        file?.cancel()
+    }
+
+    func retryFile() {
+        file?.retry()
+    }
+
+    func dismissFileResult() {
+        file?.dismissResult()
+    }
+
+    func copyFilePath() {
+        file?.copyPath()
+    }
+
+    func insertFilePath() {
+        file?.insertPath()
     }
 
     /// A short foreground bounce keeps the current PTY and asks it to repaint.
@@ -264,6 +313,7 @@ final class AgentAttachStore {
 
     func didEnterBackground() {
         image.didEnterBackground()
+        file?.didEnterBackground()
     }
 
     /// A new Transport requires a new terminal pipeline. The replacement is
@@ -462,6 +512,7 @@ final class AgentAttachStore {
         // self-breaking: the task releases the store when the teardown ends.
         return enqueueLifecycleTransition { [self] in
             await image.leaveAttach()
+            await file?.leave()
             await terminal.stop()
             linkIndex.clear()
         }

--- a/Sources/Heeler/Console/AgentComposerView.swift
+++ b/Sources/Heeler/Console/AgentComposerView.swift
@@ -28,6 +28,20 @@ struct AgentComposerKeyboardLayout: Equatable {
     }
 }
 
+struct AgentComposerActions {
+    let canAddImage: Bool
+    let canAddFile: Bool
+    let attachLinkCount: Int
+    let addImage: () -> Void
+    let addFile: () -> Void
+    let showAttachLinks: () -> Void
+    let startAgent: () -> Void
+    let manageSnippets: () -> Void
+    let renameAgent: () -> Void
+    let renameWorkspace: () -> Void
+    let closeAgent: () -> Void
+}
+
 /// The native, local-first input surface beneath the live terminal. Drafting
 /// stays on device; Send emits one `agent.prompt` request, while explicit
 /// tool-keyboard controls send terminal sequences through Attach.
@@ -37,6 +51,7 @@ struct AgentComposerView: View {
     let switcher: TerminalAgentSwitcher
     let keyboardHandoff: TerminalKeyboardHandoff
     let keyboardHeight: CGFloat
+    let actions: AgentComposerActions
     @Binding var keyboardPresentation: AgentComposerKeyboardPresentation
     let prepareKeyboardPresentation: (AgentComposerKeyboardPresentation) -> Void
     @State private var isInputFocused = false
@@ -90,7 +105,61 @@ struct AgentComposerView: View {
                             }
                         }
 
-                        HStack(spacing: 0) {
+                        HStack(spacing: 8) {
+                            Menu {
+                                Section {
+                                    Button("Add Image", systemImage: "photo") {
+                                        actions.addImage()
+                                    }
+                                    .disabled(!actions.canAddImage)
+                                    Button("Add File", systemImage: "doc") {
+                                        actions.addFile()
+                                    }
+                                    .disabled(!actions.canAddFile)
+                                }
+                                if actions.attachLinkCount > 0 {
+                                    Section {
+                                        Button(
+                                            "Attach Links (\(actions.attachLinkCount))",
+                                            systemImage: "link"
+                                        ) {
+                                            actions.showAttachLinks()
+                                        }
+                                    }
+                                }
+                                Section {
+                                    Button("New Agent", systemImage: "plus") {
+                                        actions.startAgent()
+                                    }
+                                    Button("Snippets", systemImage: "quote.bubble") {
+                                        actions.manageSnippets()
+                                    }
+                                }
+                                Section {
+                                    Button("Rename Agent", systemImage: "pencil") {
+                                        actions.renameAgent()
+                                    }
+                                    Button("Rename Workspace", systemImage: "pencil.line") {
+                                        actions.renameWorkspace()
+                                    }
+                                    Button(
+                                        "Close Agent",
+                                        systemImage: "trash",
+                                        role: .destructive
+                                    ) {
+                                        actions.closeAgent()
+                                    }
+                                }
+                            } label: {
+                                Label("Add and More", systemImage: "plus")
+                            }
+                            .buttonStyle(.bordered)
+                            .buttonBorderShape(.circle)
+                            .labelStyle(.iconOnly)
+                            .font(.footnote.weight(.semibold))
+                            .frame(minWidth: 44, minHeight: 44)
+                            .accessibilityHint("Adds an attachment or opens Agent actions")
+
                             Spacer(minLength: 0)
                             Button("Send", systemImage: "arrow.up") {
                                 Task { await store.send() }

--- a/Sources/Heeler/Console/AgentComposerView.swift
+++ b/Sources/Heeler/Console/AgentComposerView.swift
@@ -42,6 +42,19 @@ struct AgentComposerActions {
     let closeAgent: () -> Void
 }
 
+struct AgentComposerLinkPresentation: Equatable {
+    let count: Int
+
+    init?(count: Int) {
+        guard count > 0 else { return nil }
+        self.count = count
+    }
+
+    var accessibilityValue: String {
+        count == 1 ? "1 distinct link" : "\(count) distinct links"
+    }
+}
+
 /// The native, local-first input surface beneath the live terminal. Drafting
 /// stays on device; Send emits one `agent.prompt` request, while explicit
 /// tool-keyboard controls send terminal sequences through Attach.
@@ -117,16 +130,6 @@ struct AgentComposerView: View {
                                     }
                                     .disabled(!actions.canAddFile)
                                 }
-                                if actions.attachLinkCount > 0 {
-                                    Section {
-                                        Button(
-                                            "Attach Links (\(actions.attachLinkCount))",
-                                            systemImage: "link"
-                                        ) {
-                                            actions.showAttachLinks()
-                                        }
-                                    }
-                                }
                                 Section {
                                     Button("New Agent", systemImage: "plus") {
                                         actions.startAgent()
@@ -159,6 +162,24 @@ struct AgentComposerView: View {
                             .font(.footnote.weight(.semibold))
                             .frame(minWidth: 44, minHeight: 44)
                             .accessibilityHint("Adds an attachment or opens Agent actions")
+
+                            if let links = linkPresentation {
+                                Button {
+                                    actions.showAttachLinks()
+                                } label: {
+                                    HStack(spacing: 3) {
+                                        Image(systemName: "link")
+                                        Text("\(links.count)")
+                                            .monospacedDigit()
+                                    }
+                                }
+                                .buttonStyle(.bordered)
+                                .buttonBorderShape(.capsule)
+                                .font(.footnote.weight(.semibold))
+                                .frame(minHeight: 44)
+                                .accessibilityLabel("Attach Links")
+                                .accessibilityValue(links.accessibilityValue)
+                            }
 
                             Spacer(minLength: 0)
                             Button("Send", systemImage: "arrow.up") {
@@ -273,6 +294,10 @@ struct AgentComposerView: View {
               case .failed(let detail) = message.state
         else { return nil }
         return (message.id, detail)
+    }
+
+    private var linkPresentation: AgentComposerLinkPresentation? {
+        AgentComposerLinkPresentation(count: actions.attachLinkCount)
     }
 
     private var statusLabel: some View {

--- a/Sources/Heeler/Console/AgentDetailView.swift
+++ b/Sources/Heeler/Console/AgentDetailView.swift
@@ -41,7 +41,8 @@ struct AgentDetailView: View {
         self.isOnStage = isOnStage
         self.onSwitch = onSwitch
         self.onClosed = onClosed
-        _composer = State(initialValue: composerStore ?? console.composerStore(for: agent))
+        let composer = composerStore ?? console.composerStore(for: agent)
+        _composer = State(initialValue: composer)
         _attach = State(
             initialValue: attachStore
                 ?? AgentAttachStore(
@@ -50,7 +51,9 @@ struct AgentDetailView: View {
                     transportGeneration: console.hostConnectionGenerations[agent.hostID],
                     isOnStage: isOnStage,
                     runTerminal: console.terminalRunner(for: agent.hostID),
-                    stageImage: console.imageStager(for: agent.hostID)
+                    stageImage: console.imageStager(for: agent.hostID),
+                    stageFile: console.fileStager(for: agent.hostID),
+                    composer: composer
                 ) {
                     try await console.closePane(agent.agent.paneID, on: agent.hostID)
                 })

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -456,7 +456,8 @@ struct AgentTerminalView: View {
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarRole(.editor)
-        .toolbarBackground(.hidden, for: .navigationBar)
+        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
         .toolbar(.visible, for: .navigationBar)
     }
 

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -433,6 +433,9 @@ struct AgentTerminalView: View {
         .background(
             terminal.themes.selection(for: colorScheme)
                 .surfaceBackground(for: colorScheme))
+        // Let terminal output occupy the navigation bar region while keeping
+        // native Back navigation and its interactive edge gesture.
+        .ignoresSafeArea(.container, edges: .top)
         // Keep an icon-only native back bar in its own layout region. Hiding
         // the bar also disables interactive pop in a collapsed split view;
         // keeping it visible preserves both the button and the edge gesture
@@ -444,6 +447,7 @@ struct AgentTerminalView: View {
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarRole(.editor)
+        .toolbarBackground(.hidden, for: .navigationBar)
         .toolbar(.visible, for: .navigationBar)
     }
 

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -437,12 +437,9 @@ struct AgentTerminalView: View {
         // native Back navigation and its interactive edge gesture.
         .ignoresSafeArea(.container, edges: .top)
         .overlay(alignment: .top) {
-            GeometryReader { proxy in
-                terminal.themes.selection(for: colorScheme)
-                    .surfaceBackground(for: colorScheme)
-                    .frame(height: proxy.safeAreaInsets.top)
-                    .frame(maxWidth: .infinity, alignment: .top)
-            }
+            AgentStatusBarBackground(
+                color: terminal.themes.selection(for: colorScheme)
+                    .surfaceBackground(for: colorScheme))
             .allowsHitTesting(false)
             .accessibilityHidden(true)
         }
@@ -706,6 +703,62 @@ struct AgentTerminalView: View {
 
     static func displayTitle(for agent: ConsoleAgent) -> String {
         agent.agent.title.isEmpty ? agent.agent.displayName : agent.agent.title
+    }
+}
+
+/// Covers only the window's status-bar safe area. SwiftUI reports a zero top
+/// inset after `ignoresSafeArea`, so the real window inset is required here.
+private struct AgentStatusBarBackground: UIViewRepresentable {
+    let color: Color
+
+    func makeUIView(context: Context) -> StatusBarShieldView {
+        StatusBarShieldView(color: UIColor(color))
+    }
+
+    func updateUIView(_ uiView: StatusBarShieldView, context: Context) {
+        uiView.shieldColor = UIColor(color)
+    }
+
+    @MainActor
+    final class StatusBarShieldView: UIView {
+        var shieldColor: UIColor {
+            didSet { shield.backgroundColor = shieldColor }
+        }
+
+        private let shield = UIView()
+
+        init(color: UIColor) {
+            shieldColor = color
+            super.init(frame: .zero)
+            backgroundColor = .clear
+            isUserInteractionEnabled = false
+            shield.backgroundColor = color
+            addSubview(shield)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            setNeedsLayout()
+        }
+
+        override func safeAreaInsetsDidChange() {
+            super.safeAreaInsetsDidChange()
+            setNeedsLayout()
+        }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            shield.frame = CGRect(
+                x: 0,
+                y: 0,
+                width: bounds.width,
+                height: window?.safeAreaInsets.top ?? 0)
+        }
     }
 }
 

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -1,6 +1,7 @@
 import PhotosUI
 import SwiftUI
 import UIKit
+import UniformTypeIdentifiers
 
 /// The live Ghostty surface used by Agent detail. When a Composer is present,
 /// the terminal is display-only: it still renders, scrolls, opens links, and
@@ -36,6 +37,8 @@ struct AgentTerminalView: View {
     @State private var keyboardControl = TerminalKeyboardControl()
     @State private var composerKeyboardPresentation: AgentComposerKeyboardPresentation = .hidden
     @State private var selectedPhoto: PhotosPickerItem?
+    @State private var isSelectingPhoto = false
+    @State private var isSelectingFile = false
     @State private var isConfirmingClose = false
     @State private var isStartingAgent = false
     @State private var isManagingSnippets = false
@@ -80,7 +83,9 @@ struct AgentTerminalView: View {
                 transportGeneration: console.hostConnectionGenerations[agent.hostID],
                 isOnStage: isOnStage,
                 runTerminal: console.terminalRunner(for: agent.hostID),
-                stageImage: console.imageStager(for: agent.hostID)
+                stageImage: console.imageStager(for: agent.hostID),
+                stageFile: composer == nil ? nil : console.fileStager(for: agent.hostID),
+                composer: composer
             ) {
                 try await console.closePane(agent.agent.paneID, on: agent.hostID)
             })
@@ -158,6 +163,24 @@ struct AgentTerminalView: View {
         terminalSurface
         .toolbar {
             toolbarContent
+        }
+        .photosPicker(
+            isPresented: $isSelectingPhoto,
+            selection: $selectedPhoto,
+            matching: .images)
+        .fileImporter(
+            isPresented: $isSelectingFile,
+            allowedContentTypes: [.data]
+        ) { result in
+            guard case .success(let url) = result else { return }
+            attach.selectFile(url)
+        }
+        .popover(isPresented: $isShowingAttachLinks) {
+            AttachLinksView(
+                links: attach.attachLinks,
+                open: { link in openAttachLink(link) },
+                copy: { link in UIPasteboard.general.string = link.target })
+            .presentationCompactAdaptation(.sheet)
         }
         .sheet(isPresented: $isStartingAgent) {
             // StartAgentView brings its own NavigationStack.
@@ -337,14 +360,27 @@ struct AgentTerminalView: View {
             presentation: composer == nil ? .hidden : composerKeyboardPresentation)
     }
 
+    private var composerActions: AgentComposerActions {
+        AgentComposerActions(
+            canAddImage: attach.canSelectImage,
+            canAddFile: attach.canSelectFile,
+            attachLinkCount: attach.attachLinks.count,
+            addImage: { isSelectingPhoto = true },
+            addFile: { isSelectingFile = true },
+            showAttachLinks: { isShowingAttachLinks = true },
+            startAgent: { isStartingAgent = true },
+            manageSnippets: { isManagingSnippets = true },
+            renameAgent: { isRenamingAgent = true },
+            renameWorkspace: { isRenamingWorkspace = true },
+            closeAgent: { isConfirmingClose = true })
+    }
+
     private var terminalSurface: some View {
         terminalScreen
             .id(attach.terminalID)
         .overlay { statusOverlay }
         .safeAreaInset(edge: .bottom, spacing: 0) {
-            if composer == nil {
-                imageAttachStatus
-            }
+            attachmentStatus
         }
         // Below the keyboard's own inset, so the strip rides above the
         // keyboard while it is up and rests on the screen's edge once it is
@@ -358,6 +394,7 @@ struct AgentTerminalView: View {
                     switcher: agentSwitcher,
                     keyboardHandoff: keyboardHandoff,
                     keyboardHeight: composerKeyboardLayout.availableToolsHeight,
+                    actions: composerActions,
                     keyboardPresentation: $composerKeyboardPresentation,
                     prepareKeyboardPresentation: prepareComposerKeyboardPresentation)
             } else {
@@ -425,29 +462,22 @@ struct AgentTerminalView: View {
 
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
-        if !attach.attachLinks.isEmpty {
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    isShowingAttachLinks = true
-                } label: {
-                    HStack(spacing: 3) {
-                        Image(systemName: "link")
-                        Text("\(attach.attachLinks.count)")
-                            .monospacedDigit()
+        if composer == nil {
+            if !attach.attachLinks.isEmpty {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        isShowingAttachLinks = true
+                    } label: {
+                        HStack(spacing: 3) {
+                            Image(systemName: "link")
+                            Text("\(attach.attachLinks.count)")
+                                .monospacedDigit()
+                        }
                     }
-                }
-                .accessibilityLabel("Attach Links")
-                .accessibilityValue(attachLinkCountDescription)
-                .popover(isPresented: $isShowingAttachLinks) {
-                    AttachLinksView(
-                        links: attach.attachLinks,
-                        open: { link in openAttachLink(link) },
-                        copy: { link in UIPasteboard.general.string = link.target })
-                    .presentationCompactAdaptation(.sheet)
+                    .accessibilityLabel("Attach Links")
+                    .accessibilityValue(attachLinkCountDescription)
                 }
             }
-        }
-        if composer == nil {
             ToolbarItem(placement: .primaryAction) {
                 PhotosPicker(selection: $selectedPhoto, matching: .images) {
                     Label("Attach Image", systemImage: "photo.badge.plus")
@@ -455,28 +485,26 @@ struct AgentTerminalView: View {
                 .disabled(!attach.canSelectImage)
                 .accessibilityLabel("Attach Image")
             }
-        }
-        ToolbarItem(placement: .primaryAction) {
-            Menu {
-                Button("New Agent", systemImage: "plus") {
-                    isStartingAgent = true
-                }
-                if composer == nil {
+            ToolbarItem(placement: .primaryAction) {
+                Menu {
+                    Button("New Agent", systemImage: "plus") {
+                        isStartingAgent = true
+                    }
                     Button("Snippets", systemImage: "quote.bubble") {
                         isManagingSnippets = true
                     }
+                    Button("Rename Agent", systemImage: "pencil") {
+                        isRenamingAgent = true
+                    }
+                    Button("Rename Workspace", systemImage: "pencil.line") {
+                        isRenamingWorkspace = true
+                    }
+                    Button("Close Agent", systemImage: "trash", role: .destructive) {
+                        isConfirmingClose = true
+                    }
+                } label: {
+                    Label("More", systemImage: "ellipsis.circle")
                 }
-                Button("Rename Agent", systemImage: "pencil") {
-                    isRenamingAgent = true
-                }
-                Button("Rename Workspace", systemImage: "pencil.line") {
-                    isRenamingWorkspace = true
-                }
-                Button("Close Agent", systemImage: "trash", role: .destructive) {
-                    isConfirmingClose = true
-                }
-            } label: {
-                Label("More", systemImage: "ellipsis.circle")
             }
         }
     }
@@ -561,8 +589,17 @@ struct AgentTerminalView: View {
     }
 
     @ViewBuilder
-    private var imageAttachStatus: some View {
-        switch attach.imageState {
+    private var attachmentStatus: some View {
+        if let fileState = attach.fileState, fileState != .idle {
+            fileAttachStatus(fileState)
+        } else {
+            imageAttachStatus(attach.imageState)
+        }
+    }
+
+    @ViewBuilder
+    private func imageAttachStatus(_ state: ImageAttachState) -> some View {
+        switch state {
         case .idle:
             EmptyView()
         case .preparing:
@@ -606,6 +643,56 @@ struct AgentTerminalView: View {
                     Button("Insert Path") { attach.insertImagePath() }
                 }
                 Button("Done", role: .cancel) { attach.dismissImageResult() }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func fileAttachStatus(_ state: FileAttachState) -> some View {
+        switch state {
+        case .idle:
+            EmptyView()
+        case .preparing:
+            ImageAttachStatusBar(
+                icon: "doc",
+                title: "Preparing File…",
+                accessibilityLabel: "Preparing File"
+            ) {
+                Button("Cancel", role: .cancel) { attach.cancelFile() }
+            }
+        case .uploading(let progress):
+            ImageAttachStatusBar(
+                icon: "arrow.up.circle",
+                title: "Uploading File… \(Int(progress.fractionCompleted * 100))%",
+                accessibilityLabel:
+                    "Uploading File, \(Int(progress.fractionCompleted * 100)) percent"
+            ) {
+                Button("Cancel", role: .cancel) { attach.cancelFile() }
+            }
+        case .failed(let failure), .backgroundInterrupted(let failure):
+            ImageAttachStatusBar(
+                icon: "exclamationmark.triangle",
+                title: failure.message,
+                accessibilityLabel: failure.message
+            ) {
+                if failure.isRetryable {
+                    Button("Retry") { attach.retryFile() }
+                }
+                Button("Dismiss", role: .cancel) { attach.dismissFileResult() }
+            }
+        case .completed(let result):
+            ImageAttachStatusBar(
+                icon: result.copied && result.inserted ? "checkmark.circle" : "info.circle",
+                title: result.message,
+                accessibilityLabel: result.message
+            ) {
+                if !result.copied {
+                    Button("Copy Path") { attach.copyFilePath() }
+                }
+                if !result.inserted {
+                    Button("Insert Path") { attach.insertFilePath() }
+                }
+                Button("Done", role: .cancel) { attach.dismissFileResult() }
             }
         }
     }

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -436,6 +436,16 @@ struct AgentTerminalView: View {
         // Let terminal output occupy the navigation bar region while keeping
         // native Back navigation and its interactive edge gesture.
         .ignoresSafeArea(.container, edges: .top)
+        .overlay(alignment: .top) {
+            GeometryReader { proxy in
+                terminal.themes.selection(for: colorScheme)
+                    .surfaceBackground(for: colorScheme)
+                    .frame(height: proxy.safeAreaInsets.top)
+                    .frame(maxWidth: .infinity, alignment: .top)
+            }
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+        }
         // Keep an icon-only native back bar in its own layout region. Hiding
         // the bar also disables interactive pop in a collapsed split view;
         // keeping it visible preserves both the button and the edge gesture

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -433,9 +433,18 @@ struct AgentTerminalView: View {
         .background(
             terminal.themes.selection(for: colorScheme)
                 .surfaceBackground(for: colorScheme))
-        // Keep the native navigation container, and therefore its interactive
-        // edge-swipe pop gesture, while removing all visible top chrome.
-        .toolbar(.hidden, for: .navigationBar)
+        // Keep an icon-only native back bar in its own layout region. Hiding
+        // the bar also disables interactive pop in a collapsed split view;
+        // keeping it visible preserves both the button and the edge gesture
+        // without overlaying either one on the terminal grid.
+        .toolbarColorScheme(
+            terminal.themes.selection(for: colorScheme)
+                .chromeColorScheme(for: colorScheme),
+            for: .navigationBar)
+        .navigationTitle("")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarRole(.editor)
+        .toolbar(.visible, for: .navigationBar)
     }
 
     private func prepareComposerKeyboardPresentation(

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -50,16 +50,8 @@ struct AgentTerminalView: View {
     @State private var isShowingAttachLinks = false
     @State private var closeErrorMessage: String?
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
-
-    private var statusBarInset: CGFloat {
-        UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .filter { $0.activationState == .foregroundActive }
-            .flatMap(\.windows)
-            .first(where: \.isKeyWindow)?
-            .safeAreaInsets.top ?? 0
-    }
 
     init(
         agent: ConsoleAgent,
@@ -435,30 +427,13 @@ struct AgentTerminalView: View {
                 .accessibilityHidden(composerKeyboardPresentation != .tools)
             }
         }
-        // Pull the surface under the transparent navigation bar, but keep its
-        // first row below the system status bar. Padding remains inside the
-        // fixed full-screen proposal, so the Composer stays bottom-aligned.
-        .padding(.top, statusBarInset)
         .background(
             terminal.themes.selection(for: colorScheme)
                 .surfaceBackground(for: colorScheme))
-        // Let terminal output occupy the navigation bar region while keeping
-        // native Back navigation and its interactive edge gesture.
-        .ignoresSafeArea(.container, edges: .top)
-        // Keep an icon-only native back bar in its own layout region. Hiding
-        // the bar also disables interactive pop in a collapsed split view;
-        // keeping it visible preserves both the button and the edge gesture
-        // without overlaying either one on the terminal grid.
-        .toolbarColorScheme(
-            terminal.themes.selection(for: colorScheme)
-                .chromeColorScheme(for: colorScheme),
-            for: .navigationBar)
-        .navigationTitle("")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbarRole(.editor)
-        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
-        .toolbar(.visible, for: .navigationBar)
+        .overlay(alignment: .leading) {
+            AgentEdgeBackGesture { dismiss() }
+        }
+        .toolbar(.hidden, for: .navigationBar)
     }
 
     private func prepareComposerKeyboardPresentation(
@@ -706,6 +681,29 @@ struct AgentTerminalView: View {
 
     static func displayTitle(for agent: ConsoleAgent) -> String {
         agent.agent.title.isEmpty ? agent.agent.displayName : agent.agent.title
+    }
+}
+
+/// Preserve edge-swipe navigation after the title bar is removed.
+private struct AgentEdgeBackGesture: View {
+    let dismiss: @MainActor () -> Void
+
+    var body: some View {
+        Color.clear
+            .frame(width: 24)
+            .frame(maxHeight: .infinity)
+            .contentShape(.rect)
+            .gesture(
+                DragGesture(minimumDistance: 12, coordinateSpace: .global)
+                    .onEnded { value in
+                        let horizontal = value.translation.width
+                        guard value.startLocation.x <= 24,
+                              horizontal >= 72,
+                              abs(value.translation.height) <= horizontal * 0.75
+                        else { return }
+                        dismiss()
+                    })
+            .accessibilityHidden(true)
     }
 }
 

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -433,6 +433,10 @@ struct AgentTerminalView: View {
         .overlay(alignment: .leading) {
             AgentEdgeBackGesture { dismiss() }
         }
+        .toolbarColorScheme(
+            terminal.themes.selection(for: colorScheme)
+                .chromeColorScheme(for: colorScheme),
+            for: .navigationBar)
         .toolbar(.hidden, for: .navigationBar)
     }
 

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -161,9 +161,6 @@ struct AgentTerminalView: View {
 
     private var presentedSurface: some View {
         terminalSurface
-        .toolbar {
-            toolbarContent
-        }
         .photosPicker(
             isPresented: $isSelectingPhoto,
             selection: $selectedPhoto,
@@ -430,18 +427,15 @@ struct AgentTerminalView: View {
             }
         }
         // background(_:ignoresSafeAreaEdges:) defaults to .all: the theme
-        // colour reaches under the transparent navigation bar and into the
-        // home-indicator area without moving the terminal grid or touching
-        // keyboard resize. Must stay outside the safeAreaInset above.
+        // colour reaches into the status-bar and home-indicator areas without
+        // moving the terminal grid or touching keyboard resize. Must stay
+        // outside the safeAreaInset above.
         .background(
             terminal.themes.selection(for: colorScheme)
                 .surfaceBackground(for: colorScheme))
-        .toolbarColorScheme(
-            terminal.themes.selection(for: colorScheme)
-                .chromeColorScheme(for: colorScheme),
-            for: .navigationBar)
-        .navigationTitle(title)
-        .navigationBarTitleDisplayMode(.inline)
+        // Keep the native navigation container, and therefore its interactive
+        // edge-swipe pop gesture, while removing all visible top chrome.
+        .toolbar(.hidden, for: .navigationBar)
     }
 
     private func prepareComposerKeyboardPresentation(
@@ -458,55 +452,6 @@ struct AgentTerminalView: View {
     private func handleActivation() {
         let afterPossibleSuspension = activity.lastAbsenceMayHaveSuspended
         attach.didBecomeActive(afterPossibleSuspension: afterPossibleSuspension)
-    }
-
-    @ToolbarContentBuilder
-    private var toolbarContent: some ToolbarContent {
-        if composer == nil {
-            if !attach.attachLinks.isEmpty {
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        isShowingAttachLinks = true
-                    } label: {
-                        HStack(spacing: 3) {
-                            Image(systemName: "link")
-                            Text("\(attach.attachLinks.count)")
-                                .monospacedDigit()
-                        }
-                    }
-                    .accessibilityLabel("Attach Links")
-                    .accessibilityValue(attachLinkCountDescription)
-                }
-            }
-            ToolbarItem(placement: .primaryAction) {
-                PhotosPicker(selection: $selectedPhoto, matching: .images) {
-                    Label("Attach Image", systemImage: "photo.badge.plus")
-                }
-                .disabled(!attach.canSelectImage)
-                .accessibilityLabel("Attach Image")
-            }
-            ToolbarItem(placement: .primaryAction) {
-                Menu {
-                    Button("New Agent", systemImage: "plus") {
-                        isStartingAgent = true
-                    }
-                    Button("Snippets", systemImage: "quote.bubble") {
-                        isManagingSnippets = true
-                    }
-                    Button("Rename Agent", systemImage: "pencil") {
-                        isRenamingAgent = true
-                    }
-                    Button("Rename Workspace", systemImage: "pencil.line") {
-                        isRenamingWorkspace = true
-                    }
-                    Button("Close Agent", systemImage: "trash", role: .destructive) {
-                        isConfirmingClose = true
-                    }
-                } label: {
-                    Label("More", systemImage: "ellipsis.circle")
-                }
-            }
-        }
     }
 
     private func openAttachLink(_ link: AttachLink) {
@@ -734,11 +679,6 @@ struct AgentTerminalView: View {
 
     private var title: String {
         Self.displayTitle(for: agent)
-    }
-
-    private var attachLinkCountDescription: String {
-        let count = attach.attachLinks.count
-        return count == 1 ? "1 distinct link" : "\(count) distinct links"
     }
 
     static func displayTitle(for agent: ConsoleAgent) -> String {

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -53,6 +53,15 @@ struct AgentTerminalView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
 
+    private var statusBarInset: CGFloat {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter { $0.activationState == .foregroundActive }
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow)?
+            .safeAreaInsets.top ?? 0
+    }
+
     init(
         agent: ConsoleAgent,
         console: ConsoleStore,
@@ -427,9 +436,14 @@ struct AgentTerminalView: View {
                 .accessibilityHidden(composerKeyboardPresentation != .tools)
             }
         }
+        // The navigation bar remains present only as the owner of the status
+        // bar appearance. Its content and background stay hidden, while this
+        // inset keeps terminal output below the system clock.
+        .padding(.top, statusBarInset)
         .background(
             terminal.themes.selection(for: colorScheme)
                 .surfaceBackground(for: colorScheme))
+        .ignoresSafeArea(.container, edges: .top)
         .overlay(alignment: .leading) {
             AgentEdgeBackGesture { dismiss() }
         }
@@ -437,7 +451,11 @@ struct AgentTerminalView: View {
             terminal.themes.selection(for: colorScheme)
                 .chromeColorScheme(for: colorScheme),
             for: .navigationBar)
-        .toolbar(.hidden, for: .navigationBar)
+        .navigationBarBackButtonHidden(true)
+        .navigationTitle("")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.hidden, for: .navigationBar)
+        .toolbar(.visible, for: .navigationBar)
     }
 
     private func prepareComposerKeyboardPresentation(

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -437,8 +437,8 @@ struct AgentTerminalView: View {
             }
         }
         // The navigation bar remains present only as the owner of the status
-        // bar appearance. Its content and background stay hidden, while this
-        // inset keeps terminal output below the system clock.
+        // bar appearance. Its content stays hidden, while this inset keeps
+        // terminal output below the system clock.
         .padding(.top, statusBarInset)
         .background(
             terminal.themes.selection(for: colorScheme)
@@ -454,7 +454,11 @@ struct AgentTerminalView: View {
         .navigationBarBackButtonHidden(true)
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(.hidden, for: .navigationBar)
+        // `toolbarColorScheme` takes effect only while the bar background is
+        // visible. A clear visible background keeps the bar visually absent
+        // and the terminal unobscured while still applying status-bar contrast.
+        .toolbarBackground(Color.clear, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
         .toolbar(.visible, for: .navigationBar)
     }
 

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -52,6 +52,15 @@ struct AgentTerminalView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.openURL) private var openURL
 
+    private var statusBarInset: CGFloat {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter { $0.activationState == .foregroundActive }
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow)?
+            .safeAreaInsets.top ?? 0
+    }
+
     init(
         agent: ConsoleAgent,
         console: ConsoleStore,
@@ -426,23 +435,16 @@ struct AgentTerminalView: View {
                 .accessibilityHidden(composerKeyboardPresentation != .tools)
             }
         }
-        // background(_:ignoresSafeAreaEdges:) defaults to .all: the theme
-        // colour reaches into the status-bar and home-indicator areas without
-        // moving the terminal grid or touching keyboard resize. Must stay
-        // outside the safeAreaInset above.
+        // Pull the surface under the transparent navigation bar, but keep its
+        // first row below the system status bar. Padding remains inside the
+        // fixed full-screen proposal, so the Composer stays bottom-aligned.
+        .padding(.top, statusBarInset)
         .background(
             terminal.themes.selection(for: colorScheme)
                 .surfaceBackground(for: colorScheme))
         // Let terminal output occupy the navigation bar region while keeping
         // native Back navigation and its interactive edge gesture.
         .ignoresSafeArea(.container, edges: .top)
-        .overlay(alignment: .top) {
-            AgentStatusBarBackground(
-                color: terminal.themes.selection(for: colorScheme)
-                    .surfaceBackground(for: colorScheme))
-            .allowsHitTesting(false)
-            .accessibilityHidden(true)
-        }
         // Keep an icon-only native back bar in its own layout region. Hiding
         // the bar also disables interactive pop in a collapsed split view;
         // keeping it visible preserves both the button and the edge gesture
@@ -703,62 +705,6 @@ struct AgentTerminalView: View {
 
     static func displayTitle(for agent: ConsoleAgent) -> String {
         agent.agent.title.isEmpty ? agent.agent.displayName : agent.agent.title
-    }
-}
-
-/// Covers only the window's status-bar safe area. SwiftUI reports a zero top
-/// inset after `ignoresSafeArea`, so the real window inset is required here.
-private struct AgentStatusBarBackground: UIViewRepresentable {
-    let color: Color
-
-    func makeUIView(context: Context) -> StatusBarShieldView {
-        StatusBarShieldView(color: UIColor(color))
-    }
-
-    func updateUIView(_ uiView: StatusBarShieldView, context: Context) {
-        uiView.shieldColor = UIColor(color)
-    }
-
-    @MainActor
-    final class StatusBarShieldView: UIView {
-        var shieldColor: UIColor {
-            didSet { shield.backgroundColor = shieldColor }
-        }
-
-        private let shield = UIView()
-
-        init(color: UIColor) {
-            shieldColor = color
-            super.init(frame: .zero)
-            backgroundColor = .clear
-            isUserInteractionEnabled = false
-            shield.backgroundColor = color
-            addSubview(shield)
-        }
-
-        @available(*, unavailable)
-        required init?(coder: NSCoder) {
-            fatalError("init(coder:) has not been implemented")
-        }
-
-        override func didMoveToWindow() {
-            super.didMoveToWindow()
-            setNeedsLayout()
-        }
-
-        override func safeAreaInsetsDidChange() {
-            super.safeAreaInsetsDidChange()
-            setNeedsLayout()
-        }
-
-        override func layoutSubviews() {
-            super.layoutSubviews()
-            shield.frame = CGRect(
-                x: 0,
-                y: 0,
-                width: bounds.width,
-                height: window?.safeAreaInsets.top ?? 0)
-        }
     }
 }
 

--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -188,12 +188,26 @@ final class ConsoleStore {
         }
     }
 
+    func fileStager(for hostID: Host.ID) -> FileStager {
+        { [weak self] file, reporter in
+            guard let stager = await self?.liveFileStager(for: hostID) else {
+                throw TransportError.sshUnreachable(
+                    detail: "The Host is not connected.")
+            }
+            return try await stager(file, reporter)
+        }
+    }
+
     private func liveTerminalRunner(for hostID: Host.ID) -> TerminalSessionRunner? {
         projections[hostID]?.terminalRunner()
     }
 
     private func liveImageStager(for hostID: Host.ID) -> ImageStager? {
         projections[hostID]?.imageStager()
+    }
+
+    private func liveFileStager(for hostID: Host.ID) -> FileStager? {
+        projections[hostID]?.fileStager()
     }
 
     func workspaces(for hostID: Host.ID) -> [ConsoleWorkspace] {

--- a/Sources/Heeler/Console/ConsoleView.swift
+++ b/Sources/Heeler/Console/ConsoleView.swift
@@ -113,6 +113,11 @@ struct ConsoleView: View {
         } detail: {
             detail
         }
+        .modifier(
+            ConsoleStatusBarModifier(
+                scheme: terminalStatusBarColorScheme
+            )
+        )
         // Above the NavigationStack so a banner also shows over a pushed
         // Agent detail; a tap deep-links exactly like a push tap would.
         .overlay(alignment: .top) {
@@ -151,6 +156,19 @@ struct ConsoleView: View {
         Binding(
             get: { notificationRouter.path.last },
             set: { notificationRouter.path = $0.map { [$0] } ?? [] })
+    }
+
+    /// The split view owns the window's status-bar appearance on iPhone. A
+    /// pushed terminal cannot reliably override it from the detail subtree.
+    private var terminalStatusBarColorScheme: ColorScheme? {
+        guard let id = notificationRouter.path.last else { return nil }
+        let showsTerminalSurface = console.agents.contains(where: { $0.id == id })
+        let showsTerminalSyncSurface = !showsTerminalSurface
+            && MissingAgentPresentation(agentID: id, console: console, hosts: hosts).cause
+                == .hostSyncing
+        guard showsTerminalSurface || showsTerminalSyncSurface else { return nil }
+        return terminal.themes.selection(for: colorScheme)
+            .chromeColorScheme(for: colorScheme)
     }
 
     /// The detail column. Not keyed off the live Agent list alone: the
@@ -388,6 +406,22 @@ struct ConsoleView: View {
         await console.retryHost(id)
         try? await Task.sleep(for: .milliseconds(1_200))
         reconnectingHostIDs.remove(id)
+    }
+}
+
+private struct ConsoleStatusBarModifier: ViewModifier {
+    let scheme: ColorScheme?
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(iOS 27.0, *) {
+            content
+                .toolbarVisibility(.visible, for: .statusBar)
+                .toolbarColorScheme(scheme, for: .statusBar)
+        } else {
+            content
+                .toolbarColorScheme(scheme, for: .navigationBar)
+        }
     }
 }
 

--- a/Sources/Heeler/Console/HostConsoleProjection.swift
+++ b/Sources/Heeler/Console/HostConsoleProjection.swift
@@ -157,6 +157,17 @@ final class HostConsoleProjection {
         }
     }
 
+    func fileStager() -> FileStager {
+        let session = session
+        return { file, reporter in
+            try await session.withTransport { transport in
+                try await transport.stageFile(file) { progress in
+                    await reporter.report(progress)
+                }
+            }
+        }
+    }
+
     @discardableResult
     func startAgent(_ request: AgentLaunchRequest) async throws -> Agent {
         let agent = try await session.withTransport { transport in

--- a/Sources/Heeler/Files/FileAttachStore.swift
+++ b/Sources/Heeler/Files/FileAttachStore.swift
@@ -2,48 +2,48 @@ import Foundation
 import Observation
 
 typealias FileStager =
-  @Sendable (PreparedFile, ImageStageProgressReporter) async throws -> StagedFile
+    @Sendable (PreparedFile, ImageStageProgressReporter) async throws -> StagedFile
 
 struct FileAttachFailure: Sendable, Equatable {
-  let message: String
-  let isRetryable: Bool
+    let message: String
+    let isRetryable: Bool
 }
 
 struct FileAttachResult: Sendable, Equatable {
-  let stagedFile: StagedFile
-  var copied: Bool
-  var inserted: Bool
+    let stagedFile: StagedFile
+    var copied: Bool
+    var inserted: Bool
 
-  var message: String {
-    switch (copied, inserted) {
-    case (true, true):
-      "File path inserted and copied."
-    case (true, false):
-      "File path copied, but couldn't be inserted."
-    case (false, true):
-      "File path inserted, but couldn't be copied."
-    case (false, false):
-      "File uploaded, but its path couldn't be copied or inserted."
+    var message: String {
+        switch (copied, inserted) {
+        case (true, true):
+            "File path inserted and copied."
+        case (true, false):
+            "File path copied, but couldn't be inserted."
+        case (false, true):
+            "File path inserted, but couldn't be copied."
+        case (false, false):
+            "File uploaded, but its path couldn't be copied or inserted."
+        }
     }
-  }
 }
 
 enum FileAttachState: Sendable, Equatable {
-  case idle
-  case preparing
-  case uploading(ImageStageProgress)
-  case failed(FileAttachFailure)
-  case backgroundInterrupted(FileAttachFailure)
-  case completed(FileAttachResult)
+    case idle
+    case preparing
+    case uploading(ImageStageProgress)
+    case failed(FileAttachFailure)
+    case backgroundInterrupted(FileAttachFailure)
+    case completed(FileAttachResult)
 
-  var isBusy: Bool {
-    switch self {
-    case .preparing, .uploading:
-      true
-    case .idle, .failed, .backgroundInterrupted, .completed:
-      false
+    var isBusy: Bool {
+        switch self {
+        case .preparing, .uploading:
+            true
+        case .idle, .failed, .backgroundInterrupted, .completed:
+            false
+        }
     }
-  }
 }
 
 /// Coordinates one Files selection through a protected local copy, Host
@@ -51,241 +51,241 @@ enum FileAttachState: Sendable, Equatable {
 @MainActor
 @Observable
 final class FileAttachStore {
-  private enum CancellationDisposition {
-    case user
-    case background
-    case leaving
-  }
-
-  private(set) var state: FileAttachState = .idle
-
-  private let preparer: any FilePreparing
-  private let stageFile: FileStager
-  private let clipboard: any ImageClipboard
-  private weak var composer: (any ComposerDraftOperations)?
-
-  private var preparedFile: PreparedFile?
-  private var operationTask: Task<Void, Never>?
-  private var operationID: UInt64 = 0
-  private var cancellationDisposition: CancellationDisposition?
-
-  init(
-    preparer: any FilePreparing = FilePreparer(),
-    stageFile: @escaping FileStager,
-    clipboard: any ImageClipboard = SystemImageClipboard(),
-    composer: any ComposerDraftOperations
-  ) {
-    self.preparer = preparer
-    self.stageFile = stageFile
-    self.clipboard = clipboard
-    self.composer = composer
-  }
-
-  var canSelectFile: Bool {
-    !state.isBusy && composer != nil
-  }
-
-  func select(_ sourceURL: URL) {
-    guard operationTask == nil, composer != nil else { return }
-    discardRetainedPreparedFile()
-    cancellationDisposition = nil
-    operationID &+= 1
-    let currentID = operationID
-    state = .preparing
-    operationTask = Task {
-      await runSelection(sourceURL, operationID: currentID)
+    private enum CancellationDisposition {
+        case user
+        case background
+        case leaving
     }
-  }
 
-  func retry() {
-    guard operationTask == nil, let preparedFile, composer != nil else { return }
-    cancellationDisposition = nil
-    operationID &+= 1
-    let currentID = operationID
-    state = .uploading(
-      ImageStageProgress(transferredBytes: 0, totalBytes: preparedFile.byteCount))
-    operationTask = Task {
-      await runUpload(preparedFile, operationID: currentID)
+    private(set) var state: FileAttachState = .idle
+
+    private let preparer: any FilePreparing
+    private let stageFile: FileStager
+    private let clipboard: any ImageClipboard
+    private weak var composer: (any ComposerDraftOperations)?
+
+    private var preparedFile: PreparedFile?
+    private var operationTask: Task<Void, Never>?
+    private var operationID: UInt64 = 0
+    private var cancellationDisposition: CancellationDisposition?
+
+    init(
+        preparer: any FilePreparing = FilePreparer(),
+        stageFile: @escaping FileStager,
+        clipboard: any ImageClipboard = SystemImageClipboard(),
+        composer: any ComposerDraftOperations
+    ) {
+        self.preparer = preparer
+        self.stageFile = stageFile
+        self.clipboard = clipboard
+        self.composer = composer
     }
-  }
 
-  func cancel() {
-    guard let operationTask else {
-      state = .idle
-      discardRetainedPreparedFile()
-      return
+    var canSelectFile: Bool {
+        !state.isBusy && composer != nil
     }
-    cancellationDisposition = .user
-    operationTask.cancel()
-  }
 
-  func didEnterBackground() {
-    guard let operationTask else { return }
-    cancellationDisposition = .background
-    operationTask.cancel()
-  }
-
-  func copyPath() {
-    guard case .completed(var result) = state, !result.copied else { return }
-    do {
-      try clipboard.copy(result.stagedFile.path)
-      result.copied = true
-      state = .completed(result)
-    } catch {}
-  }
-
-  func insertPath() {
-    guard case .completed(var result) = state, !result.inserted,
-      let composer
-    else { return }
-    composer.insertIntoDraft("\(result.stagedFile.path) ")
-    result.inserted = true
-    state = .completed(result)
-  }
-
-  func dismissResult() {
-    guard !state.isBusy else { return }
-    discardRetainedPreparedFile()
-    state = .idle
-  }
-
-  func leave() async {
-    if let task = operationTask {
-      cancellationDisposition = .leaving
-      task.cancel()
-      await task.value
+    func select(_ sourceURL: URL) {
+        guard operationTask == nil, composer != nil else { return }
+        discardRetainedPreparedFile()
+        cancellationDisposition = nil
+        operationID &+= 1
+        let currentID = operationID
+        state = .preparing
+        operationTask = Task {
+            await runSelection(sourceURL, operationID: currentID)
+        }
     }
-    discardRetainedPreparedFile()
-    state = .idle
-  }
 
-  private func runSelection(_ sourceURL: URL, operationID: UInt64) async {
-    var unclaimedFile: PreparedFile?
-    do {
-      let file = try await preparer.prepare(sourceURL)
-      unclaimedFile = file
-      try Task.checkCancellation()
-      guard operationID == self.operationID else {
-        try? file.remove()
-        return
-      }
-      preparedFile = file
-      unclaimedFile = nil
-      state = .uploading(
-        ImageStageProgress(transferredBytes: 0, totalBytes: file.byteCount))
-      await runUploadBody(file, operationID: operationID)
-    } catch {
-      try? unclaimedFile?.remove()
-      finish(error: error, operationID: operationID)
+    func retry() {
+        guard operationTask == nil, let preparedFile, composer != nil else { return }
+        cancellationDisposition = nil
+        operationID &+= 1
+        let currentID = operationID
+        state = .uploading(
+            ImageStageProgress(transferredBytes: 0, totalBytes: preparedFile.byteCount))
+        operationTask = Task {
+            await runUpload(preparedFile, operationID: currentID)
+        }
     }
-  }
 
-  private func runUpload(_ file: PreparedFile, operationID: UInt64) async {
-    await runUploadBody(file, operationID: operationID)
-  }
-
-  private func runUploadBody(_ file: PreparedFile, operationID: UInt64) async {
-    do {
-      let staged = try await stageFile(
-        file,
-        ImageStageProgressReporter { [weak self] progress in
-          await self?.receive(progress: progress, operationID: operationID)
-        })
-      try Task.checkCancellation()
-      finishSuccess(staged, operationID: operationID)
-    } catch {
-      finish(error: error, operationID: operationID)
+    func cancel() {
+        guard let operationTask else {
+            state = .idle
+            discardRetainedPreparedFile()
+            return
+        }
+        cancellationDisposition = .user
+        operationTask.cancel()
     }
-  }
 
-  private func receive(progress: ImageStageProgress, operationID: UInt64) {
-    guard operationID == self.operationID, operationTask != nil else { return }
-    state = .uploading(progress)
-  }
-
-  private func finishSuccess(_ stagedFile: StagedFile, operationID: UInt64) {
-    guard operationID == self.operationID else { return }
-    operationTask = nil
-    cancellationDisposition = nil
-    discardRetainedPreparedFile()
-
-    var copied = false
-    do {
-      try clipboard.copy(stagedFile.path)
-      copied = true
-    } catch {}
-    var inserted = false
-    if let composer {
-      composer.insertIntoDraft("\(stagedFile.path) ")
-      inserted = true
+    func didEnterBackground() {
+        guard let operationTask else { return }
+        cancellationDisposition = .background
+        operationTask.cancel()
     }
-    state = .completed(
-      FileAttachResult(stagedFile: stagedFile, copied: copied, inserted: inserted))
-  }
 
-  private func finish(error: any Error, operationID: UInt64) {
-    guard operationID == self.operationID else { return }
-    operationTask = nil
+    func copyPath() {
+        guard case .completed(var result) = state, !result.copied else { return }
+        do {
+            try clipboard.copy(result.stagedFile.path)
+            result.copied = true
+            state = .completed(result)
+        } catch {}
+    }
 
-    if error is CancellationError || (error as? ImageStagingError) == .cancelled
-      || cancellationDisposition != nil
-    {
-      switch cancellationDisposition {
-      case .background:
-        state = .backgroundInterrupted(
-          FileAttachFailure(
-            message: "File upload paused when Heeler moved to the background.",
-            isRetryable: preparedFile != nil))
-      case .user, .leaving, .none:
+    func insertPath() {
+        guard case .completed(var result) = state, !result.inserted,
+            let composer
+        else { return }
+        composer.insertIntoDraft("\(result.stagedFile.path) ")
+        result.inserted = true
+        state = .completed(result)
+    }
+
+    func dismissResult() {
+        guard !state.isBusy else { return }
         discardRetainedPreparedFile()
         state = .idle
-      }
-      cancellationDisposition = nil
-      return
     }
 
-    let failure = Self.failure(for: error)
-    if !failure.isRetryable {
-      discardRetainedPreparedFile()
+    func leave() async {
+        if let task = operationTask {
+            cancellationDisposition = .leaving
+            task.cancel()
+            await task.value
+        }
+        discardRetainedPreparedFile()
+        state = .idle
     }
-    state = .failed(failure)
-  }
 
-  private func discardRetainedPreparedFile() {
-    try? preparedFile?.remove()
-    preparedFile = nil
-  }
-
-  private static func failure(for error: any Error) -> FileAttachFailure {
-    switch error {
-    case TransportError.sshUnreachable:
-      FileAttachFailure(
-        message: "The Host is not connected. Reconnect, then retry the upload.",
-        isRetryable: true)
-    case ImageStagingError.sftpUnavailable:
-      FileAttachFailure(
-        message: "SFTP is unavailable on this Host. Enable its SSH SFTP subsystem.",
-        isRetryable: false)
-    case let staging as ImageStagingError:
-      FileAttachFailure(
-        message: "File upload failed.",
-        isRetryable: staging.isRetryable)
-    case FilePreparationError.selectionUnavailable:
-      FileAttachFailure(
-        message: "The selected file is no longer available.",
-        isRetryable: false)
-    case FilePreparationError.sourceTooLarge:
-      FileAttachFailure(
-        message: "The selected file exceeds the 64 MiB upload limit.",
-        isRetryable: false)
-    case FilePreparationError.localStorageFailed:
-      FileAttachFailure(
-        message: "Heeler couldn't prepare the file in protected local storage.",
-        isRetryable: false)
-    default:
-      FileAttachFailure(
-        message: "File preparation failed.",
-        isRetryable: false)
+    private func runSelection(_ sourceURL: URL, operationID: UInt64) async {
+        var unclaimedFile: PreparedFile?
+        do {
+            let file = try await preparer.prepare(sourceURL)
+            unclaimedFile = file
+            try Task.checkCancellation()
+            guard operationID == self.operationID else {
+                try? file.remove()
+                return
+            }
+            preparedFile = file
+            unclaimedFile = nil
+            state = .uploading(
+                ImageStageProgress(transferredBytes: 0, totalBytes: file.byteCount))
+            await runUploadBody(file, operationID: operationID)
+        } catch {
+            try? unclaimedFile?.remove()
+            finish(error: error, operationID: operationID)
+        }
     }
-  }
+
+    private func runUpload(_ file: PreparedFile, operationID: UInt64) async {
+        await runUploadBody(file, operationID: operationID)
+    }
+
+    private func runUploadBody(_ file: PreparedFile, operationID: UInt64) async {
+        do {
+            let staged = try await stageFile(
+                file,
+                ImageStageProgressReporter { [weak self] progress in
+                    await self?.receive(progress: progress, operationID: operationID)
+                })
+            try Task.checkCancellation()
+            finishSuccess(staged, operationID: operationID)
+        } catch {
+            finish(error: error, operationID: operationID)
+        }
+    }
+
+    private func receive(progress: ImageStageProgress, operationID: UInt64) {
+        guard operationID == self.operationID, operationTask != nil else { return }
+        state = .uploading(progress)
+    }
+
+    private func finishSuccess(_ stagedFile: StagedFile, operationID: UInt64) {
+        guard operationID == self.operationID else { return }
+        operationTask = nil
+        cancellationDisposition = nil
+        discardRetainedPreparedFile()
+
+        var copied = false
+        do {
+            try clipboard.copy(stagedFile.path)
+            copied = true
+        } catch {}
+        var inserted = false
+        if let composer {
+            composer.insertIntoDraft("\(stagedFile.path) ")
+            inserted = true
+        }
+        state = .completed(
+            FileAttachResult(stagedFile: stagedFile, copied: copied, inserted: inserted))
+    }
+
+    private func finish(error: any Error, operationID: UInt64) {
+        guard operationID == self.operationID else { return }
+        operationTask = nil
+
+        if error is CancellationError || (error as? ImageStagingError) == .cancelled
+            || cancellationDisposition != nil
+        {
+            switch cancellationDisposition {
+            case .background:
+                state = .backgroundInterrupted(
+                    FileAttachFailure(
+                        message: "File upload paused when Heeler moved to the background.",
+                        isRetryable: preparedFile != nil))
+            case .user, .leaving, .none:
+                discardRetainedPreparedFile()
+                state = .idle
+            }
+            cancellationDisposition = nil
+            return
+        }
+
+        let failure = Self.failure(for: error)
+        if !failure.isRetryable {
+            discardRetainedPreparedFile()
+        }
+        state = .failed(failure)
+    }
+
+    private func discardRetainedPreparedFile() {
+        try? preparedFile?.remove()
+        preparedFile = nil
+    }
+
+    private static func failure(for error: any Error) -> FileAttachFailure {
+        switch error {
+        case TransportError.sshUnreachable:
+            FileAttachFailure(
+                message: "The Host is not connected. Reconnect, then retry the upload.",
+                isRetryable: true)
+        case ImageStagingError.sftpUnavailable:
+            FileAttachFailure(
+                message: "SFTP is unavailable on this Host. Enable its SSH SFTP subsystem.",
+                isRetryable: false)
+        case let staging as ImageStagingError:
+            FileAttachFailure(
+                message: "File upload failed.",
+                isRetryable: staging.isRetryable)
+        case FilePreparationError.selectionUnavailable:
+            FileAttachFailure(
+                message: "The selected file is no longer available.",
+                isRetryable: false)
+        case FilePreparationError.sourceTooLarge:
+            FileAttachFailure(
+                message: "The selected file exceeds the 64 MiB upload limit.",
+                isRetryable: false)
+        case FilePreparationError.localStorageFailed:
+            FileAttachFailure(
+                message: "Heeler couldn't prepare the file in protected local storage.",
+                isRetryable: false)
+        default:
+            FileAttachFailure(
+                message: "File preparation failed.",
+                isRetryable: false)
+        }
+    }
 }

--- a/Sources/Heeler/Files/FileAttachStore.swift
+++ b/Sources/Heeler/Files/FileAttachStore.swift
@@ -1,0 +1,291 @@
+import Foundation
+import Observation
+
+typealias FileStager =
+  @Sendable (PreparedFile, ImageStageProgressReporter) async throws -> StagedFile
+
+struct FileAttachFailure: Sendable, Equatable {
+  let message: String
+  let isRetryable: Bool
+}
+
+struct FileAttachResult: Sendable, Equatable {
+  let stagedFile: StagedFile
+  var copied: Bool
+  var inserted: Bool
+
+  var message: String {
+    switch (copied, inserted) {
+    case (true, true):
+      "File path inserted and copied."
+    case (true, false):
+      "File path copied, but couldn't be inserted."
+    case (false, true):
+      "File path inserted, but couldn't be copied."
+    case (false, false):
+      "File uploaded, but its path couldn't be copied or inserted."
+    }
+  }
+}
+
+enum FileAttachState: Sendable, Equatable {
+  case idle
+  case preparing
+  case uploading(ImageStageProgress)
+  case failed(FileAttachFailure)
+  case backgroundInterrupted(FileAttachFailure)
+  case completed(FileAttachResult)
+
+  var isBusy: Bool {
+    switch self {
+    case .preparing, .uploading:
+      true
+    case .idle, .failed, .backgroundInterrupted, .completed:
+      false
+    }
+  }
+}
+
+/// Coordinates one Files selection through a protected local copy, Host
+/// staging, and insertion into the local Composer draft.
+@MainActor
+@Observable
+final class FileAttachStore {
+  private enum CancellationDisposition {
+    case user
+    case background
+    case leaving
+  }
+
+  private(set) var state: FileAttachState = .idle
+
+  private let preparer: any FilePreparing
+  private let stageFile: FileStager
+  private let clipboard: any ImageClipboard
+  private weak var composer: (any ComposerDraftOperations)?
+
+  private var preparedFile: PreparedFile?
+  private var operationTask: Task<Void, Never>?
+  private var operationID: UInt64 = 0
+  private var cancellationDisposition: CancellationDisposition?
+
+  init(
+    preparer: any FilePreparing = FilePreparer(),
+    stageFile: @escaping FileStager,
+    clipboard: any ImageClipboard = SystemImageClipboard(),
+    composer: any ComposerDraftOperations
+  ) {
+    self.preparer = preparer
+    self.stageFile = stageFile
+    self.clipboard = clipboard
+    self.composer = composer
+  }
+
+  var canSelectFile: Bool {
+    !state.isBusy && composer != nil
+  }
+
+  func select(_ sourceURL: URL) {
+    guard operationTask == nil, composer != nil else { return }
+    discardRetainedPreparedFile()
+    cancellationDisposition = nil
+    operationID &+= 1
+    let currentID = operationID
+    state = .preparing
+    operationTask = Task {
+      await runSelection(sourceURL, operationID: currentID)
+    }
+  }
+
+  func retry() {
+    guard operationTask == nil, let preparedFile, composer != nil else { return }
+    cancellationDisposition = nil
+    operationID &+= 1
+    let currentID = operationID
+    state = .uploading(
+      ImageStageProgress(transferredBytes: 0, totalBytes: preparedFile.byteCount))
+    operationTask = Task {
+      await runUpload(preparedFile, operationID: currentID)
+    }
+  }
+
+  func cancel() {
+    guard let operationTask else {
+      state = .idle
+      discardRetainedPreparedFile()
+      return
+    }
+    cancellationDisposition = .user
+    operationTask.cancel()
+  }
+
+  func didEnterBackground() {
+    guard let operationTask else { return }
+    cancellationDisposition = .background
+    operationTask.cancel()
+  }
+
+  func copyPath() {
+    guard case .completed(var result) = state, !result.copied else { return }
+    do {
+      try clipboard.copy(result.stagedFile.path)
+      result.copied = true
+      state = .completed(result)
+    } catch {}
+  }
+
+  func insertPath() {
+    guard case .completed(var result) = state, !result.inserted,
+      let composer
+    else { return }
+    composer.insertIntoDraft("\(result.stagedFile.path) ")
+    result.inserted = true
+    state = .completed(result)
+  }
+
+  func dismissResult() {
+    guard !state.isBusy else { return }
+    discardRetainedPreparedFile()
+    state = .idle
+  }
+
+  func leave() async {
+    if let task = operationTask {
+      cancellationDisposition = .leaving
+      task.cancel()
+      await task.value
+    }
+    discardRetainedPreparedFile()
+    state = .idle
+  }
+
+  private func runSelection(_ sourceURL: URL, operationID: UInt64) async {
+    var unclaimedFile: PreparedFile?
+    do {
+      let file = try await preparer.prepare(sourceURL)
+      unclaimedFile = file
+      try Task.checkCancellation()
+      guard operationID == self.operationID else {
+        try? file.remove()
+        return
+      }
+      preparedFile = file
+      unclaimedFile = nil
+      state = .uploading(
+        ImageStageProgress(transferredBytes: 0, totalBytes: file.byteCount))
+      await runUploadBody(file, operationID: operationID)
+    } catch {
+      try? unclaimedFile?.remove()
+      finish(error: error, operationID: operationID)
+    }
+  }
+
+  private func runUpload(_ file: PreparedFile, operationID: UInt64) async {
+    await runUploadBody(file, operationID: operationID)
+  }
+
+  private func runUploadBody(_ file: PreparedFile, operationID: UInt64) async {
+    do {
+      let staged = try await stageFile(
+        file,
+        ImageStageProgressReporter { [weak self] progress in
+          await self?.receive(progress: progress, operationID: operationID)
+        })
+      try Task.checkCancellation()
+      finishSuccess(staged, operationID: operationID)
+    } catch {
+      finish(error: error, operationID: operationID)
+    }
+  }
+
+  private func receive(progress: ImageStageProgress, operationID: UInt64) {
+    guard operationID == self.operationID, operationTask != nil else { return }
+    state = .uploading(progress)
+  }
+
+  private func finishSuccess(_ stagedFile: StagedFile, operationID: UInt64) {
+    guard operationID == self.operationID else { return }
+    operationTask = nil
+    cancellationDisposition = nil
+    discardRetainedPreparedFile()
+
+    var copied = false
+    do {
+      try clipboard.copy(stagedFile.path)
+      copied = true
+    } catch {}
+    var inserted = false
+    if let composer {
+      composer.insertIntoDraft("\(stagedFile.path) ")
+      inserted = true
+    }
+    state = .completed(
+      FileAttachResult(stagedFile: stagedFile, copied: copied, inserted: inserted))
+  }
+
+  private func finish(error: any Error, operationID: UInt64) {
+    guard operationID == self.operationID else { return }
+    operationTask = nil
+
+    if error is CancellationError || (error as? ImageStagingError) == .cancelled
+      || cancellationDisposition != nil
+    {
+      switch cancellationDisposition {
+      case .background:
+        state = .backgroundInterrupted(
+          FileAttachFailure(
+            message: "File upload paused when Heeler moved to the background.",
+            isRetryable: preparedFile != nil))
+      case .user, .leaving, .none:
+        discardRetainedPreparedFile()
+        state = .idle
+      }
+      cancellationDisposition = nil
+      return
+    }
+
+    let failure = Self.failure(for: error)
+    if !failure.isRetryable {
+      discardRetainedPreparedFile()
+    }
+    state = .failed(failure)
+  }
+
+  private func discardRetainedPreparedFile() {
+    try? preparedFile?.remove()
+    preparedFile = nil
+  }
+
+  private static func failure(for error: any Error) -> FileAttachFailure {
+    switch error {
+    case TransportError.sshUnreachable:
+      FileAttachFailure(
+        message: "The Host is not connected. Reconnect, then retry the upload.",
+        isRetryable: true)
+    case ImageStagingError.sftpUnavailable:
+      FileAttachFailure(
+        message: "SFTP is unavailable on this Host. Enable its SSH SFTP subsystem.",
+        isRetryable: false)
+    case let staging as ImageStagingError:
+      FileAttachFailure(
+        message: "File upload failed.",
+        isRetryable: staging.isRetryable)
+    case FilePreparationError.selectionUnavailable:
+      FileAttachFailure(
+        message: "The selected file is no longer available.",
+        isRetryable: false)
+    case FilePreparationError.sourceTooLarge:
+      FileAttachFailure(
+        message: "The selected file exceeds the 64 MiB upload limit.",
+        isRetryable: false)
+    case FilePreparationError.localStorageFailed:
+      FileAttachFailure(
+        message: "Heeler couldn't prepare the file in protected local storage.",
+        isRetryable: false)
+    default:
+      FileAttachFailure(
+        message: "File preparation failed.",
+        isRetryable: false)
+    }
+  }
+}

--- a/Sources/Heeler/Files/FilePreparer.swift
+++ b/Sources/Heeler/Files/FilePreparer.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+struct PreparedFile: Sendable, Equatable {
+  let fileURL: URL
+  let fileExtension: String
+  let byteCount: Int64
+
+  init(fileURL: URL, fileExtension: String, byteCount: Int64) {
+    self.fileURL = fileURL
+    self.fileExtension = Self.safeExtension(fileExtension)
+    self.byteCount = byteCount
+  }
+
+  var remoteFilename: String {
+    fileExtension.isEmpty ? "file" : "file.\(fileExtension)"
+  }
+
+  func remove(fileManager: FileManager = .default) throws {
+    guard fileManager.fileExists(atPath: fileURL.path) else { return }
+    try fileManager.removeItem(at: fileURL)
+  }
+
+  static func safeExtension(_ candidate: String) -> String {
+    let candidate = candidate.lowercased()
+    guard !candidate.isEmpty, candidate.count <= 16 else { return "" }
+    guard
+      candidate.unicodeScalars.allSatisfy({ scalar in
+        switch scalar.value {
+        case 0x30...0x39, 0x61...0x7A:
+          true
+        default:
+          false
+        }
+      })
+    else { return "" }
+    return candidate
+  }
+}
+
+protocol FilePreparing: Sendable {
+  func prepare(_ sourceURL: URL) async throws -> PreparedFile
+}
+
+enum FilePreparationError: Error, Sendable, Equatable {
+  case selectionUnavailable
+  case sourceTooLarge
+  case localStorageFailed
+}
+
+/// Copies a document-picker result into protected app-owned temporary storage.
+/// The private copy keeps retries independent from the provider's security scope
+/// and replaces the original filename with a random local name.
+actor FilePreparer: FilePreparing {
+  static let maximumByteCount = 64 * 1_024 * 1_024
+  static let defaultDirectory = FileManager.default.temporaryDirectory
+    .appendingPathComponent("HeelerPreparedFiles", isDirectory: true)
+
+  private let maximumByteCount: Int64
+  private let directory: URL
+  private let fileManager: FileManager
+
+  init(
+    maximumByteCount: Int64 = Int64(FilePreparer.maximumByteCount),
+    directory: URL = FilePreparer.defaultDirectory,
+    fileManager: FileManager = .default
+  ) {
+    self.maximumByteCount = maximumByteCount
+    self.directory = directory
+    self.fileManager = fileManager
+  }
+
+  func prepare(_ sourceURL: URL) async throws -> PreparedFile {
+    try Task.checkCancellation()
+    let hasSecurityScope = sourceURL.startAccessingSecurityScopedResource()
+    defer {
+      if hasSecurityScope {
+        sourceURL.stopAccessingSecurityScopedResource()
+      }
+    }
+
+    let values: URLResourceValues
+    do {
+      values = try sourceURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+    } catch {
+      throw FilePreparationError.selectionUnavailable
+    }
+    guard values.isRegularFile == true else {
+      throw FilePreparationError.selectionUnavailable
+    }
+    if let sourceByteCount = values.fileSize,
+      Int64(sourceByteCount) > maximumByteCount
+    {
+      throw FilePreparationError.sourceTooLarge
+    }
+
+    do {
+      try Self.ensureDirectory(directory, fileManager: fileManager)
+    } catch {
+      throw FilePreparationError.localStorageFailed
+    }
+    let fileExtension = PreparedFile.safeExtension(sourceURL.pathExtension)
+    let filename =
+      fileExtension.isEmpty
+      ? UUID().uuidString.lowercased()
+      : "\(UUID().uuidString.lowercased()).\(fileExtension)"
+    let destinationURL = directory.appendingPathComponent(filename)
+
+    do {
+      try fileManager.copyItem(at: sourceURL, to: destinationURL)
+      try Task.checkCancellation()
+      let attributes = try fileManager.attributesOfItem(atPath: destinationURL.path)
+      guard let size = attributes[.size] as? NSNumber, size.int64Value > 0 else {
+        throw FilePreparationError.selectionUnavailable
+      }
+      guard size.int64Value <= maximumByteCount else {
+        throw FilePreparationError.sourceTooLarge
+      }
+      try fileManager.setAttributes(
+        [.protectionKey: FileProtectionType.complete],
+        ofItemAtPath: destinationURL.path)
+      var resourceValues = URLResourceValues()
+      resourceValues.isExcludedFromBackup = true
+      var mutableURL = destinationURL
+      try mutableURL.setResourceValues(resourceValues)
+      return PreparedFile(
+        fileURL: destinationURL,
+        fileExtension: fileExtension,
+        byteCount: size.int64Value)
+    } catch let error as FilePreparationError {
+      try? fileManager.removeItem(at: destinationURL)
+      throw error
+    } catch is CancellationError {
+      try? fileManager.removeItem(at: destinationURL)
+      throw CancellationError()
+    } catch {
+      try? fileManager.removeItem(at: destinationURL)
+      throw FilePreparationError.localStorageFailed
+    }
+  }
+
+  static func cleanupRemnants(
+    in directory: URL = defaultDirectory,
+    fileManager: FileManager = .default
+  ) throws {
+    guard fileManager.fileExists(atPath: directory.path) else { return }
+    for url in try fileManager.contentsOfDirectory(
+      at: directory,
+      includingPropertiesForKeys: nil,
+      options: [.skipsHiddenFiles])
+    {
+      try fileManager.removeItem(at: url)
+    }
+  }
+
+  private static func ensureDirectory(
+    _ directory: URL,
+    fileManager: FileManager
+  ) throws {
+    try fileManager.createDirectory(
+      at: directory,
+      withIntermediateDirectories: true,
+      attributes: [.protectionKey: FileProtectionType.complete])
+    var values = URLResourceValues()
+    values.isExcludedFromBackup = true
+    var mutableDirectory = directory
+    try mutableDirectory.setResourceValues(values)
+  }
+}

--- a/Sources/Heeler/Files/FilePreparer.swift
+++ b/Sources/Heeler/Files/FilePreparer.swift
@@ -1,168 +1,168 @@
 import Foundation
 
 struct PreparedFile: Sendable, Equatable {
-  let fileURL: URL
-  let fileExtension: String
-  let byteCount: Int64
+    let fileURL: URL
+    let fileExtension: String
+    let byteCount: Int64
 
-  init(fileURL: URL, fileExtension: String, byteCount: Int64) {
-    self.fileURL = fileURL
-    self.fileExtension = Self.safeExtension(fileExtension)
-    self.byteCount = byteCount
-  }
+    init(fileURL: URL, fileExtension: String, byteCount: Int64) {
+        self.fileURL = fileURL
+        self.fileExtension = Self.safeExtension(fileExtension)
+        self.byteCount = byteCount
+    }
 
-  var remoteFilename: String {
-    fileExtension.isEmpty ? "file" : "file.\(fileExtension)"
-  }
+    var remoteFilename: String {
+        fileExtension.isEmpty ? "file" : "file.\(fileExtension)"
+    }
 
-  func remove(fileManager: FileManager = .default) throws {
-    guard fileManager.fileExists(atPath: fileURL.path) else { return }
-    try fileManager.removeItem(at: fileURL)
-  }
+    func remove(fileManager: FileManager = .default) throws {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return }
+        try fileManager.removeItem(at: fileURL)
+    }
 
-  static func safeExtension(_ candidate: String) -> String {
-    let candidate = candidate.lowercased()
-    guard !candidate.isEmpty, candidate.count <= 16 else { return "" }
-    guard
-      candidate.unicodeScalars.allSatisfy({ scalar in
-        switch scalar.value {
-        case 0x30...0x39, 0x61...0x7A:
-          true
-        default:
-          false
-        }
-      })
-    else { return "" }
-    return candidate
-  }
+    static func safeExtension(_ candidate: String) -> String {
+        let candidate = candidate.lowercased()
+        guard !candidate.isEmpty, candidate.count <= 16 else { return "" }
+        guard
+            candidate.unicodeScalars.allSatisfy({ scalar in
+                switch scalar.value {
+                case 0x30...0x39, 0x61...0x7A:
+                    true
+                default:
+                    false
+                }
+            })
+        else { return "" }
+        return candidate
+    }
 }
 
 protocol FilePreparing: Sendable {
-  func prepare(_ sourceURL: URL) async throws -> PreparedFile
+    func prepare(_ sourceURL: URL) async throws -> PreparedFile
 }
 
 enum FilePreparationError: Error, Sendable, Equatable {
-  case selectionUnavailable
-  case sourceTooLarge
-  case localStorageFailed
+    case selectionUnavailable
+    case sourceTooLarge
+    case localStorageFailed
 }
 
 /// Copies a document-picker result into protected app-owned temporary storage.
 /// The private copy keeps retries independent from the provider's security scope
 /// and replaces the original filename with a random local name.
 actor FilePreparer: FilePreparing {
-  static let maximumByteCount = 64 * 1_024 * 1_024
-  static let defaultDirectory = FileManager.default.temporaryDirectory
-    .appendingPathComponent("HeelerPreparedFiles", isDirectory: true)
+    static let maximumByteCount = 64 * 1_024 * 1_024
+    static let defaultDirectory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("HeelerPreparedFiles", isDirectory: true)
 
-  private let maximumByteCount: Int64
-  private let directory: URL
-  private let fileManager: FileManager
+    private let maximumByteCount: Int64
+    private let directory: URL
+    private let fileManager: FileManager
 
-  init(
-    maximumByteCount: Int64 = Int64(FilePreparer.maximumByteCount),
-    directory: URL = FilePreparer.defaultDirectory,
-    fileManager: FileManager = .default
-  ) {
-    self.maximumByteCount = maximumByteCount
-    self.directory = directory
-    self.fileManager = fileManager
-  }
-
-  func prepare(_ sourceURL: URL) async throws -> PreparedFile {
-    try Task.checkCancellation()
-    let hasSecurityScope = sourceURL.startAccessingSecurityScopedResource()
-    defer {
-      if hasSecurityScope {
-        sourceURL.stopAccessingSecurityScopedResource()
-      }
+    init(
+        maximumByteCount: Int64 = Int64(FilePreparer.maximumByteCount),
+        directory: URL = FilePreparer.defaultDirectory,
+        fileManager: FileManager = .default
+    ) {
+        self.maximumByteCount = maximumByteCount
+        self.directory = directory
+        self.fileManager = fileManager
     }
 
-    let values: URLResourceValues
-    do {
-      values = try sourceURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
-    } catch {
-      throw FilePreparationError.selectionUnavailable
-    }
-    guard values.isRegularFile == true else {
-      throw FilePreparationError.selectionUnavailable
-    }
-    if let sourceByteCount = values.fileSize,
-      Int64(sourceByteCount) > maximumByteCount
-    {
-      throw FilePreparationError.sourceTooLarge
+    func prepare(_ sourceURL: URL) async throws -> PreparedFile {
+        try Task.checkCancellation()
+        let hasSecurityScope = sourceURL.startAccessingSecurityScopedResource()
+        defer {
+            if hasSecurityScope {
+                sourceURL.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        let values: URLResourceValues
+        do {
+            values = try sourceURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+        } catch {
+            throw FilePreparationError.selectionUnavailable
+        }
+        guard values.isRegularFile == true else {
+            throw FilePreparationError.selectionUnavailable
+        }
+        if let sourceByteCount = values.fileSize,
+            Int64(sourceByteCount) > maximumByteCount
+        {
+            throw FilePreparationError.sourceTooLarge
+        }
+
+        do {
+            try Self.ensureDirectory(directory, fileManager: fileManager)
+        } catch {
+            throw FilePreparationError.localStorageFailed
+        }
+        let fileExtension = PreparedFile.safeExtension(sourceURL.pathExtension)
+        let filename =
+            fileExtension.isEmpty
+            ? UUID().uuidString.lowercased()
+            : "\(UUID().uuidString.lowercased()).\(fileExtension)"
+        let destinationURL = directory.appendingPathComponent(filename)
+
+        do {
+            try fileManager.copyItem(at: sourceURL, to: destinationURL)
+            try Task.checkCancellation()
+            let attributes = try fileManager.attributesOfItem(atPath: destinationURL.path)
+            guard let size = attributes[.size] as? NSNumber, size.int64Value > 0 else {
+                throw FilePreparationError.selectionUnavailable
+            }
+            guard size.int64Value <= maximumByteCount else {
+                throw FilePreparationError.sourceTooLarge
+            }
+            try fileManager.setAttributes(
+                [.protectionKey: FileProtectionType.complete],
+                ofItemAtPath: destinationURL.path)
+            var resourceValues = URLResourceValues()
+            resourceValues.isExcludedFromBackup = true
+            var mutableURL = destinationURL
+            try mutableURL.setResourceValues(resourceValues)
+            return PreparedFile(
+                fileURL: destinationURL,
+                fileExtension: fileExtension,
+                byteCount: size.int64Value)
+        } catch let error as FilePreparationError {
+            try? fileManager.removeItem(at: destinationURL)
+            throw error
+        } catch is CancellationError {
+            try? fileManager.removeItem(at: destinationURL)
+            throw CancellationError()
+        } catch {
+            try? fileManager.removeItem(at: destinationURL)
+            throw FilePreparationError.localStorageFailed
+        }
     }
 
-    do {
-      try Self.ensureDirectory(directory, fileManager: fileManager)
-    } catch {
-      throw FilePreparationError.localStorageFailed
+    static func cleanupRemnants(
+        in directory: URL = defaultDirectory,
+        fileManager: FileManager = .default
+    ) throws {
+        guard fileManager.fileExists(atPath: directory.path) else { return }
+        for url in try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles])
+        {
+            try fileManager.removeItem(at: url)
+        }
     }
-    let fileExtension = PreparedFile.safeExtension(sourceURL.pathExtension)
-    let filename =
-      fileExtension.isEmpty
-      ? UUID().uuidString.lowercased()
-      : "\(UUID().uuidString.lowercased()).\(fileExtension)"
-    let destinationURL = directory.appendingPathComponent(filename)
 
-    do {
-      try fileManager.copyItem(at: sourceURL, to: destinationURL)
-      try Task.checkCancellation()
-      let attributes = try fileManager.attributesOfItem(atPath: destinationURL.path)
-      guard let size = attributes[.size] as? NSNumber, size.int64Value > 0 else {
-        throw FilePreparationError.selectionUnavailable
-      }
-      guard size.int64Value <= maximumByteCount else {
-        throw FilePreparationError.sourceTooLarge
-      }
-      try fileManager.setAttributes(
-        [.protectionKey: FileProtectionType.complete],
-        ofItemAtPath: destinationURL.path)
-      var resourceValues = URLResourceValues()
-      resourceValues.isExcludedFromBackup = true
-      var mutableURL = destinationURL
-      try mutableURL.setResourceValues(resourceValues)
-      return PreparedFile(
-        fileURL: destinationURL,
-        fileExtension: fileExtension,
-        byteCount: size.int64Value)
-    } catch let error as FilePreparationError {
-      try? fileManager.removeItem(at: destinationURL)
-      throw error
-    } catch is CancellationError {
-      try? fileManager.removeItem(at: destinationURL)
-      throw CancellationError()
-    } catch {
-      try? fileManager.removeItem(at: destinationURL)
-      throw FilePreparationError.localStorageFailed
+    private static func ensureDirectory(
+        _ directory: URL,
+        fileManager: FileManager
+    ) throws {
+        try fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: FileProtectionType.complete])
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        var mutableDirectory = directory
+        try mutableDirectory.setResourceValues(values)
     }
-  }
-
-  static func cleanupRemnants(
-    in directory: URL = defaultDirectory,
-    fileManager: FileManager = .default
-  ) throws {
-    guard fileManager.fileExists(atPath: directory.path) else { return }
-    for url in try fileManager.contentsOfDirectory(
-      at: directory,
-      includingPropertiesForKeys: nil,
-      options: [.skipsHiddenFiles])
-    {
-      try fileManager.removeItem(at: url)
-    }
-  }
-
-  private static func ensureDirectory(
-    _ directory: URL,
-    fileManager: FileManager
-  ) throws {
-    try fileManager.createDirectory(
-      at: directory,
-      withIntermediateDirectories: true,
-      attributes: [.protectionKey: FileProtectionType.complete])
-    var values = URLResourceValues()
-    values.isExcludedFromBackup = true
-    var mutableDirectory = directory
-    try mutableDirectory.setResourceValues(values)
-  }
 }

--- a/Sources/Heeler/HeelerApp.swift
+++ b/Sources/Heeler/HeelerApp.swift
@@ -11,6 +11,7 @@ struct HeelerApp: App {
 
     init() {
         try? ImagePreparer.cleanupRemnants()
+        try? FilePreparer.cleanupRemnants()
     }
 
     var body: some Scene {

--- a/Sources/Heeler/Images/ImageAttachStore.swift
+++ b/Sources/Heeler/Images/ImageAttachStore.swift
@@ -101,11 +101,17 @@ enum ImageAttachState: Sendable, Equatable {
 }
 
 /// Coordinates one selected image from Photos decoding through Host staging
-/// and terminal insertion. It owns only the app-local prepared file; completed
-/// Host files intentionally outlive this screen (ADR 0005).
+/// and insertion into either the Composer draft or a legacy Attach input. It
+/// owns only the app-local prepared file; completed Host files intentionally
+/// outlive this screen (ADR 0005).
 @MainActor
 @Observable
 final class ImageAttachStore {
+    private enum InsertionDestination {
+        case composer
+        case terminal(TerminalInputController.SessionGeneration)
+    }
+
     private enum CancellationDisposition {
         case user
         case background
@@ -118,6 +124,7 @@ final class ImageAttachStore {
     private let stageImage: ImageStager
     private let clipboard: any ImageClipboard
     private let input: TerminalInputController
+    private weak var composer: (any ComposerDraftOperations)?
 
     private var preparedImage: PreparedImage?
     private var operationTask: Task<Void, Never>?
@@ -128,43 +135,51 @@ final class ImageAttachStore {
         preparer: any ImagePreparing = ImagePreparer(),
         stageImage: @escaping ImageStager,
         clipboard: any ImageClipboard = SystemImageClipboard(),
-        input: TerminalInputController
+        input: TerminalInputController,
+        composer: (any ComposerDraftOperations)? = nil
     ) {
         self.preparer = preparer
         self.stageImage = stageImage
         self.clipboard = clipboard
         self.input = input
+        self.composer = composer
     }
 
     var canSelectImage: Bool {
-        !state.isBusy && input.liveGeneration != nil
+        !state.isBusy && insertionDestination != nil
     }
 
     func select(_ selection: any ImageSelection) {
-        guard operationTask == nil, let generation = input.liveGeneration else { return }
+        guard operationTask == nil, let destination = insertionDestination else { return }
         discardRetainedPreparedImage()
         cancellationDisposition = nil
         operationID &+= 1
         let currentID = operationID
         state = .preparing
-        input.pause()
+        pauseInput(for: destination)
         operationTask = Task {
-            await runSelection(selection, generation: generation, operationID: currentID)
+            await runSelection(
+                selection,
+                destination: destination,
+                operationID: currentID)
         }
     }
 
     func retry() {
         guard operationTask == nil, let preparedImage,
-            let generation = input.liveGeneration
+            let destination = insertionDestination
         else { return }
         cancellationDisposition = nil
         operationID &+= 1
         let currentID = operationID
         state = .uploading(
             ImageStageProgress(transferredBytes: 0, totalBytes: preparedImage.byteCount))
-        input.pause()
+        pauseInput(for: destination)
         operationTask = Task {
-            await runUpload(preparedImage, generation: generation, operationID: currentID)
+            await runUpload(
+                preparedImage,
+                destination: destination,
+                operationID: currentID)
         }
     }
 
@@ -201,7 +216,12 @@ final class ImageAttachStore {
 
     func insertPath() {
         guard case .completed(var result) = state, !result.inserted else { return }
-        result.inserted = input.insertPathIntoCurrentSession(result.stagedImage.path)
+        if let composer {
+            composer.insertIntoDraft("\(result.stagedImage.path) ")
+            result.inserted = true
+        } else {
+            result.inserted = input.insertPathIntoCurrentSession(result.stagedImage.path)
+        }
         state = .completed(result)
     }
 
@@ -224,7 +244,7 @@ final class ImageAttachStore {
 
     private func runSelection(
         _ selection: any ImageSelection,
-        generation: TerminalInputController.SessionGeneration,
+        destination: InsertionDestination,
         operationID: UInt64
     ) async {
         var unclaimedImage: PreparedImage?
@@ -240,7 +260,10 @@ final class ImageAttachStore {
             unclaimedImage = nil
             state = .uploading(
                 ImageStageProgress(transferredBytes: 0, totalBytes: image.byteCount))
-            await runUploadBody(image, generation: generation, operationID: operationID)
+            await runUploadBody(
+                image,
+                destination: destination,
+                operationID: operationID)
         } catch {
             try? unclaimedImage?.remove()
             finish(error: error, operationID: operationID)
@@ -249,15 +272,18 @@ final class ImageAttachStore {
 
     private func runUpload(
         _ image: PreparedImage,
-        generation: TerminalInputController.SessionGeneration,
+        destination: InsertionDestination,
         operationID: UInt64
     ) async {
-        await runUploadBody(image, generation: generation, operationID: operationID)
+        await runUploadBody(
+            image,
+            destination: destination,
+            operationID: operationID)
     }
 
     private func runUploadBody(
         _ image: PreparedImage,
-        generation: TerminalInputController.SessionGeneration,
+        destination: InsertionDestination,
         operationID: UInt64
     ) async {
         do {
@@ -267,7 +293,10 @@ final class ImageAttachStore {
                     await self?.receive(progress: progress, operationID: operationID)
                 })
             try Task.checkCancellation()
-            finishSuccess(staged, generation: generation, operationID: operationID)
+            finishSuccess(
+                staged,
+                destination: destination,
+                operationID: operationID)
         } catch {
             finish(error: error, operationID: operationID)
         }
@@ -280,21 +309,32 @@ final class ImageAttachStore {
 
     private func finishSuccess(
         _ stagedImage: StagedImage,
-        generation: TerminalInputController.SessionGeneration,
+        destination: InsertionDestination,
         operationID: UInt64
     ) {
         guard operationID == self.operationID else { return }
         operationTask = nil
         cancellationDisposition = nil
         discardRetainedPreparedImage()
-        input.resume()
+        resumeInput(for: destination)
 
         var copied = false
         do {
             try clipboard.copy(stagedImage.path)
             copied = true
         } catch {}
-        let inserted = input.insertPath(stagedImage.path, matching: generation)
+        let inserted: Bool
+        switch destination {
+        case .composer:
+            if let composer {
+                composer.insertIntoDraft("\(stagedImage.path) ")
+                inserted = true
+            } else {
+                inserted = false
+            }
+        case .terminal(let generation):
+            inserted = input.insertPath(stagedImage.path, matching: generation)
+        }
         state = .completed(
             ImageAttachResult(
                 stagedImage: stagedImage,
@@ -332,6 +372,24 @@ final class ImageAttachStore {
     private func discardRetainedPreparedImage() {
         try? preparedImage?.remove()
         preparedImage = nil
+    }
+
+    private var insertionDestination: InsertionDestination? {
+        if composer != nil {
+            return .composer
+        }
+        guard let generation = input.liveGeneration else { return nil }
+        return .terminal(generation)
+    }
+
+    private func pauseInput(for destination: InsertionDestination) {
+        guard case .terminal = destination else { return }
+        input.pause()
+    }
+
+    private func resumeInput(for destination: InsertionDestination) {
+        guard case .terminal = destination else { return }
+        input.resume()
     }
 
     private static func isCancellation(_ error: any Error) -> Bool {

--- a/Sources/Heeler/Images/ImageStaging.swift
+++ b/Sources/Heeler/Images/ImageStaging.swift
@@ -23,7 +23,7 @@ struct StagedImage: Sendable, Equatable {
     let path: String
 
     init(path: String) throws {
-        guard Self.isValidAbsoluteHostPath(path) else {
+        guard StagedHostPath.isValid(path) else {
             throw ImageStagingError.invalidRemotePath
         }
         self.path = path
@@ -35,7 +35,25 @@ struct StagedImage: Sendable, Equatable {
         URL(fileURLWithPath: path)
     }
 
-    private static func isValidAbsoluteHostPath(_ path: String) -> Bool {
+}
+
+struct StagedFile: Sendable, Equatable {
+    let path: String
+
+    init(path: String) throws {
+        guard StagedHostPath.isValid(path) else {
+            throw ImageStagingError.invalidRemotePath
+        }
+        self.path = path
+    }
+
+    var fileURL: URL {
+        URL(fileURLWithPath: path)
+    }
+}
+
+private enum StagedHostPath {
+    static func isValid(_ path: String) -> Bool {
         guard path.hasPrefix("/"), path != "/" else { return false }
         return path.unicodeScalars.allSatisfy { scalar in
             scalar.value >= 0x20 && scalar.value != 0x7F

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -1109,7 +1109,13 @@ actor HeelerSSHTransport: Transport {
         return "The SSH file operation failed."
     }
 
-    // MARK: Image staging
+    // MARK: Attachment staging
+
+    private struct StagingSource {
+        let fileURL: URL
+        let byteCount: Int64
+        let remoteFilename: String
+    }
 
     func stageImage(
         _ image: PreparedImage,
@@ -1124,11 +1130,46 @@ actor HeelerSSHTransport: Transport {
         else {
             throw ImageStagingError.invalidPreparedImage
         }
+        let path = try await stage(
+            StagingSource(
+                fileURL: image.fileURL,
+                byteCount: image.byteCount,
+                remoteFilename: "image.\(image.format.fileExtension)"),
+            progress: progress)
+        return try StagedImage(path: path)
+    }
+
+    func stageFile(
+        _ file: PreparedFile,
+        progress: @escaping @Sendable (ImageStageProgress) async -> Void
+    ) async throws -> StagedFile {
+        guard
+            file.byteCount > 0,
+            file.byteCount <= Int64(FilePreparer.maximumByteCount),
+            let localSize = try? FileManager.default.attributesOfItem(
+                atPath: file.fileURL.path)[.size] as? NSNumber,
+            localSize.int64Value == file.byteCount
+        else {
+            throw ImageStagingError.invalidPreparedImage
+        }
+        let path = try await stage(
+            StagingSource(
+                fileURL: file.fileURL,
+                byteCount: file.byteCount,
+                remoteFilename: file.remoteFilename),
+            progress: progress)
+        return try StagedFile(path: path)
+    }
+
+    private func stage(
+        _ source: StagingSource,
+        progress: @escaping @Sendable (ImageStageProgress) async -> Void
+    ) async throws -> String {
         guard connected, await connection.isConnected else {
             throw ImageStagingError.transferFailed
         }
 
-        await progress(ImageStageProgress(transferredBytes: 0, totalBytes: image.byteCount))
+        await progress(ImageStageProgress(transferredBytes: 0, totalBytes: source.byteCount))
         let parentDirectory = try await createStageParentDirectory()
         let operationID = UUID()
 
@@ -1142,8 +1183,8 @@ actor HeelerSSHTransport: Transport {
             // cancellable, so the write unwinds and the structured compensation
             // below runs with the client it already owns.
             return try await channelAdmission.withChannel(.ordinarySession) {
-                try await self.performImageStage(
-                    image,
+                try await self.performStage(
+                    source,
                     parentDirectory: parentDirectory,
                     operationID: operationID,
                     progress: progress)
@@ -1185,12 +1226,12 @@ actor HeelerSSHTransport: Transport {
         }
     }
 
-    private func performImageStage(
-        _ image: PreparedImage,
+    private func performStage(
+        _ source: StagingSource,
         parentDirectory: String,
         operationID: UUID,
         progress: @escaping @Sendable (ImageStageProgress) async -> Void
-    ) async throws -> StagedImage {
+    ) async throws -> String {
         let sftp: SSHSFTPClient
         do {
             sftp = try await connection.openSFTP(timeout: requestTimeout)
@@ -1204,7 +1245,7 @@ actor HeelerSSHTransport: Transport {
 
         let stageID = UUID().uuidString.lowercased()
         let remoteDirectory = "\(parentDirectory)/stage-\(stageID)"
-        let finalPath = "\(remoteDirectory)/image.\(image.format.fileExtension)"
+        let finalPath = "\(remoteDirectory)/\(source.remoteFilename)"
         var partPath: String? = "\(finalPath).part"
 
         do {
@@ -1218,8 +1259,9 @@ actor HeelerSSHTransport: Transport {
             guard let currentPartPath = partPath else {
                 throw ImageStagingError.transferFailed
             }
-            try await streamImage(
-                image,
+            try await streamFile(
+                at: source.fileURL,
+                byteCount: source.byteCount,
                 to: currentPartPath,
                 over: sftp,
                 progress: progress)
@@ -1228,7 +1270,7 @@ actor HeelerSSHTransport: Transport {
             let uploadedAttributes = try await sftp.attributes(
                 at: currentPartPath,
                 timeout: requestTimeout)
-            guard uploadedAttributes.size == UInt64(image.byteCount) else {
+            guard uploadedAttributes.size == UInt64(source.byteCount) else {
                 throw ImageStagingError.byteCountMismatch
             }
             guard uploadedAttributes.permissions == 0o600 else {
@@ -1243,16 +1285,15 @@ actor HeelerSSHTransport: Transport {
             let finalAttributes = try await sftp.attributes(
                 at: finalPath,
                 timeout: requestTimeout)
-            guard finalAttributes.size == UInt64(image.byteCount) else {
+            guard finalAttributes.size == UInt64(source.byteCount) else {
                 throw ImageStagingError.byteCountMismatch
             }
             guard finalAttributes.permissions == 0o600 else {
                 throw ImageStagingError.permissionEnforcementFailed
             }
-            let staged = try StagedImage(path: finalPath)
             imageStageClients[operationID] = nil
             try await sftp.close(timeout: requestTimeout)
-            return staged
+            return finalPath
         } catch {
             imageStageClients[operationID] = nil
             if let partPath {
@@ -1282,15 +1323,16 @@ actor HeelerSSHTransport: Transport {
         }
     }
 
-    private func streamImage(
-        _ image: PreparedImage,
+    private func streamFile(
+        at localURL: URL,
+        byteCount: Int64,
         to remotePath: String,
         over sftp: SSHSFTPClient,
         progress: @escaping @Sendable (ImageStageProgress) async -> Void
     ) async throws {
         let localFile: FileHandle
         do {
-            localFile = try FileHandle(forReadingFrom: image.fileURL)
+            localFile = try FileHandle(forReadingFrom: localURL)
         } catch {
             throw ImageStagingError.localReadFailed
         }
@@ -1304,9 +1346,9 @@ actor HeelerSSHTransport: Transport {
             try await enforcePermissions(0o600, at: remotePath, over: sftp)
             let chunkSize = 64 * 1_024
             var transferred: Int64 = 0
-            while transferred < image.byteCount {
+            while transferred < byteCount {
                 try Task.checkCancellation()
-                let remaining = image.byteCount - transferred
+                let remaining = byteCount - transferred
                 let requested = min(chunkSize, Int(remaining))
                 guard
                     let data = try localFile.read(upToCount: requested),
@@ -1318,7 +1360,7 @@ actor HeelerSSHTransport: Transport {
                 transferred += Int64(data.count)
                 await progress(ImageStageProgress(
                     transferredBytes: transferred,
-                    totalBytes: image.byteCount))
+                    totalBytes: byteCount))
             }
             guard try localFile.read(upToCount: 1)?.isEmpty != false else {
                 throw ImageStagingError.byteCountMismatch
@@ -1330,7 +1372,7 @@ actor HeelerSSHTransport: Transport {
         }
     }
 
-    /// Unlinks one abandoned `.part` so the user's image bytes do not outlive
+    /// Unlinks one abandoned `.part` so the user's attachment bytes do not outlive
     /// the failed operation, on the SFTP client that operation already owns.
     ///
     /// Detached, because the caller is usually a cancelled task and the unlink

--- a/Sources/Heeler/Transport/Transport.swift
+++ b/Sources/Heeler/Transport/Transport.swift
@@ -123,6 +123,13 @@ protocol Transport: Sendable {
         progress: @escaping @Sendable (ImageStageProgress) async -> Void
     ) async throws -> StagedImage
 
+    /// Stages one app-owned file in private Host temporary storage. The file
+    /// follows the same SFTP, permission, and atomic-completion policy as images.
+    func stageFile(
+        _ file: PreparedFile,
+        progress: @escaping @Sendable (ImageStageProgress) async -> Void
+    ) async throws -> StagedFile
+
     /// Reads the Notification Registration file (v1, `plugin/README.md`)
     /// from the Heeler plugin's config dir on this Host; nil when no
     /// device has registered yet. Throws
@@ -194,6 +201,13 @@ extension Transport {
         _ image: PreparedImage,
         progress: @escaping @Sendable (ImageStageProgress) async -> Void
     ) async throws -> StagedImage {
+        throw ImageStagingError.sftpUnavailable
+    }
+
+    func stageFile(
+        _ file: PreparedFile,
+        progress: @escaping @Sendable (ImageStageProgress) async -> Void
+    ) async throws -> StagedFile {
         throw ImageStagingError.sftpUnavailable
     }
 

--- a/Tests/HeelerTests/ComposerAttachmentTests.swift
+++ b/Tests/HeelerTests/ComposerAttachmentTests.swift
@@ -6,132 +6,132 @@ import Testing
 @Suite("Composer attachments")
 @MainActor
 struct ComposerAttachmentTests {
-  @Test func stagedImagePathIsInsertedIntoDraftWithoutATerminalInputSession() async throws {
-    let prepared = try makePreparedImage()
-    let composer = RecordingComposerDraft()
-    let input = TerminalInputController()
-    let store = ImageAttachStore(
-      preparer: StaticImagePreparer(prepared: prepared),
-      stageImage: { _, reporter in
-        await reporter.report(
-          ImageStageProgress(transferredBytes: 32, totalBytes: 32))
-        return try StagedImage(path: "/tmp/staged/image.jpg")
-      },
-      clipboard: RecordingAttachmentClipboard(),
-      input: input,
-      composer: composer)
+    @Test func stagedImagePathIsInsertedIntoDraftWithoutATerminalInputSession() async throws {
+        let prepared = try makePreparedImage()
+        let composer = RecordingComposerDraft()
+        let input = TerminalInputController()
+        let store = ImageAttachStore(
+            preparer: StaticImagePreparer(prepared: prepared),
+            stageImage: { _, reporter in
+                await reporter.report(
+                    ImageStageProgress(transferredBytes: 32, totalBytes: 32))
+                return try StagedImage(path: "/tmp/staged/image.jpg")
+            },
+            clipboard: RecordingAttachmentClipboard(),
+            input: input,
+            composer: composer)
 
-    #expect(input.liveGeneration == nil)
-    store.select(DataImageSelection(data: Data([0x01])))
-    try await waitUntil { store.state.isCompleted }
+        #expect(input.liveGeneration == nil)
+        store.select(DataImageSelection(data: Data([0x01])))
+        try await waitUntil { store.state.isCompleted }
 
-    #expect(composer.draft == "/tmp/staged/image.jpg ")
-    #expect(store.state.completedResult?.inserted == true)
-  }
-
-  @Test func stagedFilePathIsInsertedAndCopied() async throws {
-    let prepared = try makePreparedFile()
-    let composer = RecordingComposerDraft()
-    let clipboard = RecordingAttachmentClipboard()
-    let store = FileAttachStore(
-      preparer: StaticFilePreparer(prepared: prepared),
-      stageFile: { _, reporter in
-        await reporter.report(
-          ImageStageProgress(transferredBytes: 64, totalBytes: 64))
-        return try StagedFile(path: "/tmp/staged/file.txt")
-      },
-      clipboard: clipboard,
-      composer: composer)
-
-    store.select(URL(fileURLWithPath: "/provider/report.txt"))
-    try await waitUntil {
-      if case .completed = store.state { true } else { false }
+        #expect(composer.draft == "/tmp/staged/image.jpg ")
+        #expect(store.state.completedResult?.inserted == true)
     }
 
-    #expect(composer.draft == "/tmp/staged/file.txt ")
-    #expect(clipboard.copiedPaths == ["/tmp/staged/file.txt"])
-    guard case .completed(let result) = store.state else {
-      Issue.record("Expected a completed file attachment")
-      return
+    @Test func stagedFilePathIsInsertedAndCopied() async throws {
+        let prepared = try makePreparedFile()
+        let composer = RecordingComposerDraft()
+        let clipboard = RecordingAttachmentClipboard()
+        let store = FileAttachStore(
+            preparer: StaticFilePreparer(prepared: prepared),
+            stageFile: { _, reporter in
+                await reporter.report(
+                    ImageStageProgress(transferredBytes: 64, totalBytes: 64))
+                return try StagedFile(path: "/tmp/staged/file.txt")
+            },
+            clipboard: clipboard,
+            composer: composer)
+
+        store.select(URL(fileURLWithPath: "/provider/report.txt"))
+        try await waitUntil {
+            if case .completed = store.state { true } else { false }
+        }
+
+        #expect(composer.draft == "/tmp/staged/file.txt ")
+        #expect(clipboard.copiedPaths == ["/tmp/staged/file.txt"])
+        guard case .completed(let result) = store.state else {
+            Issue.record("Expected a completed file attachment")
+            return
+        }
+        #expect(result.inserted)
+        #expect(result.copied)
     }
-    #expect(result.inserted)
-    #expect(result.copied)
-  }
 
-  private func makePreparedImage() throws -> PreparedImage {
-    let url = FileManager.default.temporaryDirectory
-      .appendingPathComponent("composer-image-\(UUID().uuidString).jpg")
-    try Data(repeating: 0x41, count: 32).write(to: url)
-    return PreparedImage(
-      fileURL: url,
-      format: .jpeg,
-      pixelWidth: 8,
-      pixelHeight: 8,
-      byteCount: 32)
-  }
-
-  private func makePreparedFile() throws -> PreparedFile {
-    let url = FileManager.default.temporaryDirectory
-      .appendingPathComponent("composer-file-\(UUID().uuidString).txt")
-    try Data(repeating: 0x42, count: 64).write(to: url)
-    return PreparedFile(fileURL: url, fileExtension: "txt", byteCount: 64)
-  }
-
-  private func waitUntil(
-    timeout: Duration = .seconds(5),
-    condition: () -> Bool
-  ) async throws {
-    let deadline = ContinuousClock.now + timeout
-    while ContinuousClock.now < deadline {
-      if condition() { return }
-      try await Task.sleep(for: .milliseconds(5))
+    private func makePreparedImage() throws -> PreparedImage {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("composer-image-\(UUID().uuidString).jpg")
+        try Data(repeating: 0x41, count: 32).write(to: url)
+        return PreparedImage(
+            fileURL: url,
+            format: .jpeg,
+            pixelWidth: 8,
+            pixelHeight: 8,
+            byteCount: 32)
     }
-    #expect(condition())
-  }
+
+    private func makePreparedFile() throws -> PreparedFile {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("composer-file-\(UUID().uuidString).txt")
+        try Data(repeating: 0x42, count: 64).write(to: url)
+        return PreparedFile(fileURL: url, fileExtension: "txt", byteCount: 64)
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(5),
+        condition: () -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if condition() { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(condition())
+    }
 }
 
 private actor StaticImagePreparer: ImagePreparing {
-  let prepared: PreparedImage
+    let prepared: PreparedImage
 
-  init(prepared: PreparedImage) {
-    self.prepared = prepared
-  }
+    init(prepared: PreparedImage) {
+        self.prepared = prepared
+    }
 
-  func prepare(_ selection: any ImageSelection) async throws -> PreparedImage {
-    prepared
-  }
+    func prepare(_ selection: any ImageSelection) async throws -> PreparedImage {
+        prepared
+    }
 }
 
 private actor StaticFilePreparer: FilePreparing {
-  let prepared: PreparedFile
+    let prepared: PreparedFile
 
-  init(prepared: PreparedFile) {
-    self.prepared = prepared
-  }
+    init(prepared: PreparedFile) {
+        self.prepared = prepared
+    }
 
-  func prepare(_ sourceURL: URL) async throws -> PreparedFile {
-    prepared
-  }
+    func prepare(_ sourceURL: URL) async throws -> PreparedFile {
+        prepared
+    }
 }
 
 @MainActor
 private final class RecordingComposerDraft: ComposerDraftOperations {
-  private(set) var draft = ""
+    private(set) var draft = ""
 
-  func replaceDraft(with text: String) {
-    draft = text
-  }
+    func replaceDraft(with text: String) {
+        draft = text
+    }
 
-  func insertIntoDraft(_ text: String) {
-    draft.append(text)
-  }
+    func insertIntoDraft(_ text: String) {
+        draft.append(text)
+    }
 }
 
 @MainActor
 private final class RecordingAttachmentClipboard: ImageClipboard {
-  private(set) var copiedPaths: [String] = []
+    private(set) var copiedPaths: [String] = []
 
-  func copy(_ path: String) throws {
-    copiedPaths.append(path)
-  }
+    func copy(_ path: String) throws {
+        copiedPaths.append(path)
+    }
 }

--- a/Tests/HeelerTests/ComposerAttachmentTests.swift
+++ b/Tests/HeelerTests/ComposerAttachmentTests.swift
@@ -6,6 +6,18 @@ import Testing
 @Suite("Composer attachments")
 @MainActor
 struct ComposerAttachmentTests {
+    @Test func linksActionOnlyAppearsWhenLinksExist() {
+        #expect(AgentComposerLinkPresentation(count: 0) == nil)
+
+        let oneLink = AgentComposerLinkPresentation(count: 1)
+        #expect(oneLink?.count == 1)
+        #expect(oneLink?.accessibilityValue == "1 distinct link")
+
+        let multipleLinks = AgentComposerLinkPresentation(count: 3)
+        #expect(multipleLinks?.count == 3)
+        #expect(multipleLinks?.accessibilityValue == "3 distinct links")
+    }
+
     @Test func stagedImagePathIsInsertedIntoDraftWithoutATerminalInputSession() async throws {
         let prepared = try makePreparedImage()
         let composer = RecordingComposerDraft()

--- a/Tests/HeelerTests/ComposerAttachmentTests.swift
+++ b/Tests/HeelerTests/ComposerAttachmentTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@Suite("Composer attachments")
+@MainActor
+struct ComposerAttachmentTests {
+  @Test func stagedImagePathIsInsertedIntoDraftWithoutATerminalInputSession() async throws {
+    let prepared = try makePreparedImage()
+    let composer = RecordingComposerDraft()
+    let input = TerminalInputController()
+    let store = ImageAttachStore(
+      preparer: StaticImagePreparer(prepared: prepared),
+      stageImage: { _, reporter in
+        await reporter.report(
+          ImageStageProgress(transferredBytes: 32, totalBytes: 32))
+        return try StagedImage(path: "/tmp/staged/image.jpg")
+      },
+      clipboard: RecordingAttachmentClipboard(),
+      input: input,
+      composer: composer)
+
+    #expect(input.liveGeneration == nil)
+    store.select(DataImageSelection(data: Data([0x01])))
+    try await waitUntil { store.state.isCompleted }
+
+    #expect(composer.draft == "/tmp/staged/image.jpg ")
+    #expect(store.state.completedResult?.inserted == true)
+  }
+
+  @Test func stagedFilePathIsInsertedAndCopied() async throws {
+    let prepared = try makePreparedFile()
+    let composer = RecordingComposerDraft()
+    let clipboard = RecordingAttachmentClipboard()
+    let store = FileAttachStore(
+      preparer: StaticFilePreparer(prepared: prepared),
+      stageFile: { _, reporter in
+        await reporter.report(
+          ImageStageProgress(transferredBytes: 64, totalBytes: 64))
+        return try StagedFile(path: "/tmp/staged/file.txt")
+      },
+      clipboard: clipboard,
+      composer: composer)
+
+    store.select(URL(fileURLWithPath: "/provider/report.txt"))
+    try await waitUntil {
+      if case .completed = store.state { true } else { false }
+    }
+
+    #expect(composer.draft == "/tmp/staged/file.txt ")
+    #expect(clipboard.copiedPaths == ["/tmp/staged/file.txt"])
+    guard case .completed(let result) = store.state else {
+      Issue.record("Expected a completed file attachment")
+      return
+    }
+    #expect(result.inserted)
+    #expect(result.copied)
+  }
+
+  private func makePreparedImage() throws -> PreparedImage {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("composer-image-\(UUID().uuidString).jpg")
+    try Data(repeating: 0x41, count: 32).write(to: url)
+    return PreparedImage(
+      fileURL: url,
+      format: .jpeg,
+      pixelWidth: 8,
+      pixelHeight: 8,
+      byteCount: 32)
+  }
+
+  private func makePreparedFile() throws -> PreparedFile {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("composer-file-\(UUID().uuidString).txt")
+    try Data(repeating: 0x42, count: 64).write(to: url)
+    return PreparedFile(fileURL: url, fileExtension: "txt", byteCount: 64)
+  }
+
+  private func waitUntil(
+    timeout: Duration = .seconds(5),
+    condition: () -> Bool
+  ) async throws {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+      if condition() { return }
+      try await Task.sleep(for: .milliseconds(5))
+    }
+    #expect(condition())
+  }
+}
+
+private actor StaticImagePreparer: ImagePreparing {
+  let prepared: PreparedImage
+
+  init(prepared: PreparedImage) {
+    self.prepared = prepared
+  }
+
+  func prepare(_ selection: any ImageSelection) async throws -> PreparedImage {
+    prepared
+  }
+}
+
+private actor StaticFilePreparer: FilePreparing {
+  let prepared: PreparedFile
+
+  init(prepared: PreparedFile) {
+    self.prepared = prepared
+  }
+
+  func prepare(_ sourceURL: URL) async throws -> PreparedFile {
+    prepared
+  }
+}
+
+@MainActor
+private final class RecordingComposerDraft: ComposerDraftOperations {
+  private(set) var draft = ""
+
+  func replaceDraft(with text: String) {
+    draft = text
+  }
+
+  func insertIntoDraft(_ text: String) {
+    draft.append(text)
+  }
+}
+
+@MainActor
+private final class RecordingAttachmentClipboard: ImageClipboard {
+  private(set) var copiedPaths: [String] = []
+
+  func copy(_ path: String) throws {
+    copiedPaths.append(path)
+  }
+}

--- a/Tests/HeelerTests/FilePreparerTests.swift
+++ b/Tests/HeelerTests/FilePreparerTests.swift
@@ -5,58 +5,58 @@ import Testing
 
 @Suite("File preparer")
 struct FilePreparerTests {
-  @Test func preparedFileNormalizesUnsafeExtensions() {
-    let file = PreparedFile(
-      fileURL: URL(fileURLWithPath: "/tmp/source"),
-      fileExtension: "../SH",
-      byteCount: 1)
+    @Test func preparedFileNormalizesUnsafeExtensions() {
+        let file = PreparedFile(
+            fileURL: URL(fileURLWithPath: "/tmp/source"),
+            fileExtension: "../SH",
+            byteCount: 1)
 
-    #expect(file.fileExtension.isEmpty)
-    #expect(file.remoteFilename == "file")
-  }
-
-  @Test func createsProtectedPrivateCopyWithSafeExtension() async throws {
-    let root = FileManager.default.temporaryDirectory
-      .appendingPathComponent("file-preparer-\(UUID().uuidString)", isDirectory: true)
-    let sourceDirectory = root.appendingPathComponent("source", isDirectory: true)
-    let outputDirectory = root.appendingPathComponent("output", isDirectory: true)
-    try FileManager.default.createDirectory(
-      at: sourceDirectory,
-      withIntermediateDirectories: true)
-    defer { try? FileManager.default.removeItem(at: root) }
-    let sourceURL = sourceDirectory.appendingPathComponent("Report.TXT")
-    let data = Data("attachment contents".utf8)
-    try data.write(to: sourceURL)
-
-    let prepared = try await FilePreparer(
-      maximumByteCount: 1_024,
-      directory: outputDirectory
-    )
-    .prepare(sourceURL)
-
-    #expect(prepared.fileExtension == "txt")
-    #expect(prepared.remoteFilename == "file.txt")
-    #expect(prepared.byteCount == Int64(data.count))
-    #expect(try Data(contentsOf: prepared.fileURL) == data)
-    #expect(prepared.fileURL.deletingLastPathComponent() == outputDirectory)
-  }
-
-  @Test func rejectsFilesAboveTheConfiguredLimitWithoutLeavingACopy() async throws {
-    let root = FileManager.default.temporaryDirectory
-      .appendingPathComponent("file-preparer-limit-\(UUID().uuidString)", isDirectory: true)
-    let outputDirectory = root.appendingPathComponent("output", isDirectory: true)
-    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-    defer { try? FileManager.default.removeItem(at: root) }
-    let sourceURL = root.appendingPathComponent("large.bin")
-    try Data(repeating: 0x41, count: 9).write(to: sourceURL)
-
-    await #expect(throws: FilePreparationError.sourceTooLarge) {
-      try await FilePreparer(maximumByteCount: 8, directory: outputDirectory)
-        .prepare(sourceURL)
+        #expect(file.fileExtension.isEmpty)
+        #expect(file.remoteFilename == "file")
     }
-    let remnants = try? FileManager.default.contentsOfDirectory(
-      at: outputDirectory,
-      includingPropertiesForKeys: nil)
-    #expect(remnants?.isEmpty != false)
-  }
+
+    @Test func createsProtectedPrivateCopyWithSafeExtension() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("file-preparer-\(UUID().uuidString)", isDirectory: true)
+        let sourceDirectory = root.appendingPathComponent("source", isDirectory: true)
+        let outputDirectory = root.appendingPathComponent("output", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: sourceDirectory,
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let sourceURL = sourceDirectory.appendingPathComponent("Report.TXT")
+        let data = Data("attachment contents".utf8)
+        try data.write(to: sourceURL)
+
+        let prepared = try await FilePreparer(
+            maximumByteCount: 1_024,
+            directory: outputDirectory
+        )
+        .prepare(sourceURL)
+
+        #expect(prepared.fileExtension == "txt")
+        #expect(prepared.remoteFilename == "file.txt")
+        #expect(prepared.byteCount == Int64(data.count))
+        #expect(try Data(contentsOf: prepared.fileURL) == data)
+        #expect(prepared.fileURL.deletingLastPathComponent() == outputDirectory)
+    }
+
+    @Test func rejectsFilesAboveTheConfiguredLimitWithoutLeavingACopy() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("file-preparer-limit-\(UUID().uuidString)", isDirectory: true)
+        let outputDirectory = root.appendingPathComponent("output", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let sourceURL = root.appendingPathComponent("large.bin")
+        try Data(repeating: 0x41, count: 9).write(to: sourceURL)
+
+        await #expect(throws: FilePreparationError.sourceTooLarge) {
+            try await FilePreparer(maximumByteCount: 8, directory: outputDirectory)
+                .prepare(sourceURL)
+        }
+        let remnants = try? FileManager.default.contentsOfDirectory(
+            at: outputDirectory,
+            includingPropertiesForKeys: nil)
+        #expect(remnants?.isEmpty != false)
+    }
 }

--- a/Tests/HeelerTests/FilePreparerTests.swift
+++ b/Tests/HeelerTests/FilePreparerTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@Suite("File preparer")
+struct FilePreparerTests {
+  @Test func preparedFileNormalizesUnsafeExtensions() {
+    let file = PreparedFile(
+      fileURL: URL(fileURLWithPath: "/tmp/source"),
+      fileExtension: "../SH",
+      byteCount: 1)
+
+    #expect(file.fileExtension.isEmpty)
+    #expect(file.remoteFilename == "file")
+  }
+
+  @Test func createsProtectedPrivateCopyWithSafeExtension() async throws {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("file-preparer-\(UUID().uuidString)", isDirectory: true)
+    let sourceDirectory = root.appendingPathComponent("source", isDirectory: true)
+    let outputDirectory = root.appendingPathComponent("output", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: sourceDirectory,
+      withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let sourceURL = sourceDirectory.appendingPathComponent("Report.TXT")
+    let data = Data("attachment contents".utf8)
+    try data.write(to: sourceURL)
+
+    let prepared = try await FilePreparer(
+      maximumByteCount: 1_024,
+      directory: outputDirectory
+    )
+    .prepare(sourceURL)
+
+    #expect(prepared.fileExtension == "txt")
+    #expect(prepared.remoteFilename == "file.txt")
+    #expect(prepared.byteCount == Int64(data.count))
+    #expect(try Data(contentsOf: prepared.fileURL) == data)
+    #expect(prepared.fileURL.deletingLastPathComponent() == outputDirectory)
+  }
+
+  @Test func rejectsFilesAboveTheConfiguredLimitWithoutLeavingACopy() async throws {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("file-preparer-limit-\(UUID().uuidString)", isDirectory: true)
+    let outputDirectory = root.appendingPathComponent("output", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let sourceURL = root.appendingPathComponent("large.bin")
+    try Data(repeating: 0x41, count: 9).write(to: sourceURL)
+
+    await #expect(throws: FilePreparationError.sourceTooLarge) {
+      try await FilePreparer(maximumByteCount: 8, directory: outputDirectory)
+        .prepare(sourceURL)
+    }
+    let remnants = try? FileManager.default.contentsOfDirectory(
+      at: outputDirectory,
+      includingPropertiesForKeys: nil)
+    #expect(remnants?.isEmpty != false)
+  }
+}

--- a/Tests/HeelerTests/ImageStagingE2ETests.swift
+++ b/Tests/HeelerTests/ImageStagingE2ETests.swift
@@ -21,6 +21,32 @@ struct ImageStagingE2ETests {
         try await exercisePrivateAtomicStage(settings: environment.jumpSettings())
     }
 
+    @Test func directFileStagingPreservesSafeExtensionAndPrivatePermissions() async throws {
+        let environment = try #require(HeelerSSHTransportBehaviorEnvironment.current)
+        let bytes = Data("Composer file attachment\n".utf8)
+        let localURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("file-stage-\(UUID().uuidString).md")
+        try bytes.write(to: localURL)
+        defer { try? FileManager.default.removeItem(at: localURL) }
+        let file = PreparedFile(
+            fileURL: localURL,
+            fileExtension: "md",
+            byteCount: Int64(bytes.count))
+        let transport = try await HeelerSSHTransport.connect(
+            settings: environment.directSettings())
+
+        let staged = try await transport.stageFile(file) { _ in }
+        let stageDirectory = staged.fileURL.deletingLastPathComponent()
+        let parentDirectory = stageDirectory.deletingLastPathComponent()
+        defer { try? FileManager.default.removeItem(at: parentDirectory) }
+
+        #expect(staged.fileURL.lastPathComponent == "file.md")
+        #expect(try Data(contentsOf: staged.fileURL) == bytes)
+        let fileAttributes = try FileManager.default.attributesOfItem(atPath: staged.path)
+        #expect((fileAttributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+        try await transport.close()
+    }
+
     @Test func cancellationRemovesOnlyTheCurrentIncompletePart() async throws {
         let environment = try #require(HeelerSSHTransportBehaviorEnvironment.current)
         let identifier = UUID().uuidString.lowercased()

--- a/docs/adr/0005-keep-staged-image-cleanup-outside-mobile.md
+++ b/docs/adr/0005-keep-staged-image-cleanup-outside-mobile.md
@@ -1,11 +1,11 @@
-# Keep Staged Image cleanup outside the mobile client
+# Keep staged attachment cleanup outside the mobile client
 
-Heeler may create a Staged Image in the Host's OS-designated temporary storage for a user-requested image transfer, but it does not enumerate or delete completed remote image files. Cleanup belongs to the Host operating system or to a future Herdr-owned capability because remote file maintenance is outside the mobile client's ownership boundary. The current upload operation may delete only its own incomplete `.part` file as failure compensation; it never scans or maintains historical files. We accept that operating-system cleanup has no timing guarantee and that a Staged Image may remain indefinitely.
+Heeler may create a staged image or file in the Host's OS-designated temporary storage for a user-requested attachment transfer, but it does not enumerate or delete completed remote attachments. Cleanup belongs to the Host operating system or to a future Herdr-owned capability because remote file maintenance is outside the mobile client's ownership boundary. The current upload operation may delete only its own incomplete `.part` file as failure compensation; it never scans or maintains historical files. We accept that operating-system cleanup has no timing guarantee and that a staged attachment may remain indefinitely.
 
 ## Consequences
 
 - The app makes no remote-file TTL or deletion promise.
 - Clipboard expiration does not imply deletion of the corresponding remote file.
 - A failed or cancelled upload attempts to remove only the incomplete file created by that operation; disconnects may prevent this compensation.
-- Staged Images still use private directories, restrictive permissions, and unguessable names.
+- Staged attachments still use private directories, restrictive permissions, and unguessable names.
 - Future deterministic cleanup requires an explicit Herdr-owned interface or a new architectural decision, not a background SFTP sweep from the mobile client.

--- a/docs/adr/0006-stage-images-over-sftp.md
+++ b/docs/adr/0006-stage-images-over-sftp.md
@@ -1,20 +1,22 @@
-# Stage images over SFTP and insert their paths through Attach
+# Stage attachments over SFTP and insert their paths without submitting
 
-`Attach Image` prepares one Photos image locally, stages it in the Host operating system's temporary storage over SFTP, copies the resulting absolute path to the iOS clipboard, and inserts that path into the existing Attach input stream without submitting it. Image preparation stays outside `Transport`; `Transport.stageImage(_:)` owns SFTP, remote temporary-directory creation, restrictive permissions, partial-file handling, and the shared SSH session-channel budget. This keeps SSH library and remote shell details out of UI code and keeps image bytes out of the terminal stream.
+The Composer's Add menu accepts one image from Photos or one document from Files. Images are decoded, bounded, stripped of metadata, and re-encoded into protected app-owned temporary storage. Files are copied into protected app-owned temporary storage while the document provider's security scope is active, capped at 64 MiB, and given a private random local name. The original safe extension is retained so the Agent can identify the staged file type.
 
-`ImageAttachStore` owns the user operation, including preparation, progress, cancellation, retry, clipboard results, and the Attach session generation captured when selection or an explicit retry begins. `TerminalInputController` remains the single writer for local terminal input. Automatic insertion occurs only if that live Attach session still exists; it sends the path as one operation and a trailing space as a second operation, never Enter. A user may explicitly insert a successfully staged path into the current live session after an automatic insertion failure or session change.
+`Transport.stageImage(_:)` and `Transport.stageFile(_:)` share the same SFTP implementation: private Host temporary directories, restrictive permissions, partial-file compensation, atomic completion, and the shared SSH session-channel budget. The resulting absolute Host path is copied to the local-only expiring clipboard and appended to the local Composer draft with a trailing space. It never submits the draft. Legacy Agent surfaces without a Composer retain the image-only Attach insertion path; `TerminalInputController` remains their single writer and validates the captured Attach generation before insertion.
+
+`ImageAttachStore` and `FileAttachStore` own preparation, progress, cancellation, retry, clipboard results, and path insertion. Completed Host files intentionally outlive the screen per ADR 0005.
 
 ## Considered Options
 
-- **Send image bytes through the Attach PTY** — rejected because terminal input has no file framing and would interpret arbitrary binary bytes as keystrokes and control sequences.
+- **Send attachment bytes through the Attach PTY** — rejected because terminal input has no file framing and would interpret arbitrary binary bytes as keystrokes and control sequences.
 - **Use Herdr's private clipboard-image protocol or `pane.send_input`** — rejected because the mobile app should not depend on a private wire format or introduce a second writer beside the live Attach input stream.
 - **Stream through a remote shell command when SFTP is unavailable** — rejected for the MVP because it expands the quoting, portability, and security surface. SFTP support is an explicit Host requirement.
-- **Submit an instruction and path automatically** — rejected because the app cannot guarantee provider-specific image recognition and must not press Enter for the user.
+- **Submit an instruction and path automatically** — rejected because the app cannot guarantee provider-specific attachment recognition and must not press Send or Enter for the user.
 
 ## Consequences
 
-- The MVP is available only in a live Attach surface, handles one image at a time, and uses `PhotosPicker` as its only source.
-- The app guarantees preparation, staging, clipboard copy, and path insertion. Whether an Agent turns the Staged Image into an Image Attachment is outside the capability contract.
-- Upload and terminal rendering may continue concurrently, but all local terminal input is paused while `Attach Image` is active.
+- The Composer handles one attachment operation at a time. Images use `PhotosPicker`; files use the system document picker.
+- The app guarantees preparation, staging, clipboard copy, and path insertion. Whether an Agent consumes the staged path as an attachment is outside the capability contract.
+- Upload and terminal rendering may continue concurrently. Composer insertion does not write to the PTY; legacy image insertion pauses local terminal input while active.
 - Clipboard content is local-only, expires after 24 hours, and replaces the previously copied path.
-- Completed remote files follow ADR 0005 and are never cleaned up by the mobile client.
+- Completed remote attachments follow ADR 0005 and are never cleaned up by the mobile client.

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -1164,7 +1164,7 @@ run_suite HeelerSSHPTYE2ETests 3 1
 run_suite HeelerSSHDirectStreamLocalE2ETests 12 1
 run_suite HeelerSSHJumpHostGateE2ETests 9 1
 run_suite HeelerSSHTransportBehaviorE2ETests 31 1
-run_suite ImageStagingE2ETests 7 1
+run_suite ImageStagingE2ETests 8 1
 run_suite WeakNetworkE2ETests 8 1
 run_suite PairingCeremonyE2ETests 11 1
 


### PR DESCRIPTION
## Summary

- add a Composer plus menu for Photos, Files, and the former title-bar Agent actions
- stage image and file attachments privately over SFTP, then insert their remote paths into the draft without submitting
- show discovered Links beside the plus action
- remove visible terminal navigation chrome while preserving edge-swipe navigation
- drive status-bar contrast from the selected terminal theme at the split-view owner, including the iOS 26 fallback

## Testing

- `xcodebuild test -project Heeler.xcodeproj -scheme Heeler -destination 'platform=iOS Simulator,id=DCE8C8A7-1021-475A-965C-8D06B3877653' -only-testing:HeelerTests/TerminalThemeSettingsTests` (10 tests passed)
- `make install DEVICE=<physical iPhone>` using Xcode beta
- verified on a physical iPhone 17 Pro Max that a dark terminal theme renders light status-bar content and keeps terminal content below the status bar

Refs #182
