### PR TITLE
test: wait for the background token after Host suspends

### DIFF
--- a/Tests/HeelerTests/ContentViewActivityDriverTests.swift
+++ b/Tests/HeelerTests/ContentViewActivityDriverTests.swift
@@ -68,11 +68,13 @@ struct ContentViewActivityDriverTests {
         try await waitUntil("the driver should suspend the Host's connection") {
             console.hostStatuses[host.id] == .suspended
         }
-        // The driver also answers the coordinator: the teardown finished, so
-        // the background assertion goes back. Without the driver nothing
-        // releases it.
-        #expect(granter.endedTokens == granter.beginTokens)
-        #expect(granter.endedTokens.count == 1)
+        // `console.suspend()` publishes `.suspended` *before* the driver
+        // calls `didFinishSuspending()` and ends the assertion. Sampling
+        // the granter on the same turn as the status flip is a flake —
+        // wait for the second half the same way as the first.
+        try await waitUntil("the driver should release the background assertion") {
+            granter.endedTokens == granter.beginTokens && granter.endedTokens.count == 1
+        }
         console.setHosts([])
     }
 


### PR DESCRIPTION
## Summary
- `backgroundingPastTheGracePeriodSuspendsTheConsoleConnection` flakes on main after a green PR because it waits only for `hostStatuses == .suspended`, then immediately asserts the background token is gone.
- The driver is two steps: `await console.suspend()` (status flips) then `activity.didFinishSuspending()` (token ends). Same tree, different timing — PR passed in 0.203s, main failed in 0.229s.
- Wait for the token the same way as the status, so CI cannot sample the gap.

## Test plan
- [x] `backgroundingPastTheGracePeriodSuspendsTheConsoleConnection` still fails if `didFinishSuspending()` is deleted (not a weaker assertion)
- [x] Re-run Heeler CI on this PR; the activity-driver suite should stay green without a re-run lottery
