### PR TITLE
feat: compact binary pairing code with a popup-sized QR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,11 @@ Entries reference the issue that motivated them.
   The plugin id remains `heeler.pairing`, so already-linked Hosts do not need
   to reinstall.
 
+- The pairing popup QR is drawn with octant block characters (2×4 modules
+  per cell), so it stays square and solid at half the previous width and
+  height. The pair popup is 80%×90% so the QR and the connection details fit
+  together.
+
 ### Fixed
 
 - Malformed herdr API error responses that carry an empty id now fail the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,10 +100,14 @@ Entries reference the issue that motivated them.
   The plugin id remains `heeler.pairing`, so already-linked Hosts do not need
   to reinstall.
 
-- The pairing popup QR is drawn with octant block characters (2×4 modules
-  per cell), so it stays square and solid at half the previous width and
-  height. The pair popup is 80%×90% so the QR and the connection details fit
-  together.
+- Pairing Codes are now a compact binary envelope (v2), and the pairing
+  popup draws the QR with sextant block characters at error correction M
+  with a spec-compliant quiet zone. Together this shrinks the QR from
+  65×33 to roughly 27×18 terminal cells, renders on any terminal that
+  ships Unicode 13 glyphs (iTerm2, VS Code, Alacritty included), and
+  survives more display damage. The app decodes both v1 and v2 codes, so
+  pairing against an older plugin keeps working; scanning a new plugin's
+  QR requires this app version or later. See ADR 0014.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ Entries reference the issue that motivated them.
   Pairing and SSH access are unaffected: the Device Key already in the Host's
   `authorized_keys` keeps working.
 
+- The pairing plugin's display name is now `heeler` (was `Heeler Pairing`).
+  The plugin id remains `heeler.pairing`, so already-linked Hosts do not need
+  to reinstall.
+
 ### Fixed
 
 - Malformed herdr API error responses that carry an empty id now fail the

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		00FB65666F7C2E065D94DF2C /* StartAgentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24EF5EA39899292A1907226 /* StartAgentStore.swift */; };
 		03970FA28B8C09C524AF435E /* NotificationPrivacyCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 943C187E6425414801A4734E /* NotificationPrivacyCopyTests.swift */; };
 		052916002C06699B9F2F1A4B /* AttachTerminalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07A0F64626D74A8EC9A1FE2 /* AttachTerminalStore.swift */; };
+		08E5F88B52BA134DCA0A0308 /* PairingCodeV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC81E7E973352FBF20D8868D /* PairingCodeV2Tests.swift */; };
 		099CD816C9173740BCE1E64E /* TestWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069388B06CE04D1F3CC24740 /* TestWindow.swift */; };
 		09C7B75B4780E79E3221E9C4 /* TerminalAgentSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8509C4FD5C50A0D7AFEC1A /* TerminalAgentSwitcher.swift */; };
 		0B67978E4183023EF40B256B /* Notices in Resources */ = {isa = PBXBuildFile; fileRef = F4926339DC2CC7D0D6B58069 /* Notices */; };
@@ -27,6 +28,7 @@
 		17F313D8AE9647F8F5D4DBFD /* AgentAttachStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F8ED10B8A8A33D307789E6 /* AgentAttachStore.swift */; };
 		1AD6824BFB55CB50607AD702 /* FakeTransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696C6905D9D6EEFF77A64E2E /* FakeTransportConnector.swift */; };
 		1ADE76974DEBFD636189EE45 /* NotificationRelayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6876069E2B641D09FF1520E6 /* NotificationRelayEndpoint.swift */; };
+		1CCAA769DDCA71EC02D40707 /* pairing-code-v2.json in Resources */ = {isa = PBXBuildFile; fileRef = 791A29C99001477839E4C3E5 /* pairing-code-v2.json */; };
 		1CF0CDEFC1C46433C1F4CF06 /* IBMPlexMono-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6FF0DA87C092E176838C1EF7 /* IBMPlexMono-Bold.ttf */; };
 		1EDDD0227C94C6B7C2586A68 /* ImagePreparerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4889F56EFEFCC5004A55B4C /* ImagePreparerTests.swift */; };
 		20D4C5FBFAE65D07558E684B /* TerminalThemeSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921CA559141776BD0F02FDA7 /* TerminalThemeSettingsTests.swift */; };
@@ -51,6 +53,7 @@
 		31E4ADB22D4D655E7CFDB749 /* TerminalInputControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05AD61D4FA60884234EA856C /* TerminalInputControllerTests.swift */; };
 		3286D6FBB12157F2A19A82CE /* AgentNotificationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB37CBDC9DE0CE539FC476A0 /* AgentNotificationRenderer.swift */; };
 		35205050C9CB8E473D8A28C0 /* Base64URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32413805C1AA874DBEE37547 /* Base64URL.swift */; };
+		358A1C5490E3CBA82F6B19EF /* QRCodeContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCE41EC5B3E09610CC180C1 /* QRCodeContent.swift */; };
 		359A3FA92C332BEC1DA1982C /* NotificationConfigFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E38A3F2A443D311C8FCC218 /* NotificationConfigFile.swift */; };
 		3662BE3559CB08401960176C /* AgentNotificationRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B02412C186BA855DFD9379A /* AgentNotificationRoutingTests.swift */; };
 		3684BDED2C234F399A6758C9 /* GhosttyTheme in Frameworks */ = {isa = PBXBuildFile; productRef = E086C559FC229264CF662993 /* GhosttyTheme */; };
@@ -123,6 +126,7 @@
 		7AAD57A0A0BF63FE16C76C17 /* TerminalStatusDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856C56B29DCF048C09AF7C1C /* TerminalStatusDialogTests.swift */; };
 		7BD7F228AC8A9EDA13A63C2C /* DeviceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F4EF125BAB77F0DE121AAB /* DeviceKey.swift */; };
 		7CF1965195B7578472B615B9 /* Snippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5434768FDE9237B7BD721E /* Snippet.swift */; };
+		7D41D8A3880349D6E0E57D23 /* PairingCodeV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE43401616D9CCE4A0253B6 /* PairingCodeV2.swift */; };
 		7DE1449E409F7F06C64E5089 /* RealSSHFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B3368D352EFC805C2534F9 /* RealSSHFixture.swift */; };
 		7F8EA3E191EEC97479E3DC04 /* HerdrEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A6D0F6E54809BDE46AC1AE /* HerdrEventsTests.swift */; };
 		7FD7DF4CAB9F62BC5014F563 /* PairingCeremonyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702DF66CBA3DE023470DBA1F /* PairingCeremonyE2ETests.swift */; };
@@ -248,6 +252,7 @@
 		FC3565466275E3A63ED59687 /* PairingCeremony.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CA687285B470E3968D1DB6 /* PairingCeremony.swift */; };
 		FE166661ED7A958DBE0F48B7 /* NotificationRegistrationCeremonyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078D357A959644457EA59E43 /* NotificationRegistrationCeremonyTests.swift */; };
 		FE387FB6FB6CC68E066B23AE /* HostCredentialsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBBD602AA4969937A9306C3 /* HostCredentialsProvider.swift */; };
+		FE6703FBDDA3163B3E269845 /* PairingCodeV2VectorFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6139D1124776ADEABB498232 /* PairingCodeV2VectorFile.swift */; };
 		FEC497C4A95E5F4D945EF3BA /* EventsSessionSubscriptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AD641EA732307D72698216 /* EventsSessionSubscriptionsTests.swift */; };
 		FF4620613A476ADEB25FBA96 /* GhosttyTerminal in Frameworks */ = {isa = PBXBuildFile; productRef = BE53F92F352D5CEE9A715FA9 /* GhosttyTerminal */; };
 		FFFDB4A4BE267D1C933B0CB7 /* TerminalSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A3319D35C3BBCD2CB151843 /* TerminalSettings.swift */; };
@@ -371,6 +376,7 @@
 		5CB08528C0328AA9AFE358CE /* TerminalFontSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalFontSettings.swift; sourceTree = "<group>"; };
 		60A3266F97C243598703DB0A /* JSONValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValue.swift; sourceTree = "<group>"; };
 		6137F891C34AE9E7951804F7 /* SolvingOrbView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolvingOrbView.swift; sourceTree = "<group>"; };
+		6139D1124776ADEABB498232 /* PairingCodeV2VectorFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCodeV2VectorFile.swift; sourceTree = "<group>"; };
 		61DA61C2FD4220803AE6D533 /* PairingCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCode.swift; sourceTree = "<group>"; };
 		64B0C3E8DD054078EF85AB5A /* ImageStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStagingTests.swift; sourceTree = "<group>"; };
 		64D3B8E2EB97A8376B333914 /* AgentNameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNameTests.swift; sourceTree = "<group>"; };
@@ -392,6 +398,7 @@
 		7683DF30B1A0E9FA0064AAA2 /* HeelerSSHTransportBehaviorE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHTransportBehaviorE2ETests.swift; sourceTree = "<group>"; };
 		7780BE78D868DB0A8275E6FB /* Heeler.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Heeler.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		78F85C588963C3CE948AA9E4 /* AgentNotificationBannerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationBannerStore.swift; sourceTree = "<group>"; };
+		791A29C99001477839E4C3E5 /* pairing-code-v2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "pairing-code-v2.json"; sourceTree = "<group>"; };
 		79662827F6A91D8EFBF112F7 /* HostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostListView.swift; sourceTree = "<group>"; };
 		7A8ED9AD5019F303932B0F9C /* ImageStagingE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStagingE2ETests.swift; sourceTree = "<group>"; };
 		7B0A5D6A13F3F940E50EDCFD /* DemoScreenshotMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoScreenshotMode.swift; sourceTree = "<group>"; };
@@ -444,6 +451,7 @@
 		A7103745D02C07787E49AC70 /* NotificationEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationEnvelopeTests.swift; sourceTree = "<group>"; };
 		AACC0F2C9582DE0932380D35 /* KnownHostsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStoreTests.swift; sourceTree = "<group>"; };
 		AB48C946E14722E93FAAA410 /* TerminalAttach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAttach.swift; sourceTree = "<group>"; };
+		AEE43401616D9CCE4A0253B6 /* PairingCodeV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCodeV2.swift; sourceTree = "<group>"; };
 		B1AEA55D1F06B12005DEEE5F /* HeelerSSHSessionE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHSessionE2ETests.swift; sourceTree = "<group>"; };
 		B24EF5EA39899292A1907226 /* StartAgentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStore.swift; sourceTree = "<group>"; };
 		B2627DBEB9BFBDC600F211A1 /* NotificationPrivacyCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPrivacyCopy.swift; sourceTree = "<group>"; };
@@ -476,6 +484,7 @@
 		CC67B000BBBD99D10CB7A30E /* SnippetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetTests.swift; sourceTree = "<group>"; };
 		CE868FFAE7FC91684AF77452 /* TerminalThemePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemePreview.swift; sourceTree = "<group>"; };
 		CFB39D40748D247CC747A83D /* AppActivityCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivityCoordinatorTests.swift; sourceTree = "<group>"; };
+		CFCE41EC5B3E09610CC180C1 /* QRCodeContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeContent.swift; sourceTree = "<group>"; };
 		D026719294E631141C3A59F9 /* PairingScanStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScanStoreTests.swift; sourceTree = "<group>"; };
 		D1359A2D60189FA45F8DFB0D /* TerminalTextSafety.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTextSafety.swift; sourceTree = "<group>"; };
 		D24E7FB55E1DF14C8353ABDE /* DeviceKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyStore.swift; sourceTree = "<group>"; };
@@ -490,6 +499,7 @@
 		DA59306306EAEAA6DA78E337 /* TerminalAgentSwitcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAgentSwitcherTests.swift; sourceTree = "<group>"; };
 		DAEAF21DF91A1BCE4C9F79A3 /* AppAppearanceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAppearanceSettings.swift; sourceTree = "<group>"; };
 		DC6D0361E0EB15681156D5C7 /* NotificationKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationKeyStore.swift; sourceTree = "<group>"; };
+		DC81E7E973352FBF20D8868D /* PairingCodeV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCodeV2Tests.swift; sourceTree = "<group>"; };
 		DD17BB4EEFBB38DECB6765BF /* Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
 		DD7EC7BEC9AACD2DAF634B2C /* AgentNotificationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationRouter.swift; sourceTree = "<group>"; };
 		DD8509C4FD5C50A0D7AFEC1A /* TerminalAgentSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAgentSwitcher.swift; sourceTree = "<group>"; };
@@ -610,6 +620,7 @@
 				702DF66CBA3DE023470DBA1F /* PairingCeremonyE2ETests.swift */,
 				1F0763484EE05424146492C1 /* PairingCeremonyTests.swift */,
 				D419158B027AF5F38B73AD8B /* PairingCodeTests.swift */,
+				DC81E7E973352FBF20D8868D /* PairingCodeV2Tests.swift */,
 				D026719294E631141C3A59F9 /* PairingScanStoreTests.swift */,
 				151586845D0A1EE54968B536 /* PreflightReportTests.swift */,
 				BEE35062339F9D6B0A9E684B /* PushRegistrationStoreTests.swift */,
@@ -834,6 +845,7 @@
 			children = (
 				EEB863EF2AD319A412DB564A /* notification-payload-v1.json */,
 				F9EF9F515ABC98C4B0B483C0 /* pairing-code-v1.json */,
+				791A29C99001477839E4C3E5 /* pairing-code-v2.json */,
 			);
 			path = "test-vectors";
 			sourceTree = "<group>";
@@ -905,6 +917,7 @@
 				51B4AAB6885E0EB9D8C4A131 /* InMemorySecretStore.swift */,
 				4F172C9E024F73AD2DD96288 /* LocalSSHTestEnvironment.swift */,
 				B2DAE3FAB8786392318939A6 /* NotificationVectorFile.swift */,
+				6139D1124776ADEABB498232 /* PairingCodeV2VectorFile.swift */,
 				7461B7A0FD2A4CDF34352D45 /* PairingCodeVectorFile.swift */,
 				31B3368D352EFC805C2534F9 /* RealSSHFixture.swift */,
 				B64F59C086BFF5B062ADCE8C /* ScriptedTransport.swift */,
@@ -919,9 +932,11 @@
 			children = (
 				D4CA687285B470E3968D1DB6 /* PairingCeremony.swift */,
 				61DA61C2FD4220803AE6D533 /* PairingCode.swift */,
+				AEE43401616D9CCE4A0253B6 /* PairingCodeV2.swift */,
 				4EEAD52089A35D4B2D47AF25 /* PairingConnector.swift */,
 				45DB60007029322902FD1AFF /* PairingScanStore.swift */,
 				1674575F15764AB318626947 /* PairingScanView.swift */,
+				CFCE41EC5B3E09610CC180C1 /* QRCodeContent.swift */,
 				88062AE11DDF93EB77A63D6B /* SSHPairingConnector.swift */,
 			);
 			path = Pairing;
@@ -1137,6 +1152,7 @@
 			files = (
 				21EA3C700022C6362774EF1A /* notification-payload-v1.json in Resources */,
 				DFB9F3DD64996FFAF4E519EC /* pairing-code-v1.json in Resources */,
+				1CCAA769DDCA71EC02D40707 /* pairing-code-v2.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1232,12 +1248,14 @@
 				DE020395E7459D508F0CC401 /* NotificationSettingsView.swift in Sources */,
 				FC3565466275E3A63ED59687 /* PairingCeremony.swift in Sources */,
 				42C86E0D3EFFEA3EEF3FFA96 /* PairingCode.swift in Sources */,
+				7D41D8A3880349D6E0E57D23 /* PairingCodeV2.swift in Sources */,
 				14F3A10674FAF72C63042108 /* PairingConnector.swift in Sources */,
 				DB3815F790623647C0050290 /* PairingScanStore.swift in Sources */,
 				430EDF8111CC397CA9BD2008 /* PairingScanView.swift in Sources */,
 				D08663BD250210835FE7ED49 /* PhotosPickerImageSelection.swift in Sources */,
 				2292C89F605CE42073D49B11 /* Preflight.swift in Sources */,
 				F1896998EA513073CF4EE713 /* PushRegistrationStore.swift in Sources */,
+				358A1C5490E3CBA82F6B19EF /* QRCodeContent.swift in Sources */,
 				C1F06F7588D4713392223CC5 /* RecentWorkspaceStore.swift in Sources */,
 				F8D65F54BA2C27606B01EE73 /* RenameSheetView.swift in Sources */,
 				4CB81788CD628171F46111D3 /* RenameStore.swift in Sources */,
@@ -1371,6 +1389,8 @@
 				7FD7DF4CAB9F62BC5014F563 /* PairingCeremonyE2ETests.swift in Sources */,
 				CBAEF7D1E91053F0B15E2F31 /* PairingCeremonyTests.swift in Sources */,
 				82600FB64A99ADAD1C60D451 /* PairingCodeTests.swift in Sources */,
+				08E5F88B52BA134DCA0A0308 /* PairingCodeV2Tests.swift in Sources */,
+				FE6703FBDDA3163B3E269845 /* PairingCodeV2VectorFile.swift in Sources */,
 				B3C490CC3562CC5B4B2EB993 /* PairingCodeVectorFile.swift in Sources */,
 				F6A1A833DFFB748716D13EA9 /* PairingScanStoreTests.swift in Sources */,
 				A194C27FBF0EF6641215D33A /* PreflightReportTests.swift in Sources */,

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -28,7 +28,6 @@
 		17F313D8AE9647F8F5D4DBFD /* AgentAttachStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F8ED10B8A8A33D307789E6 /* AgentAttachStore.swift */; };
 		1AD6824BFB55CB50607AD702 /* FakeTransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696C6905D9D6EEFF77A64E2E /* FakeTransportConnector.swift */; };
 		1ADE76974DEBFD636189EE45 /* NotificationRelayEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6876069E2B641D09FF1520E6 /* NotificationRelayEndpoint.swift */; };
-		1CCAA769DDCA71EC02D40707 /* pairing-code-v2.json in Resources */ = {isa = PBXBuildFile; fileRef = 791A29C99001477839E4C3E5 /* pairing-code-v2.json */; };
 		1CF0CDEFC1C46433C1F4CF06 /* IBMPlexMono-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6FF0DA87C092E176838C1EF7 /* IBMPlexMono-Bold.ttf */; };
 		1EDDD0227C94C6B7C2586A68 /* ImagePreparerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4889F56EFEFCC5004A55B4C /* ImagePreparerTests.swift */; };
 		20D4C5FBFAE65D07558E684B /* TerminalThemeSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921CA559141776BD0F02FDA7 /* TerminalThemeSettingsTests.swift */; };
@@ -398,7 +397,6 @@
 		7683DF30B1A0E9FA0064AAA2 /* HeelerSSHTransportBehaviorE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHTransportBehaviorE2ETests.swift; sourceTree = "<group>"; };
 		7780BE78D868DB0A8275E6FB /* Heeler.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Heeler.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		78F85C588963C3CE948AA9E4 /* AgentNotificationBannerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationBannerStore.swift; sourceTree = "<group>"; };
-		791A29C99001477839E4C3E5 /* pairing-code-v2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "pairing-code-v2.json"; sourceTree = "<group>"; };
 		79662827F6A91D8EFBF112F7 /* HostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostListView.swift; sourceTree = "<group>"; };
 		7A8ED9AD5019F303932B0F9C /* ImageStagingE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStagingE2ETests.swift; sourceTree = "<group>"; };
 		7B0A5D6A13F3F940E50EDCFD /* DemoScreenshotMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoScreenshotMode.swift; sourceTree = "<group>"; };
@@ -845,7 +843,6 @@
 			children = (
 				EEB863EF2AD319A412DB564A /* notification-payload-v1.json */,
 				F9EF9F515ABC98C4B0B483C0 /* pairing-code-v1.json */,
-				791A29C99001477839E4C3E5 /* pairing-code-v2.json */,
 			);
 			path = "test-vectors";
 			sourceTree = "<group>";
