### PR TITLE
Separate Agent attachment and action menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ Entries reference the issue that motivated them.
   from Photos or a file up to 64 MiB from Files, stages the selection privately
   on the Host over SFTP, and inserts the resulting path into the local draft
   without submitting it. Discovered Links appear beside the plus menu, while
-  the former title-bar Agent actions live inside it. Agent detail omits the
-  visible title bar so terminal output uses the full area below the system
-  status bar, while preserving edge-swipe navigation and matching status-bar
-  contrast to the terminal theme. (#182)
+  the former title-bar Agent actions live in a separate More menu immediately
+  to its right. Agent detail omits the visible title bar so terminal output uses
+  the full area below the system status bar, while preserving edge-swipe
+  navigation and matching status-bar contrast to the terminal theme. (#182)
 
 - Agent detail now combines the complete live libghostty terminal with a local
   Composer. The terminal preserves TUI rendering, scrollback, and PTY resize,

--- a/Sources/Heeler/Console/AgentComposerView.swift
+++ b/Sources/Heeler/Console/AgentComposerView.swift
@@ -120,16 +120,25 @@ struct AgentComposerView: View {
 
                         HStack(spacing: 8) {
                             Menu {
-                                Section {
-                                    Button("Add Image", systemImage: "photo") {
-                                        actions.addImage()
-                                    }
-                                    .disabled(!actions.canAddImage)
-                                    Button("Add File", systemImage: "doc") {
-                                        actions.addFile()
-                                    }
-                                    .disabled(!actions.canAddFile)
+                                Button("Add Image", systemImage: "photo") {
+                                    actions.addImage()
                                 }
+                                .disabled(!actions.canAddImage)
+                                Button("Add File", systemImage: "doc") {
+                                    actions.addFile()
+                                }
+                                .disabled(!actions.canAddFile)
+                            } label: {
+                                Label("Add", systemImage: "plus")
+                            }
+                            .buttonStyle(.bordered)
+                            .buttonBorderShape(.circle)
+                            .labelStyle(.iconOnly)
+                            .font(.footnote.weight(.semibold))
+                            .frame(minWidth: 44, minHeight: 44)
+                            .accessibilityHint("Adds an image or file to the draft")
+
+                            Menu {
                                 Section {
                                     Button("New Agent", systemImage: "plus") {
                                         actions.startAgent()
@@ -154,14 +163,14 @@ struct AgentComposerView: View {
                                     }
                                 }
                             } label: {
-                                Label("Add and More", systemImage: "plus")
+                                Label("More", systemImage: "ellipsis")
                             }
                             .buttonStyle(.bordered)
                             .buttonBorderShape(.circle)
                             .labelStyle(.iconOnly)
                             .font(.footnote.weight(.semibold))
                             .frame(minWidth: 44, minHeight: 44)
-                            .accessibilityHint("Adds an attachment or opens Agent actions")
+                            .accessibilityHint("Opens Agent actions")
 
                             if let links = linkPresentation {
                                 Button {


### PR DESCRIPTION
## Summary

- keep the Agent detail plus menu focused on Add Image and Add File
- add an adjacent More menu for New Agent, Snippets, rename actions, and Close Agent
- update the Unreleased changelog to describe the split controls

## Validation

- xcodebuild test with ComposerAttachmentTests and AgentComposerStoreTests on the Heeler iPhone 17 Pro iOS 27.0 Simulator
- 15 passed, 0 failed, 0 skipped
- git diff --check

## Notes

- Manual Simulator interaction was not run.

Refs #182