### PR TITLE
fix(transport): find herdr outside the non-interactive PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Fixed
+
+- Opening an Agent no longer dies with `exec: herdr: not found` (exit 127) on a
+  Host that installed herdr via Homebrew or linuxbrew. The API socket never
+  needed `herdr` on `PATH`, so the Console could already list Agents; Attach
+  and the other CLI execs now append the usual install prefixes after the
+  session `PATH` (`~/.local/bin`, `/opt/homebrew/bin`,
+  `/home/linuxbrew/.linuxbrew/bin`). (#206)
+
 ### Added
 
 - Agent detail now places a plus menu to the left of Send. It can add an image

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -147,7 +147,7 @@ against the shorter phrase the Console composes for the same error in
 `.reconnecting` and `.failed`, and they partition the error set: the session
 emits `.failed` only where `isRetryable` is false and `.reconnecting` only
 where it is true. On `.failed` the text names an action the user can take in
-10 of the 12 cases `isRetryable` rejects outright; on `.reconnecting` it does
+11 of the 13 cases `isRetryable` rejects outright; on `.reconnecting` it does
 so in none of the 5 it accepts, restating what happened and appending the
 transport's raw detail in three of them (`jumpHostFailed` prefixes and
 inherits whichever it wraps). So what the guidance adds over the Console's

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		8C92D59797AB4EAB9C01F6DD /* SecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D2BCB4E4038F510852F71C /* SecretStore.swift */; };
 		8D9ED28E1DB5A72B471CBD45 /* AppAppearanceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEAF21DF91A1BCE4C9F79A3 /* AppAppearanceSettings.swift */; };
 		8DF7095F918DBDA5B76F24F1 /* HeelerSSH in Frameworks */ = {isa = PBXBuildFile; productRef = 13CFA5F5C15E83F411CC03BA /* HeelerSSH */; };
+		8E205B2A9767D2C9538C6D39 /* HerdrHostPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7D28071688F3A69201EEE7 /* HerdrHostPath.swift */; };
 		8E440AFCE2BF426ECD8E0A86 /* SecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D2BCB4E4038F510852F71C /* SecretStore.swift */; };
 		8EB4F2396CC905928797A622 /* AgentName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4692E780178FDFA1CF9537B1 /* AgentName.swift */; };
 		8F91EAC7F32AA058E7F23394 /* TerminalKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247FF74AD248F26A072EA263 /* TerminalKeyboard.swift */; };
@@ -246,6 +247,7 @@
 		FA19EF5420E1D4FFFEF78155 /* TerminalStatusDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DAC3DCDEF81B14A2019DDBE /* TerminalStatusDialog.swift */; };
 		FB3A2B881CE2C93601F1A90F /* SkillFrontmatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB3A0C20671F436B322D0F3 /* SkillFrontmatter.swift */; };
 		FC3565466275E3A63ED59687 /* PairingCeremony.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CA687285B470E3968D1DB6 /* PairingCeremony.swift */; };
+		FCC374190EE36E254109D6AD /* HerdrHostPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB90BB1A82BAAD178E1258F3 /* HerdrHostPathTests.swift */; };
 		FE166661ED7A958DBE0F48B7 /* NotificationRegistrationCeremonyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078D357A959644457EA59E43 /* NotificationRegistrationCeremonyTests.swift */; };
 		FE387FB6FB6CC68E066B23AE /* HostCredentialsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBBD602AA4969937A9306C3 /* HostCredentialsProvider.swift */; };
 		FEC497C4A95E5F4D945EF3BA /* EventsSessionSubscriptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AD641EA732307D72698216 /* EventsSessionSubscriptionsTests.swift */; };
@@ -430,6 +432,7 @@
 		962BDE6D5BFCD443EC3B5FF4 /* SnippetStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetStoreTests.swift; sourceTree = "<group>"; };
 		96A41E40939438986DE30402 /* TransportConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportConnector.swift; sourceTree = "<group>"; };
 		9A430D16838A39772ED0AA73 /* AgentStatusPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentStatusPalette.swift; sourceTree = "<group>"; };
+		9C7D28071688F3A69201EEE7 /* HerdrHostPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrHostPath.swift; sourceTree = "<group>"; };
 		9CFA2284DB622A6EB63D2F85 /* HerdrWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWire.swift; sourceTree = "<group>"; };
 		9D5CBA3E14F186170A2EF2CA /* AgentNotificationRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationRendererTests.swift; sourceTree = "<group>"; };
 		9F979754410821940D0C4DEC /* SolvingOrbRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolvingOrbRendererTests.swift; sourceTree = "<group>"; };
@@ -471,6 +474,7 @@
 		C82C6169E59B0000AA3FF5CC /* RenameSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameSheetView.swift; sourceTree = "<group>"; };
 		C87F6E13D72316E56DC0C571 /* NotificationPreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPreferencesStore.swift; sourceTree = "<group>"; };
 		C90B11BF4D2B2C45635B5EFE /* TerminalThemeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemeSettings.swift; sourceTree = "<group>"; };
+		CB90BB1A82BAAD178E1258F3 /* HerdrHostPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrHostPathTests.swift; sourceTree = "<group>"; };
 		CBC80D00F652CB84103C246F /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		CC2E07D2395573D9EF9DE8B9 /* StartAgentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentView.swift; sourceTree = "<group>"; };
 		CC67B000BBBD99D10CB7A30E /* SnippetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetTests.swift; sourceTree = "<group>"; };
@@ -587,6 +591,7 @@
 				B1AEA55D1F06B12005DEEE5F /* HeelerSSHSessionE2ETests.swift */,
 				7683DF30B1A0E9FA0064AAA2 /* HeelerSSHTransportBehaviorE2ETests.swift */,
 				16A6D0F6E54809BDE46AC1AE /* HerdrEventsTests.swift */,
