### PR TITLE
fix: find Homebrew herdr on Attach (fixes #206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Fixed
+
+- Opening an Agent no longer dies with `exec: herdr: not found` (exit 127) on a
+  Host that installed herdr via Homebrew or linuxbrew. The API socket never
+  needed `herdr` on `PATH`, so the Console could already list Agents; Attach
+  and the other CLI execs now prepend the usual install prefixes
+  (`~/.local/bin`, `/opt/homebrew/bin`, `/home/linuxbrew/.linuxbrew/bin`) and
+  resolve the binary to an absolute path when they can. (#206)
+
 ### Added
 
 - Agent detail now places a plus menu to the left of Send. It can add an image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ Entries reference the issue that motivated them.
 - Opening an Agent no longer dies with `exec: herdr: not found` (exit 127) on a
   Host that installed herdr via Homebrew or linuxbrew. The API socket never
   needed `herdr` on `PATH`, so the Console could already list Agents; Attach
-  and the other CLI execs now prepend the usual install prefixes
-  (`~/.local/bin`, `/opt/homebrew/bin`, `/home/linuxbrew/.linuxbrew/bin`) and
-  resolve the binary to an absolute path when they can. (#206)
+  and the other CLI execs now append the usual install prefixes after the
+  session `PATH` (`~/.local/bin`, `/opt/homebrew/bin`,
+  `/home/linuxbrew/.linuxbrew/bin`) and resolve the binary to an absolute path
+  when they can. (#206)
 
 ### Added
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -147,7 +147,7 @@ against the shorter phrase the Console composes for the same error in
 `.reconnecting` and `.failed`, and they partition the error set: the session
 emits `.failed` only where `isRetryable` is false and `.reconnecting` only
 where it is true. On `.failed` the text names an action the user can take in
-10 of the 12 cases `isRetryable` rejects outright; on `.reconnecting` it does
+11 of the 13 cases `isRetryable` rejects outright; on `.reconnecting` it does
 so in none of the 5 it accepts, restating what happened and appending the
 transport's raw detail in three of them (`jumpHostFailed` prefixes and
 inherits whichever it wraps). So what the guidance adds over the Console's

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		7CF1965195B7578472B615B9 /* Snippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5434768FDE9237B7BD721E /* Snippet.swift */; };
 		7DE1449E409F7F06C64E5089 /* RealSSHFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B3368D352EFC805C2534F9 /* RealSSHFixture.swift */; };
 		7F8EA3E191EEC97479E3DC04 /* HerdrEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A6D0F6E54809BDE46AC1AE /* HerdrEventsTests.swift */; };
+		7A91E3B24F6C80D15E38A2C1 /* HerdrHostPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8E14A07B5D93F1E6A0C4D8 /* HerdrHostPathTests.swift */; };
 		7FD7DF4CAB9F62BC5014F563 /* PairingCeremonyE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 702DF66CBA3DE023470DBA1F /* PairingCeremonyE2ETests.swift */; };
 		8021380654A6B6A28447C108 /* TerminalTouchScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578B695DF80C644E2D62060C /* TerminalTouchScroll.swift */; };
 		804C5B2318FD3F57703BA226 /* AgentStatusPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B853441AF972F5F05ADA67 /* AgentStatusPaletteTests.swift */; };
@@ -312,6 +313,7 @@
 		15A8BCC42989CA4E45A39091 /* JetBrainsMono-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Bold.ttf"; sourceTree = "<group>"; };
 		1674575F15764AB318626947 /* PairingScanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScanView.swift; sourceTree = "<group>"; };
 		16A6D0F6E54809BDE46AC1AE /* HerdrEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrEventsTests.swift; sourceTree = "<group>"; };
+		2C8E14A07B5D93F1E6A0C4D8 /* HerdrHostPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrHostPathTests.swift; sourceTree = "<group>"; };
 		176C059114F4646026196943 /* SkillProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillProbeTests.swift; sourceTree = "<group>"; };
 		19FF62E7BD9DC71E1172A472 /* TerminalTextSelectionPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTextSelectionPresenter.swift; sourceTree = "<group>"; };
 		1A3BD235B5209892137FCAF9 /* PhotosPickerImageSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosPickerImageSelection.swift; sourceTree = "<group>"; };
@@ -587,6 +589,7 @@
 				B1AEA55D1F06B12005DEEE5F /* HeelerSSHSessionE2ETests.swift */,
 				7683DF30B1A0E9FA0064AAA2 /* HeelerSSHTransportBehaviorE2ETests.swift */,
 				16A6D0F6E54809BDE46AC1AE /* HerdrEventsTests.swift */,
+				2C8E14A07B5D93F1E6A0C4D8 /* HerdrHostPathTests.swift */,
 				31F09325DE68693680E5A3BB /* HerdrSocketLocationTests.swift */,
 				A30FA0CFA49274EB428AD3E0 /* HerdrWireTests.swift */,
 				F9D664871CA1A56418C106BC /* HostDraftTests.swift */,
@@ -1345,6 +1348,7 @@
 				C626797B247A8ED6513D2EBB /* HeelerSSHSessionE2ETests.swift in Sources */,
 				DA607F169DB8EF4549F65134 /* HeelerSSHTransportBehaviorE2ETests.swift in Sources */,
 				7F8EA3E191EEC97479E3DC04 /* HerdrEventsTests.swift in Sources */,
+				7A91E3B24F6C80D15E38A2C1 /* HerdrHostPathTests.swift in Sources */,
 				2E82149F859FCBF05F9E999B /* HerdrSocketLocationTests.swift in Sources */,
 				8BC6A5F3341FEE8734ECB0B0 /* HerdrWireTests.swift in Sources */,
 				9583D6804B8922588AD7F154 /* HostDraftTests.swift in Sources */,

--- a/Sources/Heeler/Console/AttachTerminalStore.swift
+++ b/Sources/Heeler/Console/AttachTerminalStore.swift
@@ -289,6 +289,8 @@ final class AttachTerminalStore {
             "Another terminal is already open on this Host."
         case TransportError.timedOut:
             "The Host did not answer in time."
+        case TransportError.herdrBinaryNotFound:
+            TransportError.herdrBinaryNotFound.connectionGuidance
         default:
             "The session failed: \(error)"
         }

