### PR TITLE
ci: make the iOS simulator gate faster and bounded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
     # macos-26 ships Xcode 26.x and the iOS 26 simulator runtimes. Pinned
     # rather than macos-latest for reproducibility.
     runs-on: macos-26
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -125,13 +126,26 @@ jobs:
           xcodebuild -version
           xcrun simctl list runtimes
 
+      - name: Test CI watchdog
+        run: scripts/test-run-with-timeout.sh
+
       # The script selects one available iPhone 17 UDID, boots it, injects the
       # fixture environment there, and targets that same device for every test
       # action. The app deployment target is iOS 26.
       - name: Build and test
+        timeout-minutes: 32
         # The fixture runs unprivileged; HEELER_CI_MANDATORY makes the one
         # privileged part (the real-password sshd) a hard requirement here
         # rather than something merge CI may quietly run without.
         env:
           HEELER_CI_MANDATORY: "1"
         run: scripts/run-ci-ios-tests.sh
+
+      - name: Upload iOS timeout diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-ci-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/heeler-ci-diagnostics-*
+          if-no-files-found: ignore
+          retention-days: 7

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -14,6 +14,19 @@ enum TerminalLinkPolicy {
     }
 }
 
+/// The standard keyboard asks the terminal for clipboard state synchronously.
+/// Keep that system IPC behind a seam so unit tests never depend on the
+/// Simulator pasteboard service being responsive.
+@MainActor
+struct TerminalClipboard {
+    let string: () -> String?
+    let hasStrings: () -> Bool
+
+    static let system = TerminalClipboard(
+        string: { UIPasteboard.general.string },
+        hasStrings: { UIPasteboard.general.hasStrings })
+}
+
 /// A handle on the live terminal for chrome that sits outside it. The reference
 /// is weak and set by the surface itself, so an Agent switch rebuilding the
 /// terminal cannot leave the keyboard toggle or Composer quick keys driving a
@@ -116,7 +129,8 @@ struct TerminalScreenView: UIViewRepresentable {
         /// The center the terminal observes the keyboard through. Tests pass
         /// their own so one test's keyboard cannot end another test's
         /// handoff (#157); production keeps the default.
-        notificationCenter: NotificationCenter = .default
+        notificationCenter: NotificationCenter = .default,
+        clipboard: TerminalClipboard = .system
     ) -> HeelerTerminalView {
         let view = HeelerTerminalView(
             frame: .zero,
@@ -129,7 +143,8 @@ struct TerminalScreenView: UIViewRepresentable {
             keysContext: keysContext,
             theme: theme,
             fontSize: fontSize,
-            fontFamily: fontFamily)
+            fontFamily: fontFamily,
+            clipboard: clipboard)
         view.installKeyboardSwitcher(notificationCenter: notificationCenter)
         return view
     }
@@ -303,6 +318,7 @@ private final class TerminalInputTextRange: UITextRange {
 final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     private let callbackBridge: TerminalSessionCallbackBridge
     private let terminalController: TerminalController
+    private let clipboard: TerminalClipboard
     let terminalSession: InMemoryTerminalSession
     private(set) var appliedTheme: TerminalTheme
     private(set) var appliedFontSize: Float
@@ -551,9 +567,11 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         keysContext: TerminalKeysContext?,
         theme: TerminalTheme,
         fontSize: Float,
-        fontFamily: String?
+        fontFamily: String?,
+        clipboard: TerminalClipboard
     ) {
         self.keysContext = keysContext
+        self.clipboard = clipboard
         let callbackBridge = TerminalSessionCallbackBridge(
             onSizeChanged: onSizeChanged,
             onViewportTextChanged: onViewportTextChanged,
@@ -842,7 +860,7 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     }
 
     override func paste(_ sender: Any?) {
-        guard isLocalInputEnabled, let text = UIPasteboard.general.string else { return }
+        guard isLocalInputEnabled, let text = clipboard.string() else { return }
 
         // The keyboard's clipboard suggestion invokes this standard action
         // directly, bypassing Ghostty's text-input handler. Tell UIKit about
@@ -875,7 +893,7 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
 
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         if action == #selector(paste(_:)) {
-            return isLocalInputEnabled && UIPasteboard.general.hasStrings
+            return isLocalInputEnabled && clipboard.hasStrings()
         }
         return super.canPerformAction(action, withSender: sender)
     }

--- a/Tests/HeelerTests/AppForegroundRecoveryTests.swift
+++ b/Tests/HeelerTests/AppForegroundRecoveryTests.swift
@@ -97,6 +97,7 @@ struct AppForegroundRecoveryTests {
             store.hostStatuses[host.id] == .connected
         }
         try await waitUntil("its Agent should arrive") { store.agents.count == 1 }
+        try await waitUntilPaneResubscribeSettles(on: stale)
 
         // The app is out of the picture and the link dies. Nothing errors:
         // as far as this process knows the events stream is still open, and