+				CB90BB1A82BAAD178E1258F3 /* HerdrHostPathTests.swift */,
 				31F09325DE68693680E5A3BB /* HerdrSocketLocationTests.swift */,
 				A30FA0CFA49274EB428AD3E0 /* HerdrWireTests.swift */,
 				F9D664871CA1A56418C106BC /* HostDraftTests.swift */,
@@ -878,6 +883,7 @@
 				D6F4E5BC2440CFE0FEB3591B /* HeelerSSHHostKeyVerifier.swift */,
 				FE62169C67E1ED1082DB98B9 /* HeelerSSHTransport.swift */,
 				764EB7D298185F64BA26C8B2 /* HerdrEvents.swift */,
+				9C7D28071688F3A69201EEE7 /* HerdrHostPath.swift */,
 				9CFA2284DB622A6EB63D2F85 /* HerdrWire.swift */,
 				B4EA32065B4A00D219B301CF /* HostKeyFingerprint.swift */,
 				03E19BDF2824DC34B28A765C /* HostKeyPolicy.swift */,
@@ -1203,6 +1209,7 @@
 				4B05BA1966251828850D2AFF /* HeelerSSHTransport.swift in Sources */,
 				36FB81E449F98DC68A366C2E /* HerdrAPITypes.swift in Sources */,
 				E9D5DD0D136597844A8FE54B /* HerdrEvents.swift in Sources */,
+				8E205B2A9767D2C9538C6D39 /* HerdrHostPath.swift in Sources */,
 				BB26A50348D73A7852417D5B /* HerdrWire.swift in Sources */,
 				E89FDBBF01AA72A922ED0F03 /* Host.swift in Sources */,
 				91BF879F537B1B0DD0B5E78B /* HostConsoleProjection.swift in Sources */,
@@ -1345,6 +1352,7 @@
 				C626797B247A8ED6513D2EBB /* HeelerSSHSessionE2ETests.swift in Sources */,
 				DA607F169DB8EF4549F65134 /* HeelerSSHTransportBehaviorE2ETests.swift in Sources */,
 				7F8EA3E191EEC97479E3DC04 /* HerdrEventsTests.swift in Sources */,
+				FCC374190EE36E254109D6AD /* HerdrHostPathTests.swift in Sources */,
 				2E82149F859FCBF05F9E999B /* HerdrSocketLocationTests.swift in Sources */,
 				8BC6A5F3341FEE8734ECB0B0 /* HerdrWireTests.swift in Sources */,
 				9583D6804B8922588AD7F154 /* HostDraftTests.swift in Sources */,

--- a/Sources/Heeler/Console/AttachTerminalStore.swift
+++ b/Sources/Heeler/Console/AttachTerminalStore.swift
@@ -289,6 +289,8 @@ final class AttachTerminalStore {
             "Another terminal is already open on this Host."
         case TransportError.timedOut:
             "The Host did not answer in time."
+        case TransportError.herdrBinaryNotFound:
+            TransportError.herdrBinaryNotFound.connectionGuidance
         default:
             "The session failed: \(error)"
         }