--- a/Sources/Heeler/Hosts/Preflight.swift
+++ b/Sources/Heeler/Hosts/Preflight.swift
@@ -91,6 +91,13 @@ struct PreflightReport: Equatable, Sendable {
             hint =
                 "No herdr socket at \(path). Install and start herdr on the Host, "
                 + "or fix the session name."
+        case .herdrBinaryNotFound:
+            check = .herdrInstalled
+            hint =
+                "herdr is installed somewhere the SSH session cannot see "
+                + "(Homebrew is often /opt/homebrew/bin or "
+                + "/home/linuxbrew/.linuxbrew/bin). Put that directory on the "
+                + "account's non-interactive PATH, or symlink herdr into ~/.local/bin."
         case .homeDirectoryUnresolvable(let detail):
             check = .remoteEnvironment
             hint =

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -9,6 +9,9 @@ private struct HeelerSSHSessionListResponse: Decodable {
 private enum HeelerSSHAttachPumpError: Error, Sendable {
     case input(String)
     case output(String)
+    /// Remote `/bin/sh` could not exec `herdr` (exit 127). Distinct from a
+    /// herdr-the-process failure so Attach can name the PATH problem (#206).
+    case herdrMissing
 }
 
 /// The live PTY operations used by the Attach pumps. `SSHPTYChannel` is the
@@ -294,6 +297,7 @@ actor HeelerSSHTransport: Transport {
     private let channelAdmission: SSHChannelAdmission
     private let homeDirectory = SharedAsyncOperation<String>(cachesSuccess: true)
     private let notificationConfigDirectory = SharedAsyncOperation<String>(cachesSuccess: true)
+    private let herdrBinary = SharedAsyncOperation<String>(cachesSuccess: true)
     private let wake = SharedAsyncOperation<Void>(cachesSuccess: false)
     private var connected = true
 
@@ -523,7 +527,7 @@ actor HeelerSSHTransport: Transport {
     }
 
     func listSessions() async throws -> [HerdrSession] {
-        let output = try await runHostCommand(sessionListCommand)
+        let output = try await runHostCommand(await resolvedHerdrCommand(sessionListCommand))
         let sessions: [HerdrSession]
         do {
             sessions = try JSONDecoder().decode(
@@ -998,12 +1002,14 @@ actor HeelerSSHTransport: Transport {
     }
 
     private func resolveNotificationConfigDirectory() async throws -> String {
-        let listOutput = try await runNotificationPluginProbe(command: pluginListCommand)
+        let listOutput = try await runNotificationPluginProbe(
+            command: await resolvedHerdrCommand(pluginListCommand))
         let pluginID = try installedNotificationPluginID(in: listOutput)
         let configDirCommand = notificationConfigDirCommand.replacingOccurrences(
             of: SSHTransportSettings.notificationPluginIDToken,
             with: pluginID)
-        let output = try await runNotificationPluginProbe(command: configDirCommand)
+        let output = try await runNotificationPluginProbe(
+            command: await resolvedHerdrCommand(configDirCommand))
         guard
             let directory = Self.markerValue(
                 in: output,
@@ -1517,7 +1523,8 @@ actor HeelerSSHTransport: Transport {
         try await withRequestDeadline {
             try await self.wake.value {
                 let command = try Self.wakeExecCommand(
-                    wakeCommand: self.wakeCommand,
+                    wakeCommand: await self.resolvedHerdrCommand(
+                        self.wakeCommand, allowPATHPrefix: false),
                     socketPath: socketPath,
                     socketLocation: self.socketLocation)
                 let result = try await self.runExec(command)
@@ -1571,6 +1578,39 @@ actor HeelerSSHTransport: Transport {
                         detail: "home command printed: \(Self.preview(result.stdout))")
                 }
                 return home
+            }
+        }
+    }
+
+    /// Rewrites an unpathed `herdr …` command to the Host's absolute binary
+    /// when discovery finds one. `allowPATHPrefix` wraps a still-bare command
+    /// in an extra-PATH `/bin/sh`; it must stay false for attach and wake,
+    /// whose wrappers already export that PATH and append `"$1"` after
+    /// `exec`.
+    private func resolvedHerdrCommand(
+        _ command: String, allowPATHPrefix: Bool = true
+    ) async -> String {
+        guard HerdrHostPath.containsBareHerdr(command) else { return command }
+        if let path = try? await herdrBinaryPath(),
+            let rewritten = HerdrHostPath.substituting(command, herdrPath: path)
+        {
+            return rewritten
+        }
+        return allowPATHPrefix ? HerdrHostPath.prefixed(command) : command
+    }
+
+    private func herdrBinaryPath() async throws -> String {
+        try await withRequestDeadline {
+            try await self.herdrBinary.value {
+                let result = try await self.runExec(
+                    Self.cLocaleCommand(HerdrHostPath.discoveryCommand))
+                guard
+                    result.exitStatus == 0,
+                    let path = HerdrHostPath.path(from: result.stdout)
+                else {
+                    throw TransportError.herdrBinaryNotFound
+                }
+                return path
             }
         }
     }
@@ -1726,11 +1766,13 @@ actor HeelerSSHTransport: Transport {
                 throw TransportError.channelFailed(
                     detail: "The herdr session name is invalid.")
             }
-            command = "/bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
+            command = "/bin/sh -c '\(HerdrHostPath.pathExport); "
+                + "export HERDR_SOCKET_PATH=\"$1\"; "
                 + "export HERDR_SESSION=\"$2\"; \(wakeCommand) < /dev/null' wake "
                 + "\(quotedSocketPath) \(sessionName)"
         case .defaultSession, .absolutePath:
-            command = "/bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
+            command = "/bin/sh -c '\(HerdrHostPath.pathExport); "
+                + "export HERDR_SOCKET_PATH=\"$1\"; "
                 + "\(wakeCommand) < /dev/null' wake \(quotedSocketPath)"
         }
         return cLocaleCommand(command)
@@ -1947,7 +1989,8 @@ actor HeelerSSHTransport: Transport {
             admissionLease = lease
             let socketPath = try await resolvedSocketPath()
             let command = try Self.attachExecCommand(
-                attachCommand: attachCommand,
+                attachCommand: await resolvedHerdrCommand(
+                    attachCommand, allowPATHPrefix: false),
                 request: request,
                 socketPath: socketPath)
             let channel: SSHPTYChannel
@@ -2023,7 +2066,8 @@ actor HeelerSSHTransport: Transport {
         let takeover = request.takeover ? " --takeover" : ""
         // The marker goes out last thing before the exec, so earlier startup
         // chatter can be dropped.
-        return "/bin/sh -c 'export HERDR_SOCKET_PATH=\"$2\"; "
+        return "/bin/sh -c '\(HerdrHostPath.pathExport); "
+            + "export HERDR_SOCKET_PATH=\"$2\"; "
             + "printf \"\(AttachBootstrapHandshake.markerPrintfFormat)\"; "
             + "exec \(attachCommand) \"$1\"\(takeover)' attach "
             + "'\(request.target)' \(quotedSocketPath)"
@@ -2063,6 +2107,8 @@ actor HeelerSSHTransport: Transport {
                     failure = .channelFailed(detail: "attach input: \(detail)")
                 case .output(let detail):
                     failure = .channelFailed(detail: "attach channel: \(detail)")
+                case .herdrMissing:
+                    failure = .herdrBinaryNotFound
                 case nil:
                     failure = .channelFailed(detail: "attach channel: \(error)")
                 }
@@ -2143,6 +2189,9 @@ actor HeelerSSHTransport: Transport {
                             let status = try await channel.exitStatus(timeout: requestTimeout)
                             guard status == 0 else {
                                 yieldAdmitted(gate.flush())
+                                if status == 127 {
+                                    throw HeelerSSHAttachPumpError.herdrMissing
+                                }
                                 throw HeelerSSHAttachPumpError.output(
                                     "remote exit status \(status)")
                             }

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -527,7 +527,7 @@ actor HeelerSSHTransport: Transport {
     }
 
     func listSessions() async throws -> [HerdrSession] {
-        let output = try await runHostCommand(await resolvedHerdrCommand(sessionListCommand))
+        let output = try await runHostCommand(try await resolvedHerdrCommand(sessionListCommand))
         let sessions: [HerdrSession]
         do {
             sessions = try JSONDecoder().decode(
@@ -1003,13 +1003,13 @@ actor HeelerSSHTransport: Transport {
 
     private func resolveNotificationConfigDirectory() async throws -> String {
         let listOutput = try await runNotificationPluginProbe(
-            command: await resolvedHerdrCommand(pluginListCommand))
+            command: try await resolvedHerdrCommand(pluginListCommand))
         let pluginID = try installedNotificationPluginID(in: listOutput)
         let configDirCommand = notificationConfigDirCommand.replacingOccurrences(
             of: SSHTransportSettings.notificationPluginIDToken,
             with: pluginID)
         let output = try await runNotificationPluginProbe(
-            command: await resolvedHerdrCommand(configDirCommand))
+            command: try await resolvedHerdrCommand(configDirCommand))
         guard
             let directory = Self.markerValue(
                 in: output,
@@ -1047,6 +1047,9 @@ actor HeelerSSHTransport: Transport {
     private func runNotificationPluginProbe(command: String) async throws -> Data {
         do {
             let result = try await runExec(Self.cLocaleCommand(command))
+            if result.exitStatus == 127, HerdrHostPath.containsBareHerdr(command) {
+                throw TransportError.herdrBinaryNotFound
+            }
             guard result.exitStatus == 0, result.reachedEOF else {
                 throw NotificationRegistrationError.pluginProbeFailed(
                     detail: "The Host plugin probe failed.")
@@ -1056,6 +1059,8 @@ actor HeelerSSHTransport: Transport {
             throw TransportError.cancelled
         } catch TransportError.timedOut {
             throw TransportError.timedOut
+        } catch TransportError.herdrBinaryNotFound {
+            throw TransportError.herdrBinaryNotFound
         } catch let error as NotificationRegistrationError {
             throw error
         } catch {
@@ -1523,7 +1528,7 @@ actor HeelerSSHTransport: Transport {
         try await withRequestDeadline {
             try await self.wake.value {
                 let command = try Self.wakeExecCommand(
-                    wakeCommand: await self.resolvedHerdrCommand(
+                    wakeCommand: try await self.resolvedHerdrCommand(
                         self.wakeCommand, allowPATHPrefix: false),
                     socketPath: socketPath,
                     socketLocation: self.socketLocation)
@@ -1583,18 +1588,23 @@ actor HeelerSSHTransport: Transport {
     }
 
     /// Rewrites an unpathed `herdr …` command to the Host's absolute binary
-    /// when discovery finds one. `allowPATHPrefix` wraps a still-bare command
-    /// in an extra-PATH `/bin/sh`; it must stay false for attach and wake,
+    /// when discovery finds one. `allowPATHPrefix` augments a still-bare
+    /// command with the extra PATH; it must stay false for attach and wake,
     /// whose wrappers already export that PATH and append `"$1"` after
-    /// `exec`.
+    /// `exec`. Timeouts and cancellation propagate; only a definitive miss
+    /// falls through to the PATH fallback.
     private func resolvedHerdrCommand(
         _ command: String, allowPATHPrefix: Bool = true
-    ) async -> String {
+    ) async throws -> String {
         guard HerdrHostPath.containsBareHerdr(command) else { return command }
-        if let path = try? await herdrBinaryPath(),
-            let rewritten = HerdrHostPath.substituting(command, herdrPath: path)
-        {
-            return rewritten
+        do {
+            let path = try await herdrBinaryPath()
+            if let rewritten = HerdrHostPath.substituting(command, herdrPath: path) {
+                return rewritten
+            }
+        } catch TransportError.herdrBinaryNotFound {
+            // Fall through: the extra PATH on the command itself may still
+            // find a binary that the probe's marker parse rejected.
         }
         return allowPATHPrefix ? HerdrHostPath.prefixed(command) : command
     }
@@ -1621,6 +1631,9 @@ actor HeelerSSHTransport: Transport {
             guard result.reachedEOF else {
                 throw TransportError.channelFailed(
                     detail: "Host command closed before EOF")
+            }
+            if result.exitStatus == 127, HerdrHostPath.containsBareHerdr(command) {
+                throw TransportError.herdrBinaryNotFound
             }
             return result.stdout
         }
@@ -1988,9 +2001,10 @@ actor HeelerSSHTransport: Transport {
             let lease = try await channelAdmission.acquire(.attach)
             admissionLease = lease
             let socketPath = try await resolvedSocketPath()
+            let resolvedAttach = try await resolvedHerdrCommand(
+                attachCommand, allowPATHPrefix: false)
             let command = try Self.attachExecCommand(
-                attachCommand: await resolvedHerdrCommand(
-                    attachCommand, allowPATHPrefix: false),
+                attachCommand: resolvedAttach,
                 request: request,
                 socketPath: socketPath)
             let channel: SSHPTYChannel
@@ -2009,13 +2023,15 @@ actor HeelerSSHTransport: Transport {
             nextTerminalReaderID &+= 1
             let readerID = nextTerminalReaderID
             terminalChannelState = .streaming(readerID: readerID)
+            let classifyMissingHerdrOn127 = HerdrHostPath.containsBareHerdr(resolvedAttach)
             let readerTask = Task {
                 await self.runAttachChannel(
                     readerID: readerID,
                     channel: channel,
                     admissionLease: lease,
                     input: input,
-                    output: outputGate)
+                    output: outputGate,
+                    classifyMissingHerdrOn127: classifyMissingHerdrOn127)
             }
             return TerminalAttachSession(
                 output: outputGate.makeOutput,
@@ -2078,7 +2094,8 @@ actor HeelerSSHTransport: Transport {
         channel: SSHPTYChannel,
         admissionLease: SSHChannelAdmissionLease,
         input: TerminalAttachInputQueue,
-        output: HeelerSSHAttachOutputGate
+        output: HeelerSSHAttachOutputGate,
+        classifyMissingHerdrOn127: Bool
     ) async {
         var failure: TransportError?
         var sawCleanEnd = false
@@ -2090,7 +2107,8 @@ actor HeelerSSHTransport: Transport {
                     channel: channel,
                     input: input,
                     output: output,
-                    requestTimeout: requestTimeout)
+                    requestTimeout: requestTimeout,
+                    classifyMissingHerdrOn127: classifyMissingHerdrOn127)
             } catch let error as HeelerSSHAttachPumpError {
                 pumpFailure = error
                 throw error
@@ -2142,7 +2160,8 @@ actor HeelerSSHTransport: Transport {
         channel: any HeelerSSHAttachChannel,
         input: TerminalAttachInputQueue,
         output: HeelerSSHAttachOutputGate,
-        requestTimeout: Duration
+        requestTimeout: Duration,
+        classifyMissingHerdrOn127: Bool = false
     ) async throws -> Bool {
         let cancellation = HeelerSSHAttachPumpCancellation()
         return try await withThrowingTaskGroup(of: Bool.self) { group in
@@ -2189,7 +2208,7 @@ actor HeelerSSHTransport: Transport {
                             let status = try await channel.exitStatus(timeout: requestTimeout)
                             guard status == 0 else {
                                 yieldAdmitted(gate.flush())
-                                if status == 127 {
+                                if status == 127, classifyMissingHerdrOn127 {
                                     throw HeelerSSHAttachPumpError.herdrMissing
                                 }
                                 throw HeelerSSHAttachPumpError.output(

--- a/Sources/Heeler/Transport/SSHTransportSettings.swift
+++ b/Sources/Heeler/Transport/SSHTransportSettings.swift
@@ -130,3 +130,104 @@ struct SSHJumpSettings: Sendable {
         self.credentials = credentials
     }
 }
+
+/// Where `herdr` actually lives on Hosts that install it via Homebrew,
+/// linuxbrew, cargo, or a user-local prefix.
+///
+/// SSH exec is not a login shell: sshd's default `PATH` is typically
+/// `/usr/bin:/bin`, so a Host that can run `herdr` interactively still
+/// answers `exec: herdr: not found` (exit 127) on Attach. The API socket
+/// path does not need the binary — that is why the Console can list Agents
+/// while the PTY Attach dies (#206).
+enum HerdrHostPath: Sendable {
+    static let outputPrefix = "__HEELER_HERDR_BIN__="
+
+    /// Directories prepended to `PATH` on every herdr CLI exec. `$HOME`
+    /// is expanded by the remote `/bin/sh`, not by Swift.
+    static let extraPATH =
+        "$HOME/.local/bin:$HOME/.linuxbrew/bin:$HOME/.cargo/bin:"
+        + "/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin"
+
+    static var pathExport: String {
+        "export PATH=\"\(extraPATH):$PATH\""
+    }
+
+    /// Marker-delimited probe: `command -v` under the extra PATH, then the
+    /// same locations as absolute files. Login-shell noise is ignored the
+    /// same way as the home-directory probe.
+    static var discoveryCommand: String {
+        "/bin/sh -c '\(pathExport); "
+            + "bin=$(command -v herdr 2>/dev/null) || true; "
+            + "if [ -n \"$bin\" ] && [ -x \"$bin\" ]; then "
+            + "printf \"\(outputPrefix)%s\\n\" \"$bin\"; exit 0; fi; "
+            + "for p in \"$HOME/.local/bin/herdr\" \"$HOME/.linuxbrew/bin/herdr\" "
+            + "\"$HOME/.cargo/bin/herdr\" /opt/homebrew/bin/herdr "
+            + "/usr/local/bin/herdr /home/linuxbrew/.linuxbrew/bin/herdr; do "
+            + "if [ -x \"$p\" ]; then printf \"\(outputPrefix)%s\\n\" \"$p\"; "
+            + "exit 0; fi; done; exit 1'"
+    }
+
+    /// True when `command` still invokes an unpathed `herdr` word.
+    static func containsBareHerdr(_ command: String) -> Bool {
+        bareHerdrRange(in: command) != nil
+    }
+
+    /// Replaces each unpathed `herdr` command word with the absolute binary.
+    /// The path is left unquoted so it can sit inside the existing
+    /// single-quoted `/bin/sh -c` wrappers; whitespace is refused because
+    /// that would split the exec word. Leaves `/opt/herdr-wake` alone.
+    static func substituting(_ command: String, herdrPath: String) -> String? {
+        guard RemoteShellPath.isQuotableAbsolute(herdrPath),
+            !herdrPath.contains(where: \.isWhitespace)
+        else { return nil }
+        var result = command
+        while let range = bareHerdrRange(in: result) {
+            result.replaceSubrange(range, with: herdrPath)
+        }
+        return result
+    }
+
+    /// Wraps a quote-free command so the extra PATH is visible to a bare
+    /// `herdr`. Used when discovery did not produce a path.
+    static func prefixed(_ command: String) -> String {
+        guard !command.contains("'") else { return command }
+        return "/bin/sh -c '\(pathExport); \(command)'"
+    }
+
+    static func path(from output: Data) -> String? {
+        String(decoding: output, as: UTF8.self)
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .reversed()
+            .first { $0.hasPrefix(outputPrefix) }
+            .map { line in
+                var value = String(line.dropFirst(outputPrefix.count))
+                if value.last == "\r" { value.removeLast() }
+                return value
+            }
+            .flatMap { path in
+                RemoteShellPath.isQuotableAbsolute(path)
+                    && !path.contains(where: \.isWhitespace) ? path : nil
+            }
+    }
+
+    private static func bareHerdrRange(in command: String) -> Range<String.Index>? {
+        var search = command.startIndex
+        while let found = command[search...].range(of: "herdr") {
+            let start = found.lowerBound
+            let end = found.upperBound
+            let precededByPath = start > command.startIndex
+                && isCommandWordChar(command[command.index(before: start)])
+            let followedByWord = end < command.endIndex && isCommandWordChar(command[end])
+            if !precededByPath && !followedByWord {
+                return found
+            }
+            search = end
+        }
+        return nil
+    }
+
+    private static func isCommandWordChar(_ character: Character) -> Bool {
+        character.isLetter || character.isNumber || character == "." || character == "_"
+            || character == "-" || character == "/"
+    }
+}

--- a/Sources/Heeler/Transport/SSHTransportSettings.swift
+++ b/Sources/Heeler/Transport/SSHTransportSettings.swift
@@ -142,19 +142,24 @@ struct SSHJumpSettings: Sendable {
 enum HerdrHostPath: Sendable {
     static let outputPrefix = "__HEELER_HERDR_BIN__="
 
-    /// Directories prepended to `PATH` on every herdr CLI exec. `$HOME`
-    /// is expanded by the remote `/bin/sh`, not by Swift.
+    /// Directories appended to `PATH` on herdr CLI execs so an existing
+    /// session binary keeps priority. `$HOME` is expanded by the remote
+    /// `/bin/sh`, not by Swift.
     static let extraPATH =
         "$HOME/.local/bin:$HOME/.linuxbrew/bin:$HOME/.cargo/bin:"
         + "/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin"
 
-    static var pathExport: String {
-        "export PATH=\"\(extraPATH):$PATH\""
+    static var pathAssignment: String {
+        "PATH=\"$PATH:\(extraPATH)\""
     }
 
-    /// Marker-delimited probe: `command -v` under the extra PATH, then the
-    /// same locations as absolute files. Login-shell noise is ignored the
-    /// same way as the home-directory probe.
+    static var pathExport: String {
+        "export \(pathAssignment)"
+    }
+
+    /// Marker-delimited probe: `command -v` under the existing PATH plus the
+    /// extra prefixes, then the same locations as absolute files. Login-shell
+    /// noise is ignored the same way as the home-directory probe.
     static var discoveryCommand: String {
         "/bin/sh -c '\(pathExport); "
             + "bin=$(command -v herdr 2>/dev/null) || true; "
@@ -174,12 +179,10 @@ enum HerdrHostPath: Sendable {
 
     /// Replaces each unpathed `herdr` command word with the absolute binary.
     /// The path is left unquoted so it can sit inside the existing
-    /// single-quoted `/bin/sh -c` wrappers; whitespace is refused because
-    /// that would split the exec word. Leaves `/opt/herdr-wake` alone.
+    /// single-quoted `/bin/sh -c` wrappers; only a conservative shell-word
+    /// alphabet is accepted. Leaves `/opt/herdr-wake` alone.
     static func substituting(_ command: String, herdrPath: String) -> String? {
-        guard RemoteShellPath.isQuotableAbsolute(herdrPath),
-            !herdrPath.contains(where: \.isWhitespace)
-        else { return nil }
+        guard isSafeUnquotedAbsolute(herdrPath) else { return nil }
         var result = command
         while let range = bareHerdrRange(in: result) {
             result.replaceSubrange(range, with: herdrPath)
@@ -187,11 +190,14 @@ enum HerdrHostPath: Sendable {
         return result
     }
 
-    /// Wraps a quote-free command so the extra PATH is visible to a bare
-    /// `herdr`. Used when discovery did not produce a path.
+    /// Makes the extra prefixes visible to a still-bare `herdr` without a
+    /// second `/bin/sh -c` wrapper, so quoted injectable commands (the
+    /// default plugin config-dir probe) keep working.
     static func prefixed(_ command: String) -> String {
-        guard !command.contains("'") else { return command }
-        return "/bin/sh -c '\(pathExport); \(command)'"
+        guard let range = bareHerdrRange(in: command) else { return command }
+        var result = command
+        result.replaceSubrange(range.lowerBound..<range.lowerBound, with: pathAssignment + " ")
+        return result
     }
 
     static func path(from output: Data) -> String? {
@@ -205,9 +211,20 @@ enum HerdrHostPath: Sendable {
                 return value
             }
             .flatMap { path in
-                RemoteShellPath.isQuotableAbsolute(path)
-                    && !path.contains(where: \.isWhitespace) ? path : nil
+                isSafeUnquotedAbsolute(path) ? path : nil
             }
+    }
+
+    /// Paths spliced unquoted into `/bin/sh -c` bodies. Letters, digits,
+    /// `.`, `_`, `-`, and `/` only — no `;|&$` or whitespace.
+    static func isSafeUnquotedAbsolute(_ path: String) -> Bool {
+        guard path.hasPrefix("/"), path.count > 1 else { return false }
+        return path.utf8.allSatisfy { byte in
+            (0x30...0x39).contains(byte)
+                || (0x41...0x5A).contains(byte)
+                || (0x61...0x7A).contains(byte)
+                || byte == 0x2E || byte == 0x5F || byte == 0x2D || byte == 0x2F
+        }
     }
 
     private static func bareHerdrRange(in command: String) -> Range<String.Index>? {
@@ -228,6 +245,6 @@ enum HerdrHostPath: Sendable {
 
     private static func isCommandWordChar(_ character: Character) -> Bool {
         character.isLetter || character.isNumber || character == "." || character == "_"
-            || character == "-" || character == "/"
+            || character == "-" || character == "/" || character == "="
     }
 }

--- a/Sources/Heeler/Transport/Transport.swift
+++ b/Sources/Heeler/Transport/Transport.swift
@@ -558,6 +558,10 @@ indirect enum TransportError: Error, Sendable, Equatable {
     /// The herdr API socket path does not exist on the Host: herdr is not
     /// installed there, or the socket path is wrong.
     case socketNotFound(path: String)
+    /// The herdr CLI is not on the SSH session's PATH and was not found in
+    /// the well-known install prefixes. The API socket can still work — that
+    /// is why the Console may list Agents while Attach fails (#206).
+    case herdrBinaryNotFound
     /// libssh2 cannot distinguish a listening Unix socket rejected by SSH
     /// policy from a stale socket file. The Host needs either herdr started or
     /// stream-local forwarding enabled; presenting a narrower cause would be
@@ -606,7 +610,7 @@ indirect enum TransportError: Error, Sendable, Equatable {
             true
         case .authenticationFailed, .tcpForwardingUnavailable,
             .deviceKeyCorrupt, .hostKeyRejected, .hostKeyMismatch,
-            .socketNotFound, .protocolVersionMismatch,
+            .socketNotFound, .herdrBinaryNotFound, .protocolVersionMismatch,
             .streamLocalOpenFailed,
             .homeDirectoryUnresolvable, .eventsChannelAlreadyOpen,
             .terminalChannelAlreadyOpen, .malformedResponse:

--- a/Sources/Heeler/Transport/TransportError+Presentation.swift
+++ b/Sources/Heeler/Transport/TransportError+Presentation.swift
@@ -17,6 +17,11 @@ extension TransportError {
             "The host key changed. Verify the machine before updating trust."
         case .socketNotFound:
             "The herdr socket was not found. Check this Host's session."
+        case .herdrBinaryNotFound:
+            "herdr is not on this Host's SSH PATH. Homebrew installs are often "
+                + "at /opt/homebrew/bin or /home/linuxbrew/.linuxbrew/bin — "
+                + "put that directory on the account's non-interactive PATH, "
+                + "or symlink herdr into ~/.local/bin."
         case .streamLocalOpenFailed:
             "herdr is not running on this Host. If it is running, check SSH stream-local forwarding."
         case .protocolVersionMismatch(let server, let supported):

--- a/Tests/HeelerTests/HerdrHostPathTests.swift
+++ b/Tests/HeelerTests/HerdrHostPathTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@Suite("Herdr host PATH")
+struct HerdrHostPathTests {
+    @Test func extraPATHIncludesHomebrewAndLinuxbrewPrefixes() {
+        #expect(HerdrHostPath.extraPATH.contains("$HOME/.local/bin"))
+        #expect(HerdrHostPath.extraPATH.contains("/opt/homebrew/bin"))
+        #expect(HerdrHostPath.extraPATH.contains("/home/linuxbrew/.linuxbrew/bin"))
+        #expect(HerdrHostPath.extraPATH.contains("$HOME/.linuxbrew/bin"))
+    }
+
+    @Test func discoveryIgnoresLoginShellNoiseAroundItsMarker() {
+        let noise = Data(
+            """
+            Last login: Tue Aug 18
+            __HEELER_HERDR_BIN__=/home/linuxbrew/.linuxbrew/bin/herdr
+            motd leftover
+            """.utf8)
+        #expect(HerdrHostPath.path(from: noise) == "/home/linuxbrew/.linuxbrew/bin/herdr")
+    }
+
+    @Test func discoveryRejectsARelativeOrUnquotableMarker() {
+        #expect(HerdrHostPath.path(from: Data("__HEELER_HERDR_BIN__=herdr\n".utf8)) == nil)
+        #expect(
+            HerdrHostPath.path(
+                from: Data("__HEELER_HERDR_BIN__=/tmp/it's-herdr\n".utf8)) == nil)
+    }
+
+    @Test func bareHerdrIsTheUnpathedCommandWord() {
+        #expect(HerdrHostPath.containsBareHerdr("herdr agent attach"))
+        #expect(HerdrHostPath.containsBareHerdr("herdr session list --json"))
+        #expect(
+            HerdrHostPath.containsBareHerdr(
+                "/bin/sh -c 'printf \"%s\" \"$(herdr plugin config-dir x)\"'"))
+        #expect(!HerdrHostPath.containsBareHerdr("/opt/herdr-wake --foreground"))
+        #expect(!HerdrHostPath.containsBareHerdr("/nonexistent/herdr plugin list --json"))
+        #expect(!HerdrHostPath.containsBareHerdr("/bin/sh /tmp/fake-attach.sh"))
+    }
+
+    @Test func substitutingRewritesOnlyTheBareCommandWord() throws {
+        let linuxbrew = "/home/linuxbrew/.linuxbrew/bin/herdr"
+        #expect(
+            HerdrHostPath.substituting("herdr agent attach", herdrPath: linuxbrew)
+                == "\(linuxbrew) agent attach")
+        #expect(
+            HerdrHostPath.substituting(
+                "herdr plugin list --json", herdrPath: linuxbrew)
+                == "\(linuxbrew) plugin list --json")
+        #expect(
+            HerdrHostPath.substituting(
+                "herdr agent attach", herdrPath: "/home/u/My herdr/bin/herdr") == nil)
+
+        let configDir = "/bin/sh -c 'printf \"%s\" \"$(herdr plugin config-dir x)\"'"
+        #expect(
+            HerdrHostPath.substituting(configDir, herdrPath: linuxbrew)
+                == "/bin/sh -c 'printf \"%s\" \"$(\(linuxbrew) plugin config-dir x)\"'")
+        // The replacement itself ends in `herdr`; that must not match again.
+        #expect(
+            HerdrHostPath.substituting(
+                "\(linuxbrew) agent attach", herdrPath: "/opt/homebrew/bin/herdr")
+                == "\(linuxbrew) agent attach")
+    }
+
+    @Test func prefixedWrapsAQuoteFreeCommand() {
+        let wrapped = HerdrHostPath.prefixed("herdr session list --json")
+        #expect(wrapped.contains(HerdrHostPath.pathExport))
+        #expect(wrapped.contains("herdr session list --json"))
+        #expect(HerdrHostPath.prefixed("printf 'no wrap'") == "printf 'no wrap'")
+    }
+
+    @Test func attachExecExportsTheExtraPATHBeforeExec() throws {
+        let command = try HeelerSSHTransport.attachExecCommand(
+            attachCommand: "herdr agent attach",
+            request: TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24),
+            socketPath: "/tmp/fake.sock")
+        #expect(command.contains(HerdrHostPath.pathExport))
+        #expect(command.contains("/home/linuxbrew/.linuxbrew/bin"))
+        #expect(command.contains("exec herdr agent attach"))
+    }
+
+    @Test func attachExecKeepsAResolvedAbsoluteBinary() throws {
+        let command = try HeelerSSHTransport.attachExecCommand(
+            attachCommand: "/home/linuxbrew/.linuxbrew/bin/herdr agent attach",
+            request: TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24),
+            socketPath: "/tmp/fake.sock")
+        #expect(
+            command.contains("exec /home/linuxbrew/.linuxbrew/bin/herdr agent attach"))
+    }
+}

--- a/Tests/HeelerTests/HerdrHostPathTests.swift
+++ b/Tests/HeelerTests/HerdrHostPathTests.swift
@@ -10,6 +10,9 @@ struct HerdrHostPathTests {
         #expect(HerdrHostPath.extraPATH.contains("/opt/homebrew/bin"))
         #expect(HerdrHostPath.extraPATH.contains("/home/linuxbrew/.linuxbrew/bin"))
         #expect(HerdrHostPath.extraPATH.contains("$HOME/.linuxbrew/bin"))
+        // Existing PATH entries keep priority over the extra prefixes.
+        #expect(HerdrHostPath.pathExport.hasPrefix("export PATH=\"$PATH:"))
+        #expect(HerdrHostPath.discoveryCommand.contains("export PATH=\"$PATH:"))
     }
 
     @Test func discoveryIgnoresLoginShellNoiseAroundItsMarker() {
@@ -27,6 +30,13 @@ struct HerdrHostPathTests {
         #expect(
             HerdrHostPath.path(
                 from: Data("__HEELER_HERDR_BIN__=/tmp/it's-herdr\n".utf8)) == nil)
+        #expect(
+            HerdrHostPath.path(
+                from: Data("__HEELER_HERDR_BIN__=/opt/homebrew/bin/herdr;notify\n".utf8))
+                == nil)
+        #expect(!HerdrHostPath.isSafeUnquotedAbsolute("/opt/homebrew/bin/herdr;x"))
+        #expect(!HerdrHostPath.isSafeUnquotedAbsolute("/tmp/foo$bar/herdr"))
+        #expect(HerdrHostPath.isSafeUnquotedAbsolute("/home/linuxbrew/.linuxbrew/bin/herdr"))
     }
 
     @Test func bareHerdrIsTheUnpathedCommandWord() {
@@ -38,6 +48,7 @@ struct HerdrHostPathTests {
         #expect(!HerdrHostPath.containsBareHerdr("/opt/herdr-wake --foreground"))
         #expect(!HerdrHostPath.containsBareHerdr("/nonexistent/herdr plugin list --json"))
         #expect(!HerdrHostPath.containsBareHerdr("/bin/sh /tmp/fake-attach.sh"))
+        #expect(!HerdrHostPath.containsBareHerdr("ENV=herdr /bin/sh -c 'true'"))
     }
 
     @Test func substitutingRewritesOnlyTheBareCommandWord() throws {
@@ -52,6 +63,10 @@ struct HerdrHostPathTests {
         #expect(
             HerdrHostPath.substituting(
                 "herdr agent attach", herdrPath: "/home/u/My herdr/bin/herdr") == nil)
+        #expect(
+            HerdrHostPath.substituting(
+                "herdr agent attach",
+                herdrPath: "/opt/homebrew/bin/herdr;notify-send") == nil)
 
         let configDir = "/bin/sh -c 'printf \"%s\" \"$(herdr plugin config-dir x)\"'"
         #expect(
@@ -64,11 +79,15 @@ struct HerdrHostPathTests {
                 == "\(linuxbrew) agent attach")
     }
 
-    @Test func prefixedWrapsAQuoteFreeCommand() {
+    @Test func prefixedAugmentsBareHerdrWithoutASecondShell() {
         let wrapped = HerdrHostPath.prefixed("herdr session list --json")
-        #expect(wrapped.contains(HerdrHostPath.pathExport))
+        #expect(wrapped.hasPrefix("\(HerdrHostPath.pathAssignment) herdr "))
         #expect(wrapped.contains("herdr session list --json"))
-        #expect(HerdrHostPath.prefixed("printf 'no wrap'") == "printf 'no wrap'")
+
+        let quoted = SSHTransportSettings.defaultNotificationConfigDirCommand
+        let prefixed = HerdrHostPath.prefixed(quoted)
+        #expect(prefixed.contains("$(\(HerdrHostPath.pathAssignment) herdr plugin config-dir"))
+        #expect(!prefixed.hasPrefix("/bin/sh -c '\(HerdrHostPath.pathExport)"))
     }
 
     @Test func attachExecExportsTheExtraPATHBeforeExec() throws {
@@ -78,6 +97,7 @@ struct HerdrHostPathTests {
             socketPath: "/tmp/fake.sock")
         #expect(command.contains(HerdrHostPath.pathExport))
         #expect(command.contains("/home/linuxbrew/.linuxbrew/bin"))
+        #expect(command.contains("export PATH=\"$PATH:"))
         #expect(command.contains("exec herdr agent attach"))
     }
 
@@ -88,5 +108,7 @@ struct HerdrHostPathTests {
             socketPath: "/tmp/fake.sock")
         #expect(
             command.contains("exec /home/linuxbrew/.linuxbrew/bin/herdr agent attach"))
+        #expect(!HerdrHostPath.containsBareHerdr(
+            "/home/linuxbrew/.linuxbrew/bin/herdr agent attach"))
     }
 }

--- a/Tests/HeelerTests/PreflightReportTests.swift
+++ b/Tests/HeelerTests/PreflightReportTests.swift
@@ -41,6 +41,19 @@ struct PreflightReportTests {
         }
     }
 
+    @Test func missingBinaryHintNamesTheHomebrewPrefixes() {
+        let report = PreflightReport.failure(
+            .herdrBinaryNotFound, authMethod: .deviceKey)
+        guard case .failed(let hint) = report[.herdrInstalled] else {
+            Issue.record("herdr check should fail")
+            return
+        }
+        #expect(hint.contains("/opt/homebrew/bin"))
+        #expect(hint.contains("/home/linuxbrew/.linuxbrew/bin"))
+        #expect(hint.contains("~/.local/bin"))
+        #expect(report[.serverRunning] == .blocked)
+    }
+
     @Test func streamLocalFailureGuidesTowardForwardingRatherThanInstallation() {
         let report = PreflightReport.failure(
             .streamLocalOpenFailed(path: "/home/dev/.config/herdr/herdr.sock"),
@@ -67,6 +80,7 @@ struct PreflightReportTests {
         (.jumpHostFailed(.sshUnreachable(detail: "refused")), .connection),
         (.tcpForwardingUnavailable, .connection),
         (.socketNotFound(path: "/home/dev/.config/herdr/herdr.sock"), .herdrInstalled),
+        (.herdrBinaryNotFound, .herdrInstalled),
         (.homeDirectoryUnresolvable(detail: "no $HOME"), .remoteEnvironment),
         (.streamLocalOpenFailed(path: "/home/dev/.config/herdr/herdr.sock"), .serverRunning),
         // Below the floor: the only direction that still produces this error

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -1546,7 +1546,8 @@ struct TerminalAttachTests {
             request: TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24),
             socketPath: "/tmp/fake.sock")
         #expect(
-            command == "/bin/sh -c 'export HERDR_SOCKET_PATH=\"$2\"; "
+            command == "/bin/sh -c '\(HerdrHostPath.pathExport); "
+                + "export HERDR_SOCKET_PATH=\"$2\"; "
                 + "printf \"\(AttachBootstrapHandshake.markerPrintfFormat)\"; "
                 + "exec /bin/sh /tmp/fake-attach.sh \"$1\"' attach "
                 + "'w1:p1' '/tmp/fake.sock'")
@@ -1563,7 +1564,8 @@ struct TerminalAttachTests {
             socketPath: "/home/u/.config/herdr/sessions/dev/herdr.sock")
 
         #expect(
-            command == "/bin/sh -c 'export HERDR_SOCKET_PATH=\"$2\"; "
+            command == "/bin/sh -c '\(HerdrHostPath.pathExport); "
+                + "export HERDR_SOCKET_PATH=\"$2\"; "
                 + "printf \"\(AttachBootstrapHandshake.markerPrintfFormat)\"; "
                 + "exec herdr agent attach \"$1\" --takeover' attach "
                 + "'w1:p1' '/home/u/.config/herdr/sessions/dev/herdr.sock'")
@@ -1608,6 +1610,23 @@ struct TerminalAttachTests {
         let printfRange = try #require(command.range(of: markerPrintf))
         let execRange = try #require(command.range(of: "exec herdr agent attach"))
         #expect(printfRange.upperBound <= execRange.lowerBound)
+    }
+
+    @Test func attachExit127IsTypedAsAMissingHerdrBinary() async throws {
+        let channel = FakeAttachPTYChannel(reads: [nil], remoteExitStatus: 127)
+        let input = TerminalAttachInputQueue()
+        let source = HeelerSSHAttachOutputGate.makeStream()
+
+        do {
+            _ = try await HeelerSSHTransport.runAttachPumps(
+                channel: channel,
+                input: input,
+                output: source.gate,
+                requestTimeout: .seconds(1))
+            Issue.record("exit 127 should fail the attach pumps")
+        } catch {
+            #expect(String(describing: error) == "herdrMissing")
+        }
     }
 
     @Test func gateWithholdsStartupChatterUntilTheHandshake() {
@@ -1684,17 +1703,20 @@ private actor FakeAttachPTYChannel: HeelerSSHAttachChannel {
     private var reads: [Data?]
     private let writeError: (any Error & Sendable)?
     private let blockAfterReads: Bool
+    private let remoteExitStatus: Int32
     private var didReadFirst = false
     private var firstReadWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(
         reads: [Data?],
         writeError: (any Error & Sendable)? = nil,
-        blockAfterReads: Bool = false
+        blockAfterReads: Bool = false,
+        remoteExitStatus: Int32 = 0
     ) {
         self.reads = reads
         self.writeError = writeError
         self.blockAfterReads = blockAfterReads
+        self.remoteExitStatus = remoteExitStatus
     }
 
     func write(_: Data, timeout _: Duration) async throws {
@@ -1720,7 +1742,7 @@ private actor FakeAttachPTYChannel: HeelerSSHAttachChannel {
 
     func resize(columns _: Int, rows _: Int, timeout _: Duration) async throws {}
 
-    func exitStatus(timeout _: Duration) async throws -> Int32 { 0 }
+    func exitStatus(timeout _: Duration) async throws -> Int32 { remoteExitStatus }
 
     func waitUntilFirstRead() async {
         guard !didReadFirst else { return }

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -1622,10 +1622,30 @@ struct TerminalAttachTests {
                 channel: channel,
                 input: input,
                 output: source.gate,
-                requestTimeout: .seconds(1))
+                requestTimeout: .seconds(1),
+                classifyMissingHerdrOn127: true)
             Issue.record("exit 127 should fail the attach pumps")
         } catch {
             #expect(String(describing: error) == "herdrMissing")
+        }
+    }
+
+    @Test func attachExit127OnAResolvedCommandStaysAChannelFailure() async throws {
+        let channel = FakeAttachPTYChannel(reads: [nil], remoteExitStatus: 127)
+        let input = TerminalAttachInputQueue()
+        let source = HeelerSSHAttachOutputGate.makeStream()
+
+        do {
+            _ = try await HeelerSSHTransport.runAttachPumps(
+                channel: channel,
+                input: input,
+                output: source.gate,
+                requestTimeout: .seconds(1),
+                classifyMissingHerdrOn127: false)
+            Issue.record("exit 127 should fail the attach pumps")
+        } catch {
+            #expect(String(describing: error).contains("remote exit status 127"))
+            #expect(String(describing: error) != "herdrMissing")
         }
     }
 

--- a/Tests/HeelerTests/TransportErrorPresentationTests.swift
+++ b/Tests/HeelerTests/TransportErrorPresentationTests.swift
@@ -28,6 +28,13 @@ struct TransportErrorPresentationTests {
                 == "The connection failed: connection reset")
     }
 
+    @Test func missingHerdrBinaryNamesTheHomebrewPATH() {
+        let guidance = TransportError.herdrBinaryNotFound.connectionGuidance
+        #expect(guidance.contains("/opt/homebrew/bin"))
+        #expect(guidance.contains("/home/linuxbrew/.linuxbrew/bin"))
+        #expect(TransportError.herdrBinaryNotFound.isRetryable == false)
+    }
+
     @Test func streamLocalOpenFailureLeadsWithHerdrNotRunning() {
         #expect(
             TransportError.streamLocalOpenFailed(path: "/tmp/herdr.sock").connectionGuidance

--- a/Tests/HeelerTests/WakeCommandTests.swift
+++ b/Tests/HeelerTests/WakeCommandTests.swift
@@ -27,7 +27,8 @@ struct WakeCommandTests {
             socketLocation: .namedSession("testloop"))
 
         #expect(
-            command == "LC_ALL=C /bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
+            command == "LC_ALL=C /bin/sh -c '\(HerdrHostPath.pathExport); "
+                + "export HERDR_SOCKET_PATH=\"$1\"; "
                 + "export HERDR_SESSION=\"$2\"; herdr remote-client-bridge < /dev/null' wake "
                 + "'/home/u/.config/herdr/sessions/testloop/herdr.sock' testloop")
     }
@@ -39,7 +40,8 @@ struct WakeCommandTests {
             socketLocation: .defaultSession)
 
         #expect(
-            command == "LC_ALL=C /bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
+            command == "LC_ALL=C /bin/sh -c '\(HerdrHostPath.pathExport); "
+                + "export HERDR_SOCKET_PATH=\"$1\"; "
                 + "/opt/herdr-wake --foreground < /dev/null' wake "
                 + "'/home/u/.config/herdr/herdr.sock'")
     }
@@ -51,7 +53,8 @@ struct WakeCommandTests {
             socketLocation: .absolutePath("/home/u/My Config/herdr.sock"))
 
         #expect(
-            command == "LC_ALL=C /bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
+            command == "LC_ALL=C /bin/sh -c '\(HerdrHostPath.pathExport); "
+                + "export HERDR_SOCKET_PATH=\"$1\"; "
                 + "/opt/herdr-wake --foreground < /dev/null' wake "
                 + "'/home/u/My Config/herdr.sock'")
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

```
attach: line 0: exec: herdr: not found
Session Ended
channelFailed(detail: "attach channel: remote exit status 127")
```

Reporter’s herdr is Homebrew/linuxbrew at `/home/linuxbrew/.linuxbrew/bin/herdr`.

The Console talks to `herdr.sock` over stream-local forwarding and never looks up the `herdr` binary. Attach (and wake / session list / plugin CLI) still `exec herdr …` on a non-interactive SSH session whose default `PATH` is typically `/usr/bin:/bin`.

## Fix

- Append the usual install prefixes **after** the session `PATH` on attach and wake (`~/.local/bin`, `~/.linuxbrew/bin`, `~/.cargo/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `/home/linuxbrew/.linuxbrew/bin`), so an existing `herdr` keeps priority.
- Probe once per Host for an absolute `herdr` and substitute that path into default CLI commands. Only a safe unquoted path (letters, digits, `.`, `_`, `-`, `/`) is accepted.
- Discovery timeouts and cancellation propagate; only a definitive miss falls back to the extra PATH.
- PATH fallback prefixes the `herdr` word in place, so quoted commands such as the default plugin config-dir probe still get the extra prefixes.
- Map attach exit 127 to `TransportError.herdrBinaryNotFound` only while the exec is still a bare `herdr`. A resolved or injectable command that exits 127 stays a channel failure.
- Session-list and plugin probes that still invoke bare `herdr` and exit 127 also surface `herdrBinaryNotFound`.

Injectable test commands (`/opt/herdr-wake`, `/nonexistent/herdr …`) are left alone.

## Note on a missing socket

A Host whose preflight fails at **herdr installed** with `No herdr socket at ~/.config/herdr/herdr.sock` is a different failure: the API socket file is absent. This PR does not start herdr on a missing socket.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01399-f06c-712d-949e-e15dd8afb428?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01399-f06c-712d-949e-e15dd8afb428&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