@@ -220,6 +221,7 @@ struct AppForegroundRecoveryTests {
             store.hostStatuses[host.id] == .connected
         }
         let generation = try #require(store.hostConnectionGenerations[host.id])
+        try await waitUntilPaneResubscribeSettles(on: stale)
 
         await stale.failPing(
             atCall: 2, with: .sshUnreachable(detail: "the Host is unreachable"))
@@ -262,6 +264,7 @@ struct AppForegroundRecoveryTests {
         try await waitUntil("the Host should come up connected") {
             store.hostStatuses[host.id] == .connected
         }
+        try await waitUntilPaneResubscribeSettles(on: stale)
 
         await stale.failPing(atCall: 2, with: .streamLocalOpenFailed(path: socketPath))
         activity.didEnterBackground()
@@ -371,6 +374,8 @@ struct AppForegroundRecoveryTests {
             store.hostStatuses[host.id] == .connected
         }
 
+        try await waitUntilPaneResubscribeSettles(on: stopped)
+
         // herdr stops while the app is away. The return's ping opens a
         // stream-local channel onto a socket nothing is serving, which is
         // configuration-class and correctly stops the reconnect loop.
@@ -424,6 +429,7 @@ struct AppForegroundRecoveryTests {
             store.hostStatuses[host.id] == .connected
         }
         let generation = try #require(store.hostConnectionGenerations[host.id])
+        try await waitUntilPaneResubscribeSettles(on: stopped)
 
         await stopped.failPing(atCall: 2, with: failure)
         activity.didEnterBackground()
@@ -837,6 +843,23 @@ struct AppForegroundRecoveryTests {
     /// loop would overshoot this many times over.
     private func settle() async {
         try? await Task.sleep(for: .milliseconds(50))
+    }
+
+    /// Waits until `transport`'s events stream has settled after the initial
+    /// snapshot. The projection reinstalls pane-scoped subscriptions right
+    /// after that snapshot, which ends and re-opens the events stream, and
+    /// `EventsSession.revalidate()` deliberately no-ops while no stream is
+    /// live — the in-flight resubscribe is already re-proving the link. A
+    /// foreground return raced into that window therefore skips the ping
+    /// these tests script and assert on. The second snapshot fetch is
+    /// ordered strictly after the re-opened stream went live, so its
+    /// arrival pins the settled state.
+    private func waitUntilPaneResubscribeSettles(
+        on transport: ScriptedTransport
+    ) async throws {
+        try await waitUntil("the pane resubscribe should settle") {
+            await transport.snapshotFetchCount >= 2
+        }
     }
 
     /// Polls until `condition` holds, yielding so the store's tasks progress.

--- a/Tests/HeelerTests/HeelerSSHDirectStreamLocalE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHDirectStreamLocalE2ETests.swift
@@ -211,36 +211,6 @@ struct HeelerSSHDirectStreamLocalE2ETests {
         }
         try await transport.close()
     }
-
-    /// Historical spike measurement (spec #110, ADR 0011, recorded in
-    /// `Packages/HeelerSSH/README.md`): 22.368 ms per exchange through
-    /// `exec` + `socat` against 0.514 ms through direct-streamlocal on the
-    /// same authenticated loopback session. Printed for comparison only —
-    /// absolute loopback timing is scheduler-dependent across CI runs and is
-    /// not a merge gate. Accidental remote-process fallback is guarded by the
-    /// socat-free Host PATH in `scripts/run-ci-ios-tests.sh` and by the rest
-    /// of this suite's functional direct-streamlocal coverage.
-    static let recordedSocatBaselinePerExchange = Duration.microseconds(22_368)
-
-    @Test("repeatable loopback measurement prints comparison telemetry")
-    func loopbackMeasurementPrintsComparisonTelemetry() async throws {
-        let environment = try #require(DirectStreamLocalTestEnvironment.current)
-        let connection = try await environment.deviceKeyConnection(to: environment.endpoint)
-        try await withClosingDirectConnection(connection) { connection in
-            let iterations = 25
-            let started = ContinuousClock.now
-            for _ in 0..<iterations {
-                try await expectPing(connection, socketPath: environment.socketPath)
-            }
-            let elapsed = ContinuousClock.now - started
-            let perExchange = elapsed / iterations
-            print(
-                "direct-streamlocal loopback telemetry: \(iterations) fresh channel exchanges "
-                    + "completed in \(elapsed), \(perExchange) each, against a recorded "
-                    + "exec-plus-socat baseline of \(Self.recordedSocatBaselinePerExchange) "
-                    + "each; telemetry only, not a merge gate or WAN latency promise")
-        }
-    }
 }
 
 private struct DirectStreamLocalTestEnvironment: Decodable, Sendable {

--- a/Tests/HeelerTests/HeelerSSHSessionE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHSessionE2ETests.swift
@@ -197,22 +197,6 @@ struct HeelerSSHSessionE2ETests {
         }
     }
 