--- a/Sources/Heeler/Hosts/Preflight.swift
+++ b/Sources/Heeler/Hosts/Preflight.swift
@@ -133,6 +133,11 @@ struct PreflightReport: Equatable, Sendable {
             // taxonomy total anyway.
             check = .connection
             hint = "The connection is busy. Try again."
+        case .herdrBinaryNotFound:
+            // Preflight is one connect + ping and never execs herdr, so this
+            // case cannot fire here. Keep the closed taxonomy total anyway.
+            check = .connection
+            hint = "The herdr CLI was not found on the Host."
         case .jumpHostFailed(let underlying):
             // The first hop broke, so the Host itself was never contacted and
             // nothing about it has been disproved. Name the Jump Host as the

--- a/Sources/Heeler/Notifications/NotificationPreferencesStore.swift
+++ b/Sources/Heeler/Notifications/NotificationPreferencesStore.swift
@@ -226,6 +226,8 @@ final class NotificationPreferencesStore {
             "The Host is not connected."
         case TransportError.timedOut:
             "The Host did not answer in time."
+        case TransportError.herdrBinaryNotFound:
+            TransportError.herdrBinaryNotFound.connectionGuidance
         case is TransportError:
             "The connection to the Host failed."
         default:

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -9,6 +9,9 @@ private struct HeelerSSHSessionListResponse: Decodable {
 private enum HeelerSSHAttachPumpError: Error, Sendable {
     case input(String)
     case output(String)
+    /// Remote process exited nonzero. Distinct from a channel I/O failure so
+    /// Attach can map a bare-`herdr` exit 127 onto the PATH problem (#206).
+    case remoteExit(Int32)
 }
 
 /// The live PTY operations used by the Attach pumps. `SSHPTYChannel` is the
@@ -1040,7 +1043,13 @@ actor HeelerSSHTransport: Transport {
 
     private func runNotificationPluginProbe(command: String) async throws -> Data {
         do {
-            let result = try await runExec(Self.cLocaleCommand(command))
+            let result = try await runExec(
+                Self.cLocaleCommand(HerdrHostPath.wrappingBareHerdr(command)))
+            if let missing = HerdrHostPath.missingBinaryError(
+                exitStatus: result.exitStatus, command: command)
+            {
+                throw missing
+            }
             guard result.exitStatus == 0, result.reachedEOF else {
                 throw NotificationRegistrationError.pluginProbeFailed(
                     detail: "The Host plugin probe failed.")
@@ -1050,6 +1059,8 @@ actor HeelerSSHTransport: Transport {
             throw TransportError.cancelled
         } catch TransportError.timedOut {
             throw TransportError.timedOut
+        } catch TransportError.herdrBinaryNotFound {
+            throw TransportError.herdrBinaryNotFound
         } catch let error as NotificationRegistrationError {
             throw error
         } catch {
@@ -1577,7 +1588,13 @@ actor HeelerSSHTransport: Transport {
 
     private func runHostCommand(_ command: String) async throws -> Data {
         try await withRequestDeadline {
-            let result = try await self.runExec(Self.cLocaleCommand(command))
+            let result = try await self.runExec(
+                Self.cLocaleCommand(HerdrHostPath.wrappingBareHerdr(command)))
+            if let missing = HerdrHostPath.missingBinaryError(
+                exitStatus: result.exitStatus, command: command)
+            {
+                throw missing
+            }
             guard result.reachedEOF else {
                 throw TransportError.channelFailed(
                     detail: "Host command closed before EOF")
@@ -1705,17 +1722,8 @@ actor HeelerSSHTransport: Transport {
         String(decoding: data.prefix(200), as: UTF8.self)
     }
 
-    /// Additional PATH entries to probe before the bare herdr command.
-    /// Covers Homebrew (Intel + Apple Silicon) and Cargo installs, which are
-    /// absent from the non-interactive /bin/sh PATH (#206).
-    private static let herdrPathPrefix = "/usr/local/bin:/opt/homebrew/bin:$HOME/.cargo/bin:$PATH"
-
     private static func cLocaleCommand(_ command: String) -> String {
         "LC_ALL=C \(command)"
-    }
-
-    private static func pathAugmentedCommand(_ command: String) -> String {
-        "PATH=\"\(herdrPathPrefix)\" LC_ALL=C \(command)"
     }
 
     /// The exec command that wakes a stopped herdr server (#6). A named
@@ -1729,19 +1737,20 @@ actor HeelerSSHTransport: Transport {
                 detail: "The remote socket path cannot be quoted safely.")
         }
         let command: String
-        let augmentedCommand = pathAugmentedCommand(wakeCommand)
         switch socketLocation {
         case .namedSession(let sessionName):
             guard HerdrSessionName.isValid(sessionName) else {
                 throw TransportError.channelFailed(
                     detail: "The herdr session name is invalid.")
             }
-            command = "/bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
-                + "export HERDR_SESSION=\"$2\"; \(augmentedCommand) < /dev/null' wake "
+            command = "/bin/sh -c '\(HerdrHostPath.pathExport); "
+                + "export HERDR_SOCKET_PATH=\"$1\"; "
+                + "export HERDR_SESSION=\"$2\"; \(wakeCommand) < /dev/null' wake "
                 + "\(quotedSocketPath) \(sessionName)"
         case .defaultSession, .absolutePath:
-            command = "/bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
-                + "\(augmentedCommand) < /dev/null' wake \(quotedSocketPath)"
+            command = "/bin/sh -c '\(HerdrHostPath.pathExport); "
+                + "export HERDR_SOCKET_PATH=\"$1\"; "
+                + "\(wakeCommand) < /dev/null' wake \(quotedSocketPath)"
         }
         return cLocaleCommand(command)
     }
@@ -1982,7 +1991,8 @@ actor HeelerSSHTransport: Transport {
                     channel: channel,
                     admissionLease: lease,
                     input: input,
-                    output: outputGate)
+                    output: outputGate,
+                    attachCommand: attachCommand)
             }
             return TerminalAttachSession(
                 output: outputGate.makeOutput,
@@ -2033,11 +2043,21 @@ actor HeelerSSHTransport: Transport {
         let takeover = request.takeover ? " --takeover" : ""
         // The marker goes out last thing before the exec, so earlier startup
         // chatter can be dropped.
-        let augmentedCommand = pathAugmentedCommand(attachCommand)
-        return "/bin/sh -c 'export HERDR_SOCKET_PATH=\"$2\"; "
+        return "/bin/sh -c '\(HerdrHostPath.pathExport); "
+            + "export HERDR_SOCKET_PATH=\"$2\"; "
             + "printf \"\(AttachBootstrapHandshake.markerPrintfFormat)\"; "
-            + "exec \(augmentedCommand) \"$1\"\(takeover)' attach "
+            + "exec \(attachCommand) \"$1\"\(takeover)' attach "
             + "'\(request.target)' \(quotedSocketPath)"
+    }
+
+    /// Maps a remote attach exit onto the Transport taxonomy. Exit 127 is
+    /// `herdrBinaryNotFound` only when the exec'd command is still a bare
+    /// `herdr` word; injectable scripts keep the generic channel failure.
+    static func attachChannelFailure(
+        exitStatus: Int32, attachCommand: String
+    ) -> TransportError {
+        HerdrHostPath.missingBinaryError(exitStatus: exitStatus, command: attachCommand)
+            ?? .channelFailed(detail: "attach channel: remote exit status \(exitStatus)")
     }
 
     private func runAttachChannel(
@@ -2045,7 +2065,8 @@ actor HeelerSSHTransport: Transport {
         channel: SSHPTYChannel,
         admissionLease: SSHChannelAdmissionLease,
         input: TerminalAttachInputQueue,
-        output: HeelerSSHAttachOutputGate
+        output: HeelerSSHAttachOutputGate,
+        attachCommand: String
     ) async {
         var failure: TransportError?
         var sawCleanEnd = false
@@ -2074,6 +2095,9 @@ actor HeelerSSHTransport: Transport {
                     failure = .channelFailed(detail: "attach input: \(detail)")
                 case .output(let detail):
                     failure = .channelFailed(detail: "attach channel: \(detail)")
+                case .remoteExit(let status):
+                    failure = Self.attachChannelFailure(
+                        exitStatus: status, attachCommand: attachCommand)
                 case nil:
                     failure = .channelFailed(detail: "attach channel: \(error)")
                 }
@@ -2154,8 +2178,7 @@ actor HeelerSSHTransport: Transport {
                             let status = try await channel.exitStatus(timeout: requestTimeout)
                             guard status == 0 else {
                                 yieldAdmitted(gate.flush())
-                                throw HeelerSSHAttachPumpError.output(
-                                    "remote exit status \(status)")
+                                throw HeelerSSHAttachPumpError.remoteExit(status)
                             }
                             yieldAdmitted(gate.flush())
                             return true

--- a/Sources/Heeler/Transport/HerdrHostPath.swift
+++ b/Sources/Heeler/Transport/HerdrHostPath.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Where `herdr` actually lives on Hosts that install it via Homebrew,
+/// linuxbrew, cargo, or a user-local prefix.
+///
+/// SSH exec is not a login shell: sshd's default `PATH` is typically
+/// `/usr/bin:/bin`, so a Host that can run `herdr` interactively still
+/// answers `exec: herdr: not found` (exit 127) on Attach. The API socket
+/// path does not need the binary — that is why the Console can list Agents
+/// while the PTY Attach dies (#206).
+///
+/// Extra prefixes are appended after the session `PATH` so an existing
+/// `herdr` keeps priority. There is no separate discovery probe: those
+/// prefixes already cover the same directories, and a probe would add a
+/// round trip inside attach/wake/session-list deadlines.
+///
+/// Two ways the prefixes get onto a command, pick by how `herdr` is spelled:
+/// - ``wrappingBareHerdr(_:)`` at the exec site when the command *word* is
+///   still an unpathed `herdr` (session list, plugin list, and those
+///   overrides).
+/// - Bake ``pathExport`` into an existing `/bin/sh -c` body when `herdr`
+///   lives inside that body (the default plugin config-dir probe uses
+///   command substitution). Wrapping looks only at the command word, so it
+///   cannot see that inner `herdr`.
+enum HerdrHostPath: Sendable {
+    /// Directories appended to `PATH` on herdr CLI execs. `$HOME` is
+    /// expanded by the remote `/bin/sh`, not by Swift.
+    static let extraPATH =
+        "$HOME/.local/bin:$HOME/.linuxbrew/bin:$HOME/.cargo/bin:"
+        + "/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin"
+
+    static var pathAssignment: String {
+        "PATH=\"$PATH:\(extraPATH)\""
+    }
+
+    static var pathExport: String {
+        "export \(pathAssignment)"
+    }
+
+    /// True when `command` invokes an unpathed `herdr` as its command word.
+    /// Leading `NAME=value` assignments are skipped, so `HERDR_X=1 herdr …`
+    /// still counts. Quoted literals (`'herdr: not json'`), `ENV=herdr` in
+    /// front of another command, and absolute injectables (`/opt/herdr-wake`,
+    /// `/nonexistent/herdr`) stay false.
+    static func isBareHerdrCommand(_ command: String) -> Bool {
+        commandWord(in: command) == "herdr"
+    }
+
+    /// Wraps a still-bare `herdr …` in `/bin/sh` so the extra prefixes are
+    /// visible even when the account shell is fish (`$PATH` is a list there).
+    /// The wrap therefore runs under POSIX sh, not the login shell: a `herdr`
+    /// that exists only as a shell function or alias is not visible.
+    /// Injectable commands whose command word is not `herdr` are unchanged.
+    /// Embedded single quotes are escaped with `'\''` so a per-Host override
+    /// such as `herdr --config '/x/y' session list` still gets the PATH fix.
+    static func wrappingBareHerdr(_ command: String) -> String {
+        guard isBareHerdrCommand(command) else { return command }
+        let escaped = command.replacingOccurrences(of: "'", with: "'\\''")
+        return "/bin/sh -c '\(pathExport); exec \(escaped)'"
+    }
+
+    /// Exit 127 from a still-bare `herdr` is the PATH miss (#206). Any other
+    /// status, or an injectable command, is left for the caller.
+    static func missingBinaryError(
+        exitStatus: Int32, command: String
+    ) -> TransportError? {
+        guard exitStatus == 127, isBareHerdrCommand(command) else { return nil }
+        return .herdrBinaryNotFound
+    }
+
+    private static func commandWord(in command: String) -> Substring? {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed.split(whereSeparator: \.isWhitespace)
+            .first { !isEnvironmentAssignment($0) }
+    }
+
+    /// POSIX `NAME=value` words a shell would consume before the command.
+    private static func isEnvironmentAssignment(_ word: Substring) -> Bool {
+        guard let separator = word.firstIndex(of: "="), separator > word.startIndex else {
+            return false
+        }
+        let name = word[..<separator]
+        guard let first = name.first, first.isASCII else { return false }
+        guard first.isLetter || first == "_" else { return false }
+        return name.dropFirst().allSatisfy { character in
+            character.isASCII
+                && (character.isLetter || character.isNumber || character == "_")
+        }
+    }
+}

--- a/Sources/Heeler/Transport/SSHTransportSettings.swift
+++ b/Sources/Heeler/Transport/SSHTransportSettings.swift
@@ -29,7 +29,8 @@ struct SSHTransportSettings: Sendable {
     static let notificationPluginIDToken = "__HEELER_PLUGIN_ID__"
 
     static let defaultNotificationConfigDirCommand =
-        "/bin/sh -c 'printf \"__HEELER_PLUGIN_CONFIG_DIR__=%s\\n\" "
+        "/bin/sh -c '\(HerdrHostPath.pathExport); "
+        + "printf \"__HEELER_PLUGIN_CONFIG_DIR__=%s\\n\" "
         + "\"$(herdr plugin config-dir \(notificationPluginIDToken))\"'"
 
     /// The default of ``requestTimeout``, named so budgets derived from it
@@ -62,8 +63,9 @@ struct SSHTransportSettings: Sendable {
     /// the strategy from spec #16: `herdr remote-client-bridge` ensures the
     /// server is running (spawn + wait for socket) before bridging, then
     /// exits on stdin EOF. Injectable so tests can substitute a script at
-    /// the environment boundary; per-Host override also covers hosts where
-    /// herdr is not on the login shell's PATH.
+    /// the environment boundary. The exec wrapper already appends the
+    /// well-known install prefixes to PATH; a per-Host override is for a
+    /// binary that lives somewhere else, or for a test fixture.
     var wakeCommand: String = Self.defaultWakeCommand
     /// Official Host-local CLI command for discovering default and named
     /// sessions. It does not depend on a running API socket.
@@ -76,8 +78,9 @@ struct SSHTransportSettings: Sendable {
     /// Command that attaches interactively to a Pane, sent as the exec request
     /// on the Host's dedicated PTY channel (#11); the attach target and
     /// takeover flag are appended. Injectable so tests can substitute a script
-    /// at the environment boundary; per-Host override also covers hosts where
-    /// herdr is not on PATH.
+    /// at the environment boundary. The exec wrapper already appends the
+    /// well-known install prefixes to PATH; a per-Host override is for a
+    /// binary that lives somewhere else, or for a test fixture.
     var attachCommand: String = Self.defaultAttachCommand
     /// Command used to print a marker-delimited remote home directory. It is
     /// injectable only at the environment boundary for real-SSH tests.

--- a/Sources/Heeler/Transport/Transport.swift
+++ b/Sources/Heeler/Transport/Transport.swift
@@ -558,6 +558,10 @@ indirect enum TransportError: Error, Sendable, Equatable {
     /// The herdr API socket path does not exist on the Host: herdr is not
     /// installed there, or the socket path is wrong.
     case socketNotFound(path: String)
+    /// The herdr CLI is not on the SSH session's PATH and was not found in
+    /// the well-known install prefixes. The API socket can still work — that
+    /// is why the Console may list Agents while Attach fails (#206).
+    case herdrBinaryNotFound
     /// libssh2 cannot distinguish a listening Unix socket rejected by SSH
     /// policy from a stale socket file. The Host needs either herdr started or
     /// stream-local forwarding enabled; presenting a narrower cause would be
@@ -606,7 +610,7 @@ indirect enum TransportError: Error, Sendable, Equatable {
             true
         case .authenticationFailed, .tcpForwardingUnavailable,
             .deviceKeyCorrupt, .hostKeyRejected, .hostKeyMismatch,
-            .socketNotFound, .protocolVersionMismatch,
+            .socketNotFound, .herdrBinaryNotFound, .protocolVersionMismatch,
             .streamLocalOpenFailed,
             .homeDirectoryUnresolvable, .eventsChannelAlreadyOpen,
             .terminalChannelAlreadyOpen, .malformedResponse:

--- a/Sources/Heeler/Transport/TransportError+Presentation.swift
+++ b/Sources/Heeler/Transport/TransportError+Presentation.swift
@@ -17,6 +17,11 @@ extension TransportError {
             "The host key changed. Verify the machine before updating trust."
         case .socketNotFound:
             "The herdr socket was not found. Check this Host's session."
+        case .herdrBinaryNotFound:
+            "herdr is not on this Host's SSH PATH. Homebrew installs are often "
+                + "at /opt/homebrew/bin or /home/linuxbrew/.linuxbrew/bin — "
+                + "put that directory on the account's non-interactive PATH, "
+                + "or symlink herdr into ~/.local/bin."
         case .streamLocalOpenFailed:
             "herdr is not running on this Host. If it is running, check SSH stream-local forwarding."
         case .protocolVersionMismatch(let server, let supported):

--- a/Tests/HeelerTests/HerdrHostPathTests.swift
+++ b/Tests/HeelerTests/HerdrHostPathTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@Suite("Herdr host PATH")
+struct HerdrHostPathTests {
+    @Test func extraPATHIncludesHomebrewAndLinuxbrewPrefixes() {
+        #expect(HerdrHostPath.extraPATH.contains("$HOME/.local/bin"))
+        #expect(HerdrHostPath.extraPATH.contains("/opt/homebrew/bin"))
+        #expect(HerdrHostPath.extraPATH.contains("/home/linuxbrew/.linuxbrew/bin"))
+        #expect(HerdrHostPath.extraPATH.contains("$HOME/.linuxbrew/bin"))
+        #expect(HerdrHostPath.extraPATH.contains("$HOME/.cargo/bin"))
+        #expect(HerdrHostPath.extraPATH.contains("/usr/local/bin"))
+        // Existing PATH entries keep priority over the extra prefixes.
+        #expect(HerdrHostPath.pathExport.hasPrefix("export PATH=\"$PATH:"))
+    }
+
+    @Test func bareHerdrIsOnlyTheCommandWord() {
+        #expect(HerdrHostPath.isBareHerdrCommand("herdr agent attach"))
+        #expect(HerdrHostPath.isBareHerdrCommand("herdr session list --json"))
+        #expect(HerdrHostPath.isBareHerdrCommand("herdr plugin list --json"))
+        #expect(HerdrHostPath.isBareHerdrCommand("  herdr remote-client-bridge"))
+        #expect(HerdrHostPath.isBareHerdrCommand("HERDR_X=1 herdr session list --json"))
+        #expect(HerdrHostPath.isBareHerdrCommand("FOO=bar BAZ=qux herdr plugin list --json"))
+        #expect(HerdrHostPath.isBareHerdrCommand("herdr --config '/tmp/x y' session list"))
+        #expect(!HerdrHostPath.isBareHerdrCommand("/opt/herdr-wake --foreground"))
+        #expect(!HerdrHostPath.isBareHerdrCommand("/nonexistent/herdr plugin list --json"))
+        #expect(!HerdrHostPath.isBareHerdrCommand("/bin/sh /tmp/fake-attach.sh"))
+        // Assignment whose *value* is "herdr", then a different command word.
+        #expect(!HerdrHostPath.isBareHerdrCommand("ENV=herdr /bin/sh -c 'true'"))
+        #expect(!HerdrHostPath.isBareHerdrCommand("herdr=1 session list --json"))
+        // Quoted literals must not count as the command word (#206 review).
+        #expect(!HerdrHostPath.isBareHerdrCommand("printf '%s' 'herdr: not json'"))
+        #expect(
+            !HerdrHostPath.isBareHerdrCommand(
+                SSHTransportSettings.defaultNotificationConfigDirCommand))
+    }
+
+    @Test func wrappingBareHerdrUsesPOSIXShAndLeavesInjectablesAlone() {
+        let wrapped = HerdrHostPath.wrappingBareHerdr("herdr session list --json")
+        #expect(wrapped.hasPrefix("/bin/sh -c '\(HerdrHostPath.pathExport); exec herdr "))
+        #expect(wrapped.contains("exec herdr session list --json"))
+
+        #expect(
+            HerdrHostPath.wrappingBareHerdr("/opt/herdr-wake --foreground")
+                == "/opt/herdr-wake --foreground")
+        #expect(
+            HerdrHostPath.wrappingBareHerdr("/nonexistent/herdr plugin list --json")
+                == "/nonexistent/herdr plugin list --json")
+        #expect(
+            HerdrHostPath.wrappingBareHerdr("printf '%s' 'herdr: not json'")
+                == "printf '%s' 'herdr: not json'")
+    }
+
+    @Test func wrappingKeepsAQuotedOverrideOnThePATHFix() {
+        let wrapped = HerdrHostPath.wrappingBareHerdr(
+            "herdr --config '/tmp/x y' session list --json")
+        #expect(wrapped.hasPrefix("/bin/sh -c '\(HerdrHostPath.pathExport); exec herdr "))
+        #expect(wrapped.contains(#"exec herdr --config '\''/tmp/x y'\'' session list --json"#))
+    }
+
+    @Test func wrappingKeepsLeadingEnvironmentAssignments() {
+        let wrapped = HerdrHostPath.wrappingBareHerdr("HERDR_X=1 herdr session list --json")
+        #expect(wrapped.contains("exec HERDR_X=1 herdr session list --json"))
+        #expect(wrapped.contains(HerdrHostPath.pathExport))
+    }
+
+    @Test func wrappingUsesPOSIXShBecauseFishTreatsPATHAsAList() {
+        // fish joins `"$PATH"` with spaces, not colons. The wrap therefore
+        // never lets the account shell expand PATH: POSIX sh does it.
+        let wrapped = HerdrHostPath.wrappingBareHerdr("herdr session list --json")
+        #expect(wrapped.hasPrefix("/bin/sh -c '"))
+        #expect(HerdrHostPath.pathExport.contains("\"$PATH:"))
+        #expect(!wrapped.hasPrefix("PATH="))
+        #expect(!wrapped.hasPrefix("export PATH="))
+    }
+
+    @Test func missingBinaryErrorIsOnlyBareHerdrExit127() {
+        #expect(
+            HerdrHostPath.missingBinaryError(
+                exitStatus: 127, command: "herdr session list --json")
+                == .herdrBinaryNotFound)
+        #expect(
+            HerdrHostPath.missingBinaryError(
+                exitStatus: 127, command: "HERDR_X=1 herdr session list --json")
+                == .herdrBinaryNotFound)
+        #expect(
+            HerdrHostPath.missingBinaryError(
+                exitStatus: 127, command: "/nonexistent/herdr plugin list --json")
+                == nil)
+        #expect(
+            HerdrHostPath.missingBinaryError(
+                exitStatus: 1, command: "herdr session list --json")
+                == nil)
+    }
+
+    @Test func notificationConfigDirDefaultExportsTheExtraPATH() {
+        let command = SSHTransportSettings.defaultNotificationConfigDirCommand
+        #expect(command.contains(HerdrHostPath.pathExport))
+        #expect(command.contains("/home/linuxbrew/.linuxbrew/bin"))
+        // Command substitution would swallow a 127; do not pretend to classify it.
+        #expect(!HerdrHostPath.isBareHerdrCommand(command))
+        #expect(HerdrHostPath.wrappingBareHerdr(command) == command)
+    }
+
+    @Test func attachExecExportsTheExtraPATHBeforeExec() throws {
+        let command = try HeelerSSHTransport.attachExecCommand(
+            attachCommand: "herdr agent attach",
+            request: TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24),
+            socketPath: "/tmp/fake.sock")
+        #expect(command.contains(HerdrHostPath.pathExport))
+        #expect(command.contains("/home/linuxbrew/.linuxbrew/bin"))
+        #expect(command.contains("export PATH=\"$PATH:"))
+        #expect(command.contains("exec herdr agent attach"))
+    }
+
+    @Test func attachExecKeepsAnInjectableAbsoluteCommand() throws {
+        let command = try HeelerSSHTransport.attachExecCommand(
+            attachCommand: "/home/linuxbrew/.linuxbrew/bin/herdr agent attach",
+            request: TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24),
+            socketPath: "/tmp/fake.sock")
+        #expect(
+            command.contains("exec /home/linuxbrew/.linuxbrew/bin/herdr agent attach"))
+        #expect(
+            !HerdrHostPath.isBareHerdrCommand(
+                "/home/linuxbrew/.linuxbrew/bin/herdr agent attach"))
+    }
+}

--- a/Tests/HeelerTests/PreflightReportTests.swift
+++ b/Tests/HeelerTests/PreflightReportTests.swift
@@ -64,6 +64,8 @@ struct PreflightReportTests {
         (.cancelled, .connection),
         (.channelFailed(detail: "boom"), .connection),
         (.eventsChannelAlreadyOpen, .connection),
+        // Not reachable from connect+ping (preflight never execs herdr).
+        (.herdrBinaryNotFound, .connection),
         (.jumpHostFailed(.sshUnreachable(detail: "refused")), .connection),
         (.tcpForwardingUnavailable, .connection),
         (.socketNotFound(path: "/home/dev/.config/herdr/herdr.sock"), .herdrInstalled),

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -1546,9 +1546,10 @@ struct TerminalAttachTests {
             request: TerminalAttachRequest(target: "w1:p1", cols: 80, rows: 24),
             socketPath: "/tmp/fake.sock")
         #expect(
-            command == "/bin/sh -c 'export HERDR_SOCKET_PATH=\"$2\"; "
+            command == "/bin/sh -c '\(HerdrHostPath.pathExport); "
+                + "export HERDR_SOCKET_PATH=\"$2\"; "
                 + "printf \"\(AttachBootstrapHandshake.markerPrintfFormat)\"; "
-                + "exec PATH=\"/usr/local/bin:/opt/homebrew/bin:$HOME/.cargo/bin:$PATH\" LC_ALL=C /bin/sh /tmp/fake-attach.sh \"$1\"' attach "
+                + "exec /bin/sh /tmp/fake-attach.sh \"$1\"' attach "
                 + "'w1:p1' '/tmp/fake.sock'")
     }
 
@@ -1563,9 +1564,10 @@ struct TerminalAttachTests {
             socketPath: "/home/u/.config/herdr/sessions/dev/herdr.sock")
 
         #expect(
-            command == "/bin/sh -c 'export HERDR_SOCKET_PATH=\"$2\"; "
+            command == "/bin/sh -c '\(HerdrHostPath.pathExport); "
+                + "export HERDR_SOCKET_PATH=\"$2\"; "
                 + "printf \"\(AttachBootstrapHandshake.markerPrintfFormat)\"; "
-                + "exec PATH=\"/usr/local/bin:/opt/homebrew/bin:$HOME/.cargo/bin:$PATH\" LC_ALL=C herdr agent attach \"$1\" --takeover' attach "
+                + "exec herdr agent attach \"$1\" --takeover' attach "
                 + "'w1:p1' '/home/u/.config/herdr/sessions/dev/herdr.sock'")
         // An exec request, not a line typed into a shell: no trailing newline.
         #expect(!command.hasSuffix("\n"))
@@ -1606,8 +1608,54 @@ struct TerminalAttachTests {
         #expect(command.contains(markerPrintf))
         // Marker is the last thing before exec of attach, not after it.
         let printfRange = try #require(command.range(of: markerPrintf))
-        let execRange = try #require(command.range(of: "PATH=\"/usr/local/bin:/opt/homebrew/bin:$HOME/.cargo/bin:$PATH\" LC_ALL=C herdr agent attach"))
+        let execRange = try #require(command.range(of: "exec herdr agent attach"))
         #expect(printfRange.upperBound <= execRange.lowerBound)
+    }
+
+    @Test func attachExit127OnBareHerdrIsAMissingBinary() {
+        #expect(
+            HeelerSSHTransport.attachChannelFailure(
+                exitStatus: 127, attachCommand: "herdr agent attach")
+                == .herdrBinaryNotFound)
+    }
+
+    @Test func attachExit127OnAnInjectableCommandStaysAChannelFailure() {
+        #expect(
+            HeelerSSHTransport.attachChannelFailure(
+                exitStatus: 127, attachCommand: "/bin/sh /tmp/fake-attach.sh")
+                == .channelFailed(detail: "attach channel: remote exit status 127"))
+    }
+
+    @Test func attachExit127OnAnAbsoluteHerdrStaysAChannelFailure() {
+        #expect(
+            HeelerSSHTransport.attachChannelFailure(
+                exitStatus: 127,
+                attachCommand: "/nonexistent/herdr agent attach")
+                == .channelFailed(detail: "attach channel: remote exit status 127"))
+    }
+
+    @Test func attachNonzeroExitBesides127StaysAChannelFailure() {
+        #expect(
+            HeelerSSHTransport.attachChannelFailure(
+                exitStatus: 23, attachCommand: "herdr agent attach")
+                == .channelFailed(detail: "attach channel: remote exit status 23"))
+    }
+
+    @Test func attachPumpsReportARemoteExitStatus() async throws {
+        let channel = FakeAttachPTYChannel(reads: [nil], remoteExitStatus: 127)
+        let input = TerminalAttachInputQueue()
+        let source = HeelerSSHAttachOutputGate.makeStream()
+
+        do {
+            _ = try await HeelerSSHTransport.runAttachPumps(
+                channel: channel,
+                input: input,
+                output: source.gate,
+                requestTimeout: .seconds(1))
+            Issue.record("exit 127 should fail the attach pumps")
+        } catch {
+            #expect(String(describing: error) == "remoteExit(127)")
+        }
     }
 
     @Test func gateWithholdsStartupChatterUntilTheHandshake() {
@@ -1684,17 +1732,20 @@ private actor FakeAttachPTYChannel: HeelerSSHAttachChannel {
     private var reads: [Data?]
     private let writeError: (any Error & Sendable)?
     private let blockAfterReads: Bool
+    private let remoteExitStatus: Int32
     private var didReadFirst = false
     private var firstReadWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(
         reads: [Data?],
         writeError: (any Error & Sendable)? = nil,
-        blockAfterReads: Bool = false
+        blockAfterReads: Bool = false,
+        remoteExitStatus: Int32 = 0
     ) {
         self.reads = reads
         self.writeError = writeError
         self.blockAfterReads = blockAfterReads
+        self.remoteExitStatus = remoteExitStatus
     }
 
     func write(_: Data, timeout _: Duration) async throws {
@@ -1720,7 +1771,7 @@ private actor FakeAttachPTYChannel: HeelerSSHAttachChannel {
 
     func resize(columns _: Int, rows _: Int, timeout _: Duration) async throws {}
 
-    func exitStatus(timeout _: Duration) async throws -> Int32 { 0 }
+    func exitStatus(timeout _: Duration) async throws -> Int32 { remoteExitStatus }
 
     func waitUntilFirstRead() async {
         guard !didReadFirst else { return }

--- a/Tests/HeelerTests/TransportErrorPresentationTests.swift
+++ b/Tests/HeelerTests/TransportErrorPresentationTests.swift
@@ -22,6 +22,13 @@ struct TransportErrorPresentationTests {
         #expect(TransportError.tcpForwardingUnavailable.isRetryable == false)
     }
 
+    @Test func missingHerdrBinaryNamesTheHomebrewPATH() {
+        let guidance = TransportError.herdrBinaryNotFound.connectionGuidance
+        #expect(guidance.contains("/opt/homebrew/bin"))
+        #expect(guidance.contains("/home/linuxbrew/.linuxbrew/bin"))
+        #expect(TransportError.herdrBinaryNotFound.isRetryable == false)
+    }
+
     @Test func channelFailureIncludesItsDiagnosticDetail() {
         #expect(
             TransportError.channelFailed(detail: "connection reset").connectionGuidance

--- a/Tests/HeelerTests/WakeCommandTests.swift
+++ b/Tests/HeelerTests/WakeCommandTests.swift
@@ -27,8 +27,9 @@ struct WakeCommandTests {
             socketLocation: .namedSession("testloop"))
 
         #expect(
-            command == "LC_ALL=C /bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
-                + "export HERDR_SESSION=\"$2\"; PATH=\"/usr/local/bin:/opt/homebrew/bin:$HOME/.cargo/bin:$PATH\" LC_ALL=C herdr remote-client-bridge < /dev/null' wake "
+            command == "LC_ALL=C /bin/sh -c '\(HerdrHostPath.pathExport); "
+                + "export HERDR_SOCKET_PATH=\"$1\"; "
+                + "export HERDR_SESSION=\"$2\"; herdr remote-client-bridge < /dev/null' wake "
                 + "'/home/u/.config/herdr/sessions/testloop/herdr.sock' testloop")
     }
 
@@ -39,8 +40,9 @@ struct WakeCommandTests {
             socketLocation: .defaultSession)
 
         #expect(
-            command == "LC_ALL=C /bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
-                + "PATH=\"/usr/local/bin:/opt/homebrew/bin:$HOME/.cargo/bin:$PATH\" LC_ALL=C /opt/herdr-wake --foreground < /dev/null' wake "
+            command == "LC_ALL=C /bin/sh -c '\(HerdrHostPath.pathExport); "
+                + "export HERDR_SOCKET_PATH=\"$1\"; "
+                + "/opt/herdr-wake --foreground < /dev/null' wake "
                 + "'/home/u/.config/herdr/herdr.sock'")
     }
 
@@ -51,8 +53,9 @@ struct WakeCommandTests {
             socketLocation: .absolutePath("/home/u/My Config/herdr.sock"))
 
         #expect(
-            command == "LC_ALL=C /bin/sh -c 'export HERDR_SOCKET_PATH=\"$1\"; "
-                + "PATH=\"/usr/local/bin:/opt/homebrew/bin:$HOME/.cargo/bin:$PATH\" LC_ALL=C /opt/herdr-wake --foreground < /dev/null' wake "
+            command == "LC_ALL=C /bin/sh -c '\(HerdrHostPath.pathExport); "
+                + "export HERDR_SOCKET_PATH=\"$1\"; "
+                + "/opt/herdr-wake --foreground < /dev/null' wake "
                 + "'/home/u/My Config/herdr.sock'")
     }
 