@@ -1152,7 +1149,6 @@
 			files = (
 				21EA3C700022C6362774EF1A /* notification-payload-v1.json in Resources */,
 				DFB9F3DD64996FFAF4E519EC /* pairing-code-v1.json in Resources */,
-				1CCAA769DDCA71EC02D40707 /* pairing-code-v2.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Heeler/Pairing/PairingCode.swift
+++ b/Sources/Heeler/Pairing/PairingCode.swift
@@ -1,15 +1,17 @@
 import Foundation
 
 /// A parsed Pairing Code: the versioned payload the pairing plugin renders as
-/// a QR image (ADR 0007). Wire format:
+/// a QR image (ADR 0007). This file decodes the v1 wire format:
 ///
 ///     HERDR-PAIR:<version>:<base64url(JSON, no padding)>
 ///
-/// The schema and error taxonomy live in `plugin/README.md`; the shared test
-/// vectors in `plugin/test-vectors/pairing-code-v1.json` are the single
-/// source of truth for both this decoder and the plugin's encoder. Unknown
-/// payload fields are ignored (additive v1 metadata); breaking changes bump
-/// the version, which both implementations must honor together.
+/// The compact binary v2 envelope is decoded in `PairingCodeV2.swift`, which
+/// also owns the scan-entry dispatch between the two. The schema and error
+/// taxonomy live in `plugin/README.md`; the shared test vectors in
+/// `plugin/test-vectors/pairing-code-v1.json` are the single source of truth
+/// for both this decoder and the plugin's encoder. Unknown payload fields are
+/// ignored (additive v1 metadata); breaking changes bump the version, which
+/// both implementations must honor together.
 struct PairingCode: Sendable, Equatable {
     static let prefix = "HERDR-PAIR"
     static let version = 1
@@ -136,7 +138,9 @@ struct PairingCode: Sendable, Equatable {
         return HostKeyFingerprint(digest: digest)
     }
 
-    private static func containsWhitespace(_ text: String) -> Bool {
+    // Internal for the v2 decoder in PairingCodeV2.swift, which enforces the
+    // same field rules.
+    static func containsWhitespace(_ text: String) -> Bool {
         text.unicodeScalars.contains { CharacterSet.whitespacesAndNewlines.contains($0) }
     }
 }

--- a/Sources/Heeler/Pairing/PairingCodeV2.swift
+++ b/Sources/Heeler/Pairing/PairingCodeV2.swift
@@ -31,10 +31,13 @@ struct ScannedQRCode: Sendable, Equatable {
 ///     then per address: type 0x04 (4 raw IPv4 bytes), 0x06 (16 raw IPv6
 ///     bytes, no zone), or 0x00 (u8 hostname length 1...255 + UTF-8)
 ///
-/// Errors map onto the v1 taxonomy: wrong magic → `badPrefix`, wrong version
-/// → `unsupportedVersion`, truncated input / trailing bytes / a scanned
-/// string that cannot be byte-recovered → `badEncoding`, every field-level
-/// violation → `badPayload`.
+/// Errors map onto the v1 taxonomy, aligned with the shared v2 vectors:
+/// wrong magic → `badPrefix`; wrong version → `unsupportedVersion`;
+/// structural damage → `badEncoding` (truncated input, trailing bytes, a
+/// scanned string that cannot be byte-recovered, reserved flag bits, an
+/// unknown address type, malformed UTF-8 — v1 likewise treats undecodable
+/// bytes as `badEncoding`); out-of-range field values → `badPayload` (port 0,
+/// usernameLen 0, addressCount 0, hostname length 0, expiry 0, whitespace).
 extension PairingCode {
     static let v2Magic: [UInt8] = [0x48, 0x50]  // "HP"
     static let v2Version: UInt8 = 0x02
@@ -110,7 +113,7 @@ extension PairingCode {
         }
         let flags = try reader.byte()
         guard flags & ~0x01 == 0 else {
-            throw .badPayload(reason: "reserved flag bits set (flags \(flags))")
+            throw .badEncoding
         }
         let port = try reader.uint16()
         guard port > 0 else {
@@ -120,7 +123,7 @@ extension PairingCode {
         guard usernameLength > 0 else {
             throw .badPayload(reason: "usernameLen must be in 1..255")
         }
-        let username = try utf8String(reader.take(Int(usernameLength)), field: "username")
+        let username = try utf8String(reader.take(Int(usernameLength)))
         guard !containsWhitespace(username) else {
             throw .badPayload(reason: "username must not contain whitespace")
         }
@@ -173,21 +176,21 @@ extension PairingCode {
             guard length > 0 else {
                 throw .badPayload(reason: "hostname length must be in 1..255")
             }
-            let hostname = try utf8String(reader.take(Int(length)), field: "hostname")
+            let hostname = try utf8String(reader.take(Int(length)))
             guard !containsWhitespace(hostname) else {
                 throw .badPayload(reason: "hostname must not contain whitespace")
             }
             return hostname
-        case let type:
-            throw .badPayload(reason: "unknown address type \(type)")
+        default:
+            throw .badEncoding
         }
     }
 
-    private static func utf8String(
-        _ bytes: [UInt8], field: String
-    ) throws(PairingCodeError) -> String {
+    // Malformed UTF-8 is badEncoding, matching v1's treatment of an
+    // undecodable body and the shared vectors.
+    private static func utf8String(_ bytes: [UInt8]) throws(PairingCodeError) -> String {
         guard let text = String(bytes: bytes, encoding: .utf8) else {
-            throw .badPayload(reason: "\(field) is not valid UTF-8")
+            throw .badEncoding
         }
         return text
     }

--- a/Sources/Heeler/Pairing/PairingCodeV2.swift
+++ b/Sources/Heeler/Pairing/PairingCodeV2.swift
@@ -1,0 +1,239 @@
+import Darwin
+import Foundation
+
+/// One recognized QR code as the scan pipeline delivered it: Vision's decoded
+/// text when it produced any, and the exact data content recovered from the
+/// symbol's error-corrected codewords when the barcode descriptor was
+/// available. At least one is expected to be present; which one is
+/// trustworthy is the dispatch's problem (see `PairingCode.decodeScanned`).
+struct ScannedQRCode: Sendable, Equatable {
+    var string: String?
+    var bytes: Data?
+}
+
+/// Pairing Code v2: the compact binary envelope the plugin renders as a
+/// byte-mode QR segment, replacing v1's `HERDR-PAIR:1:<base64url JSON>` text
+/// (see `docs/research/terminal-qr-rendering.md` for why it is raw binary).
+/// v1 codes keep decoding forever — older Hosts keep their older plugin — so
+/// the scan entry dispatches on what was scanned.
+///
+/// Wire format (all integers big-endian):
+///
+///     0  2   magic "HP" (0x48 0x50)
+///     2  1   version 0x02
+///     3  1   flags: bit0 = bootstrap credential present; other bits reserved
+///     4  2   port, u16, 1...65535
+///     6  1   usernameLen, 1...255
+///     7  n   username, UTF-8, no whitespace
+///     +  32  hostKeyFingerprint, raw SHA-256 digest bytes
+///     [flags bit0: 32 bytes bootstrapSeed, u32 expiresAt unix seconds]
+///     +  1   addressCount, 1...255
+///     then per address: type 0x04 (4 raw IPv4 bytes), 0x06 (16 raw IPv6
+///     bytes, no zone), or 0x00 (u8 hostname length 1...255 + UTF-8)
+///
+/// Errors map onto the v1 taxonomy: wrong magic → `badPrefix`, wrong version
+/// → `unsupportedVersion`, truncated input / trailing bytes / a scanned
+/// string that cannot be byte-recovered → `badEncoding`, every field-level
+/// violation → `badPayload`.
+extension PairingCode {
+    static let v2Magic: [UInt8] = [0x48, 0x50]  // "HP"
+    static let v2Version: UInt8 = 0x02
+
+    /// Decodes whatever the scanner delivered for one QR code, dispatching
+    /// between the v1 text envelope and the v2 binary envelope.
+    ///
+    /// Delivery order: a string with the v1 prefix takes the proven v1 path
+    /// unchanged. Otherwise the descriptor-recovered bytes are authoritative
+    /// — measured on this OS generation (macOS 26.5 Vision, shared codebase
+    /// with iOS), `payloadStringValue` for a binary byte-mode payload is nil
+    /// when the bytes are not valid UTF-8 and is truncated at the first NUL
+    /// when they are, so it is NOT the Latin-1 byte-per-scalar surface this
+    /// dispatch's string fallback assumes; a real v2 envelope essentially
+    /// never survives it. The string fallback stays for older OS decoders
+    /// that do surface Latin-1 text.
+    static func decodeScanned(_ scanned: ScannedQRCode) throws(PairingCodeError) -> PairingCode {
+        if let string = scanned.string, string.hasPrefix("\(prefix):") {
+            return try decode(string)
+        }
+        if let bytes = scanned.bytes {
+            return try decodeScannedBytes(bytes)
+        }
+        guard let string = scanned.string else {
+            throw .badPrefix
+        }
+        return try decodeScanned(string)
+    }
+
+    /// Decodes a scanned string on its own: leading v2 magic → recover bytes
+    /// (one Unicode scalar per byte, the Latin-1 reading of a byte-mode
+    /// segment) and decode v2; anything else → the v1 path with its existing
+    /// errors. A v1 code can never start with "HP" ("HERDR-PAIR" begins
+    /// "HE"), and any scalar above U+00FF cannot come from a byte-mode
+    /// payload, so recovery rejects it as `badEncoding`.
+    static func decodeScanned(_ string: String) throws(PairingCodeError) -> PairingCode {
+        var scalars = string.unicodeScalars.makeIterator()
+        guard scalars.next() == "H", scalars.next() == "P" else {
+            return try decode(string)
+        }
+        var bytes = Data()
+        bytes.reserveCapacity(string.unicodeScalars.count)
+        for scalar in string.unicodeScalars {
+            guard scalar.value <= 0xFF else {
+                throw .badEncoding
+            }
+            bytes.append(UInt8(scalar.value))
+        }
+        return try decodeV2(bytes)
+    }
+
+    /// Decodes recovered payload bytes: v2 magic → the binary decoder;
+    /// anything else is v1 text (or not a Pairing Code at all).
+    static func decodeScannedBytes(_ data: Data) throws(PairingCodeError) -> PairingCode {
+        if data.starts(with: v2Magic) {
+            return try decodeV2(data)
+        }
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw .badPrefix
+        }
+        return try decode(string)
+    }
+
+    /// Decodes and validates a v2 binary envelope.
+    static func decodeV2(_ data: Data) throws(PairingCodeError) -> PairingCode {
+        var reader = V2Reader(data)
+        guard try reader.take(2) == v2Magic else {
+            throw .badPrefix
+        }
+        let version = try reader.byte()
+        guard version == v2Version else {
+            throw .unsupportedVersion(found: String(version))
+        }
+        let flags = try reader.byte()
+        guard flags & ~0x01 == 0 else {
+            throw .badPayload(reason: "reserved flag bits set (flags \(flags))")
+        }
+        let port = try reader.uint16()
+        guard port > 0 else {
+            throw .badPayload(reason: "port must be in 1..65535")
+        }
+        let usernameLength = try reader.byte()
+        guard usernameLength > 0 else {
+            throw .badPayload(reason: "usernameLen must be in 1..255")
+        }
+        let username = try utf8String(reader.take(Int(usernameLength)), field: "username")
+        guard !containsWhitespace(username) else {
+            throw .badPayload(reason: "username must not contain whitespace")
+        }
+        // The wire carries the raw digest; in memory the fingerprint keeps
+        // its v1 form and re-encodes to "SHA256:<unpadded base64>" on demand.
+        let fingerprint = HostKeyFingerprint(digest: Data(try reader.take(32)))
+
+        let bootstrap: Bootstrap?
+        if flags & 0x01 != 0 {
+            let seed = Data(try reader.take(32))
+            let expiresAt = try reader.uint32()
+            bootstrap = Bootstrap(
+                seed: seed, expiresAt: Date(timeIntervalSince1970: TimeInterval(expiresAt)))
+        } else {
+            bootstrap = nil
+        }
+
+        let addressCount = try reader.byte()
+        guard addressCount > 0 else {
+            throw .badPayload(reason: "addressCount must be in 1..255")
+        }
+        var addresses: [String] = []
+        addresses.reserveCapacity(Int(addressCount))
+        for _ in 0..<addressCount {
+            addresses.append(try address(&reader))
+        }
+        guard reader.isAtEnd else {
+            throw .badEncoding
+        }
+
+        return PairingCode(
+            addresses: addresses, port: Int(port), username: username,
+            hostKeyFingerprint: fingerprint, bootstrap: bootstrap)
+    }
+
+    private static func address(_ reader: inout V2Reader) throws(PairingCodeError) -> String {
+        switch try reader.byte() {
+        case 0x04:
+            return try reader.take(4).map { String($0) }.joined(separator: ".")
+        case 0x06:
+            guard let text = ipv6String(try reader.take(16)) else {
+                throw .badPayload(reason: "unrepresentable IPv6 address")
+            }
+            return text
+        case 0x00:
+            let length = try reader.byte()
+            guard length > 0 else {
+                throw .badPayload(reason: "hostname length must be in 1..255")
+            }
+            let hostname = try utf8String(reader.take(Int(length)), field: "hostname")
+            guard !containsWhitespace(hostname) else {
+                throw .badPayload(reason: "hostname must not contain whitespace")
+            }
+            return hostname
+        case let type:
+            throw .badPayload(reason: "unknown address type \(type)")
+        }
+    }
+
+    private static func utf8String(
+        _ bytes: [UInt8], field: String
+    ) throws(PairingCodeError) -> String {
+        guard let text = String(bytes: bytes, encoding: .utf8) else {
+            throw .badPayload(reason: "\(field) is not valid UTF-8")
+        }
+        return text
+    }
+
+    /// RFC 5952 canonical text for 16 raw IPv6 bytes. Darwin's `inet_ntop`
+    /// already produces it: lowercase hex, the first longest all-zero run
+    /// compressed to `::`, never a single group.
+    private static func ipv6String(_ raw: [UInt8]) -> String? {
+        var address = in6_addr()
+        withUnsafeMutableBytes(of: &address) { $0.copyBytes(from: raw) }
+        var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+        guard inet_ntop(AF_INET6, &address, &buffer, socklen_t(INET6_ADDRSTRLEN)) != nil else {
+            return nil
+        }
+        let length = buffer.firstIndex(of: 0) ?? buffer.count
+        return String(decoding: buffer[..<length].map { UInt8(bitPattern: $0) }, as: UTF8.self)
+    }
+}
+
+/// Sequential big-endian reader over the v2 envelope. Running out of bytes is
+/// always the truncated-input rejection, `badEncoding`.
+private struct V2Reader {
+    private let bytes: [UInt8]
+    private var offset = 0
+
+    init(_ data: Data) {
+        bytes = [UInt8](data)
+    }
+
+    var isAtEnd: Bool { offset == bytes.count }
+
+    mutating func byte() throws(PairingCodeError) -> UInt8 {
+        guard offset < bytes.count else { throw .badEncoding }
+        defer { offset += 1 }
+        return bytes[offset]
+    }
+
+    mutating func take(_ count: Int) throws(PairingCodeError) -> [UInt8] {
+        guard bytes.count - offset >= count else { throw .badEncoding }
+        defer { offset += count }
+        return Array(bytes[offset..<offset + count])
+    }
+
+    mutating func uint16() throws(PairingCodeError) -> UInt16 {
+        let raw = try take(2)
+        return UInt16(raw[0]) << 8 | UInt16(raw[1])
+    }
+
+    mutating func uint32() throws(PairingCodeError) -> UInt32 {
+        try take(4).reduce(0) { ($0 << 8) | UInt32($1) }
+    }
+}

--- a/Sources/Heeler/Pairing/PairingCodeV2.swift
+++ b/Sources/Heeler/Pairing/PairingCodeV2.swift
@@ -132,6 +132,9 @@ extension PairingCode {
         if flags & 0x01 != 0 {
             let seed = Data(try reader.take(32))
             let expiresAt = try reader.uint32()
+            guard expiresAt > 0 else {
+                throw .badPayload(reason: "expiresAt must be a positive unix-seconds integer")
+            }
             bootstrap = Bootstrap(
                 seed: seed, expiresAt: Date(timeIntervalSince1970: TimeInterval(expiresAt)))
         } else {

--- a/Sources/Heeler/Pairing/PairingScanStore.swift
+++ b/Sources/Heeler/Pairing/PairingScanStore.swift
@@ -74,8 +74,9 @@ final class PairingScanStore {
         self.now = now
     }
 
-    /// Convenience for the pipeline's historical shape: a bare decoded
-    /// string, as v1 QR codes always deliver.
+    /// Test-only convenience: the pipeline's historical shape, a bare
+    /// decoded string with no descriptor bytes, as v1 QR codes deliver. The
+    /// scan view submits a full `ScannedQRCode`.
     func submit(scannedCode: String) {
         submit(scanned: ScannedQRCode(string: scannedCode, bytes: nil))
     }

--- a/Sources/Heeler/Pairing/PairingScanStore.swift
+++ b/Sources/Heeler/Pairing/PairingScanStore.swift
@@ -17,7 +17,7 @@ struct PairingFailure: Equatable, Sendable {
     let canRetry: Bool
 }
 
-/// Drives Scan to Pair (#62, #66): turns strings recognized by the QR
+/// Drives Scan to Pair (#62, #66): turns codes recognized by the QR
 /// scanner into a parsed Pairing Code, runs the ceremony through the
 /// injected `PairingConnector`, and persists the Host only after the
 /// verified reconnect, with its fingerprint pinned so preflight never
@@ -74,10 +74,16 @@ final class PairingScanStore {
         self.now = now
     }
 
+    /// Convenience for the pipeline's historical shape: a bare decoded
+    /// string, as v1 QR codes always deliver.
     func submit(scannedCode: String) {
+        submit(scanned: ScannedQRCode(string: scannedCode, bytes: nil))
+    }
+
+    func submit(scanned: ScannedQRCode) {
         guard pairingCode == nil else { return }
         do {
-            let code = try PairingCode.decode(scannedCode)
+            let code = try PairingCode.decodeScanned(scanned)
             pairingCode = code
             attemptCode = code
             enrolledViaBootstrap = false

--- a/Sources/Heeler/Pairing/PairingScanView.swift
+++ b/Sources/Heeler/Pairing/PairingScanView.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import CoreImage
 import SwiftUI
+import Vision
 import VisionKit
 
 /// Scan to Pair (#62, #66): the camera entry for Pairing Codes, with the

--- a/Sources/Heeler/Pairing/PairingScanView.swift
+++ b/Sources/Heeler/Pairing/PairingScanView.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreImage
 import SwiftUI
 import VisionKit
 
@@ -99,7 +100,7 @@ struct PairingScanView: View {
     }
 
     private var scannerViewport: some View {
-        PairingCodeScanner { store.submit(scannedCode: $0) }
+        PairingCodeScanner { store.submit(scanned: $0) }
             .ignoresSafeArea(edges: .bottom)
             .overlay(alignment: .bottom) {
                 Text(store.scanFailureMessage ?? "Point the camera at the Pairing Code shown by herdr.")
@@ -248,9 +249,10 @@ private struct PairingCeremonyView: View {
 }
 
 /// The system scanner (VisionKit), narrowed to QR codes. Reports every newly
-/// recognized payload string; filtering and parsing belong to the store.
+/// recognized code — the decoded string plus the exact bytes recovered from
+/// the symbol descriptor; filtering and parsing belong to the store.
 private struct PairingCodeScanner: UIViewControllerRepresentable {
-    let onScan: (String) -> Void
+    let onScan: (ScannedQRCode) -> Void
 
     func makeCoordinator() -> Coordinator {
         Coordinator(onScan: onScan)
@@ -274,21 +276,38 @@ private struct PairingCodeScanner: UIViewControllerRepresentable {
 
     @MainActor
     final class Coordinator: NSObject, DataScannerViewControllerDelegate {
-        private let onScan: (String) -> Void
+        private let onScan: (ScannedQRCode) -> Void
 
-        init(onScan: @escaping (String) -> Void) {
+        init(onScan: @escaping (ScannedQRCode) -> Void) {
             self.onScan = onScan
         }
 
+        // What a byte-mode QR actually delivers here, measured against Vision
+        // on this OS generation (macOS 26.5 probe; Vision is shared code with
+        // iOS): `payloadStringValue` is nil when the payload is not valid
+        // UTF-8 and truncated at the first NUL when it is — there is no
+        // Latin-1 byte-per-scalar fallback, so a binary v2 envelope cannot
+        // ride the string. `observation.payloadData` is byte-identical to
+        // `CIQRCodeDescriptor.errorCorrectedPayload`: the raw codeword stream
+        // including segment headers and padding, not the payload itself.
+        // Recovering the exact bytes therefore goes through the descriptor
+        // plus `QRCodeContent.segmentBytes`. Both surfaces are reported; the
+        // store's dispatch decides which to trust.
         func dataScanner(
             _ dataScanner: DataScannerViewController,
             didAdd addedItems: [RecognizedItem],
             allItems: [RecognizedItem]
         ) {
             for case .barcode(let barcode) in addedItems {
-                if let payload = barcode.payloadStringValue {
-                    onScan(payload)
+                let descriptor = barcode.observation.barcodeDescriptor as? CIQRCodeDescriptor
+                let bytes = descriptor.flatMap {
+                    QRCodeContent.segmentBytes(
+                        errorCorrectedPayload: $0.errorCorrectedPayload,
+                        symbolVersion: $0.symbolVersion)
                 }
+                let scanned = ScannedQRCode(string: barcode.payloadStringValue, bytes: bytes)
+                guard scanned.string != nil || scanned.bytes != nil else { continue }
+                onScan(scanned)
             }
         }
     }

--- a/Sources/Heeler/Pairing/QRCodeContent.swift
+++ b/Sources/Heeler/Pairing/QRCodeContent.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Recovers the exact data content of a QR symbol from its error-corrected
+/// codeword stream — `CIQRCodeDescriptor.errorCorrectedPayload`, which
+/// `VNBarcodeObservation.payloadData` returns byte-identical (verified
+/// empirically against Vision on this OS generation). The stream is the
+/// ISO/IEC 18004 data codewords: a sequence of (mode, count, content)
+/// segments, then a terminator and pad bytes. This is the only faithful way
+/// to read a binary byte-mode payload, because Vision's decoded string drops
+/// or mangles bytes that are not clean UTF-8 text (see the dispatch note in
+/// `PairingCodeV2.swift`).
+enum QRCodeContent {
+    /// The concatenated content of all data segments, or nil when the stream
+    /// contains a segment kind we do not decode (ECI, kanji, structured
+    /// append, FNC1) or is malformed. Callers treat nil as "not recoverable
+    /// here" and fall back to the decoded string.
+    static func segmentBytes(errorCorrectedPayload: Data, symbolVersion: Int) -> Data? {
+        guard symbolVersion >= 1 else { return nil }
+        var reader = BitReader(errorCorrectedPayload)
+        var content = Data()
+        // A stream that fills the symbol exactly may omit the 4-bit
+        // terminator, so running out of bits between segments is a clean end.
+        while let mode = reader.read(4), mode != 0b0000 {
+            switch mode {
+            case 0b0100:  // byte: 8 bits per byte
+                guard let count = reader.read(symbolVersion <= 9 ? 8 : 16) else { return nil }
+                for _ in 0..<count {
+                    guard let byte = reader.read(8) else { return nil }
+                    content.append(UInt8(byte))
+                }
+            case 0b0001:  // numeric: 3 digits per 10 bits
+                let countBits = symbolVersion <= 9 ? 10 : symbolVersion <= 26 ? 12 : 14
+                guard var remaining = reader.read(countBits) else { return nil }
+                while remaining > 0 {
+                    let digits = min(remaining, 3)
+                    guard
+                        let value = reader.read([4, 7, 10][digits - 1]),
+                        value < [10, 100, 1000][digits - 1]
+                    else { return nil }
+                    var text = String(value)
+                    text = String(repeating: "0", count: digits - text.count) + text
+                    content.append(contentsOf: text.utf8)
+                    remaining -= digits
+                }
+            case 0b0010:  // alphanumeric: 2 characters per 11 bits
+                let countBits = symbolVersion <= 9 ? 9 : symbolVersion <= 26 ? 11 : 13
+                guard var remaining = reader.read(countBits) else { return nil }
+                while remaining > 0 {
+                    let characters = min(remaining, 2)
+                    guard
+                        let value = reader.read(characters == 2 ? 11 : 6),
+                        value < (characters == 2 ? 45 * 45 : 45)
+                    else { return nil }
+                    if characters == 2 {
+                        content.append(alphanumeric[value / 45])
+                    }
+                    content.append(alphanumeric[value % 45])
+                    remaining -= characters
+                }
+            default:
+                return nil
+            }
+        }
+        return content.isEmpty ? nil : content
+    }
+
+    /// The 45-character alphanumeric-mode table (ISO/IEC 18004 §7.4.4).
+    private static let alphanumeric = [UInt8]("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:".utf8)
+
+    private struct BitReader {
+        private let bytes: [UInt8]
+        private var bitIndex = 0
+
+        init(_ data: Data) {
+            bytes = [UInt8](data)
+        }
+
+        mutating func read(_ width: Int) -> Int? {
+            guard bitIndex + width <= bytes.count * 8 else { return nil }
+            var value = 0
+            for _ in 0..<width {
+                value = (value << 1) | Int((bytes[bitIndex / 8] >> (7 - bitIndex % 8)) & 1)
+                bitIndex += 1
+            }
+            return value
+        }
+    }
+}

--- a/Tests/HeelerTests/PairingCodeV2Tests.swift
+++ b/Tests/HeelerTests/PairingCodeV2Tests.swift
@@ -1,0 +1,431 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+/// Decoder tests for the compact binary Pairing Code v2 envelope, built
+/// byte-by-byte from the wire-format table (magic "HP", version 0x02, flags,
+/// port, username, digest, optional bootstrap, addresses). The shared-vector
+/// suite below covers the cross-implementation file once it exists.
+@Suite("Pairing Code v2 envelope")
+struct PairingCodeV2Tests {
+    /// The digest behind the v1 vectors' fingerprint, so both envelope
+    /// versions are checked against the same display string.
+    static let digestBytes = [UInt8](
+        Data(base64Encoded: "6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg=")!)
+    static let fingerprint = "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg"
+
+    @Test func decodesConfigOnlyEnvelope() throws {
+        let code = try PairingCode.decodeV2(Envelope().data)
+
+        #expect(code.addresses == ["192.168.1.42"])
+        #expect(code.port == 22)
+        #expect(code.username == "ada")
+        #expect(code.hostKeyFingerprint.displayString == Self.fingerprint)
+        #expect(code.bootstrap == nil)
+    }
+
+    @Test func decodesBootstrapEnvelope() throws {
+        var envelope = Envelope()
+        envelope.flags = 0x01
+        envelope.bootstrap = (seed: (0...31).map { UInt8($0) }, expiresAt: 1_753_305_600)
+
+        let code = try PairingCode.decodeV2(envelope.data)
+
+        let bootstrap = try #require(code.bootstrap)
+        #expect(bootstrap.seed == Data((0...31).map { UInt8($0) }))
+        #expect(bootstrap.expiresAt == Date(timeIntervalSince1970: 1_753_305_600))
+    }
+
+    @Test func decodesEveryAddressKindInTryOrder() throws {
+        var envelope = Envelope()
+        envelope.addresses = [
+            [0x04, 192, 168, 1, 42],
+            [0x06, 0xFD, 0x7A, 0x11, 0x5C, 0xA1, 0xE0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01],
+            [0x00, 16] + Array("mac-studio.local".utf8),
+        ]
+
+        let code = try PairingCode.decodeV2(envelope.data)
+
+        #expect(code.addresses == ["192.168.1.42", "fd7a:115c:a1e0::1", "mac-studio.local"])
+    }
+
+    @Test(arguments: [
+        (Array(repeating: UInt8(0), count: 15) + [1], "::1"),
+        (
+            [0x20, 0x01, 0x0D, 0xB8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1] as [UInt8],
+            "2001:db8::1:0:0:1"
+        ),
+        (
+            [0x20, 0x01, 0x0D, 0xB8, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6] as [UInt8],
+            "2001:db8:1:2:3:4:5:6"
+        ),
+    ])
+    func canonicalizesIPv6(raw: [UInt8], expected: String) throws {
+        var envelope = Envelope()
+        envelope.addresses = [[0x06] + raw]
+
+        #expect(try PairingCode.decodeV2(envelope.data).addresses == [expected])
+    }
+
+    @Test func acceptsMaximumPort() throws {
+        var envelope = Envelope()
+        envelope.port = 65535
+
+        #expect(try PairingCode.decodeV2(envelope.data).port == 65535)
+    }
+
+    /// A byte-mode payload surfaced as text is one Unicode scalar per byte
+    /// (the Latin-1 reading); recovering it must reproduce the exact bytes.
+    @Test func roundTripsThroughTheScannedStringPath() throws {
+        var envelope = Envelope()
+        envelope.flags = 0x01
+        envelope.bootstrap = (seed: (0...31).map { UInt8($0) }, expiresAt: 1_753_305_600)
+        let data = envelope.data
+
+        let viaString = try PairingCode.decodeScanned(latin1String(data))
+
+        #expect(viaString == (try PairingCode.decodeV2(data)))
+    }
+
+    @Test func rejectsScannedStringWithScalarAboveLatin1() {
+        #expect(throws: PairingCodeError.badEncoding) {
+            try PairingCode.decodeScanned("HP\u{02}\u{0102}")
+        }
+    }
+
+    @Test func scannedStringWithoutMagicTakesTheV1Path() {
+        #expect(throws: PairingCodeError.badPrefix) {
+            try PairingCode.decodeScanned("https://example.com/some-other-qr")
+        }
+    }
+
+    struct RejectCase: Sendable, CustomStringConvertible {
+        let name: String
+        let data: Data
+        let wireCode: String
+        var description: String { name }
+    }
+
+    static let rejectCases: [RejectCase] = {
+        var cases: [RejectCase] = []
+        func add(_ name: String, _ wireCode: String, _ mutate: (inout Envelope) -> Void) {
+            var envelope = Envelope()
+            mutate(&envelope)
+            cases.append(RejectCase(name: name, data: envelope.data, wireCode: wireCode))
+        }
+        add("wrong magic", "bad_prefix") { $0.magic = [0x51, 0x52] }
+        add("version 1", "unsupported_version") { $0.version = 0x01 }
+        add("version 3", "unsupported_version") { $0.version = 0x03 }
+        add("reserved flag bit", "bad_payload") { $0.flags = 0x02 }
+        add("reserved flag bit alongside bootstrap", "bad_payload") { envelope in
+            envelope.flags = 0x81
+            envelope.bootstrap = (seed: Array(repeating: 0, count: 32), expiresAt: 1)
+        }
+        add("port zero", "bad_payload") { $0.port = 0 }
+        add("username length zero", "bad_payload") { envelope in
+            envelope.username = []
+            envelope.usernameLength = 0
+        }
+        add("username is not UTF-8", "bad_payload") { $0.username = [0xC3, 0x28, 0x41] }
+        add("username contains whitespace", "bad_payload") { $0.username = [0x61, 0x20, 0x62] }
+        add("declared username length overruns the envelope", "bad_encoding") {
+            $0.usernameLength = 200
+        }
+        add("address count zero", "bad_payload") { envelope in
+            envelope.addresses = []
+            envelope.addressCount = 0
+        }
+        add("address count overruns the envelope", "bad_encoding") { $0.addressCount = 3 }
+        add("unknown address type", "bad_payload") { $0.addresses = [[0x07, 1, 2, 3, 4]] }
+        add("hostname length zero", "bad_payload") { $0.addresses = [[0x00, 0x00]] }
+        add("hostname is not UTF-8", "bad_payload") { $0.addresses = [[0x00, 2, 0xC3, 0x28]] }
+        add("hostname contains whitespace", "bad_payload") {
+            $0.addresses = [[0x00, 3] + Array("a b".utf8)]
+        }
+        add("trailing bytes", "bad_encoding") { $0.trailing = [0x00] }
+        return cases
+    }()
+
+    @Test(arguments: rejectCases)
+    func rejects(testCase: RejectCase) {
+        do {
+            _ = try PairingCode.decodeV2(testCase.data)
+            Issue.record("unexpectedly decoded \(testCase.name)")
+        } catch {
+            #expect(error.wireCode == testCase.wireCode, "\(testCase.name)")
+        }
+    }
+
+    /// Every proper prefix of a valid envelope is truncated input. The
+    /// decoder reads strictly front to back, so each cut must surface as
+    /// `badEncoding`, never a misleading field error or a successful decode.
+    @Test func rejectsEveryTruncation() {
+        var envelope = Envelope()
+        envelope.flags = 0x01
+        envelope.bootstrap = (seed: (0...31).map { UInt8($0) }, expiresAt: 1_753_305_600)
+        envelope.addresses = [
+            [0x04, 10, 0, 0, 7],
+            [0x00, 5] + Array("studio".utf8.prefix(5)),
+        ]
+        let data = envelope.data
+
+        for length in 0..<data.count {
+            #expect(throws: PairingCodeError.badEncoding, "cut at \(length)") {
+                try PairingCode.decodeV2(data.prefix(length))
+            }
+        }
+    }
+
+    @Test func reportsTheFoundVersion() {
+        var envelope = Envelope()
+        envelope.version = 0x07
+        do {
+            _ = try PairingCode.decodeV2(envelope.data)
+            Issue.record("unexpectedly decoded a version-7 envelope")
+        } catch {
+            #expect(error == .unsupportedVersion(found: "7"))
+        }
+    }
+
+    // MARK: Scan-entry dispatch
+
+    static let v1Code = PairingCodeVectorFile.shared.valid[0].code
+
+    @Test func dispatchesV1StringsToTheV1Decoder() throws {
+        let viaDispatch = try PairingCode.decodeScanned(
+            ScannedQRCode(string: Self.v1Code, bytes: nil))
+
+        #expect(viaDispatch == (try PairingCode.decode(Self.v1Code)))
+    }
+
+    @Test func dispatchesV2BytesToTheV2Decoder() throws {
+        let data = Envelope().data
+
+        let viaDispatch = try PairingCode.decodeScanned(ScannedQRCode(string: nil, bytes: data))
+
+        #expect(viaDispatch == (try PairingCode.decodeV2(data)))
+    }
+
+    /// When Vision surfaces both a (lossy) string and descriptor-recovered
+    /// bytes for a binary payload, the bytes win.
+    @Test func prefersBytesOverANonV1String() throws {
+        let data = Envelope().data
+
+        let viaDispatch = try PairingCode.decodeScanned(
+            ScannedQRCode(string: "HP\u{02}mangled", bytes: data))
+
+        #expect(viaDispatch == (try PairingCode.decodeV2(data)))
+    }
+
+    @Test func dispatchesV1TextArrivingAsBytes() throws {
+        let viaBytes = try PairingCode.decodeScannedBytes(Data(Self.v1Code.utf8))
+
+        #expect(viaBytes == (try PairingCode.decode(Self.v1Code)))
+    }
+
+    @Test func rejectsBytesThatAreNeitherEnvelope() {
+        #expect(throws: PairingCodeError.badPrefix) {
+            try PairingCode.decodeScannedBytes(Data([0xFF, 0xFE, 0x00]))
+        }
+    }
+
+    @Test func rejectsAnEmptyScan() {
+        #expect(throws: PairingCodeError.badPrefix) {
+            try PairingCode.decodeScanned(ScannedQRCode(string: nil, bytes: nil))
+        }
+    }
+}
+
+/// Builds v2 envelopes from the wire-format table, with each field
+/// overridable to produce the invalid shapes.
+private struct Envelope {
+    var magic: [UInt8] = PairingCode.v2Magic
+    var version: UInt8 = PairingCode.v2Version
+    var flags: UInt8 = 0x00
+    var port: UInt16 = 22
+    var username: [UInt8] = Array("ada".utf8)
+    /// Overrides the length byte; nil derives it from `username`.
+    var usernameLength: UInt8?
+    var digest: [UInt8] = PairingCodeV2Tests.digestBytes
+    var bootstrap: (seed: [UInt8], expiresAt: UInt32)?
+    /// Overrides the count byte; nil derives it from `addresses`.
+    var addressCount: UInt8?
+    var addresses: [[UInt8]] = [[0x04, 192, 168, 1, 42]]
+    var trailing: [UInt8] = []
+
+    var data: Data {
+        var bytes = magic
+        bytes.append(version)
+        bytes.append(flags)
+        bytes.append(contentsOf: [UInt8(port >> 8), UInt8(port & 0xFF)])
+        bytes.append(usernameLength ?? UInt8(username.count))
+        bytes.append(contentsOf: username)
+        bytes.append(contentsOf: digest)
+        if let bootstrap {
+            bytes.append(contentsOf: bootstrap.seed)
+            for shift in stride(from: 24, through: 0, by: -8) {
+                bytes.append(UInt8(truncatingIfNeeded: bootstrap.expiresAt >> shift))
+            }
+        }
+        bytes.append(addressCount ?? UInt8(addresses.count))
+        for address in addresses {
+            bytes.append(contentsOf: address)
+        }
+        bytes.append(contentsOf: trailing)
+        return Data(bytes)
+    }
+}
+
+/// The byte-per-scalar string a Latin-1 reading of a byte-mode QR payload
+/// produces.
+private func latin1String(_ data: Data) -> String {
+    var view = String.UnicodeScalarView()
+    for byte in data {
+        view.append(Unicode.Scalar(byte))
+    }
+    return String(view)
+}
+
+/// Fixtures captured from Vision on macOS 26.5: real
+/// `CIQRCodeDescriptor.errorCorrectedPayload` streams (byte-identical to
+/// `VNBarcodeObservation.payloadData`) for QR codes generated from known
+/// payloads, so the segment walk is checked against what the scanner
+/// actually hands over, padding and all.
+@Suite("QR code content extraction")
+struct QRCodeContentTests {
+    @Test func extractsASingleByteModeSegment() {
+        // 9 binary bytes incl. NULs, version-1 symbol.
+        let stream = Data(hexEncoded: "40948500200001600017f0ec11ec11ec11ec11")!
+
+        let bytes = QRCodeContent.segmentBytes(errorCorrectedPayload: stream, symbolVersion: 1)
+
+        #expect(bytes == Data(hexEncoded: "48500200001600017f"))
+    }
+
+    @Test func extractsAFullV2Envelope() {
+        // An 84-byte bootstrap envelope, version-5 symbol.
+        let stream = Data(
+            hexEncoded: "45448500201001603616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af2300"
+                + "04333b01f888a53acf2d8000102030405060708090a0b0c0d0e0f10111213141516"
+                + "1718191a1b1c1d1e1f688230800104c0a8012a0ec11ec11ec11ec11ec11ec11ec11"
+                + "ec11ec11ec11ec11")!
+
+        let bytes = QRCodeContent.segmentBytes(errorCorrectedPayload: stream, symbolVersion: 5)
+
+        #expect(
+            bytes
+                == Data(
+                    hexEncoded: "48500201001603616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230"
+                        + "004333b01f888a53acf2d8000102030405060708090a0b0c0d0e0f101112131415"
+                        + "161718191a1b1c1d1e1f688230800104c0a8012a"))
+    }
+
+    @Test func extractsMixedAlphanumericAndByteSegments() {
+        // CoreImage split this v1-style ASCII envelope into alphanumeric and
+        // byte segments; the walk must reassemble the original text.
+        let text = "HERDR-PAIR:1:eyJhZGRycyI6WyIxOTIuMTY4LjEuNDIiXSwicG9ydCI6MjIsInVzZXIiOiJhZGEi"
+            + "LCJmcCI6IlNIQTI1Njo2K2puY05kaWJzRzJjcXZmb0xBcEdyTzhDdklBQUVNenNCK0lpbE9zOHRnIn0"
+        let stream = Data(
+            hexEncoded: "206b0b9993a237b45f7b6247b2bca5342d23a93cb1bca49b2bbca4bc27aa24baa6"
+                + "aa2c9a263522baa72224b4ac29bbb4b1a39cbcb221a49b26b524b9a4b72b3d2d2c24b4a7"
+                + "b4a5342d23a2b4a621a536b1a1a49b24b62724a8aa2498a73537992599383aac981ab5b0"
+                + "aba53d293d253531ac2d36b1183c2131a2b23caa3d34223235b62128aaab2732b72721a5"
+                + "98363831229cbd27a4293724b71800")!
+
+        let bytes = QRCodeContent.segmentBytes(errorCorrectedPayload: stream, symbolVersion: 7)
+
+        #expect(bytes == Data(text.utf8))
+    }
+
+    @Test func extractsNumericSegmentsInAVersion10PlusSymbol() {
+        // A 304-byte payload in a version-11 symbol (16-bit byte counts);
+        // CoreImage carved digit runs into numeric segments.
+        var expected = Data([0x48, 0x50, 0x02, 0x00])
+        expected.append(contentsOf: (0..<300).map { UInt8(truncatingIfNeeded: $0 % 251 + 1) })
+        let stream = Data(
+            hexEncoded: "40033485002000102030405060708090a0b0c0d0e0f101112131415161718191a1"
+                + "b1c1d1e1f202122232425262728292a2b2c2d2e2f100a03159a9a50001ce8ecf0f4f8fd"
+                + "0080d1cd452a1570b3d732fd628cada13596e0e1d400d25b5c5d5e5f60616263646566"
+                + "6768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a"
+                + "8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadae"
+                + "afb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2"
+                + "d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6"
+                + "f7f8f9fafb0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+                + "202122232425262728292a2b2c2d2e2f30310ec11ec11ec11ec11ec11ec11ec11ec11ec1"
+                + "1ec11ec11")!
+
+        let bytes = QRCodeContent.segmentBytes(errorCorrectedPayload: stream, symbolVersion: 11)
+
+        #expect(bytes == expected)
+    }
+
+    @Test func refusesSegmentKindsItCannotDecode() {
+        // ECI (0111) leading the stream: bail out rather than misread.
+        #expect(
+            QRCodeContent.segmentBytes(
+                errorCorrectedPayload: Data([0x71, 0xA4, 0x00]), symbolVersion: 1) == nil)
+    }
+
+    @Test func refusesAnEmptyStream() {
+        #expect(
+            QRCodeContent.segmentBytes(errorCorrectedPayload: Data([0x00, 0xEC]), symbolVersion: 1)
+                == nil)
+    }
+}
+
+/// The cross-implementation v2 vectors, mirroring the v1 arrangement. The
+/// file is produced by the plugin package; until it lands on an integrated
+/// branch these tests skip.
+@Suite(
+    "Pairing Code v2 shared vectors",
+    .enabled(if: PairingCodeV2VectorFile.shared != nil))
+struct PairingCodeV2VectorTests {
+    private static let vectors = PairingCodeV2VectorFile.shared
+
+    @Test func sharedVectorFileHasCases() {
+        #expect((Self.vectors?.valid.count ?? 0) >= 1)
+        #expect((Self.vectors?.invalid.count ?? 0) >= 1)
+    }
+
+    @Test(arguments: vectors?.valid ?? [])
+    func decodesValidVector(vector: PairingCodeV2VectorFile.Valid) throws {
+        let data = try #require(Data(hexEncoded: vector.codeHex), "codeHex must be hex")
+
+        let code = try PairingCode.decodeV2(data)
+
+        #expect(code.addresses == vector.payload.addresses)
+        #expect(code.port == vector.payload.port)
+        #expect(code.username == vector.payload.username)
+        #expect(code.hostKeyFingerprint.displayString == vector.payload.hostKeyFingerprint)
+        if let expectedSeed = vector.payload.bootstrapSeed {
+            let bootstrap = try #require(code.bootstrap)
+            #expect(bootstrap.seed.base64URLEncodedString() == expectedSeed)
+            let expectedExpiry = try #require(vector.payload.expiresAt)
+            #expect(
+                bootstrap.expiresAt == Date(timeIntervalSince1970: TimeInterval(expectedExpiry)))
+        } else {
+            #expect(code.bootstrap == nil)
+        }
+
+        // The same envelope surfaced as a Latin-1 string must decode
+        // identically through the scan dispatch.
+        #expect(try PairingCode.decodeScanned(latin1String(data)) == code)
+    }
+
+    @Test(arguments: vectors?.invalid ?? [])
+    func rejectsInvalidVector(vector: PairingCodeV2VectorFile.Invalid) throws {
+        do {
+            if let codeHex = vector.codeHex {
+                let data = try #require(Data(hexEncoded: codeHex), "codeHex must be hex")
+                _ = try PairingCode.decodeV2(data)
+            } else {
+                let code = try #require(vector.code, "invalid vector carries neither form")
+                _ = try PairingCode.decodeScanned(code)
+            }
+            Issue.record("unexpectedly decoded \(vector.name)")
+        } catch let error as PairingCodeError {
+            #expect(error.wireCode == vector.error, "\(vector.name)")
+        }
+    }
+}

--- a/Tests/HeelerTests/PairingCodeV2Tests.swift
+++ b/Tests/HeelerTests/PairingCodeV2Tests.swift
@@ -60,6 +60,11 @@ struct PairingCodeV2Tests {
             [0x20, 0x01, 0x0D, 0xB8, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6] as [UInt8],
             "2001:db8:1:2:3:4:5:6"
         ),
+        // RFC 5952 §4.2.2: an isolated zero group must not become "::".
+        (
+            [0x20, 0x01, 0x0D, 0xB8, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1] as [UInt8],
+            "2001:db8:0:1:1:1:1:1"
+        ),
     ])
     func canonicalizesIPv6(raw: [UInt8], expected: String) throws {
         var envelope = Envelope()
@@ -121,6 +126,10 @@ struct PairingCodeV2Tests {
         add("reserved flag bit alongside bootstrap", "bad_payload") { envelope in
             envelope.flags = 0x81
             envelope.bootstrap = (seed: Array(repeating: 0, count: 32), expiresAt: 1)
+        }
+        add("bootstrap expiry zero", "bad_payload") { envelope in
+            envelope.flags = 0x01
+            envelope.bootstrap = (seed: (0...31).map { UInt8($0) }, expiresAt: 0)
         }
         add("port zero", "bad_payload") { $0.port = 0 }
         add("username length zero", "bad_payload") { envelope in

--- a/Tests/HeelerTests/PairingCodeV2Tests.swift
+++ b/Tests/HeelerTests/PairingCodeV2Tests.swift
@@ -122,8 +122,8 @@ struct PairingCodeV2Tests {
         add("wrong magic", "bad_prefix") { $0.magic = [0x51, 0x52] }
         add("version 1", "unsupported_version") { $0.version = 0x01 }
         add("version 3", "unsupported_version") { $0.version = 0x03 }
-        add("reserved flag bit", "bad_payload") { $0.flags = 0x02 }
-        add("reserved flag bit alongside bootstrap", "bad_payload") { envelope in
+        add("reserved flag bit", "bad_encoding") { $0.flags = 0x02 }
+        add("reserved flag bit alongside bootstrap", "bad_encoding") { envelope in
             envelope.flags = 0x81
             envelope.bootstrap = (seed: Array(repeating: 0, count: 32), expiresAt: 1)
         }
@@ -136,7 +136,7 @@ struct PairingCodeV2Tests {
             envelope.username = []
             envelope.usernameLength = 0
         }
-        add("username is not UTF-8", "bad_payload") { $0.username = [0xC3, 0x28, 0x41] }
+        add("username is not UTF-8", "bad_encoding") { $0.username = [0xC3, 0x28, 0x41] }
         add("username contains whitespace", "bad_payload") { $0.username = [0x61, 0x20, 0x62] }
         add("declared username length overruns the envelope", "bad_encoding") {
             $0.usernameLength = 200
@@ -146,9 +146,9 @@ struct PairingCodeV2Tests {
             envelope.addressCount = 0
         }
         add("address count overruns the envelope", "bad_encoding") { $0.addressCount = 3 }
-        add("unknown address type", "bad_payload") { $0.addresses = [[0x07, 1, 2, 3, 4]] }
+        add("unknown address type", "bad_encoding") { $0.addresses = [[0x07, 1, 2, 3, 4]] }
         add("hostname length zero", "bad_payload") { $0.addresses = [[0x00, 0x00]] }
-        add("hostname is not UTF-8", "bad_payload") { $0.addresses = [[0x00, 2, 0xC3, 0x28]] }
+        add("hostname is not UTF-8", "bad_encoding") { $0.addresses = [[0x00, 2, 0xC3, 0x28]] }
         add("hostname contains whitespace", "bad_payload") {
             $0.addresses = [[0x00, 3] + Array("a b".utf8)]
         }
@@ -399,7 +399,7 @@ struct PairingCodeV2VectorTests {
 
     @Test(arguments: vectors?.valid ?? [])
     func decodesValidVector(vector: PairingCodeV2VectorFile.Valid) throws {
-        let data = try #require(Data(hexEncoded: vector.codeHex), "codeHex must be hex")
+        let data = try #require(Data(hexEncoded: vector.envelopeHex), "envelopeHex must be hex")
 
         let code = try PairingCode.decodeV2(data)
 
@@ -425,8 +425,8 @@ struct PairingCodeV2VectorTests {
     @Test(arguments: vectors?.invalid ?? [])
     func rejectsInvalidVector(vector: PairingCodeV2VectorFile.Invalid) throws {
         do {
-            if let codeHex = vector.codeHex {
-                let data = try #require(Data(hexEncoded: codeHex), "codeHex must be hex")
+            if let envelopeHex = vector.envelopeHex {
+                let data = try #require(Data(hexEncoded: envelopeHex), "envelopeHex must be hex")
                 _ = try PairingCode.decodeV2(data)
             } else {
                 let code = try #require(vector.code, "invalid vector carries neither form")

--- a/Tests/HeelerTests/Support/PairingCodeV2VectorFile.swift
+++ b/Tests/HeelerTests/Support/PairingCodeV2VectorFile.swift
@@ -7,9 +7,9 @@ import Foundation
 /// until integration lands the file.
 ///
 /// Expected schema, mirroring v1 with the envelope carried as bytes:
-/// `valid` entries have `name`, `codeHex` (the binary envelope as hex), and
+/// `valid` entries have `name`, `envelopeHex` (the binary envelope as hex), and
 /// `payload` (same shape as v1); `invalid` entries have `name`, `error`, and
-/// either `codeHex` or `code` (a scanned-string form, for cases only
+/// either `envelopeHex` or `code` (a scanned-string form, for cases only
 /// expressible as text, such as scalars above U+00FF).
 struct PairingCodeV2VectorFile: Decodable, Sendable {
     let valid: [Valid]
@@ -17,14 +17,14 @@ struct PairingCodeV2VectorFile: Decodable, Sendable {
 
     struct Valid: Decodable, Sendable, CustomStringConvertible {
         let name: String
-        let codeHex: String
+        let envelopeHex: String
         let payload: PairingCodeVectorFile.Payload
         var description: String { name }
     }
 
     struct Invalid: Decodable, Sendable, CustomStringConvertible {
         let name: String
-        let codeHex: String?
+        let envelopeHex: String?
         let code: String?
         /// The expected error identifier, e.g. "bad_prefix".
         let error: String

--- a/Tests/HeelerTests/Support/PairingCodeV2VectorFile.swift
+++ b/Tests/HeelerTests/Support/PairingCodeV2VectorFile.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// The shared Pairing Code v2 vectors from `plugin/test-vectors/`, the same
+/// arrangement as `PairingCodeVectorFile` for v1. The v2 file is produced by
+/// the plugin package and does not exist on every branch: `shared` is nil
+/// when it is absent, and the vector-driven suite skips via `.enabled(if:)`
+/// until integration lands the file.
+///
+/// Expected schema, mirroring v1 with the envelope carried as bytes:
+/// `valid` entries have `name`, `codeHex` (the binary envelope as hex), and
+/// `payload` (same shape as v1); `invalid` entries have `name`, `error`, and
+/// either `codeHex` or `code` (a scanned-string form, for cases only
+/// expressible as text, such as scalars above U+00FF).
+struct PairingCodeV2VectorFile: Decodable, Sendable {
+    let valid: [Valid]
+    let invalid: [Invalid]
+
+    struct Valid: Decodable, Sendable, CustomStringConvertible {
+        let name: String
+        let codeHex: String
+        let payload: PairingCodeVectorFile.Payload
+        var description: String { name }
+    }
+
+    struct Invalid: Decodable, Sendable, CustomStringConvertible {
+        let name: String
+        let codeHex: String?
+        let code: String?
+        /// The expected error identifier, e.g. "bad_prefix".
+        let error: String
+        var description: String { name }
+    }
+
+    static let shared: PairingCodeV2VectorFile? = {
+        let url =
+            Bundle(for: BundleLocator.self)
+            .url(forResource: "pairing-code-v2", withExtension: "json") ?? sourceTreeURL
+        guard let url, FileManager.default.fileExists(atPath: url.path) else { return nil }
+        do {
+            return try JSONDecoder().decode(PairingCodeV2VectorFile.self, from: Data(contentsOf: url))
+        } catch {
+            fatalError("shared pairing v2 vectors exist but failed to load: \(error)")
+        }
+    }()
+
+    /// The repo checkout's copy, reachable from Simulator test hosts. Lets
+    /// the suite light up the moment the plugin package lands the file, even
+    /// before a project regeneration bundles it as a test resource.
+    private static var sourceTreeURL: URL? {
+        URL(fileURLWithPath: #filePath)  // Tests/HeelerTests/Support/…
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("plugin/test-vectors/pairing-code-v2.json")
+    }
+
+    private final class BundleLocator {}
+}
+
+extension Data {
+    /// Decodes an even-length hex string (case-insensitive), or nil.
+    init?(hexEncoded text: String) {
+        guard text.count.isMultiple(of: 2) else { return nil }
+        var data = Data(capacity: text.count / 2)
+        var digits = text.makeIterator()
+        while let high = digits.next() {
+            guard
+                let low = digits.next(),
+                let highValue = high.hexDigitValue, let lowValue = low.hexDigitValue,
+                highValue < 16, lowValue < 16
+            else { return nil }
+            data.append(UInt8(highValue << 4 | lowValue))
+        }
+        self = data
+    }
+}

--- a/docs/adr/0014-binary-pairing-code-v2.md
+++ b/docs/adr/0014-binary-pairing-code-v2.md
@@ -1,0 +1,32 @@
+# Encode Pairing Code v2 as raw binary
+
+The Pairing Code v1 envelope is an ASCII prefix plus base64url JSON. A typical
+308-character payload requires a version 11 QR, which is too large for the
+pairing popup's terminal cell budget.
+
+## Decision
+
+The plugin emits Pairing Code v2 as a compact binary envelope and passes its
+bytes directly to the QR encoder's byte-mode segment. Fixed-width binary fields
+carry the port, SHA-256 host-key digest, Bootstrap Key seed, and expiry. IP
+addresses use their packed representation; usernames and hostnames remain
+length-prefixed UTF-8. Shared Node and Swift vectors define the exact bytes and
+IPv6 canonical text.
+
+The app accepts both v1 and v2 during migration. The plugin emits only v2.
+
+## Rejected alternative
+
+Base45 in QR alphanumeric mode was rejected. As measured in
+`docs/research/terminal-qr-rendering.md`, a 130-byte payload costs 1,086 QR data
+bits with Base45 versus 1,052 bits in raw byte mode. Both reach version 6 at
+error correction L, but Base45 leaves only two bits of capacity and becomes
+version 9 if a reader or encoder treats it as byte-mode text. It adds encoding
+without improving density or compatibility inside Heeler's controlled scanner.
+
+## Consequences
+
+Pairing Code v2 is small enough to fit the popup at a materially lower QR
+version. It is an opaque binary protocol rather than copyable text, so the
+shared vectors are the compatibility contract and breaking changes require a
+new envelope version.

--- a/docs/research/terminal-qr-rendering.md
+++ b/docs/research/terminal-qr-rendering.md
@@ -1,0 +1,595 @@
+# Terminal QR Rendering and Payload Size
+
+Date: 2026-08-13
+
+Research note for the Pairing Code QR in `plugin/src/terminal-qr.js`. Every
+claim below cites the source that owns it: a file and line in the project's own
+repository, a spec clause, or an RFC section. Where the primary source was
+behind a paywall or a bot wall, that is stated rather than papered over.
+
+## TL;DR
+
+Three findings change what we should do, in descending order of confidence.
+
+**1. Our quiet zone is half of what the spec requires, and it is nearly free to
+fix.** `terminal-qr.js:17` sets `QUIET_ZONE_MODULES = 2`. Denso Wave, who
+invented QR Code and authored the standard, states that "QR Code requires a
+four-module wide margin at all sides of a symbol" and that two modules is the
+Micro QR figure, not the QR figure. libqrencode, mdp/qrterminal, and
+skip2/go-qrcode all default to 4. Russ Cox — author of the encoder qrterminal
+uses — filed mdp/qrterminal#5 specifically about a 1-module border, reporting
+that "many readers I tried back in 2012 could not recognize the code." Going
+from 2 to 4 costs our current render **two columns and one row** (33x17 becomes
+35x18). Do this regardless of anything else on this page.
+
+**2. Payload compaction is worth doing, but not for the reason we assumed.** It
+does *not* unlock half-blocks. Half-blocks need the symbol at version 3 or
+smaller (29 modules) to fit 20 rows, which is roughly a 48-byte payload — far
+below the ~130 bytes a compacted envelope would reach. What compaction actually
+buys is (a) sextants become viable, which is a large terminal-compatibility win
+over octants, and (b) error correction can rise from L to M or Q inside the same
+cell budget. The second is the more valuable of the two.
+
+**3. Sextants are the only candidate whose module squareness depends on the
+font.** Half-blocks (1 module wide x 2 tall per cell) and octants (2x4) both
+produce square modules in a 1:2 cell and degrade gracefully as line height
+varies. Sextants (2x3) produce modules stretched vertically by `2H/3W`, which is
+1.33 at a 1:2 cell and 1.47 at a 1:2.2 cell. ZXing's finder-pattern cross-check
+rejects a candidate whose vertical run differs from its horizontal run by more
+than 40% (`FinderPatternFinder.java`, `crossCheckVertical`). So sextants sit
+just inside the tolerance at nominal line height and cross it if the user's
+terminal has loose leading. That is a real risk, not a theoretical one.
+
+### Recommendation
+
+Keep octants as the rendering, and change the payload and the parameters around
+it:
+
+- Raise `QUIET_ZONE_MODULES` to 4 now. Cost: 2 columns, 1 row.
+- Keep the `\e[47m\e[30m` white-background wrapper. This is already correct and
+  is the one decision in this file that the evidence unambiguously supports; see
+  [Polarity](#polarity-inverted-vs-white-background) for why unwrapped block
+  glyphs are a coin flip.
+- Compact the envelope to ~130 bytes binary, then **spend the savings on error
+  correction, not on shrinking the QR**. At ~130 bytes, EC M renders as 29x15
+  octant cells — smaller than what we ship today at EC L *and* with double the
+  error correction. This mirrors what SatoshiPortal/bullbitcoin-mobile#2049 did
+  after a real camera scan failure.
+- Do **not** switch to sextants purely as a compatibility play without first
+  measuring the actual cell aspect ratio in herdr's rendering path. The 33%
+  vertical stretch is inside ZXing's budget with no cushion.
+- If universal half-block rendering ever becomes a hard requirement, treat it as
+  a payload-architecture change rather than a rendering change: the QR would
+  have to carry a <=48-byte reference and the credential would be fetched over
+  the connection it establishes. That is the Tailscale and Discord pattern, and
+  it is the only route to a half-block QR in a 20-row popup.
+
+### Cell math
+
+Budget: roughly 66 columns x 20 rows (the `pair` pane is `width = "80%"`,
+`height = "90%"` per `plugin/herdr-plugin.toml:22-23`). All figures use a
+4-module quiet zone. Computed with the repo's own `qrcode` dependency.
+
+| Payload | EC | Version | Modules | ANSI 2-space | Half `▀▄█` | Sextant | Octant |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| current 308-char envelope | L | v11 | 61 | 138x69 | 69x35 | 35x23 | **35x18** |
+| current 308-char envelope | M | v13 | 69 | 154x77 | 77x39 | 39x26 | **39x20** |
+| current 308-char envelope | Q | v16 | 81 | 178x89 | 89x45 | 45x30 | 45x23 |
+| compacted ~130B binary | L | v6 | 41 | 98x49 | 49x25 | **25x17** | **25x13** |
+| compacted ~130B binary | M | v8 | 49 | 114x57 | 57x29 | **29x19** | **29x15** |
+| compacted ~130B binary | Q | v9 | 53 | 122x61 | 61x31 | 31x21 | **31x16** |
+| compacted ~64B binary | L | v4 | 33 | 82x41 | 41x21 | **21x14** | **21x11** |
+| compacted ~64B binary | M | v5 | 37 | 90x45 | 45x23 | **23x15** | **23x12** |
+
+Bold entries fit 66x20. The shipping renderer today (octant, quiet zone 2,
+EC L) measures 33x17.
+
+Note the shape of the table: **the half-block column never fits**, at any
+payload size we would realistically reach. Even a 64-byte payload is 41x21, one
+row over. This is the single most important number on this page, because
+half-blocks are what essentially every comparable project ships.
+
+## Per-project findings
+
+### What dominates in practice
+
+Half-blocks, by a wide margin, for phone-scanned login QRs. whatsmeow — the
+library behind most WhatsApp bridges — documents exactly two recipes in
+`client_test.go:59-60`:
+
+```go
+// e.g. qrterminal.GenerateHalfBlock(evt.Code, qrterminal.L, os.Stdout)
+// or just manually `echo 2@... | qrencode -t ansiutf8` in a terminal
+```
+
+Both are half-block. Neither is small. WhatsApp's 277-character payload lands on
+QR version 11 — the same version as our 308-character envelope — which
+`GenerateHalfBlock` renders as **69 columns x 35 rows**. Nobody minds, because
+it goes to a full terminal rather than a popup. Our 66x20 constraint is the
+unusual part of this problem, not our payload.
+
+### Rendering table
+
+| Project | Glyphs | Polarity | Quiet zone | Capability detection | Source |
+| --- | --- | --- | --- | --- | --- |
+| libqrencode `-t ANSI` / `ANSI256` | two spaces per module with bg color | dark-on-light, explicit `\e[47m`/`\e[40m` (or 256-color `231`/`16`) | 4 | none | `qrenc.c:749-831`, default at `:1427-1432` |
+| libqrencode `-t UTF8` | `▀▄█` + space | **dark module = blank**, assumes light foreground on dark bg | 4 (rendered as `margin/2` rows of double-height glyphs, so still 4 modules) | none | `qrenc.c:847-930`; margin loop at `:838` |
+| libqrencode `-t ANSIUTF8` | same glyphs, plus forced `\e[40;37;1m` | safe — carries its own black bg and white fg | 4 | none | `qrenc.c:872-882` |
+| libqrencode `-t UTF8i` / `ANSIUTF8i` | glyph roles swapped | dark module = `█`, for light-background terminals | 4 | none | `qrenc.c:860-870` |
+| mdp/qrterminal `Generate` | two spaces per module with bg color | safe, explicit bg | 4, clamped to min 1 | Sixel probe via `\e[c` | `qrterminal.go:14-15, 29, 132-152, 209-211` |
+| mdp/qrterminal `GenerateHalfBlock` | `▀▄█` + space | dark module = `" "`, assumes light fg on dark bg | 4 | none | `qrterminal.go:18-21, 154-198, 252-263` |
+| skip2/go-qrcode `ToString` | `██` per module | dark module = `"  "`, assumes light fg on dark bg | 4 | none | `qrcode.go:555-568`; `version.go` `quietZoneSize() = 4` |
+| skip2/go-qrcode `ToSmallString` | `▀▄█` + space | same | 4 | none | `qrcode.go:573-608` |
+| Tailscale `tailscale up --qr` | wraps skip2 with `auto`/`ascii`/`large`/`small` | `inverse = false` | 4 (inherited) | **the best in class** — see below | `util/qrcodes/qrcodes.go`, `qrcodes_linux.go:23-82` |
+| node-qrcode `{type:'terminal'}` default | two spaces per module with bg color | safe, explicit bg | **1**, and `margin` is ignored | none | `lib/renderer/terminal/terminal.js:9-30` |
+| node-qrcode `{type:'terminal', small:true}` | `▀▄█` + space with fg/bg setup | `inverse` option, default light-on-dark-ish | **1** | none | `lib/renderer/terminal/terminal-small.js:9-22, 70-75` |
+| node-qrcode `{type:'utf8'}` | `▀▄█` + space | **dark module = `█`** — opposite of libqrencode and go-qrcode | 4 | none | `lib/renderer/utf8.js:3-8` |
+| gtanner/qrcode-terminal default | two spaces per module with bg color | safe, explicit bg | **1** | none | `lib/main.js:3-4, 81-89` |
+| gtanner/qrcode-terminal `{small:true}` | `▀▄█` + space | dark module = `" "` | **1** | none | `lib/main.js:55-74` |
+| qrcp | delegates to `ToSmallString` | exposes `inverseColor` flag | 4 | none | `qr/qr.go` |
+| whatsmeow (documented recipe) | `qrterminal.GenerateHalfBlock` or `qrencode -t ansiutf8` | either | 4 | none | `client_test.go:59-60` |
+
+Nobody in this list uses braille, quadrants, sextants, or octants. Our octant
+renderer is, as far as this survey found, without precedent in a shipping
+project. That cuts both ways: it is why it fits our popup, and it is why there
+is no field evidence for it.
+
+### Tailscale's capability detection is worth copying in spirit
+
+`util/qrcodes/qrcodes_linux.go:23-82` is the only real terminal-capability
+detection found anywhere in this survey. It:
+
+1. checks `LC_CTYPE`/`LANG` for a `.UTF-8` suffix, falling back to ASCII if
+   absent;
+2. checks `isatty`;
+3. on a raw Linux console, issues a `KDGKBMODE` ioctl to confirm Unicode
+   keyboard mode;
+4. issues a `GIO_UNIMAP` ioctl to read the console font's actual
+   Unicode-to-glyph map and confirms that `█`, `▀`, and `▄` are really present
+   before using them.
+
+The comment naming the bug that forced this is at `:26-28`, pointing at
+tailscale/tailscale#12935 ("make simpler QR codes on less capable terminals?"),
+which reported unusable output on a qemu VGA console under `TERM=vt220`. The
+fixing PR (#18182) states plainly: "The default Fixed and Terminus fonts don't
+contain half-block characters (`▀` and `▄`), but do contain the full-block
+character (`█`)."
+
+We cannot run ioctls from inside a herdr popup, and our situation is different
+(we depend on Unicode 16 glyphs, not Unicode 1.1 ones). But the lesson holds:
+**a project that shipped half-blocks still found terminals that could not render
+them**, and it responded by adding a fallback rather than by asserting
+compatibility.
+
+## Payload encoding
+
+### Mode efficiency
+
+The three relevant QR modes, per RFC 9285 §4/§4.1 which normatively cites
+ISO/IEC 18004 §7.3.4 and Table 2:
+
+- numeric: 10 bits per 3 digits = 3.33 bits/char
+- alphanumeric: 11 bits per 2 chars = 5.5 bits/char, over the 45-character set
+  `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:` (uppercase only)
+- byte: 8 bits/char
+
+Capacities at EC L, verified by recomputation from the ISO error-correction
+tables as embedded in nayuki/QR-Code-generator `QrCode.java:773-790`:
+
+| Version | Modules | byte (L) | alnum (L) | numeric (L) |
+| --- | --- | --- | --- | --- |
+| 5 | 37x37 | 106 | 154 | 255 |
+| 6 | 41x41 | 134 | 195 | 322 |
+| 7 | 45x45 | 154 | 224 | 370 |
+| 8 | 49x49 | 192 | 279 | 461 |
+| 9 | 53x53 | 230 | 335 | 552 |
+| 10 | 57x57 | 271 | 395 | 652 |
+| 11 | 61x61 | 321 | 468 | 772 |
+
+### Base45 would make our QR bigger, not smaller
+
+This is the most important correction to the framing of the original question.
+
+**Base45 costs 8.25 QR data bits per source byte; raw byte mode costs 8.00.**
+Base45 encodes 2 bytes into 3 alphanumeric characters (RFC 9285 §4), and each
+alphanumeric character costs 5.5 bits, so 2 bytes cost 16.5 bits. Byte mode
+costs 16. RFC 9285 never claims to beat byte mode — it claims to beat Base64
+(10.67 bits/byte), and its stated motivation (§1) is that "Even in Byte mode, a
+typical QR code reader tries to interpret a byte sequence as text encoded in
+UTF-8 or ISO/IEC 8859-1. Thus, QR codes cannot be used to encode arbitrary
+binary data directly."
+
+That argument is about reader compatibility, not density. It was contested
+directly in the draft's issue tracker (Netnod/base45#4, 2021-06-13): "Base45 is
+an encoding for binary data which uses 8.25 bits per byte... while 8-bit Bytes
+Mode could be a much more straightforward 'encoding' which would use 8 bits per
+byte." The RFC author's response was that QR's byte mode "is in reality a
+character mode as well," and that "many of us wanted Aztec encoding and not QR,
+but in the discussions more people wanted QR than Aztec." The Dutch health
+ministry found the overhead unacceptable and forked
+(minvws/base45-go#1): "we use a base45 encoding that uses the exact same method
+as base58, and which has the exact same efficiency as QR binary mode. The EU
+variant isn't of the same efficiency as QR binary mode."
+
+For our 130-byte target, concretely, at EC L:
+
+| Encoding | Chars | QR data bits | Version | Modules |
+| --- | --- | --- | --- | --- |
+| raw byte mode | 130 | 1052 | v6 | 41x41 |
+| Base45 -> alphanumeric | 195 | 1086 | v6 | 41x41 |
+| Base32 -> alphanumeric | 208 | 1157 | v7 | 45x45 |
+| Base64 -> byte mode | 176 | 1420 | v8 | 49x49 |
+| uppercase hex -> alphanumeric | 260 | 1443 | v8 | 49x49 |
+| Base45 misdetected as byte mode | 195 | 1572 | v9 | 53x53 |
+
+Base45 and raw byte mode land on the same version, with Base45 using 34 more
+bits and leaving only 2 bits of headroom under v6's 1088-bit ceiling. The last
+row is the practical trap: if any character in the payload falls outside the
+45-character alphanumeric set, the encoder drops the whole segment to byte mode
+and the result is two versions *worse* than doing nothing.
+
+**Conclusion for us: encode the compacted envelope as raw bytes. Do not
+Base45-encode it.** Our current payload is base64url inside an ASCII envelope,
+which is the Base64 row of that table — the worst realistic option.
+
+### EU DCC, for the record
+
+The chain is CBOR -> COSE_Sign1 -> ZLIB/DEFLATE -> Base45 -> `"HC1:"` prefix ->
+QR, specified in ehn-dcc-development/eu-dcc-hcert-spec `hcert_spec.md` §4.2.1
+and §4.2.2. §4.2.2 mandates the mode and recommends the level: "An error
+correction rate of 'Q' (around 25%) is RECOMMENDED. The Alphanumeric (Mode
+2/QR Code symbols 0010) MUST be used in conjunction with Base45." The
+reference implementation asserts on it (`python-hcert` `hcert/optical.py:64-65`).
+The Commission Implementing Decision (EU) 2021/1073 Annex I could not be read
+directly — EUR-Lex returns a bot challenge — so all DCC citations here are to
+the eHN GitHub org rather than to the legal text.
+
+Two empirical findings from the official test vectors
+(`eu-digital-green-certificates/dgc-testdata`) are worth carrying over:
+
+- **The deflate step does not compress.** Measured across six national vectors,
+  zlib output was *larger* than its input in five of six cases (e.g. SE/1:
+  340 -> 345 bytes; BE/1: 336 -> 347). The payload is a high-entropy ECDSA
+  signature plus compact CBOR; deflate contributes only its own framing. Any
+  compression step we add to a signature-dominated payload will behave the same.
+- **`"HC1:"` is not an alphanumeric-mode trick.** The DCC spec contains no such
+  argument; the recorded reason (hcert-spec PR #47) is to "mimic a URI scheme
+  and prohibit automatic searches when scanned."
+
+### What comparable pairing QRs actually carry
+
+| System | Payload | Type | Length | Version @ L | Half-block @ qz4 | Octant @ qz4 |
+| --- | --- | --- | --- | --- | --- | --- |
+| WhatsApp multi-device | `https://wa.me/settings/linked_devices#ref,noise,identity,adv,type` | URL (since 2026-05) | 277 chars | v11 | 69x35 | 35x18 |
+| Signal device link | `sgnl://linkdevice?uuid=…&pub_key=…&capabilities=…` | app-only URI | 112-137 chars | v6 | 49x25 | 25x13 |
+| Discord remote auth | `https://discord.com/ra/<43-char fingerprint>` | URL | ~66 chars | v4 | 41x21 | 21x11 |
+| Tailscale | `https://login.tailscale.com/a/<hex>` | URL | 42-46 chars | v3 | **37x19** | 19x10 |
+| WireGuard | raw `wg-quick` `.conf` text | opaque, no deep-link | 249-351 bytes | v10-v12 | 73x37 | 37x19 |
+| EU DCC | `HC1:` + Base45 | opaque | 481-604 chars | v17-v19 @ Q | — | — |
+| **Heeler today** | `HERDR-PAIR:1:<base64url JSON>` | opaque | 308 chars | v11 | 69x35 | 35x18 |
+
+Sources: whatsmeow `pair.go:115-120` (the exact `fmt.Sprintf` with five
+comma-separated base64 fields; the URL wrapper and fifth field were added
+2026-05-11 in commit `876de1e9` — before that it was an opaque 237-char string);
+Signal-Desktop `ts/util/signalRoutes.std.ts:335-359` and signal-cli
+`DeviceLinkUrl.java:47-57`; Tailscale `util/qrcodes/qrcodes.go:25` (EC level M,
+hardcoded) and the URL shapes documented at `cmd/tailscale/cli/up.go:274`.
+Discord's format has **no primary source** — `discord/discord-api-docs` has zero
+hits for `/ra/` or `remote_auth`, and the only documentation is the
+community reverse-engineering project `discord-userdoccers`; treat it as
+low-confidence. WireGuard has three negative results worth recording: the
+official `wireguard-tools` repo has zero hits for `qrencode`/`qrcode`, both
+official apps only *scan* QRs and never generate them, and the widely repeated
+`qrencode -t ansiutf8 < peer.conf` recipe is folklore rather than documentation.
+
+The pattern across the ones that stay small is the same: **the QR carries a
+short reference to server-held state, not the credential itself.** Discord's
+fingerprint approach is the cleanest — the QR holds only a SHA-256 digest of an
+ephemeral public key, the key exchange runs over a separate WebSocket, and the
+token flows back through the already-authenticated device. The payload is
+constant at ~66 bytes regardless of credential size, and a photographed QR is
+not directly usable.
+
+Heeler's envelope is structurally the opposite: it is self-contained precisely
+because there is no third party, and the addresses it carries are the thing the
+phone needs before it can talk to anything. That is a defensible design, but it
+is the reason we are at v11 while Tailscale is at v3.
+
+### Uppercasing to reach alphanumeric mode
+
+Real and well documented, but only for payloads that are already
+case-insensitive. BIP-173 (`bip-0173.mediawiki:189-196`) is the canonical
+statement: "inside QR codes uppercase SHOULD be used, as those permit the use of
+''alphanumeric mode'', which is 45% more compact than the normal ''byte mode''."
+Adopted downstream by BOLT11 (`11-payment-encoding.md:38`), LNURL LUD-01
+(`01.md:10`), and Cashu NUT-26 (`26.md:18`).
+
+Two corrections that matter if we ever cite this: BIP-173's "45% more compact"
+is the wrong direction — 8/5.5 = 1.4545 means alphanumeric fits 45% *more data
+per bit*, but the volume reduction is 1 - 5.5/8 = **31.25%**. And RFC 3986
+§6.2.2.1 makes only `scheme://host` case-insensitive; path, query, and fragment
+are case-sensitive, so uppercasing a whole URL is not generally safe.
+
+For numeric mode there is exactly one production precedent: SMART Health Cards
+maps each JWS character to two digits (`docs/index.md:562`) for a documented 20%
+gain over byte mode, using a two-segment QR (`shc:/` in byte mode, payload in
+numeric mode). And there is one strong counter-example: EMVCo's merchant-
+presented QR spec §4.12.1.1 *forbids* everything but byte mode — "all the data
+shall be encoded using Byte Mode. Alphanumeric Mode, Numeric mode, Kanji,
+Structured Append, and FCN1 mode shall not be used."
+
+None of this applies to us. Our payload is binary; byte mode is already optimal.
+
+## Scannability evidence
+
+### Quiet zone
+
+ISO/IEC 18004:2024 §5.3.1 (readable in the free ISO preview): "The symbol shall
+be surrounded on all four sides by a quiet zone border." The clause that states
+the width (§5.3.8 in the 2024 numbering, §6.3.8 in 2015) is **not** in the free
+preview, so the four-module figure is cited to Denso Wave, the inventor and
+spec author: "QR Code requires a four-module wide margin at all sides of a
+symbol," and separately "a two-module wide margin is enough for Micro QR Code."
+
+The field evidence is mdp/qrterminal#5, filed by Russ Cox: "the QR spec says
+that the code itself must be placed in a 4-pixel-wide white border or 'quiet
+zone'... The example on your front page only has a 1-pixel border, which may not
+be enough for some readers," followed by a concrete failure — Facebook put a QR
+on a roof with an insufficient border, and "many readers I tried back in 2012
+could not recognize the code in the image." The maintainer fixed it in v1.0.0.
+
+Note that `QRCode.toString(text, {type:'terminal'})` in node-qrcode — the
+library we depend on — ships a 1-module quiet zone and silently ignores the
+`margin` option (`lib/renderer/terminal/terminal.js:7` comments out the options
+lookup entirely). We do not use that renderer, but it is a reminder that the
+dependency will not supply a correct quiet zone for us.
+
+### Polarity: inverted vs white background
+
+ISO/IEC 18004:2024 §5.2 (free preview) is explicit, and contradicts the common
+folklore:
+
+> **Reflectance reversal**: Symbols are intended to be read when marked so that
+> the image is either dark on light or light on dark... The specifications in
+> this document are based on dark images on a light background, therefore in the
+> case of symbols produced with reflectance reversal references to dark or light
+> modules should be taken as references to light or dark modules respectively.
+
+This capability was added in the 2006 second edition (per the Introduction).
+Whether a *conforming decoder* must attempt reversal is in a clause not covered
+by the preview and could not be verified.
+
+Decoder reality, however, is split:
+
+| Decoder | Inverted support | Source |
+| --- | --- | --- |
+| ZXing (Java) | off by default, requires the `ALSO_INVERTED` hint (added in PR #1371, 2021) | `DecodeHintType.java` |
+| zxing-cpp | **on by default** | `ReaderOptions.h:113-114`, "Try detecting inverted ('reversed reflectance') codes... (default: true)" |
+| zbar | supported but off by default, needs `-Stest-inverted` | `zbar.h:188`; PR #33 |
+
+ZXing's maintainer states in issue #1844 that "inverted QR codes are not
+technically valid QR codes" — which is wrong against ISO 18004:2006 and later,
+but is an accurate description of what ZXing Java does.
+
+For iOS the evidence is thin and indirect. Apple's `VNDetectBarcodesRequest`
+documentation says nothing about polarity. An Apple DTS engineer wrote in
+Developer Forums thread 112660 that "Assuming that the barcode symbology
+supports white-bars-on-dark-backgrounds, the reading speed should be similar
+regardless of the color of the bars," and a 2015 developer report (thread 5376)
+confirms inverted QR working under `AVCaptureMetadataOutput`. That points the
+right way but is not a guarantee.
+
+**The decisive evidence is a shipped bug fix.** gtanner/qrcode-terminal PR #8
+(merged, released as 0.9.5):
+
+> The generated QR codes in the original version didn't work when using a
+> terminal with black text on white background. This change makes the library
+> use an actual color code for black (or at least dark grey) background for the
+> black color, just as it was using the color code for white.
+
+node-qrcode then copied that approach with an explicit comment at
+`lib/renderer/terminal/terminal.js:9`: "use same scheme as
+https://github.com/gtanner/qrcode-terminal because it actually works! =)". And
+node-qrcode's maintainer, on issue #185: "utf8 doesn't contain color information
+for the renderer, like ansii escapes do in terminals. Qrcode can't get this
+'right' for you because the result is just text."
+
+This matters because the bare-glyph renderers do not agree with each other on
+which way is up. libqrencode `-t UTF8`, mdp/qrterminal `GenerateHalfBlock`,
+skip2/go-qrcode `ToString`, and gtanner `{small:true}` all render a **dark
+module as blank** and a light module as `█` — i.e. they assume a light
+foreground on a dark terminal. node-qrcode's `utf8.js` does the exact opposite
+(`BB: '█'`). A user with the wrong terminal theme gets a photographic negative
+from half of these libraries.
+
+Our `\e[47m\e[30m` wrapper (`terminal-qr.js:13`) sidesteps this entirely by
+carrying its own background. Keep it.
+
+Tailscale's `const inverse = false // Modern scanners can read QR codes of any
+colour.` deserves a caveat: it was introduced by sfllaw in PR #18182 (merged
+2026-01-08) and **no reviewer discussed it**. It is an uncited developer
+assertion, not a measured result. Given ZXing Java and zbar both default to *not*
+trying inversion, it is optimistic.
+
+### Braille
+
+The evidence is empty rather than negative. A GitHub-wide search found only two
+braille QR projects (`kitty-crow/braille-qr`, 0 stars, created 2026-07-28;
+`marcus7777/QRinBraillePatternDots`, 2 stars), neither of which states anything
+about whether a phone can scan the output. Multiple issue searches for braille
+QR scan failures returned nothing.
+
+The mechanical argument against it is strong, though, and comes from the
+terminals' own rendering code. Braille glyphs are dots with mandatory gaps and
+never fill the cell. xterm.js's rasterizer says so directly
+(`CustomGlyphRasterizer.ts:127-141`): "Columns: left=1-2, right=5-6 (leaving 0
+and 7 as margins, 3-4 as gap)", and it draws circles with
+`radius = Math.min(xEighth, yEighth)` inside an 80%-height inset. Ghostty's
+`src/font/sprite/draw/braille.zig` computes `w = min(width/4, height/8)` with
+half-spacing margins — same result.
+
+So U+28FF (all eight dots) still does not produce a solid cell, and adjacent
+dark modules never merge. ZXing's finder detection depends on the contiguous
+1:1:3:1:1 run-length ratio (`FinderPatternFinder.java:186-206`); a 3-module dark
+run rendered in braille becomes three dots separated by light gaps, which breaks
+that ratio at the binarization stage unless camera blur happens to fill them in.
+The existing rejection of braille in `terminal-qr.js:5-6` ("braille... sparse
+dots") is well founded.
+
+### Aspect ratio
+
+ISO/IEC 18004:2024 §5.3.1 requires "nominally square modules." No numerical
+tolerance appears in the free preview; print-quality tolerances live in the
+normatively referenced ISO/IEC 15415, which was not accessible.
+
+The operative number comes from ZXing instead. `FinderPatternFinder.java`
+`crossCheckVertical` compares the vertical extent of a candidate finder pattern
+against the horizontal extent already measured:
+
+```java
+// If we found a finder-pattern-like section, but its size is
+// more than 40% different than the original, assume it's a false positive
+if (5 * Math.abs(stateCountTotal - originalStateCountTotal) >= 2 * originalStateCountTotal) {
+  return Float.NaN;
+}
+```
+
+That is the anisotropy budget: **±40%**. Downstream, `Detector.java:229-259`
+collapses the horizontal and vertical module-size estimates into a single scalar
+before `computeDimension` (`:198-217`) snaps the result to `mod 4`, so a
+symmetric stretch mostly cancels — but the snap tolerates only ±1. Once the
+dimension is right, the full perspective transform absorbs the scaling.
+
+Mapping that onto a terminal cell of width `W` and height `H`:
+
+| Glyph | Modules/cell | Module aspect (h:w) | At `H/W = 2` | At `H/W = 2.2` |
+| --- | --- | --- | --- | --- |
+| half-block | 1 x 2 | `H / 2W` | 1.00 | 1.10 |
+| sextant | 2 x 3 | `2H / 3W` | 1.33 | 1.47 |
+| octant | 2 x 4 | `H / 2W` | 1.00 | 1.10 |
+
+Half-blocks and octants are square at nominal metrics and stay well inside the
+budget as line height varies. Sextants start at 33% and cross ZXing's 40%
+threshold at `H/W = 2.1`. Common monospace metrics (0.6em
+advance, 1.2em line height) put `H/W` at exactly 2.0, so sextants would work —
+but any terminal or herdr configuration with looser leading eats the remaining
+7 percentage points.
+
+### Glyph availability
+
+Verified against `unicode.org/Public/UCD/latest/ucd/DerivedAge.txt`:
+
+```
+2500..2595    ; 1.1    box drawing + half/full blocks (▀ ▄ █)
+2596..259F    ; 3.2    quadrants
+2800..28FF    ; 3.0    braille
+1FB00..1FB92  ; 13.0   sextants (1FB00..1FB3B, 60 chars)
+1CD00..1CEB3  ; 16.0   octants (1CD00..1CDE5, 230 chars)
+```
+
+The octant count confirms our table construction: 230 octant code points plus
+the 26 patterns reused from older blocks equals the 256 entries in
+`OCTANT_TABLE`, matching `OCTANT_EXCEPTIONS` at `terminal-qr.js:24-32`.
+
+Terminal support, from each terminal's own glyph-synthesis source:
+
+| Terminal | Half-blocks | Sextants | Octants | Source |
+| --- | --- | --- | --- | --- |
+| Ghostty | yes | yes | yes | `src/font/sprite/draw/{block,symbols_for_legacy_computing,symbols_for_legacy_computing_supplement}.zig` |
+| kitty | yes | yes (>=0.19.3) | yes (**0.40.0**, 2025-03-08) | `docs/changelog.rst` |
+| WezTerm | yes | yes | yes | `customglyph.rs:3682-3688`, `OCTANT_PATTERNS: [u8; 230]` |
+| foot | yes | yes | yes | `box-drawing.c:2287, 2673, 3252` |
+| Alacritty | yes | yes | **no** | `builtin_font.rs:31` — range ends at `1fb3b` |
+| iTerm2 | yes | yes | **no** | `iTermBoxDrawingBezierCurveFactory.m` — zero hits for "octant" |
+| VS Code (xterm.js WebGL) | yes | yes | **no** | `CustomGlyphDefinitions.ts` — has a `1FB00-1FB3B` region, no `1CD00` region |
+| Terminal.app | font-dependent, often broken | unknown | unknown | closed source; see below |
+
+Terminal.app has no first-party statement, but gtanner/qrcode-terminal has a
+cluster of reports: #21 ("QR code looks strange in my terminal and cannot be
+scanned", macOS Terminal + Monaco), where a commenter notes "This is not only an
+issue with 'Monaco'. I could reproduce this with almost any monospaced font on
+my machine except 'Courier New'", another confirms "It looks strange in the mac
+terminal, but displays well in iterm"; plus #32, #23 (Windows cmd), and #44.
+So even *half-blocks* — Unicode 1.1 characters — are unreliable on Terminal.app.
+
+**This is the strongest argument against octants**: they render on four
+terminals (Ghostty, kitty >= 0.40, WezTerm, foot) and fail on the three most
+common ones after those (iTerm2, VS Code, Alacritty). Sextants add all three
+back. Octants are 23 months old as of this writing.
+
+## Open questions
+
+- What is the actual cell aspect ratio in the terminals herdr users run? This
+  single number decides whether sextants are safe. It should be measured, not
+  assumed.
+- Can a herdr popup detect the host terminal at all (e.g. via `TERM`,
+  `TERM_PROGRAM`, or a DA1 query round-trip through the pane)? Tailscale's
+  ioctl approach is unavailable to us, but `TERM_PROGRAM` alone would separate
+  iTerm2 and VS Code from Ghostty and kitty, which is most of the decision.
+- Is the ~130-byte compacted envelope actually achievable? The estimate assumes
+  binary IP addresses, a raw 32-byte fingerprint, and a raw 32-byte seed. If the
+  seed can become a 16-byte single-use token that the plugin maps to a key
+  locally, the payload drops to ~110 bytes without weakening a 2-minute
+  single-use credential — worth checking against ADR 0007.
+- Does raising EC from L to M change the real-world scan rate for our render? The
+  bullbitcoin evidence says it can be decisive, but that was a print/screen
+  scan, not a terminal one.
+
+## Sources
+
+**Specifications**
+
+- ISO/IEC 18004:2024, free preview (clauses 5.1, 5.2, 5.3.1): https://cdn.standards.iteh.ai/samples/83389/dee29007cb62437f9767323e6af02f90/ISO-IEC-18004-2024.pdf
+- ISO/IEC 18004:2015, free preview (TOC, §6.2, §6.3.8): https://cdn.standards.iteh.ai/samples/62021/ff5c1d3362cd40268efeaa692b724138/ISO-IEC-18004-2015.pdf
+- Denso Wave, quiet zone: https://www.qrcode.com/en/howto/code.html and https://www.qrcode.com/en/codes/microqr.html
+- Denso Wave, versions: https://www.qrcode.com/en/about/version.html
+- RFC 9285, The Base45 Data Encoding: https://www.rfc-editor.org/rfc/rfc9285.html
+- RFC 3986 §3.1, §6.2.2.1: https://www.rfc-editor.org/rfc/rfc3986
+- EU DCC hcert spec §4.2.1, §4.2.2: https://github.com/ehn-dcc-development/eu-dcc-hcert-spec/blob/main/hcert_spec.md
+- EMVCo QRCPS-MPM v1.1 §4.12.1.1 (byte mode mandated)
+- Unicode UCD: https://www.unicode.org/Public/UCD/latest/ucd/DerivedAge.txt and `Blocks.txt`
+
+**Terminal renderers**
+
+- libqrencode `qrenc.c`: https://raw.githubusercontent.com/fukuchi/libqrencode/master/qrenc.c
+- mdp/qrterminal: https://github.com/mdp/qrterminal/blob/master/qrterminal.go
+- skip2/go-qrcode: https://github.com/skip2/go-qrcode/blob/master/qrcode.go
+- node-qrcode: https://github.com/soldair/node-qrcode/tree/master/lib/renderer
+- gtanner/qrcode-terminal: https://github.com/gtanner/qrcode-terminal/blob/master/lib/main.js
+- Tailscale `util/qrcodes`: https://github.com/tailscale/tailscale/tree/main/util/qrcodes
+- qrcp: https://github.com/claudiodangelis/qrcp/blob/main/qr/qr.go
+
+**Decoders**
+
+- ZXing `FinderPatternFinder.java`: https://github.com/zxing/zxing/blob/master/core/src/main/java/com/google/zxing/qrcode/detector/FinderPatternFinder.java
+- ZXing `Detector.java`: https://github.com/zxing/zxing/blob/master/core/src/main/java/com/google/zxing/qrcode/detector/Detector.java
+- zxing-cpp `ReaderOptions.h`: https://github.com/zxing-cpp/zxing-cpp/blob/master/core/src/ReaderOptions.h
+- zbar `zbar.h`, PR #33: https://github.com/mchehab/zbar
+- ZXing issues #1378, #1844; PR #1371
+
+**Payload formats**
+
+- whatsmeow `pair.go`, `client_test.go`: https://github.com/tulir/whatsmeow
+- Signal-Desktop `ts/util/signalRoutes.std.ts`; signal-cli `DeviceLinkUrl.java`
+- libsignal `rust/core/src/curve.rs`, `rust/net/src/proto/chat_provisioning.proto`
+- BIP-173: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+- SMART Health Cards `docs/index.md`: https://github.com/smart-on-fhir/health-cards
+- Netnod/base45 issue #4; minvws/base45-go issue #1
+- nayuki/QR-Code-generator (capacity tables): https://github.com/nayuki/QR-Code-generator
+
+**Field reports**
+
+- mdp/qrterminal#5 (quiet zone, Russ Cox), PR #8
+- gtanner/qrcode-terminal PR #8 (forced background), issues #21, #23, #32, #44
+- soldair/node-qrcode issues #33, #127, #185
+- tailscale/tailscale issue #12935, PRs #17084, #18182
+- sparrowwallet/sparrow#1358; SatoshiPortal/bullbitcoin-mobile#2049
+- Apple Developer Forums threads 112660, 5376
+
+**Could not be accessed**
+
+- ISO/IEC 18004 §5.3.8 / §6.3.8 (quiet zone width) and the decoder conformance
+  clauses — behind the ISO paywall; the free preview stops short of both.
+- Commission Implementing Decision (EU) 2021/1073 Annex I — EUR-Lex returns a
+  bot challenge to non-browser clients.
+- Discord's remote-auth protocol — no first-party documentation exists.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,4 +1,4 @@
-# Heeler Pairing plugin
+# heeler
 
 A [herdr plugin](https://herdr.dev/docs/plugins/) that renders a **Pairing Code**
 QR so the Heeler app can add this machine as a Host by scanning it

--- a/plugin/herdr-plugin.toml
+++ b/plugin/herdr-plugin.toml
@@ -19,6 +19,8 @@ command = ["node", "src/pair-action.js"]
 id = "pair"
 title = "Pair device"
 placement = "popup"
+width = "80%"
+height = "90%"
 command = ["node", "src/pair-popup.js"]
 
 [[events]]

--- a/plugin/herdr-plugin.toml
+++ b/plugin/herdr-plugin.toml
@@ -1,5 +1,5 @@
 id = "heeler.pairing"
-name = "Heeler Pairing"
+name = "heeler"
 version = "0.3.0"
 min_herdr_version = "0.7.5"
 description = "Pair a Heeler device by scanning a QR Pairing Code"

--- a/plugin/src/envelope.js
+++ b/plugin/src/envelope.js
@@ -1,4 +1,4 @@
-// Pairing Code v1 envelope (ADR 0007).
+// Pairing Code envelopes (ADRs 0007 and 0014).
 //
 // Wire format: "HERDR-PAIR:<version>:<base64url(JSON, no padding)>".
 // The JSON payload uses short wire keys; see README.md for the schema and
@@ -6,13 +6,26 @@
 // Unknown payload fields are ignored (additive metadata); breaking changes
 // bump the version, which both implementations must honor.
 
+import { isIP } from "node:net";
+import { TextDecoder } from "node:util";
+
 export const PAIRING_CODE_PREFIX = "HERDR-PAIR";
 export const PAIRING_CODE_VERSION = 1;
+export const PAIRING_CODE_V2_VERSION = 2;
 
 const BOOTSTRAP_SEED_BYTES = 32;
+const FINGERPRINT_BYTES = 32;
+const IPV6_BYTES = 16;
+const V2_MAGIC = Buffer.from("HP", "ascii");
+const V2_BOOTSTRAP_FLAG = 0x01;
+const V2_KNOWN_FLAGS = V2_BOOTSTRAP_FLAG;
+const ADDRESS_TYPE_HOSTNAME = 0x00;
+const ADDRESS_TYPE_IPV4 = 0x04;
+const ADDRESS_TYPE_IPV6 = 0x06;
 // OpenSSH fingerprint: "SHA256:" + unpadded standard base64 of a 32-byte digest.
 const FINGERPRINT_PATTERN = /^SHA256:[A-Za-z0-9+/]{43}$/;
 const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 
 export class PairingCodeError extends Error {
   /**
@@ -94,6 +107,133 @@ export function encodePairingCode(payload) {
   return `${PAIRING_CODE_PREFIX}:${PAIRING_CODE_VERSION}:${body}`;
 }
 
+function encodeUtf8(text, what) {
+  const bytes = Buffer.from(text, "utf8");
+  try {
+    if (UTF8_DECODER.decode(bytes) !== text) {
+      fail("bad_payload", `${what} is not valid Unicode`);
+    }
+  } catch {
+    fail("bad_payload", `${what} is not valid Unicode`);
+  }
+  return bytes;
+}
+
+function ipv6ToBytes(address) {
+  let expanded = address;
+  const lastColon = expanded.lastIndexOf(":");
+  const tail = expanded.slice(lastColon + 1);
+  if (tail.includes(".")) {
+    const octets = tail.split(".").map(Number);
+    const high = (octets[0] << 8) | octets[1];
+    const low = (octets[2] << 8) | octets[3];
+    expanded = `${expanded.slice(0, lastColon + 1)}${high.toString(16)}:${low.toString(16)}`;
+  }
+
+  const halves = expanded.split("::");
+  const left = halves[0] === "" ? [] : halves[0].split(":");
+  const right = halves.length === 1 || halves[1] === "" ? [] : halves[1].split(":");
+  const missing = halves.length === 2 ? 8 - left.length - right.length : 0;
+  const groups = [...left, ...Array(missing).fill("0"), ...right].map((group) =>
+    Number.parseInt(group, 16),
+  );
+  const bytes = Buffer.alloc(IPV6_BYTES);
+  groups.forEach((group, index) => bytes.writeUInt16BE(group, index * 2));
+  return bytes;
+}
+
+function bytesToIPv6(bytes) {
+  const groups = Array.from({ length: 8 }, (_, index) => bytes.readUInt16BE(index * 2));
+  let bestStart = -1;
+  let bestLength = 0;
+  for (let index = 0; index < groups.length; ) {
+    if (groups[index] !== 0) {
+      index += 1;
+      continue;
+    }
+    let end = index;
+    while (end < groups.length && groups[end] === 0) {
+      end += 1;
+    }
+    if (end - index > bestLength) {
+      bestStart = index;
+      bestLength = end - index;
+    }
+    index = end;
+  }
+
+  // Canonical v2 text is lowercase hexadecimal without leading zeroes. The
+  // longest run of at least two zero groups is compressed; ties use the first.
+  if (bestLength >= 2) {
+    const before = groups.slice(0, bestStart).map((group) => group.toString(16)).join(":");
+    const after = groups
+      .slice(bestStart + bestLength)
+      .map((group) => group.toString(16))
+      .join(":");
+    return `${before}::${after}`;
+  }
+  return groups.map((group) => group.toString(16)).join(":");
+}
+
+function encodeAddress(address) {
+  const type = isIP(address);
+  if (type === ADDRESS_TYPE_IPV4) {
+    return Buffer.from([ADDRESS_TYPE_IPV4, ...address.split(".").map(Number)]);
+  }
+  if (type === ADDRESS_TYPE_IPV6 && !address.includes("%")) {
+    return Buffer.concat([Buffer.from([ADDRESS_TYPE_IPV6]), ipv6ToBytes(address)]);
+  }
+
+  const hostname = encodeUtf8(address, "hostname");
+  if (hostname.length > 0xff) {
+    fail("bad_payload", "hostname UTF-8 encoding must be at most 255 bytes");
+  }
+  return Buffer.concat([Buffer.from([ADDRESS_TYPE_HOSTNAME, hostname.length]), hostname]);
+}
+
+/**
+ * Encode a Pairing Code payload into the compact binary v2 envelope.
+ *
+ * @returns {Buffer} bytes intended for a QR byte-mode segment
+ */
+export function encodePairingCodeV2(payload) {
+  validatePayload(payload);
+  if (payload.addresses.length > 0xff) {
+    fail("bad_payload", "addresses must contain at most 255 entries");
+  }
+
+  const username = encodeUtf8(payload.username, "username");
+  if (username.length > 0xff) {
+    fail("bad_payload", "username UTF-8 encoding must be at most 255 bytes");
+  }
+  if (payload.expiresAt !== undefined && payload.expiresAt > 0xffffffff) {
+    fail("bad_payload", "expiresAt must fit in an unsigned 32-bit integer");
+  }
+
+  const flags = payload.bootstrapSeed === undefined ? 0 : V2_BOOTSTRAP_FLAG;
+  const header = Buffer.alloc(7);
+  V2_MAGIC.copy(header, 0);
+  header[2] = PAIRING_CODE_V2_VERSION;
+  header[3] = flags;
+  header.writeUInt16BE(payload.port, 4);
+  header[6] = username.length;
+
+  const fingerprintText = payload.hostKeyFingerprint.slice("SHA256:".length);
+  const fingerprint = Buffer.from(fingerprintText, "base64");
+  if (fingerprint.toString("base64").replace(/=+$/, "") !== fingerprintText) {
+    fail("bad_payload", "hostKeyFingerprint must use canonical unpadded base64");
+  }
+  const chunks = [header, username, fingerprint];
+  if (payload.bootstrapSeed !== undefined) {
+    const expiresAt = Buffer.alloc(4);
+    expiresAt.writeUInt32BE(payload.expiresAt);
+    chunks.push(Buffer.from(payload.bootstrapSeed), expiresAt);
+  }
+  chunks.push(Buffer.from([payload.addresses.length]));
+  chunks.push(...payload.addresses.map(encodeAddress));
+  return Buffer.concat(chunks);
+}
+
 function decodeBase64UrlStrict(text, what, errorCode) {
   if (!BASE64URL_PATTERN.test(text) || text.length % 4 === 1) {
     fail(errorCode, `${what} is not unpadded base64url`);
@@ -148,6 +288,111 @@ export function decodePairingCode(code) {
   }
   if (wire.exp !== undefined) {
     payload.expiresAt = wire.exp;
+  }
+  validatePayload(payload);
+  return payload;
+}
+
+function decodeUtf8(bytes, what) {
+  try {
+    return UTF8_DECODER.decode(bytes);
+  } catch {
+    fail("bad_encoding", `${what} is not valid UTF-8`);
+  }
+}
+
+/**
+ * Decode and validate a compact binary Pairing Code v2 envelope.
+ *
+ * @param {Buffer|Uint8Array} bytes
+ * @returns {{addresses: string[], port: number, username: string,
+ *            hostKeyFingerprint: string, bootstrapSeed?: Buffer, expiresAt?: number}}
+ * @throws {PairingCodeError} with a step-taxonomy code:
+ *   bad_prefix | unsupported_version | bad_encoding | bad_payload
+ */
+export function decodePairingCodeV2(bytes) {
+  if (!(bytes instanceof Uint8Array)) {
+    fail("bad_encoding", "Pairing Code v2 must be a byte array");
+  }
+  const envelope = Buffer.from(bytes);
+  let offset = 0;
+
+  function take(length, what) {
+    if (offset + length > envelope.length) {
+      fail("bad_encoding", `truncated Pairing Code v2 ${what}`);
+    }
+    const value = envelope.subarray(offset, offset + length);
+    offset += length;
+    return value;
+  }
+
+  function readUInt8(what) {
+    return take(1, what)[0];
+  }
+
+  if (envelope.length < V2_MAGIC.length) {
+    fail("bad_encoding", "truncated Pairing Code v2 magic");
+  }
+  if (!take(V2_MAGIC.length, "magic").equals(V2_MAGIC)) {
+    fail("bad_prefix", "expected Pairing Code v2 magic HP");
+  }
+  const version = readUInt8("version");
+  if (version !== PAIRING_CODE_V2_VERSION) {
+    fail("unsupported_version", `unsupported Pairing Code version "${version}"`);
+  }
+  const flags = readUInt8("flags");
+  if ((flags & ~V2_KNOWN_FLAGS) !== 0) {
+    fail("bad_encoding", "Pairing Code v2 has reserved flags set");
+  }
+
+  const port = take(2, "port").readUInt16BE(0);
+  if (port === 0) {
+    fail("bad_payload", "port must be in 1..65535");
+  }
+  const usernameLength = readUInt8("username length");
+  if (usernameLength === 0) {
+    fail("bad_payload", "username must not be empty");
+  }
+  const username = decodeUtf8(take(usernameLength, "username"), "username");
+  const fingerprint = take(FINGERPRINT_BYTES, "host key fingerprint");
+  const hostKeyFingerprint = `SHA256:${fingerprint.toString("base64").replace(/=+$/, "")}`;
+
+  let bootstrapSeed;
+  let expiresAt;
+  if ((flags & V2_BOOTSTRAP_FLAG) !== 0) {
+    bootstrapSeed = Buffer.from(take(BOOTSTRAP_SEED_BYTES, "bootstrap seed"));
+    expiresAt = take(4, "expiry").readUInt32BE(0);
+  }
+
+  const addressCount = readUInt8("address count");
+  if (addressCount === 0) {
+    fail("bad_payload", "addresses must not be empty");
+  }
+  const addresses = [];
+  for (let index = 0; index < addressCount; index += 1) {
+    const type = readUInt8(`address ${index + 1} type`);
+    if (type === ADDRESS_TYPE_IPV4) {
+      addresses.push([...take(4, `address ${index + 1}`)].join("."));
+    } else if (type === ADDRESS_TYPE_IPV6) {
+      addresses.push(bytesToIPv6(take(IPV6_BYTES, `address ${index + 1}`)));
+    } else if (type === ADDRESS_TYPE_HOSTNAME) {
+      const length = readUInt8(`address ${index + 1} hostname length`);
+      if (length === 0) {
+        fail("bad_payload", "hostname must not be empty");
+      }
+      addresses.push(decodeUtf8(take(length, `address ${index + 1} hostname`), "hostname"));
+    } else {
+      fail("bad_encoding", `unknown Pairing Code v2 address type ${type}`);
+    }
+  }
+  if (offset !== envelope.length) {
+    fail("bad_encoding", "Pairing Code v2 has trailing bytes");
+  }
+
+  const payload = { addresses, port, username, hostKeyFingerprint };
+  if (bootstrapSeed !== undefined) {
+    payload.bootstrapSeed = bootstrapSeed;
+    payload.expiresAt = expiresAt;
   }
   validatePayload(payload);
   return payload;

--- a/plugin/src/pair-popup.js
+++ b/plugin/src/pair-popup.js
@@ -8,8 +8,6 @@
 
 import os from "node:os";
 import { emitKeypressEvents } from "node:readline";
-import QRCode from "qrcode";
-
 import { candidateAddresses } from "./addresses.js";
 import { readHostKeyFingerprint } from "./host-key.js";
 import { encodePairingCode } from "./envelope.js";
@@ -29,6 +27,7 @@ import {
   toggleAll,
   selectedAddresses,
 } from "./select-list.js";
+import { renderTerminalQr } from "./terminal-qr.js";
 
 const DEFAULT_SSH_PORT = 22;
 // How often the QR screen checks whether Enrollment has completed. The pending
@@ -74,7 +73,7 @@ function renderChecklist(state, warning) {
 
 async function renderPairingCode(payload) {
   const code = encodePairingCode(payload);
-  const qr = await QRCode.toString(code, { type: "terminal", small: true });
+  const qr = renderTerminalQr(code);
   const expires = new Date(payload.expiresAt * 1000).toLocaleTimeString();
   const lines = [
     `${BOLD}Scan with Heeler${RESET}`,

--- a/plugin/src/pair-popup.js
+++ b/plugin/src/pair-popup.js
@@ -10,7 +10,7 @@ import os from "node:os";
 import { emitKeypressEvents } from "node:readline";
 import { candidateAddresses } from "./addresses.js";
 import { readHostKeyFingerprint } from "./host-key.js";
-import { encodePairingCode } from "./envelope.js";
+import { encodePairingCodeV2 } from "./envelope.js";
 import { commentOf, removeKeyLine, sweepExpiredBootstrapLines } from "./authorized-keys.js";
 import {
   beginPairing,
@@ -72,7 +72,7 @@ function renderChecklist(state, warning) {
 }
 
 async function renderPairingCode(payload) {
-  const code = encodePairingCode(payload);
+  const code = encodePairingCodeV2(payload);
   const qr = renderTerminalQr(code);
   const expires = new Date(payload.expiresAt * 1000).toLocaleTimeString();
   const lines = [

--- a/plugin/src/terminal-qr.js
+++ b/plugin/src/terminal-qr.js
@@ -1,0 +1,103 @@
+// Square terminal QR via octants (2x4 modules per cell, Unicode 16).
+// A cell is about twice as tall as it is wide, so two modules per column and
+// four per row keep the module square -- the same aspect as half-blocks at a
+// quarter of the area, which is what lets a version-11 Pairing Code fit a
+// popup. Unlike braille (same geometry), octant blocks fill the cell, so dark
+// regions are solid ink and finder patterns stay camera-readable. Requires a
+// terminal that renders Symbols for Legacy Computing Supplement (Ghostty,
+// Kitty, and other terminals with built-in block glyph synthesis do).
+
+import QRCode from "qrcode";
+
+const RESET = "\u001b[0m";
+const WHITE_BG_BLACK_FG = "\u001b[47m\u001b[30m";
+
+const CELL_WIDTH = 2;
+const CELL_HEIGHT = 4;
+const QUIET_ZONE_MODULES = 2;
+
+// The octant block U+1CD00..U+1CDE5 encodes every 2x4 pattern in increasing
+// bit order (bit n = octant position n+1, positions row-major top-left to
+// bottom-right), skipping the 26 patterns that reuse older characters:
+// space, full/half/quarter blocks, quadrants, and the Unicode 16 single-cell
+// and middle-column fills. Verified against UnicodeData.txt 16.0.
+const OCTANT_EXCEPTIONS = new Map([
+  [0x00, 0x20], [0x01, 0x1cea8], [0x02, 0x1ceab], [0x03, 0x1fb82],
+  [0x05, 0x2598], [0x0a, 0x259d], [0x0f, 0x2580], [0x14, 0x1fbe6],
+  [0x28, 0x1fbe7], [0x3f, 0x1fb85], [0x40, 0x1cea3], [0x50, 0x2596],
+  [0x55, 0x258c], [0x5a, 0x259e], [0x5f, 0x259b], [0x80, 0x1cea0],
+  [0xa0, 0x2597], [0xa5, 0x259a], [0xaa, 0x2590], [0xaf, 0x259c],
+  [0xc0, 0x2582], [0xf0, 0x2584], [0xf5, 0x2599], [0xfa, 0x259f],
+  [0xfc, 0x2586], [0xff, 0x2588],
+]);
+
+export const OCTANT_TABLE = (() => {
+  const table = [];
+  let next = 0x1cd00;
+  for (let bits = 0; bits < 256; bits++) {
+    const codePoint = OCTANT_EXCEPTIONS.get(bits) ?? next++;
+    table.push(String.fromCodePoint(codePoint));
+  }
+  return table;
+})();
+
+function isDark(modules, x, y) {
+  if (x < 0 || y < 0 || x >= modules.size || y >= modules.size) {
+    return false;
+  }
+  return Boolean(modules.get(y, x));
+}
+
+function packCell(modules, originX, originY) {
+  let bits = 0;
+  for (let row = 0; row < CELL_HEIGHT; row++) {
+    for (let column = 0; column < CELL_WIDTH; column++) {
+      if (isDark(modules, originX + column, originY + row)) {
+        bits |= 1 << (row * CELL_WIDTH + column);
+      }
+    }
+  }
+  return OCTANT_TABLE[bits];
+}
+
+/**
+ * Render `text` as a compact inverted terminal QR (black modules on white).
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function renderTerminalQr(text) {
+  const qr = QRCode.create(text, { errorCorrectionLevel: "L" });
+  const { modules } = qr;
+  const total = modules.size + QUIET_ZONE_MODULES * 2;
+  const columns = Math.ceil(total / CELL_WIDTH);
+  const rows = Math.ceil(total / CELL_HEIGHT);
+  const lines = [];
+
+  for (let row = 0; row < rows; row++) {
+    let line = WHITE_BG_BLACK_FG;
+    for (let col = 0; col < columns; col++) {
+      const x = col * CELL_WIDTH - QUIET_ZONE_MODULES;
+      const y = row * CELL_HEIGHT - QUIET_ZONE_MODULES;
+      line += packCell(modules, x, y);
+    }
+    line += RESET;
+    lines.push(line);
+  }
+
+  return lines.join("\n");
+}
+
+export function measureTerminalQr(text) {
+  const rendered = renderTerminalQr(text);
+  const stripped = rendered.replace(/\u001b\[[0-9;]*m/g, "");
+  const rows = stripped.split("\n");
+  return {
+    rendered,
+    rows: rows.length,
+    columns: rows.reduce(
+      (max, line) => Math.max(max, [...line].length),
+      0,
+    ),
+  };
+}

--- a/plugin/src/terminal-qr.js
+++ b/plugin/src/terminal-qr.js
@@ -1,11 +1,14 @@
-// Square terminal QR via octants (2x4 modules per cell, Unicode 16).
-// A cell is about twice as tall as it is wide, so two modules per column and
-// four per row keep the module square -- the same aspect as half-blocks at a
-// quarter of the area, which is what lets a version-11 Pairing Code fit a
-// popup. Unlike braille (same geometry), octant blocks fill the cell, so dark
-// regions are solid ink and finder patterns stay camera-readable. Requires a
-// terminal that renders Symbols for Legacy Computing Supplement (Ghostty,
-// Kitty, and other terminals with built-in block glyph synthesis do).
+// Compact terminal QR via sextants (2x3 modules per cell, Unicode 13).
+// Sextants render on Ghostty/kitty/WezTerm/foot plus iTerm2, VS Code, and
+// Alacritty; octants (Unicode 16) miss those last three. The trade-off is a
+// ~1.33-1.47 vertical stretch (2H/3W at typical 1:2-1:2.2 cells): inside
+// Apple's detector tolerance, at the edge of ZXing's ±40% finder-pattern
+// budget. See docs/research/terminal-qr-rendering.md (§Glyph availability,
+// §Aspect ratio). Unlike braille (same 2x3 geometry), sextant blocks fill
+// the cell, so dark regions are solid ink and finder patterns stay
+// camera-readable. Keep the white-background wrapper: unwrapped block
+// glyphs inherit the terminal theme and become a photographic negative
+// on light-on-dark (research note §Polarity).
 
 import QRCode from "qrcode";
 
@@ -13,33 +16,27 @@ const RESET = "\u001b[0m";
 const WHITE_BG_BLACK_FG = "\u001b[47m\u001b[30m";
 
 const CELL_WIDTH = 2;
-const CELL_HEIGHT = 4;
-const QUIET_ZONE_MODULES = 2;
+const CELL_HEIGHT = 3;
+const QUIET_ZONE_MODULES = 4;
+const ERROR_CORRECTION_LEVEL = "M";
 
-// The octant block U+1CD00..U+1CDE5 encodes every 2x4 pattern in increasing
-// bit order (bit n = octant position n+1, positions row-major top-left to
-// bottom-right), skipping the 26 patterns that reuse older characters:
-// space, full/half/quarter blocks, quadrants, and the Unicode 16 single-cell
-// and middle-column fills. Verified against UnicodeData.txt 16.0.
-const OCTANT_EXCEPTIONS = new Map([
-  [0x00, 0x20], [0x01, 0x1cea8], [0x02, 0x1ceab], [0x03, 0x1fb82],
-  [0x05, 0x2598], [0x0a, 0x259d], [0x0f, 0x2580], [0x14, 0x1fbe6],
-  [0x28, 0x1fbe7], [0x3f, 0x1fb85], [0x40, 0x1cea3], [0x50, 0x2596],
-  [0x55, 0x258c], [0x5a, 0x259e], [0x5f, 0x259b], [0x80, 0x1cea0],
-  [0xa0, 0x2597], [0xa5, 0x259a], [0xaa, 0x2590], [0xaf, 0x259c],
-  [0xc0, 0x2582], [0xf0, 0x2584], [0xf5, 0x2599], [0xfa, 0x259f],
-  [0xfc, 0x2586], [0xff, 0x2588],
-]);
+// The sextant block U+1FB00..U+1FB3B encodes 60 of the 64 2x3 patterns.
+// Bit n (0..5) is the dot at column n%2, row n/2 (row-major, top-left).
+// Four patterns reuse older block characters. Verified against
+// UnicodeData.txt 16.0.
+function sextantChar(value) {
+  if (value === 0) return " ";
+  if (value === 21) return "\u258C";
+  if (value === 42) return "\u2590";
+  if (value === 63) return "\u2588";
+  return String.fromCodePoint(
+    0x1fb00 + (value - 1 - (value > 21 ? 1 : 0) - (value > 42 ? 1 : 0)),
+  );
+}
 
-export const OCTANT_TABLE = (() => {
-  const table = [];
-  let next = 0x1cd00;
-  for (let bits = 0; bits < 256; bits++) {
-    const codePoint = OCTANT_EXCEPTIONS.get(bits) ?? next++;
-    table.push(String.fromCodePoint(codePoint));
-  }
-  return table;
-})();
+export const SEXTANT_TABLE = Array.from({ length: 64 }, (_, value) =>
+  sextantChar(value),
+);
 
 function isDark(modules, x, y) {
   if (x < 0 || y < 0 || x >= modules.size || y >= modules.size) {
@@ -57,17 +54,25 @@ function packCell(modules, originX, originY) {
       }
     }
   }
-  return OCTANT_TABLE[bits];
+  return SEXTANT_TABLE[bits];
+}
+
+function createQr(payload) {
+  const options = { errorCorrectionLevel: ERROR_CORRECTION_LEVEL };
+  if (payload instanceof Uint8Array) {
+    return QRCode.create([{ data: payload, mode: "byte" }], options);
+  }
+  return QRCode.create(payload, options);
 }
 
 /**
- * Render `text` as a compact inverted terminal QR (black modules on white).
+ * Render `payload` as a compact inverted terminal QR (black modules on white).
  *
- * @param {string} text
+ * @param {string | Uint8Array} payload
  * @returns {string}
  */
-export function renderTerminalQr(text) {
-  const qr = QRCode.create(text, { errorCorrectionLevel: "L" });
+export function renderTerminalQr(payload) {
+  const qr = createQr(payload);
   const { modules } = qr;
   const total = modules.size + QUIET_ZONE_MODULES * 2;
   const columns = Math.ceil(total / CELL_WIDTH);
@@ -88,8 +93,8 @@ export function renderTerminalQr(text) {
   return lines.join("\n");
 }
 
-export function measureTerminalQr(text) {
-  const rendered = renderTerminalQr(text);
+export function measureTerminalQr(payload) {
+  const rendered = renderTerminalQr(payload);
   const stripped = rendered.replace(/\u001b\[[0-9;]*m/g, "");
   const rows = stripped.split("\n");
   return {

--- a/plugin/test-vectors/pairing-code-v2.json
+++ b/plugin/test-vectors/pairing-code-v2.json
@@ -1,0 +1,104 @@
+{
+  "description": "Shared Pairing Code v2 test vectors. Single source of truth for the compact binary envelope, consumed by both the Node plugin tests and the Swift app tests (ADR 0014). envelopeHex is the exact QR byte-mode payload. IPv6 payload strings use lowercase hexadecimal without leading zeroes and compress the longest, first-on-tie run of at least two zero groups.",
+  "valid": [
+    {
+      "name": "minimal config-only single IPv4",
+      "envelopeHex": "48500200001603616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d80104c0a8012a",
+      "payload": {
+        "addresses": ["192.168.1.42"],
+        "port": 22,
+        "username": "ada",
+        "hostKeyFingerprint": "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg"
+      }
+    },
+    {
+      "name": "full IPv4 IPv6 hostname and bootstrap credential",
+      "envelopeHex": "4850020108ae056772616365ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d8000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f6881520003040a00000706fd7a115ca1e000000000000000000001000e6865656c65722e6578616d706c65",
+      "payload": {
+        "addresses": ["10.0.0.7", "fd7a:115c:a1e0::1", "heeler.example"],
+        "port": 2222,
+        "username": "grace",
+        "hostKeyFingerprint": "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg",
+        "bootstrapSeed": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+        "expiresAt": 1753305600
+      }
+    },
+    {
+      "name": "multibyte UTF-8 username and hostname",
+      "envelopeHex": "48500200ffff06e794a8e688b7ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d801000ee4b8bbe69cba2e6578616d706c65",
+      "payload": {
+        "addresses": ["主机.example"],
+        "port": 65535,
+        "username": "用户",
+        "hostKeyFingerprint": "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg"
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "name": "wrong magic",
+      "envelopeHex": "00500200001603616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d80104c0a8012a",
+      "error": "bad_prefix"
+    },
+    {
+      "name": "unsupported version",
+      "envelopeHex": "48500300001603616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d80104c0a8012a",
+      "error": "unsupported_version"
+    },
+    {
+      "name": "reserved flag bit set",
+      "envelopeHex": "48500280001603616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d80104c0a8012a",
+      "error": "bad_encoding"
+    },
+    {
+      "name": "truncated IPv4 address",
+      "envelopeHex": "48500200001603616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d80104c0a801",
+      "error": "bad_encoding"
+    },
+    {
+      "name": "trailing byte",
+      "envelopeHex": "48500200001603616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d80104c0a8012a00",
+      "error": "bad_encoding"
+    },
+    {
+      "name": "port zero",
+      "envelopeHex": "48500200000003616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d80104c0a8012a",
+      "error": "bad_payload"
+    },
+    {
+      "name": "username length zero",
+      "envelopeHex": "48500200001600616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d80104c0a8012a",
+      "error": "bad_payload"
+    },
+    {
+      "name": "address count zero",
+      "envelopeHex": "48500200001603616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d80004c0a8012a",
+      "error": "bad_payload"
+    },
+    {
+      "name": "malformed username UTF-8",
+      "envelopeHex": "48500200001603c0af61ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d80104c0a8012a",
+      "error": "bad_encoding"
+    },
+    {
+      "name": "unknown address type",
+      "envelopeHex": "48500200001603616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d801ffc0a8012a",
+      "error": "bad_encoding"
+    },
+    {
+      "name": "hostname length zero",
+      "envelopeHex": "48500200001603616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d8010000",
+      "error": "bad_payload"
+    },
+    {
+      "name": "malformed hostname UTF-8",
+      "envelopeHex": "48500200001603616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d8010002c0af",
+      "error": "bad_encoding"
+    },
+    {
+      "name": "bootstrap expiry zero",
+      "envelopeHex": "4850020108ae056772616365ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d8000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f0000000003040a00000706fd7a115ca1e000000000000000000001000e6865656c65722e6578616d706c65",
+      "error": "bad_payload"
+    }
+  ]
+}

--- a/plugin/test-vectors/pairing-code-v2.json
+++ b/plugin/test-vectors/pairing-code-v2.json
@@ -32,6 +32,26 @@
         "username": "用户",
         "hostKeyFingerprint": "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg"
       }
+    },
+    {
+      "name": "IPv6 equal zero runs compress the first run",
+      "envelopeHex": "48500200001603616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d8010600010000000000020000000000030004",
+      "payload": {
+        "addresses": ["1::2:0:0:3:4"],
+        "port": 22,
+        "username": "ada",
+        "hostKeyFingerprint": "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg"
+      }
+    },
+    {
+      "name": "IPv6 edge compression preserves an isolated zero group",
+      "envelopeHex": "48500200001603616461ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d803060000000000000000000000000000000106200100000000000000000000000000000620010db8000000010001000100010001",
+      "payload": {
+        "addresses": ["::1", "2001::", "2001:db8:0:1:1:1:1:1"],
+        "port": 22,
+        "username": "ada",
+        "hostKeyFingerprint": "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg"
+      }
     }
   ],
   "invalid": [

--- a/plugin/test/envelope-v2.test.js
+++ b/plugin/test/envelope-v2.test.js
@@ -36,7 +36,7 @@ function fromVectorShape(payload) {
 
 suite("Pairing Code v2 shared vectors", () => {
   test("vector file covers the contract", () => {
-    assert.equal(vectors.valid.length, 3);
+    assert.equal(vectors.valid.length, 5);
     assert.ok(vectors.invalid.length >= 13);
   });
 

--- a/plugin/test/envelope-v2.test.js
+++ b/plugin/test/envelope-v2.test.js
@@ -1,0 +1,124 @@
+import { test, suite } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  decodePairingCodeV2,
+  encodePairingCodeV2,
+  PairingCodeError,
+} from "../src/envelope.js";
+
+const vectors = JSON.parse(
+  readFileSync(new URL("../test-vectors/pairing-code-v2.json", import.meta.url), "utf8"),
+);
+
+function toVectorShape(payload) {
+  const shape = {
+    addresses: payload.addresses,
+    port: payload.port,
+    username: payload.username,
+    hostKeyFingerprint: payload.hostKeyFingerprint,
+  };
+  if (payload.bootstrapSeed !== undefined) {
+    shape.bootstrapSeed = payload.bootstrapSeed.toString("base64url");
+    shape.expiresAt = payload.expiresAt;
+  }
+  return shape;
+}
+
+function fromVectorShape(payload) {
+  const input = { ...payload };
+  if (input.bootstrapSeed !== undefined) {
+    input.bootstrapSeed = Buffer.from(input.bootstrapSeed, "base64url");
+  }
+  return input;
+}
+
+suite("Pairing Code v2 shared vectors", () => {
+  test("vector file covers the contract", () => {
+    assert.equal(vectors.valid.length, 3);
+    assert.ok(vectors.invalid.length >= 13);
+  });
+
+  for (const vector of vectors.valid) {
+    test(`decodes: ${vector.name}`, () => {
+      const decoded = decodePairingCodeV2(Buffer.from(vector.envelopeHex, "hex"));
+      assert.deepEqual(toVectorShape(decoded), vector.payload);
+    });
+
+    test(`encodes canonically: ${vector.name}`, () => {
+      const encoded = encodePairingCodeV2(fromVectorShape(vector.payload));
+      assert.equal(encoded.toString("hex"), vector.envelopeHex);
+    });
+
+    test(`round-trips: ${vector.name}`, () => {
+      const input = fromVectorShape(vector.payload);
+      assert.deepEqual(toVectorShape(decodePairingCodeV2(encodePairingCodeV2(input))), vector.payload);
+    });
+  }
+
+  for (const vector of vectors.invalid) {
+    test(`rejects (${vector.error}): ${vector.name}`, () => {
+      assert.throws(
+        () => decodePairingCodeV2(Buffer.from(vector.envelopeHex, "hex")),
+        (error) => error instanceof PairingCodeError && error.code === vector.error,
+      );
+    });
+  }
+});
+
+suite("encodePairingCodeV2", () => {
+  const base = {
+    addresses: ["192.168.1.42"],
+    port: 22,
+    username: "ada",
+    hostKeyFingerprint: "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg",
+  };
+
+  test("uses the specified offsets for a hand-computed minimal envelope", () => {
+    const bytes = encodePairingCodeV2(base);
+    assert.equal(bytes.length, 48);
+    assert.equal(bytes.subarray(0, 2).toString("ascii"), "HP");
+    assert.equal(bytes[2], 2);
+    assert.equal(bytes[3], 0);
+    assert.equal(bytes.readUInt16BE(4), 22);
+    assert.equal(bytes[6], 3);
+    assert.equal(bytes.subarray(7, 10).toString("utf8"), "ada");
+    assert.equal(
+      bytes.subarray(10, 42).toString("hex"),
+      "ebe8e770d7626ec1b672abdfa0b0291ab3bc0af230004333b01f888a53acf2d8",
+    );
+    assert.equal(bytes[42], 1);
+    assert.equal(bytes[43], 4);
+    assert.deepEqual([...bytes.subarray(44, 48)], [192, 168, 1, 42]);
+  });
+
+  test("canonicalizes IPv6 after a binary round-trip", () => {
+    const decoded = decodePairingCodeV2(
+      encodePairingCodeV2({ ...base, addresses: ["2001:0DB8:0:0:0:0:0:1"] }),
+    );
+    assert.deepEqual(decoded.addresses, ["2001:db8::1"]);
+  });
+
+  test("falls back to hostname encoding for non-IP address strings", () => {
+    const bytes = encodePairingCodeV2({ ...base, addresses: ["fe80::1%en0"] });
+    assert.equal(bytes[43], 0);
+    assert.deepEqual(decodePairingCodeV2(bytes).addresses, ["fe80::1%en0"]);
+  });
+
+  test("rejects values that do not fit v2 length fields", () => {
+    const bads = [
+      { ...base, addresses: Array(256).fill("192.0.2.1") },
+      { ...base, username: "ü".repeat(128) },
+      { ...base, addresses: [`${"é".repeat(124)}.example`] },
+      { ...base, bootstrapSeed: Buffer.alloc(32), expiresAt: 0x1_0000_0000 },
+      { ...base, hostKeyFingerprint: `SHA256:${"/".repeat(43)}` },
+    ];
+    for (const bad of bads) {
+      assert.throws(
+        () => encodePairingCodeV2(bad),
+        (error) => error instanceof PairingCodeError && error.code === "bad_payload",
+      );
+    }
+  });
+});

--- a/plugin/test/terminal-qr.test.js
+++ b/plugin/test/terminal-qr.test.js
@@ -6,7 +6,7 @@ import { encodePairingCode } from "../src/envelope.js";
 import {
   measureTerminalQr,
   renderTerminalQr,
-  OCTANT_TABLE,
+  SEXTANT_TABLE,
 } from "../src/terminal-qr.js";
 
 const typicalCode = encodePairingCode({
@@ -18,50 +18,65 @@ const typicalCode = encodePairingCode({
   expiresAt: 1753305600,
 });
 
-const bitsByOctant = new Map(OCTANT_TABLE.map((ch, bits) => [ch, bits]));
+const bitsBySextant = new Map(SEXTANT_TABLE.map((ch, bits) => [ch, bits]));
 
 suite("terminal QR", () => {
   test("a typical Pairing Code stays within a herdr popup", () => {
     const { rows, columns } = measureTerminalQr(typicalCode);
     assert.ok(columns <= 40, `expected <= 40 columns, got ${columns}`);
-    assert.ok(rows <= 20, `expected <= 20 rows, got ${rows}`);
+    assert.ok(rows <= 26, `expected <= 26 rows, got ${rows}`);
   });
 
-  test("packs a 2×4 octant cell so the QR is square in a 1:2 terminal grid", () => {
-    const qr = QRCode.create("HELLO", { errorCorrectionLevel: "L" });
+  test("packs a 2×3 sextant cell (modules + 4-module quiet zone)", () => {
+    const qr = QRCode.create("HELLO", { errorCorrectionLevel: "M" });
     const { rows, columns } = measureTerminalQr("HELLO");
-    const total = qr.modules.size + 4;
+    const total = qr.modules.size + 8;
     assert.equal(columns, Math.ceil(total / 2));
-    assert.equal(rows, Math.ceil(total / 4));
-    assert.ok(
-      Math.abs(columns - 2 * rows) <= 2,
-      `expected columns ≈ 2×rows for a square QR, got ${columns}×${rows}`,
-    );
+    assert.equal(rows, Math.ceil(total / 3));
   });
 
-  test("the octant table matches Unicode 16 (spot checks)", () => {
-    assert.equal(OCTANT_TABLE.length, 256);
-    assert.equal(new Set(OCTANT_TABLE).size, 256);
-    assert.equal(OCTANT_TABLE[0x00], " ");
-    assert.equal(OCTANT_TABLE[0x04], String.fromCodePoint(0x1cd00));
-    assert.equal(OCTANT_TABLE[0x0f], "▀");
-    assert.equal(OCTANT_TABLE[0x55], "▌");
-    assert.equal(OCTANT_TABLE[0xf0], "▄");
-    assert.equal(OCTANT_TABLE[0xfe], String.fromCodePoint(0x1cde5));
-    assert.equal(OCTANT_TABLE[0xff], "█");
+  test("the sextant table matches Unicode 13 (spot checks)", () => {
+    assert.equal(SEXTANT_TABLE.length, 64);
+    assert.equal(new Set(SEXTANT_TABLE).size, 64);
+    assert.equal(SEXTANT_TABLE[0], " ");
+    assert.equal(SEXTANT_TABLE[1], String.fromCodePoint(0x1fb00));
+    assert.equal(SEXTANT_TABLE[21], "▌");
+    assert.equal(SEXTANT_TABLE[42], "▐");
+    assert.equal(SEXTANT_TABLE[63], "█");
+    const blockChars = SEXTANT_TABLE.filter((ch) => {
+      const cp = ch.codePointAt(0);
+      return cp >= 0x1fb00 && cp <= 0x1fb3b;
+    });
+    assert.equal(blockChars.length, 60);
+    assert.equal(new Set(blockChars).size, 60);
   });
 
   test("emits solid inverted blocks a camera can read", () => {
     const rendered = renderTerminalQr("HELLO");
     assert.match(rendered, /\u001b\[47m\u001b\[30m/);
-    assert.match(rendered, /[\u{1CD00}-\u{1CDE5}▀-▟]/u);
+    assert.match(rendered, /[\u{1FB00}-\u{1FB3B}▌▐█]/u);
     assert.doesNotMatch(rendered, /[\u2800-\u28FF]/);
+    assert.doesNotMatch(rendered, /[\u{1CD00}-\u{1CDE5}]/u);
+  });
+
+  test("renders a Uint8Array payload in byte mode", () => {
+    const payload = Uint8Array.from([0x00, 0xff, 0x10, 0x80, 0x7f]);
+    const rendered = renderTerminalQr(payload);
+    assert.match(rendered, /\u001b\[47m\u001b\[30m/);
+    assert.match(rendered, /[\u{1FB00}-\u{1FB3B}▌▐█]/u);
+    const qr = QRCode.create([{ data: payload, mode: "byte" }], {
+      errorCorrectionLevel: "M",
+    });
+    const { rows, columns } = measureTerminalQr(payload);
+    const total = qr.modules.size + 8;
+    assert.equal(columns, Math.ceil(total / 2));
+    assert.equal(rows, Math.ceil(total / 3));
   });
 
   test("round-trips modules so finder patterns stay intact", () => {
-    const qr = QRCode.create(typicalCode, { errorCorrectionLevel: "L" });
+    const qr = QRCode.create(typicalCode, { errorCorrectionLevel: "M" });
     const { modules } = qr;
-    const quiet = 2;
+    const quiet = 4;
     const lines = renderTerminalQr(typicalCode)
       .replace(/\u001b\[[0-9;]*m/g, "")
       .split("\n")
@@ -69,9 +84,9 @@ suite("terminal QR", () => {
     let mismatches = 0;
     for (let y = 0; y < modules.size; y++) {
       for (let x = 0; x < modules.size; x++) {
-        const cell = lines[Math.floor((y + quiet) / 4)][Math.floor((x + quiet) / 2)];
-        const bits = bitsByOctant.get(cell);
-        const bit = 1 << (((y + quiet) % 4) * 2 + ((x + quiet) % 2));
+        const cell = lines[Math.floor((y + quiet) / 3)][Math.floor((x + quiet) / 2)];
+        const bits = bitsBySextant.get(cell);
+        const bit = 1 << (((y + quiet) % 3) * 2 + ((x + quiet) % 2));
         const dark = (bits & bit) !== 0;
         if (dark !== Boolean(modules.get(y, x))) mismatches++;
       }

--- a/plugin/test/terminal-qr.test.js
+++ b/plugin/test/terminal-qr.test.js
@@ -1,0 +1,81 @@
+import { test, suite } from "node:test";
+import assert from "node:assert/strict";
+import QRCode from "qrcode";
+
+import { encodePairingCode } from "../src/envelope.js";
+import {
+  measureTerminalQr,
+  renderTerminalQr,
+  OCTANT_TABLE,
+} from "../src/terminal-qr.js";
+
+const typicalCode = encodePairingCode({
+  addresses: ["192.168.1.42", "100.101.102.103", "fd7a:115c:a1e0::1"],
+  port: 22,
+  username: "zingerbee",
+  hostKeyFingerprint: "SHA256:6+jncNdibsG2cqvfoLApGrO8CvIwAEMzsB+IilOs8tg",
+  bootstrapSeed: Buffer.alloc(32, 7),
+  expiresAt: 1753305600,
+});
+
+const bitsByOctant = new Map(OCTANT_TABLE.map((ch, bits) => [ch, bits]));
+
+suite("terminal QR", () => {
+  test("a typical Pairing Code stays within a herdr popup", () => {
+    const { rows, columns } = measureTerminalQr(typicalCode);
+    assert.ok(columns <= 40, `expected <= 40 columns, got ${columns}`);
+    assert.ok(rows <= 20, `expected <= 20 rows, got ${rows}`);
+  });
+
+  test("packs a 2×4 octant cell so the QR is square in a 1:2 terminal grid", () => {
+    const qr = QRCode.create("HELLO", { errorCorrectionLevel: "L" });
+    const { rows, columns } = measureTerminalQr("HELLO");
+    const total = qr.modules.size + 4;
+    assert.equal(columns, Math.ceil(total / 2));
+    assert.equal(rows, Math.ceil(total / 4));
+    assert.ok(
+      Math.abs(columns - 2 * rows) <= 2,
+      `expected columns ≈ 2×rows for a square QR, got ${columns}×${rows}`,
+    );
+  });
+
+  test("the octant table matches Unicode 16 (spot checks)", () => {
+    assert.equal(OCTANT_TABLE.length, 256);
+    assert.equal(new Set(OCTANT_TABLE).size, 256);
+    assert.equal(OCTANT_TABLE[0x00], " ");
+    assert.equal(OCTANT_TABLE[0x04], String.fromCodePoint(0x1cd00));
+    assert.equal(OCTANT_TABLE[0x0f], "▀");
+    assert.equal(OCTANT_TABLE[0x55], "▌");
+    assert.equal(OCTANT_TABLE[0xf0], "▄");
+    assert.equal(OCTANT_TABLE[0xfe], String.fromCodePoint(0x1cde5));
+    assert.equal(OCTANT_TABLE[0xff], "█");
+  });
+
+  test("emits solid inverted blocks a camera can read", () => {
+    const rendered = renderTerminalQr("HELLO");
+    assert.match(rendered, /\u001b\[47m\u001b\[30m/);
+    assert.match(rendered, /[\u{1CD00}-\u{1CDE5}▀-▟]/u);
+    assert.doesNotMatch(rendered, /[\u2800-\u28FF]/);
+  });
+
+  test("round-trips modules so finder patterns stay intact", () => {
+    const qr = QRCode.create(typicalCode, { errorCorrectionLevel: "L" });
+    const { modules } = qr;
+    const quiet = 2;
+    const lines = renderTerminalQr(typicalCode)
+      .replace(/\u001b\[[0-9;]*m/g, "")
+      .split("\n")
+      .map((line) => [...line]);
+    let mismatches = 0;
+    for (let y = 0; y < modules.size; y++) {
+      for (let x = 0; x < modules.size; x++) {
+        const cell = lines[Math.floor((y + quiet) / 4)][Math.floor((x + quiet) / 2)];
+        const bits = bitsByOctant.get(cell);
+        const bit = 1 << (((y + quiet) % 4) * 2 + ((x + quiet) % 2));
+        const dark = (bits & bit) !== 0;
+        if (dark !== Boolean(modules.get(y, x))) mismatches++;
+      }
+    }
+    assert.equal(mismatches, 0);
+  });
+});

--- a/project.yml
+++ b/project.yml
@@ -134,6 +134,11 @@ targets:
       # tests consume, bundled so the Swift tests cannot drift from it.
       - path: plugin/test-vectors/pairing-code-v1.json
         buildPhase: resources
+      # The v2 vectors are produced by the plugin side; optional so this
+      # project generates before they land, bundled automatically after.
+      - path: plugin/test-vectors/pairing-code-v2.json
+        buildPhase: resources
+        optional: true
       # Shared notification envelope vectors (ADR 0008), same arrangement.
       - path: plugin/test-vectors/notification-payload-v1.json
         buildPhase: resources

--- a/project.yml
+++ b/project.yml
@@ -134,11 +134,6 @@ targets:
       # tests consume, bundled so the Swift tests cannot drift from it.
       - path: plugin/test-vectors/pairing-code-v1.json
         buildPhase: resources
-      # The v2 vectors are produced by the plugin side; optional so this
-      # project generates before they land, bundled automatically after.
-      - path: plugin/test-vectors/pairing-code-v2.json
-        buildPhase: resources
-        optional: true
       # Shared notification envelope vectors (ADR 0008), same arrangement.
       - path: plugin/test-vectors/notification-payload-v1.json
         buildPhase: resources


### PR DESCRIPTION
## Summary

The pairing popup's QR was a version-11 symbol (61 modules) rendered at 65×33 terminal cells — too tall for the popup and clipped in typical windows. This PR shrinks it to **27×18 cells** by attacking both factors:

- **Pairing Code v2** (ADR 0014): a compact binary envelope (~112 bytes vs the 308-char `HERDR-PAIR:1:<base64url JSON>`) carried in a QR byte-mode segment. Raw bytes beat any re-encoding: Base45/alphanumeric was evaluated and rejected with measurements (see `docs/research/terminal-qr-rendering.md`).
- **Sextant rendering** (Unicode 13, 2×3 modules per cell) with a spec-compliant 4-module quiet zone and error correction raised L→M. Renders on iTerm2, VS Code, and Alacritty, which the earlier octant (Unicode 16) approach could not.

Compatibility: the app decodes both v1 and v2, so pairing against an older plugin keeps working. The plugin now emits only v2, so scanning a new plugin's QR requires this app version.

Also included: the plugin display-name rename to `heeler`, the terminal-QR research note, and the interim octant implementation this work supersedes (kept in history).

## Work packages

| Package | Branch (merged here) | Content |
|---|---|---|
| qr-envelope-v2-node | feat/qr-envelope-v2-node | v2 encode/decode in `plugin/src/envelope.js`, popup wiring, `plugin/test-vectors/pairing-code-v2.json` (5 valid / 13 invalid cases incl. IPv6 canonicalization edges), ADR 0014 |
| qr-envelope-v2-swift | feat/qr-envelope-v2-swift | v2 decode + scan-entry dispatch (`PairingCodeV2.swift`), QR codeword-stream extraction (`QRCodeContent.swift`) since Vision returns nil `payloadStringValue` for binary payloads, vector-driven cross-implementation suite |
| qr-render-sextant | feat/qr-render-sextant | Sextant cell packing in `plugin/src/terminal-qr.js`, quiet zone 2→4, EC L→M, `string | Uint8Array` renderer input |

Each package was independently reviewed (diff-graded against its brief) before merging; the wire format was cross-verified by decoding the committed vectors with an independent re-implementation.

## Test evidence

- `plugin`: `npm test` — 191 pass / 0 fail
- `make test` on this branch — **TEST SUCCEEDED**: 991 tests in 104 suites (app), 26 tests in 2 suites (HeelerSSH runner: 9 executed, 17 locally-gated skips as usual)
- The gated suite "Pairing Code v2 shared vectors" executed (not skipped) and passed: Node-encoded vectors decode byte-exact in Swift
- End-to-end: real v2 envelope (112 bytes) renders at 27×18 cells
- Scannability validated on-device earlier in the round: iPhone camera decodes sextant-rendered QRs at both current and compacted sizes (1.47× vertical stretch is within Apple's detector tolerance)

## Remaining risk (needs one on-device pass before release)

VisionKit's `DataScannerViewController` behavior for barcodes whose `payloadStringValue` is nil is unverified: if it suppresses such items, the scan view must switch its capture layer to `AVCaptureMetadataOutput` — the decoder and dispatch are delivery-agnostic and would not change. Verify by scanning a v2 QR with the app itself (not the camera app) on a device.