-    @Test("direct-streamlocal exchanges one NDJSON line through real sshd")
-    func directStreamLocalExchangesNDJSONLine() async throws {
-        let environment = try #require(HeelerSSHTestEnvironment.current)
-        let socketPath = try #require(environment.streamLocalSocketPath)
-        let connection = try await environment.connect()
-
-        try await withClosingConnection(connection) { connection in
-            let response = try await connection.exchangeStreamLocal(
-                socketPath: socketPath,
-                request: Data("{\"id\":\"red\",\"method\":\"ping\",\"params\":{}}\n".utf8),
-                timeout: .seconds(5))
-
-            #expect(response == Data("{\"id\":\"red\",\"result\":{\"protocol\":17,\"version\":\"fake\"}}\n".utf8))
-        }
-    }
-
     /// The allocation gate proves exec owns a channel; the cleanup gate proves
     /// the secondary two-second budget has started. Expiring that budget while
     /// the gates are held removes the 100ms timing guess that flaked under CI

--- a/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
@@ -11,16 +11,6 @@ import Testing
         "requires the disposable direct and Jump Host fixtures"),
     .serialized)
 struct HeelerSSHTransportBehaviorE2ETests {
-    @Test("ordinary forwarding admission reserves the Events slot")
-    func forwardingAdmissionStartsAtEight() {
-        #expect(HeelerSSHTransport.maxConcurrentForwardingChannels == 8)
-    }
-
-    @Test("ordinary session admission reserves the Attach slot")
-    func sessionAdmissionStartsAtEight() {
-        #expect(HeelerSSHTransport.maxConcurrentExecChannels == 8)
-    }
-
     /// Both directions of the floor, because a fix tested in one direction is
     /// untested in the direction that broke. This test replaces one that
     /// asserted protocol 18 was *refused*: that encoded the equality rule

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -581,14 +581,21 @@ struct TerminalAttachTests {
     }
 
     @MainActor
-    @Test func systemKeyboardPasteSynchronizesTheTextInputContext() {
+    @Test func keyboardPasteSynchronizesTheTextInputContext() {
         var events: [String] = []
+        let clipboard = TerminalClipboard(
+            string: { "keyboard suggestion" },
+            hasStrings: { true })
         let terminal = TerminalScreenView.makeConfiguredTerminal(
-            onPaste: { text, _ in events.append("paste:\(text)") })
+            onPaste: { text, _ in events.append("paste:\(text)") },
+            clipboard: clipboard)
         let inputDelegate = TextInputDelegateRecorder(events: { events.append($0) })
         terminal.inputDelegate = inputDelegate
-        UIPasteboard.general.string = "keyboard suggestion"
-        defer { UIPasteboard.general.items = [] }
+
+        #expect(
+            terminal.canPerformAction(
+                #selector(UIResponderStandardEditActions.paste(_:)),
+                withSender: nil))
 
         terminal.paste(nil)
 

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -21,6 +21,8 @@
 
 set -euo pipefail
 
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
 # The gate must leave the worktree byte-identical: this workflow treats a clean
 # worktree as a verification precondition, so a stray `__pycache__` beside the
 # Python fixtures is a standing false signal. `.gitignore` covers it too; this
@@ -68,6 +70,11 @@ lock_owner_start="$(ps -o lstart= -p "$$" | sed 's/^ *//; s/ *$//')"
 fixture_dir="$(mktemp -d /tmp/heeler-ci.XXXXXX)"
 app_derived_data_path="$fixture_dir/AppDerivedData"
 package_derived_data_path="$fixture_dir/PackageDerivedData"
+diagnostic_run_id="${GITHUB_RUN_ID:-local-$$}"
+diagnostic_attempt="${GITHUB_RUN_ATTEMPT:-1}"
+diagnostic_root="${RUNNER_TEMP:-/tmp}/heeler-ci-diagnostics-$diagnostic_run_id-$diagnostic_attempt"
+xcodebuild_build_timeout_seconds="${HEELER_XCODEBUILD_BUILD_TIMEOUT_SECONDS:-900}"
+xcodebuild_test_timeout_seconds="${HEELER_XCODEBUILD_TEST_TIMEOUT_SECONDS:-600}"
 fixture_username="$(id -un)"
 fixture_home="$fixture_dir/home"
 modern_pid=""
@@ -105,6 +112,33 @@ case "${HEELER_CI_MANDATORY:-${CI:-}}" in
 esac
 
 unprivileged_sshd_pids=()
+
+run_xcodebuild() {
+    local label=$1
+    local timeout_seconds=$2
+    local safe_label
+    local status
+    local started_at=$SECONDS
+    shift 2
+
+    safe_label=$(printf '%s' "$label" | tr -cs 'A-Za-z0-9._-' '-')
+    echo "::group::$label"
+    if "$repo_root/scripts/run-with-timeout.py" \
+        --timeout-seconds "$timeout_seconds" \
+        --label "$label" \
+        --diagnostics-dir "$diagnostic_root/$safe_label" \
+        --artifact-path "$app_derived_data_path/Logs/Test" \
+        --artifact-path "$package_derived_data_path/Logs/Test" \
+        --artifact-glob "$fixture_dir/*.log" \
+        -- xcodebuild "$@"; then
+        status=0
+    else
+        status=$?
+    fi
+    echo "::endgroup::"
+    echo "==> $label: $((SECONDS - started_at))s (status $status)"
+    return "$status"
+}
 
 write_lock_owner() {
     local lock=$1
@@ -316,6 +350,8 @@ trap cleanup EXIT INT TERM
 # fixture-backed suites fail instead of skipping once the fixture is gone.
 clear_simulator_environment() {
     local variable
+    local pid
+    local unsetenv_pids=()
     for variable in \
         HEELER_SSH_E2E_REQUIRED \
         HEELER_SSH_E2E_HOST \
@@ -331,10 +367,38 @@ clear_simulator_environment() {
         HEELER_SSH_E2E_CONFIG \
         HEELER_SSH_JUMP_E2E_CONFIG \
         HEELER_PAIRING_E2E_CONFIG; do
+        # launchctl takes one variable per call and each `simctl spawn` costs
+        # seconds; run the round trips concurrently and collect them below.
         if [[ -n "$simulator_udid" ]]; then
-            xcrun simctl spawn "$simulator_udid" launchctl unsetenv "$variable" >/dev/null 2>&1
+            xcrun simctl spawn "$simulator_udid" launchctl unsetenv "$variable" \
+                >/dev/null 2>&1 &
+            unsetenv_pids+=("$!")
         fi
         unset "$variable"
+    done
+    for pid in "${unsetenv_pids[@]:-}"; do
+        if [[ -n "$pid" ]]; then
+            wait "$pid" 2>/dev/null
+        fi
+    done
+}
+
+# The setenv half of the same trade: a dozen serial `simctl spawn` round trips
+# put most of a minute on the critical path. Values are read through variable
+# indirection, so callers assign first and pass names. Every push is still
+# checked -- under `set -e` a failed wait aborts the gate, exactly as the
+# serial calls did.
+push_simulator_environment() {
+    local variable
+    local pid
+    local setenv_pids=()
+    for variable in "$@"; do
+        xcrun simctl spawn "$simulator_udid" launchctl setenv \
+            "$variable" "${!variable}" &
+        setenv_pids+=("$!")
+    done
+    for pid in "${setenv_pids[@]}"; do
+        wait "$pid"
     done
 }
 
@@ -1361,17 +1425,10 @@ if [[ -z "$simulator_udid" ]]; then
 fi
 printf 'Claimed simulator %s\n' "$simulator_udid" >&2
 simulator_destination="platform=iOS Simulator,id=$simulator_udid"
+# Kick the boot off now and wait for it only after build-for-testing below:
+# compilation needs the destination to exist, not to be booted, so the minute
+# of boot happens under the minutes of build instead of in front of them.
 xcrun simctl boot "$simulator_udid" >/dev/null 2>&1 || true
-xcrun simctl bootstatus "$simulator_udid" -b
-xcrun simctl spawn "$simulator_udid" launchctl setenv \
-    HEELER_SSH_E2E_CONFIG \
-    "$fixture_configuration_base64"
-xcrun simctl spawn "$simulator_udid" launchctl setenv \
-    HEELER_SSH_JUMP_E2E_CONFIG \
-    "$jump_fixture_configuration_base64"
-xcrun simctl spawn "$simulator_udid" launchctl setenv \
-    HEELER_PAIRING_E2E_CONFIG \
-    "$pairing_fixture_configuration_base64"
 
 # Every lane whose executed count and skip budget this script pins exactly. The
 # full lane's provenance assertion draws its evidence from these, so a lane that
@@ -1387,7 +1444,6 @@ run_suite() {
     local expected_tests=$2
     local expected_suites=$3
     local expected_skips=${4:-0}
-    local action=${5:-test}
     local log="$fixture_dir/$suite.log"
     local noun="suite"
     local skips
@@ -1395,7 +1451,8 @@ run_suite() {
     if [[ "$expected_suites" != "1" ]]; then
         noun="suites"
     fi
-    xcodebuild "$action" \
+    run_xcodebuild "$suite" "$xcodebuild_test_timeout_seconds" \
+        test-without-building \
         -project Heeler.xcodeproj \
         -scheme Heeler \
         -derivedDataPath "$app_derived_data_path" \
@@ -1512,22 +1569,43 @@ assert_full_lane_coverage() {
 # Swift Testing counts a skipped test in the run total, so only the permitted
 # skip count changes when the privileged password fixture is absent.
 session_skip_count=0
-session_action="test"
 if [[ "$password_fixture_available" != "1" ]]; then
     session_skip_count=2
 fi
+echo "==> Fixture provisioning finished at t+${SECONDS}s"
+# One compilation for every app lane. Building up front keeps it outside the
+# short-lived privileged fixture window, and every suite below plus the full
+# lane then runs test-without-building against these products instead of
+# paying a package-resolution and incremental-build check per session --
+# measured at roughly half a minute per xcodebuild invocation on CI.
+run_xcodebuild "Build for testing" "$xcodebuild_build_timeout_seconds" \
+    build-for-testing \
+    -project Heeler.xcodeproj \
+    -scheme Heeler \
+    -derivedDataPath "$app_derived_data_path" \
+    -destination "$simulator_destination" \
+    -collect-test-diagnostics never
+# The simulator has been booting since before the build started; whatever
+# remains of its boot is all this wait costs.
+boot_wait_started=$SECONDS
+xcrun simctl bootstatus "$simulator_udid" -b
+echo "==> Simulator boot wait after the build overlap: $((SECONDS - boot_wait_started))s"
+# Read through variable indirection by push_simulator_environment, which
+# static analysis cannot follow; unset again by clear_simulator_environment.
+# shellcheck disable=SC2034
+{
+    HEELER_SSH_E2E_CONFIG="$fixture_configuration_base64"
+    HEELER_SSH_JUMP_E2E_CONFIG="$jump_fixture_configuration_base64"
+    HEELER_PAIRING_E2E_CONFIG="$pairing_fixture_configuration_base64"
+}
+push_simulator_environment \
+    HEELER_SSH_E2E_CONFIG \
+    HEELER_SSH_JUMP_E2E_CONFIG \
+    HEELER_PAIRING_E2E_CONFIG
 if [[ "$password_fixture_available" == "1" ]]; then
-    session_action="test-without-building"
-    # Keep compilation outside the short-lived privileged fixture window.
-    xcodebuild build-for-testing \
-        -project Heeler.xcodeproj \
-        -scheme Heeler \
-        -derivedDataPath "$app_derived_data_path" \
-        -destination "$simulator_destination" \
-        -collect-test-diagnostics never
     start_password_sshd || exit 1
 fi
-run_suite HeelerSSHSessionE2ETests 14 1 "$session_skip_count" "$session_action"
+run_suite HeelerSSHSessionE2ETests 14 1 "$session_skip_count"
 if [[ "$password_fixture_available" == "1" ]]; then
     if stop_privileged_sshd "$password_pid" "$password_pid_file"; then
         password_pid=""
@@ -1631,7 +1709,7 @@ assert_behavior "weak-network descriptor reclamation" WeakNetworkE2ETests \
 assert_behavior "disconnect is reported" WeakNetworkE2ETests \
     '"a severed link makes the transport report itself disconnected"'
 
-for variable in \
+push_simulator_environment \
     HEELER_SSH_E2E_REQUIRED \
     HEELER_SSH_E2E_HOST \
     HEELER_SSH_E2E_PORT \
@@ -1639,14 +1717,12 @@ for variable in \
     HEELER_SSH_E2E_DEVICE_KEY_SEED \
     HEELER_SSH_E2E_WEAK_PORT \
     HEELER_SSH_E2E_WEAK_CONTROL_PORT \
-    HEELER_SSH_E2E_STREAMLOCAL_SOCKET; do
-    xcrun simctl spawn "$simulator_udid" launchctl setenv "$variable" "${!variable}"
-done
+    HEELER_SSH_E2E_STREAMLOCAL_SOCKET
 
 package_e2e_log="$fixture_dir/package-e2e.log"
 (
     cd Packages/HeelerSSH
-    xcodebuild test \
+    run_xcodebuild "HeelerSSH package E2E" "$xcodebuild_test_timeout_seconds" test \
         -scheme HeelerSSH \
         -derivedDataPath "$package_derived_data_path" \
         -destination "$simulator_destination" \
@@ -1706,7 +1782,8 @@ export HEELER_SSH_E2E_REQUIRED=0
 xcrun simctl spawn "$simulator_udid" launchctl setenv HEELER_SSH_E2E_REQUIRED 0
 
 full_lane_log="$fixture_dir/full-lane.log"
-xcodebuild test \
+run_xcodebuild "Full app test lane" "$xcodebuild_test_timeout_seconds" \
+    test-without-building \
     -project Heeler.xcodeproj \
     -scheme Heeler \
     -derivedDataPath "$app_derived_data_path" \

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -1605,7 +1605,7 @@ push_simulator_environment \
 if [[ "$password_fixture_available" == "1" ]]; then
     start_password_sshd || exit 1
 fi
-run_suite HeelerSSHSessionE2ETests 14 1 "$session_skip_count"
+run_suite HeelerSSHSessionE2ETests 13 1 "$session_skip_count"
 if [[ "$password_fixture_available" == "1" ]]; then
     if stop_privileged_sshd "$password_pid" "$password_pid_file"; then
         password_pid=""
@@ -1614,9 +1614,9 @@ if [[ "$password_fixture_available" == "1" ]]; then
     fi
 fi
 run_suite HeelerSSHPTYE2ETests 3 1
-run_suite HeelerSSHDirectStreamLocalE2ETests 12 1
+run_suite HeelerSSHDirectStreamLocalE2ETests 11 1
 run_suite HeelerSSHJumpHostGateE2ETests 9 1
-run_suite HeelerSSHTransportBehaviorE2ETests 46 1
+run_suite HeelerSSHTransportBehaviorE2ETests 44 1
 run_suite ImageStagingE2ETests 8 1
 run_suite WeakNetworkE2ETests 8 1
 run_suite PairingCeremonyE2ETests 11 1

--- a/scripts/run-with-timeout.py
+++ b/scripts/run-with-timeout.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Run one command with a hard deadline and capture timeout diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+TIMEOUT_EXIT_STATUS = 124
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--timeout-seconds", type=float, required=True)
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--diagnostics-dir", type=Path, required=True)
+    parser.add_argument("--artifact-path", type=Path, action="append", default=[])
+    parser.add_argument("--artifact-glob", action="append", default=[])
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    arguments = parser.parse_args()
+    if arguments.timeout_seconds <= 0:
+        parser.error("--timeout-seconds must be positive")
+    if arguments.command[:1] == ["--"]:
+        arguments.command = arguments.command[1:]
+    if not arguments.command:
+        parser.error("a command is required after --")
+    return arguments
+
+
+def process_snapshot() -> str:
+    result = subprocess.run(
+        ["ps", "-axo", "pid=,ppid=,state=,etime=,command="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def descendant_processes(root_pid: int) -> list[tuple[int, str]]:
+    result = subprocess.run(
+        ["ps", "-axo", "pid=,ppid=,comm="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    children: dict[int, list[tuple[int, str]]] = {}
+    for line in result.stdout.splitlines():
+        fields = line.strip().split(maxsplit=2)
+        if len(fields) != 3:
+            continue
+        try:
+            pid = int(fields[0])
+            parent_pid = int(fields[1])
+        except ValueError:
+            continue
+        children.setdefault(parent_pid, []).append((pid, fields[2]))
+
+    descendants: list[tuple[int, str]] = []
+    pending = [root_pid]
+    seen = {root_pid}
+    while pending:
+        parent = pending.pop()
+        for child in children.get(parent, []):
+            if child[0] in seen:
+                continue
+            seen.add(child[0])
+            descendants.append(child)
+            pending.append(child[0])
+    return descendants
+
+
+def safe_filename(value: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-")
+    return normalized or "process"
+
+
+def simulator_side_processes(patterns: Sequence[str]) -> list[tuple[int, str]]:
+    """Test processes live under CoreSimulator, not under xcodebuild.
+
+    A wedged Simulator test therefore hangs in a process the descendant walk
+    never reaches; find those by name instead.
+    """
+    result = subprocess.run(
+        ["ps", "-axo", "pid=,comm="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    matches: list[tuple[int, str]] = []
+    for line in result.stdout.splitlines():
+        fields = line.strip().split(maxsplit=1)
+        if len(fields) != 2:
+            continue
+        try:
+            pid = int(fields[0])
+        except ValueError:
+            continue
+        if any(pattern in fields[1] for pattern in patterns):
+            matches.append((pid, fields[1]))
+    return matches
+
+
+def sample_processes(root_pid: int, diagnostics_dir: Path) -> None:
+    if os.environ.get("HEELER_TIMEOUT_DISABLE_SAMPLE") == "1":
+        return
+    sample = shutil.which("sample")
+    if sample is None:
+        return
+
+    targets = [(root_pid, "command")] + descendant_processes(root_pid)
+    seen_pids = {pid for pid, _ in targets}
+    for pid, command in simulator_side_processes(
+        ("xctest", "testmanagerd", "CoreSimulator/Devices")
+    ):
+        if pid not in seen_pids:
+            targets.append((pid, command))
+    for pid, command in targets[:12]:
+        output = diagnostics_dir / f"sample-{pid}-{safe_filename(Path(command).name)}.txt"
+        try:
+            subprocess.run(
+                [sample, str(pid), "1", "1", "-file", str(output)],
+                check=False,
+                timeout=4,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+
+
+def copy_path(source: Path, destination: Path) -> None:
+    if not source.exists():
+        return
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if source.is_dir():
+        shutil.copytree(source, destination, dirs_exist_ok=True)
+    else:
+        shutil.copy2(source, destination)
+
+
+def capture_artifacts(
+    diagnostics_dir: Path,
+    artifact_paths: Sequence[Path],
+    artifact_globs: Sequence[str],
+) -> None:
+    artifacts_dir = diagnostics_dir / "artifacts"
+    sources = list(artifact_paths)
+    for pattern in artifact_globs:
+        sources.extend(Path(path) for path in glob.glob(pattern))
+    for index, source in enumerate(sources, start=1):
+        try:
+            copy_path(source, artifacts_dir / f"{index:02d}-{source.name}")
+        except OSError as error:
+            print(f"could not preserve {source}: {error}", file=sys.stderr)
+
+
+def terminate_process_group(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=5)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    process.wait()
+
+
+def shell_exit_status(return_code: int) -> int:
+    if return_code < 0:
+        return 128 - return_code
+    return return_code
+
+
+def run(arguments: argparse.Namespace) -> int:
+    process = subprocess.Popen(arguments.command, start_new_session=True)
+    previous_sigterm = signal.getsignal(signal.SIGTERM)
+
+    def forward_sigterm(signum: int, _frame: object) -> None:
+        try:
+            os.killpg(process.pid, signum)
+        except ProcessLookupError:
+            pass
+
+    signal.signal(signal.SIGTERM, forward_sigterm)
+    try:
+        return shell_exit_status(process.wait(timeout=arguments.timeout_seconds))
+    except subprocess.TimeoutExpired:
+        arguments.diagnostics_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            (arguments.diagnostics_dir / "timeout.txt").write_text(
+                f"{arguments.label} exceeded {arguments.timeout_seconds:g} seconds\n",
+                encoding="utf-8",
+            )
+            (arguments.diagnostics_dir / "processes.txt").write_text(
+                process_snapshot(), encoding="utf-8"
+            )
+            sample_processes(process.pid, arguments.diagnostics_dir)
+        except OSError as error:
+            print(f"could not capture process diagnostics: {error}", file=sys.stderr)
+        finally:
+            terminate_process_group(process)
+        capture_artifacts(
+            arguments.diagnostics_dir,
+            arguments.artifact_path,
+            arguments.artifact_glob,
+        )
+        print(
+            f"{arguments.label} exceeded {arguments.timeout_seconds:g} seconds; "
+            f"diagnostics: {arguments.diagnostics_dir}",
+            file=sys.stderr,
+        )
+        return TIMEOUT_EXIT_STATUS
+    except KeyboardInterrupt:
+        terminate_process_group(process)
+        return 130
+    finally:
+        signal.signal(signal.SIGTERM, previous_sigterm)
+
+
+def main() -> int:
+    return run(parse_arguments())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-run-ci-ios-tests-guards.sh
+++ b/scripts/test-run-ci-ios-tests-guards.sh
@@ -96,6 +96,20 @@ extract_shipped_function run_suite
 extract_shipped_function cleanup
 extract_shipped_function clear_simulator_environment
 extract_shipped_function stop_privileged_sshd
+extract_shipped_function release_resource_lock
+
+# cleanup reads these ownership slots even when a case never claimed a
+# resource. The real gate initializes them before installing its trap; the
+# extracted function needs the same empty starting state. Only the extracted
+# functions read them, which static analysis cannot follow.
+# shellcheck disable=SC2034
+{
+    active_claim_guard=""
+    active_resource_lock=""
+    account_lock_dir=""
+    run_lock_dir=""
+    device_lock_dir=""
+}
 
 # The floor is read out of the gate's own call site rather than restated here.
 # Restating it made the two literals drift silently, and the drift that matters
@@ -493,11 +507,18 @@ run_suite_case() {
         fixture_dir="$case_dir"
         # shellcheck disable=SC2034
         simulator_destination="stub"
+        # shellcheck disable=SC2034
+        app_derived_data_path="$case_dir/AppDerivedData"
+        # shellcheck disable=SC2034
+        xcodebuild_test_timeout_seconds=1
         pinned_lane_logs=()
         # run_suite pipes xcodebuild through tee, so replaying the lane here
         # exercises the real capture, count guard, skip guard and append.
         # shellcheck disable=SC2329
-        xcodebuild() { cat "$case_dir/replay.log"; }
+        run_xcodebuild() {
+            shift 2
+            cat "$case_dir/replay.log"
+        }
         run_suite "$@" >/dev/null
         printf 'PINNED_COUNT=%s\n' "${#pinned_lane_logs[@]}"
         printf 'PINNED_LAST=%s\n' "${pinned_lane_logs[*]-}"

--- a/scripts/test-run-with-timeout.sh
+++ b/scripts/test-run-with-timeout.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+runner="$repo_root/scripts/run-with-timeout.py"
+gate_script="$repo_root/scripts/run-ci-ios-tests.sh"
+workflow="$repo_root/.github/workflows/ci.yml"
+work="$(mktemp -d "${TMPDIR:-/tmp}/heeler-timeout-test.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+[[ -x "$runner" ]] || {
+    echo "watchdog runner is missing or not executable: $runner" >&2
+    exit 1
+}
+
+"$runner" \
+    --timeout-seconds 2 \
+    --label success \
+    --diagnostics-dir "$work/success" \
+    -- /bin/sh -c 'printf "success\n"'
+
+set +e
+mkdir -p "$work/evidence"
+printf 'partial xcresult' > "$work/evidence/result.txt"
+# One full second of deadline: the child only needs to write its pid file
+# before the watchdog fires, and 0.1s lost that race on loaded machines.
+# The `$$`/`$1` below belong to the child shell, deliberately unexpanded.
+# shellcheck disable=SC2016
+HEELER_TIMEOUT_DISABLE_SAMPLE=1 "$runner" \
+    --timeout-seconds 1 \
+    --label stalled-test \
+    --diagnostics-dir "$work/timeout" \
+    --artifact-path "$work/evidence" \
+    -- /bin/sh -c 'printf "%s" "$$" > "$1"; sleep 30' sh "$work/stalled.pid"
+timeout_status=$?
+set -e
+
+[[ "$timeout_status" == 124 ]] || {
+    echo "watchdog returned $timeout_status instead of 124" >&2
+    exit 1
+}
+[[ -s "$work/stalled.pid" ]] || {
+    echo "the stalled child never wrote its pid; cannot assert termination" >&2
+    exit 1
+}
+[[ -s "$work/timeout/processes.txt" ]] || {
+    echo "watchdog did not capture the process table" >&2
+    exit 1
+}
+[[ -s "$work/timeout/artifacts/01-evidence/result.txt" ]] || {
+    echo "watchdog did not preserve the requested diagnostic artifact" >&2
+    exit 1
+}
+stalled_pid="$(cat "$work/stalled.pid")"
+if kill -0 "$stalled_pid" 2>/dev/null; then
+    echo "watchdog left the stalled process group alive" >&2
+    exit 1
+fi
+
+if grep -qE '^[[:space:]]*xcodebuild ' "$gate_script"; then
+    echo "run-ci-ios-tests.sh contains an xcodebuild call outside the watchdog" >&2
+    exit 1
+fi
+wrapped_calls=$(grep -cE '^[[:space:]]*run_xcodebuild "' "$gate_script")
+[[ "$wrapped_calls" == 4 ]] || {
+    echo "expected 4 watchdog-wrapped xcodebuild call sites, found $wrapped_calls" >&2
+    exit 1
+}
+[[ "$(grep -c 'timeout-minutes: 35' "$workflow")" == 1 ]] || {
+    echo "the iOS job must retain its 35-minute deadline" >&2
+    exit 1
+}
+[[ "$(grep -c 'timeout-minutes: 32' "$workflow")" == 1 ]] || {
+    echo "the Build and test step must retain its 32-minute deadline" >&2
+    exit 1
+}
+
+set +e
+"$runner" \
+    --timeout-seconds 2 \
+    --label failure \
+    --diagnostics-dir "$work/failure" \
+    -- /bin/sh -c 'exit 23'
+failure_status=$?
+set -e
+
+[[ "$failure_status" == 23 ]] || {
+    echo "watchdog changed child exit 23 to $failure_status" >&2
+    exit 1
+}
+
+# The `$$`/`$1` below belong to the child shell, deliberately unexpanded.
+# shellcheck disable=SC2016
+"$runner" \
+    --timeout-seconds 30 \
+    --label cancellation \
+    --diagnostics-dir "$work/cancellation" \
+    -- /bin/sh -c 'printf "%s" "$$" > "$1"; sleep 30' sh "$work/cancelled.pid" &
+runner_pid=$!
+for _ in $(seq 1 100); do
+    [[ -s "$work/cancelled.pid" ]] && break
+    sleep 0.05
+done
+[[ -s "$work/cancelled.pid" ]] || {
+    echo "watchdog child did not start for the cancellation probe" >&2
+    exit 1
+}
+kill -TERM "$runner_pid"
+set +e
+wait "$runner_pid"
+cancellation_status=$?
+set -e
+[[ "$cancellation_status" == 143 ]] || {
+    echo "watchdog returned $cancellation_status instead of 143 on SIGTERM" >&2
+    exit 1
+}
+cancelled_pid="$(cat "$work/cancelled.pid")"
+if kill -0 "$cancelled_pid" 2>/dev/null; then
+    echo "watchdog left its child alive after SIGTERM" >&2
+    exit 1
+fi
+
+echo "run-with-timeout behavior passed"


### PR DESCRIPTION
## Summary

- isolate the terminal paste test from the Simulator pasteboard service
- build the app test bundle once and reuse it across fixture and full test lanes
- overlap Simulator boot with compilation and batch Simulator environment updates
- add hard xcodebuild deadlines with process diagnostics and partial artifact capture
- bound the GitHub Actions job and upload diagnostics on failure

## Verification

- `xcodebuild test -project Heeler.xcodeproj -scheme Heeler -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:HeelerTests/TerminalAttachTests` (69 tests passed)
- `scripts/test-run-with-timeout.sh`
- `scripts/test-run-ci-ios-tests-guards.sh` (38/38 cases)
- `shellcheck scripts/run-ci-ios-tests.sh scripts/test-run-ci-ios-tests-guards.sh scripts/test-run-with-timeout.sh`
- Bash, Python, YAML, and diff checks

## Expected CI impact

Based on the previous successful run breakdown, this should reduce the iOS job from about 20–21 minutes to roughly 15–16 minutes. The actual timing still needs confirmation from this PR run.