### PR DESCRIPTION
## Summary

The Console can list Spaces and Agents over the API socket, but Attach (and the other CLI execs) die with `exec: herdr: not found` (exit 127) when herdr lives in Homebrew, linuxbrew, cargo, or `~/.local`. SSH exec is not a login shell; sshd's default `PATH` is typically `/usr/bin:/bin`.

This appends the usual install prefixes after the session `PATH` inside the existing `/bin/sh` wrappers, and wraps a still-bare `herdr …` CLI the same way. A bare-herdr exit 127 becomes `TransportError.herdrBinaryNotFound` with a PATH repair message. Injectable test commands (`/opt/herdr-wake`, `/nonexistent/herdr`) are left alone.

There is no per-Host discovery probe: those prefixes already cover the same directories, and a probe would add a round trip inside attach/wake/session-list deadlines. Preflight stays one connect + ping and never execs herdr.

Fixes #206

## Testing

- `xcodebuild test -project Heeler.xcodeproj -scheme Heeler -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:HeelerTests/WakeCommandTests -only-testing:HeelerTests/TerminalAttachTests -only-testing:HeelerTests/TransportErrorPresentationTests -only-testing:HeelerTests/HerdrHostPathTests -only-testing:HeelerTests/PreflightReportTests`
  - 108 tests in 5 suites, `TEST SUCCEEDED`

> [!NOTE]
> Rebased onto main after #209 merged. This PR supersedes #209's implementation entirely: POSIX sh does not apply variable assignments placed after `exec` (the attach wrapper there exits 126), and the extra prefixes must append after the session PATH so an existing `herdr` keeps priority.
