### PR TITLE
feat: pin agents in the console list and live activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,13 @@ Entries reference the issue that motivated them.
 - Pin agents from the Console list with a long-press toggle. Pinned agents
   stay at the top, most recently pinned first. Long-press a chip in the Agent
   switcher on the detail screen to pin or unpin it there too. Lock-screen Live
-  Activities show each Host's active agents: status counts plus the top agents (pinned
-  eligible first, then blocked, done, working), updating in near real time
-  while the app is open and via push after it suspends, ending when every
-  agent goes idle. Agent names, titles, and host names stay end-to-end
-  encrypted and are decrypted on device at render time; the relay sees only
-  the counts. Opt in per Host from Notification Settings; requires the
-  updated herdr plugin.
+  Activities show each Host's active agents: status counts plus the top
+  agents (pinned eligible first, then blocked, done, working), updating in
+  near real time while the app is open and via push after it suspends, ending
+  when every agent goes idle. Agent names, titles, and host names stay
+  end-to-end encrypted and are decrypted on device at render time; the relay
+  sees only the counts. Opt in per Host from Notification Settings; requires
+  the updated herdr plugin.
 
 - Agent detail now places a plus menu to the left of Send. It can add an image
   from Photos or a file up to 64 MiB from Files, stages the selection privately

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Entries reference the issue that motivated them.
   when every agent goes idle. Agent names, titles, and host names stay
   end-to-end encrypted and are decrypted on device at render time; the relay
   sees only the counts. Opt in per Host from Notification Settings; requires
-  the updated herdr plugin.
+  the updated herdr plugin. (#212)
 
 - Agent detail now places a plus menu to the left of Send. It can add an image
   from Photos or a file up to 64 MiB from Files, stages the selection privately

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Entries reference the issue that motivated them.
 
 ### Added
 
+- Pin agents from the Console list with a long-press toggle. Pinned agents
+  stay at the top, most recently pinned first, and the lock-screen Live
+  Activity shows pinned eligible agents ahead of the usual status order.
+
 - Lock-screen Live Activities show each Host's active agents: status counts
   plus the top agents (blocked first), updating in near real time while the
   app is open and via push after it suspends, ending when every agent goes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ Entries reference the issue that motivated them.
 ### Added
 
 - Pin agents from the Console list with a long-press toggle. Pinned agents
-  stay at the top, most recently pinned first. Lock-screen Live Activities
-  show each Host's active agents: status counts plus the top agents (pinned
+  stay at the top, most recently pinned first. Long-press a chip in the Agent
+  switcher on the detail screen to pin or unpin it there too. Lock-screen Live
+  Activities show each Host's active agents: status counts plus the top agents (pinned
   eligible first, then blocked, done, working), updating in near real time
   while the app is open and via push after it suspends, ending when every
   agent goes idle. Agent names, titles, and host names stay end-to-end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,14 @@ Entries reference the issue that motivated them.
 ### Added
 
 - Pin agents from the Console list with a long-press toggle. Pinned agents
-  stay at the top, most recently pinned first, and the lock-screen Live
-  Activity shows pinned eligible agents ahead of the usual status order.
-
-- Lock-screen Live Activities show each Host's active agents: status counts
-  plus the top agents (blocked first), updating in near real time while the
-  app is open and via push after it suspends, ending when every agent goes
-  idle. Agent names, titles, and host names stay end-to-end encrypted and are
-  decrypted on device at render time; the relay sees only the counts. Opt in
-  per Host from Notification Settings; requires the updated herdr plugin.
+  stay at the top, most recently pinned first. Lock-screen Live Activities
+  show each Host's active agents: status counts plus the top agents (pinned
+  eligible first, then blocked, done, working), updating in near real time
+  while the app is open and via push after it suspends, ending when every
+  agent goes idle. Agent names, titles, and host names stay end-to-end
+  encrypted and are decrypted on device at render time; the relay sees only
+  the counts. Opt in per Host from Notification Settings; requires the
+  updated herdr plugin.
 
 - Agent detail now places a plus menu to the left of Send. It can add an image
   from Photos or a file up to 64 MiB from Files, stages the selection privately

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,6 +78,13 @@ _Avoid_: sandbox, branch copy, checkout folder
 The native dashboard surface: the flat, status-sorted list of Agents across Hosts, plus the Agent detail screen.
 _Avoid_: dashboard, home
 
+**Pin**:
+A user-chosen Console marker on an Agent's pane slot (`hostID` + `paneID`).
+Pinned agents float to the top of the Console list and the Live Activity
+by recency. Pins persist locally and are never pruned, so a pane id that
+returns after a herdr restart stays pinned.
+_Avoid_: favorite, star, bookmark
+
 **Composer**:
 The local input control below the Agent's live terminal: a native draft field
 that composes a message entirely on device and delivers it in one piece. Its

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -254,6 +254,8 @@
 		DA9ABDB7E506248091ACF17E /* EventsSessionKeepaliveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 823B2239BDC425FCE456B625 /* EventsSessionKeepaliveTests.swift */; };
 		DB28307A5B8386139CA7EDEE /* TerminalKeyboardInset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CF0F9F0EDF8757DC1D275D2 /* TerminalKeyboardInset.swift */; };
 		DB3815F790623647C0050290 /* PairingScanStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DB60007029322902FD1AFF /* PairingScanStore.swift */; };
+		DC580B52C0F6509F92BB289C /* PinnedAgentsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768235F2FBD7790800281BC3 /* PinnedAgentsStoreTests.swift */; };
+		DDD5A27BA1126296E5AF7EAA /* PinnedAgentsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2437B1D6B97638031514C0F /* PinnedAgentsStore.swift */; };
 		DE020395E7459D508F0CC401 /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC98A5038CD109556BE903F /* NotificationSettingsView.swift */; };
 		DF1D75FBECE8FABC8E3A093D /* AppForegroundRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B248F9372687FDBE3AD24A1 /* AppForegroundRecoveryTests.swift */; };
 		DF88C6F619C253A98F0EC3F6 /* NotificationDisclosureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5416AE7B7A89E2987620E65E /* NotificationDisclosureView.swift */; };
@@ -450,6 +452,7 @@
 		7461B7A0FD2A4CDF34352D45 /* PairingCodeVectorFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCodeVectorFile.swift; sourceTree = "<group>"; };
 		7625958E48639DCE4F5A8391 /* EventsSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSession.swift; sourceTree = "<group>"; };
 		764EB7D298185F64BA26C8B2 /* HerdrEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrEvents.swift; sourceTree = "<group>"; };
+		768235F2FBD7790800281BC3 /* PinnedAgentsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedAgentsStoreTests.swift; sourceTree = "<group>"; };
 		7683DF30B1A0E9FA0064AAA2 /* HeelerSSHTransportBehaviorE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHTransportBehaviorE2ETests.swift; sourceTree = "<group>"; };
 		7780BE78D868DB0A8275E6FB /* Heeler.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Heeler.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		78F85C588963C3CE948AA9E4 /* AgentNotificationBannerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationBannerStore.swift; sourceTree = "<group>"; };
@@ -516,6 +519,7 @@
 		AB48C946E14722E93FAAA410 /* TerminalAttach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAttach.swift; sourceTree = "<group>"; };
 		AD69BB4579A415BE96578319 /* HeelerWidgets.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = HeelerWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		B1AEA55D1F06B12005DEEE5F /* HeelerSSHSessionE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHSessionE2ETests.swift; sourceTree = "<group>"; };
+		B2437B1D6B97638031514C0F /* PinnedAgentsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedAgentsStore.swift; sourceTree = "<group>"; };
 		B24EF5EA39899292A1907226 /* StartAgentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStore.swift; sourceTree = "<group>"; };
 		B2627DBEB9BFBDC600F211A1 /* NotificationPrivacyCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPrivacyCopy.swift; sourceTree = "<group>"; };
 		B2DAE3FAB8786392318939A6 /* NotificationVectorFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationVectorFile.swift; sourceTree = "<group>"; };
@@ -711,6 +715,7 @@
 				1F0763484EE05424146492C1 /* PairingCeremonyTests.swift */,
 				D419158B027AF5F38B73AD8B /* PairingCodeTests.swift */,
 				D026719294E631141C3A59F9 /* PairingScanStoreTests.swift */,
+				768235F2FBD7790800281BC3 /* PinnedAgentsStoreTests.swift */,
 				151586845D0A1EE54968B536 /* PreflightReportTests.swift */,
 				BEE35062339F9D6B0A9E684B /* PushRegistrationStoreTests.swift */,
 				3801638051F3E5F394CF3FBD /* ReconnectPolicyTests.swift */,
@@ -884,6 +889,7 @@
 				C74A32020C9520EB5629B071 /* ConsoleView.swift */,
 				2D6996CA1550E32EE6AC3669 /* GitBranchName.swift */,
 				88E1434C9C39A6419A3A0D79 /* HostConsoleProjection.swift */,
+				B2437B1D6B97638031514C0F /* PinnedAgentsStore.swift */,
 				C7BD377C8BB7AA8205DD8AFC /* RecentWorkspaceStore.swift */,
 				C82C6169E59B0000AA3FF5CC /* RenameSheetView.swift */,
 				381B00805D3CDEEE94DAE35B /* RenameStore.swift */,
@@ -1428,6 +1434,7 @@
 				DB3815F790623647C0050290 /* PairingScanStore.swift in Sources */,
 				430EDF8111CC397CA9BD2008 /* PairingScanView.swift in Sources */,
 				D08663BD250210835FE7ED49 /* PhotosPickerImageSelection.swift in Sources */,
+				DDD5A27BA1126296E5AF7EAA /* PinnedAgentsStore.swift in Sources */,
 				2292C89F605CE42073D49B11 /* Preflight.swift in Sources */,
 				F1896998EA513073CF4EE713 /* PushRegistrationStore.swift in Sources */,
 				C1F06F7588D4713392223CC5 /* RecentWorkspaceStore.swift in Sources */,
@@ -1578,6 +1585,7 @@
 				82600FB64A99ADAD1C60D451 /* PairingCodeTests.swift in Sources */,
 				B3C490CC3562CC5B4B2EB993 /* PairingCodeVectorFile.swift in Sources */,
 				F6A1A833DFFB748716D13EA9 /* PairingScanStoreTests.swift in Sources */,
+				DC580B52C0F6509F92BB289C /* PinnedAgentsStoreTests.swift in Sources */,
 				A194C27FBF0EF6641215D33A /* PreflightReportTests.swift in Sources */,
 				630CF9C336B79F04A9477C58 /* PushRegistrationStoreTests.swift in Sources */,
 				7DE1449E409F7F06C64E5089 /* RealSSHFixture.swift in Sources */,

--- a/Sources/Heeler/Console/AgentCardView.swift
+++ b/Sources/Heeler/Console/AgentCardView.swift
@@ -7,7 +7,7 @@ import UIKit
 /// `claude` — the workspace is what tells the rows apart.
 struct AgentCardView: View {
     let agent: ConsoleAgent
-    let isPinned: Bool = false
+    var isPinned: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {

--- a/Sources/Heeler/Console/AgentCardView.swift
+++ b/Sources/Heeler/Console/AgentCardView.swift
@@ -7,6 +7,7 @@ import UIKit
 /// `claude` — the workspace is what tells the rows apart.
 struct AgentCardView: View {
     let agent: ConsoleAgent
+    let isPinned: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -14,6 +15,13 @@ struct AgentCardView: View {
                 Text(headline)
                     .font(.headline)
                     .lineLimit(1)
+                if isPinned {
+                    Image(systemName: "pin.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .layoutPriority(1)
+                        .accessibilityLabel("Pinned")
+                }
                 Spacer(minLength: 8)
                 AgentStatusBadge(status: agent.agent.status)
             }

--- a/Sources/Heeler/Console/AgentComposerView.swift
+++ b/Sources/Heeler/Console/AgentComposerView.swift
@@ -286,13 +286,14 @@ struct AgentComposerView: View {
     private var focusPreservingSwitcher: TerminalAgentSwitcher {
         TerminalAgentSwitcher(
             items: switcher.items,
-            selectedID: switcher.selectedID
-        ) { id in
-            if isInputFocused {
-                keyboardHandoff.arm(for: id)
-            }
-            switcher.onSelect(id)
-        }
+            selectedID: switcher.selectedID,
+            onSelect: { id in
+                if isInputFocused {
+                    keyboardHandoff.arm(for: id)
+                }
+                switcher.onSelect(id)
+            },
+            onTogglePin: switcher.onTogglePin)
     }
 
     private var latestFailure: (id: AgentComposerStore.Message.ID, detail: String)? {

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -330,11 +330,13 @@ struct AgentTerminalView: View {
     private var agentSwitcher: TerminalAgentSwitcher {
         TerminalAgentSwitcher(
             items: console.agents.map {
-                TerminalAgentSwitcherItem(
-                    id: $0.id, title: $0.switcherLabel, status: $0.agent.status)
+                TerminalAgentSwitcherItem(agent: $0, pins: console.pins)
             },
             selectedID: agent.id,
-            onSelect: switchToAgent)
+            onSelect: switchToAgent,
+            onTogglePin: { id in
+                console.togglePin(hostID: id.hostID, paneID: id.paneID)
+            })
     }
 
     private var terminalKeysContext: TerminalKeysContext {

--- a/Sources/Heeler/Console/ConsoleAgent.swift
+++ b/Sources/Heeler/Console/ConsoleAgent.swift
@@ -94,10 +94,25 @@ extension AgentStatus {
 }
 
 extension [ConsoleAgent] {
-    /// The Console order: status bucket first, then stable Host/workspace/
-    /// pane keys so rows never jitter between equal statuses.
-    func consoleSorted() -> [ConsoleAgent] {
+    /// The Console order: pinned agents first by pin rank (0 = most recently
+    /// pinned), then the unpinned remainder by status bucket and stable
+    /// Host/workspace/pane keys so rows never jitter between equal statuses.
+    func consoleSorted(
+        pinRank: (ConsoleAgent) -> Int? = { _ in nil }
+    ) -> [ConsoleAgent] {
         sorted { lhs, rhs in
+            let lhsRank = pinRank(lhs)
+            let rhsRank = pinRank(rhs)
+            switch (lhsRank, rhsRank) {
+            case (let lhsRank?, let rhsRank?):
+                if lhsRank != rhsRank { return lhsRank < rhsRank }
+            case (_?, nil):
+                return true
+            case (nil, _?):
+                return false
+            case (nil, nil):
+                break
+            }
             let lhsBucket = lhs.agent.status.consoleSortBucket
             let rhsBucket = rhs.agent.status.consoleSortBucket
             if lhsBucket != rhsBucket { return lhsBucket < rhsBucket }

--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -2,7 +2,7 @@ import Foundation
 import Observation
 
 /// The Console aggregate: reconciles the Host catalog and publishes one
-/// status-sorted Agent list across every Host. Each HostConsoleProjection
+/// pin-then-status-sorted Agent list across every Host. Each HostConsoleProjection
 /// owns its own convergence, retry, snippets and Host-scoped RPC behavior.
 @MainActor
 @Observable
@@ -53,14 +53,26 @@ final class ConsoleStore {
     /// suspend can finish first and leave every Host suspended with nothing
     /// left to re-activate it.
     @ObservationIgnored private var lifecycleTask: Task<Void, Never>?
+    /// Shared with the Console list: a pin toggle must re-sort `agents` in
+    /// the same turn, so the store lives here rather than only on the view.
+    let pins: PinnedAgentsStore
 
     init(
         snapshotRetryDelay: Duration = .seconds(2),
+        pins: PinnedAgentsStore = PinnedAgentsStore(),
         makeSession: @escaping @Sendable (Host, [EventSubscription]) -> EventsSession =
             ConsoleStore.sshSessionFactory()
     ) {
         self.snapshotRetryDelay = snapshotRetryDelay
+        self.pins = pins
         self.makeSession = makeSession
+    }
+
+    /// Pins or unpins the Agent and re-sorts the published list in the same
+    /// turn — a pin must not wait on a reconnect to move.
+    func togglePin(hostID: Host.ID, paneID: String) {
+        pins.togglePin(hostID: hostID, paneID: paneID)
+        rebuild()
     }
 
     /// Aligns Host projections with the catalog. Editing a Host replaces its
@@ -381,7 +393,9 @@ final class ConsoleStore {
         let current = Array(projections.values)
         agents = current
             .flatMap { $0.agentsByPane.values }
-            .consoleSorted()
+            .consoleSorted { agent in
+                pins.pinRank(hostID: agent.hostID, paneID: agent.agent.paneID)
+            }
         hostStatuses = Dictionary(
             uniqueKeysWithValues: current.compactMap { projection in
                 projection.status.map { (projection.host.id, $0) }

--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -391,11 +391,12 @@ final class ConsoleStore {
 
     private func rebuild() {
         let current = Array(projections.values)
-        agents = current
-            .flatMap { $0.agentsByPane.values }
-            .consoleSorted { agent in
-                pins.pinRank(hostID: agent.hostID, paneID: agent.agent.paneID)
-            }
+        let unsorted = current.flatMap { $0.agentsByPane.values }
+        let pinRanks = Dictionary(uniqueKeysWithValues: unsorted.compactMap { agent in
+            pins.pinRank(hostID: agent.hostID, paneID: agent.agent.paneID)
+                .map { (agent.id, $0) }
+        })
+        agents = unsorted.consoleSorted { pinRanks[$0.id] }
         hostStatuses = Dictionary(
             uniqueKeysWithValues: current.compactMap { projection in
                 projection.status.map { (projection.host.id, $0) }

--- a/Sources/Heeler/Console/ConsoleView.swift
+++ b/Sources/Heeler/Console/ConsoleView.swift
@@ -304,7 +304,21 @@ struct ConsoleView: View {
                 }
                 ForEach(filteredAgents) { agent in
                     NavigationLink(value: agent.id) {
-                        AgentCardView(agent: agent)
+                        AgentCardView(
+                            agent: agent,
+                            isPinned: console.pins.isPinned(
+                                hostID: agent.hostID, paneID: agent.agent.paneID))
+                    }
+                    .contextMenu {
+                        let pinned = console.pins.isPinned(
+                            hostID: agent.hostID, paneID: agent.agent.paneID)
+                        Button(
+                            pinned ? "Unpin" : "Pin",
+                            systemImage: pinned ? "pin.slash" : "pin"
+                        ) {
+                            console.togglePin(
+                                hostID: agent.hostID, paneID: agent.agent.paneID)
+                        }
                     }
                 }
             }

--- a/Sources/Heeler/Console/PinnedAgentsStore.swift
+++ b/Sources/Heeler/Console/PinnedAgentsStore.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Observation
+
+/// Pins the user has chosen on Console rows, keyed by `(hostID, paneID)` —
+/// the same identity as `ConsoleAgent.ID`. Array order is recency: most
+/// recently pinned first. Entries are never pruned; a pane that has closed
+/// leaves a dangling pin so the same pane id coming back after a herdr
+/// restart is still pinned.
+@MainActor
+@Observable
+final class PinnedAgentsStore {
+    private static let defaultsKey = "pinned-agents"
+    private static let blobVersion = 1
+
+    private struct PersistedBlob: Codable {
+        let version: Int
+        let entries: [Entry]
+    }
+
+    private struct Entry: Codable, Equatable {
+        let hostID: UUID
+        let paneID: String
+    }
+
+    private var entries: [Entry]
+    // UserDefaults is documented thread-safe; Sendable modulo that promise.
+    @ObservationIgnored private nonisolated(unsafe) let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        guard let data = defaults.data(forKey: Self.defaultsKey) else {
+            entries = []
+            return
+        }
+        do {
+            let blob = try JSONDecoder().decode(PersistedBlob.self, from: data)
+            guard blob.version == Self.blobVersion else {
+                entries = []
+                return
+            }
+            entries = blob.entries
+        } catch {
+            entries = []
+        }
+    }
+
+    func isPinned(hostID: Host.ID, paneID: String) -> Bool {
+        pinRank(hostID: hostID, paneID: paneID) != nil
+    }
+
+    /// Pins when unpinned, unpins when pinned. Pinning again moves the
+    /// entry to most-recent.
+    func togglePin(hostID: Host.ID, paneID: String) {
+        if isPinned(hostID: hostID, paneID: paneID) {
+            entries.removeAll { $0.hostID == hostID && $0.paneID == paneID }
+        } else {
+            pin(hostID: hostID, paneID: paneID)
+        }
+        persist()
+    }
+
+    /// Pane ids pinned for this Host, most-recently-pinned first.
+    func pinnedPaneIDs(for hostID: Host.ID) -> [String] {
+        entries.compactMap { $0.hostID == hostID ? $0.paneID : nil }
+    }
+
+    /// 0 = most recently pinned. nil when not pinned.
+    func pinRank(hostID: Host.ID, paneID: String) -> Int? {
+        entries.firstIndex { $0.hostID == hostID && $0.paneID == paneID }
+    }
+
+    /// Inserts at the front after dropping any existing copy, so a re-pin
+    /// becomes most-recent without duplicating the entry.
+    private func pin(hostID: Host.ID, paneID: String) {
+        entries.removeAll { $0.hostID == hostID && $0.paneID == paneID }
+        entries.insert(Entry(hostID: hostID, paneID: paneID), at: 0)
+    }
+
+    private func persist() {
+        let blob = PersistedBlob(version: Self.blobVersion, entries: entries)
+        guard let data = try? JSONEncoder().encode(blob) else { return }
+        defaults.set(data, forKey: Self.defaultsKey)
+    }
+}

--- a/Sources/Heeler/Console/PinnedAgentsStore.swift
+++ b/Sources/Heeler/Console/PinnedAgentsStore.swift
@@ -23,6 +23,9 @@ final class PinnedAgentsStore {
     }
 
     private var entries: [Entry]
+    /// Increments on every pin toggle so observers (Live Activity) can
+    /// rebuild without waiting for the Console list to change identity.
+    private(set) var revision: UInt64 = 0
     // UserDefaults is documented thread-safe; Sendable modulo that promise.
     @ObservationIgnored private nonisolated(unsafe) let defaults: UserDefaults
 
@@ -58,6 +61,7 @@ final class PinnedAgentsStore {
             pin(hostID: hostID, paneID: paneID)
         }
         persist()
+        revision += 1
     }
 
     /// Pane ids pinned for this Host, most-recently-pinned first.

--- a/Sources/Heeler/Console/PinnedAgentsStore.swift
+++ b/Sources/Heeler/Console/PinnedAgentsStore.swift
@@ -35,6 +35,7 @@ final class PinnedAgentsStore {
         do {
             let blob = try JSONDecoder().decode(PersistedBlob.self, from: data)
             guard blob.version == Self.blobVersion else {
+                // Pins are cheap to lose: unknown versions start empty and the next write clobbers them, unlike SnippetStore's no-write policy.
                 entries = []
                 return
             }
@@ -64,15 +65,13 @@ final class PinnedAgentsStore {
         entries.compactMap { $0.hostID == hostID ? $0.paneID : nil }
     }
 
-    /// 0 = most recently pinned. nil when not pinned.
+    /// Position in the global pin recency order (lower = more recent).
+    /// Comparable across Hosts; not an index into `pinnedPaneIDs(for:)`.
     func pinRank(hostID: Host.ID, paneID: String) -> Int? {
         entries.firstIndex { $0.hostID == hostID && $0.paneID == paneID }
     }
 
-    /// Inserts at the front after dropping any existing copy, so a re-pin
-    /// becomes most-recent without duplicating the entry.
     private func pin(hostID: Host.ID, paneID: String) {
-        entries.removeAll { $0.hostID == hostID && $0.paneID == paneID }
         entries.insert(Entry(hostID: hostID, paneID: paneID), at: 0)
     }
 

--- a/Sources/Heeler/ContentView.swift
+++ b/Sources/Heeler/ContentView.swift
@@ -81,6 +81,9 @@ struct ContentView: View {
                 },
                 connectionStatus: { [weak console] id in
                     console?.hostStatuses[id]
+                },
+                pinnedPaneIDs: { [weak console] id in
+                    console?.pins.pinnedPaneIDs(for: id) ?? []
                 }))
     }
 
@@ -123,6 +126,9 @@ struct ContentView: View {
             notificationRouter.agentsDidChange(console.agents)
             bannerStore.agentsDidChange(console.agents)
             liveActivities.agentsDidChange(console.agents)
+        }
+        .onChange(of: console.pins.revision) {
+            liveActivities.pinsDidChange()
         }
         // Live Activity taps: an agent row deep-links to that agent's
         // detail through the same router notification taps use; a tap

--- a/Sources/Heeler/LiveActivities/AgentActivityContentBuilder.swift
+++ b/Sources/Heeler/LiveActivities/AgentActivityContentBuilder.swift
@@ -20,7 +20,13 @@ enum AgentActivityContentBuilder {
     static let maxCiphertextBytes = 2800
 
     /// Nil when no Agent is working, blocked, or done — the end signal.
-    static func desire(from agents: [ConsoleAgent], hostName: String) -> AgentActivityDesire? {
+    /// `pinnedPaneIDs` is most-recently-pinned first; pins reorder the
+    /// eligible list and never change eligibility or counts.
+    static func desire(
+        from agents: [ConsoleAgent],
+        hostName: String,
+        pinnedPaneIDs: [String] = []
+    ) -> AgentActivityDesire? {
         let eligible = agents.filter { isEligible($0.agent.status) }
         guard !eligible.isEmpty else { return nil }
         var working = 0
@@ -34,7 +40,8 @@ enum AgentActivityContentBuilder {
             default: break
             }
         }
-        let details = Array(sorted(eligible).prefix(maxAgents)).map(detail(from:))
+        let details = Array(sorted(eligible, pinnedPaneIDs: pinnedPaneIDs).prefix(maxAgents))
+            .map(detail(from:))
         return AgentActivityDesire(
             counts: .init(working: working, blocked: blocked, done: done),
             hostName: prefixGraphemes(hostName, max: maxHostGraphemes),
@@ -82,9 +89,12 @@ enum AgentActivityContentBuilder {
         agents: [ConsoleAgent],
         hostName: String,
         key: Data,
-        nonce: Data? = nil
+        nonce: Data? = nil,
+        pinnedPaneIDs: [String] = []
     ) -> AgentActivityAttributes.ContentState? {
-        guard let desire = desire(from: agents, hostName: hostName) else { return nil }
+        guard let desire = desire(
+            from: agents, hostName: hostName, pinnedPaneIDs: pinnedPaneIDs)
+        else { return nil }
         return content(for: desire, key: key, nonce: nonce)
     }
 
@@ -92,8 +102,25 @@ enum AgentActivityContentBuilder {
         status == .working || status == .blocked || status == .done
     }
 
-    private static func sorted(_ agents: [ConsoleAgent]) -> [ConsoleAgent] {
+    /// Pinned eligible agents first, by pin-list index (most recent = 0);
+    /// the rest keep status rank then pane-id byte order. Unknown or
+    /// ineligible pin ids are simply not in `agents`.
+    private static func sorted(
+        _ agents: [ConsoleAgent], pinnedPaneIDs: [String]
+    ) -> [ConsoleAgent] {
         agents.sorted { lhs, rhs in
+            let leftPin = pinnedPaneIDs.firstIndex(of: lhs.agent.paneID)
+            let rightPin = pinnedPaneIDs.firstIndex(of: rhs.agent.paneID)
+            switch (leftPin, rightPin) {
+            case let (left?, right?):
+                if left != right { return left < right }
+            case (_?, nil):
+                return true
+            case (nil, _?):
+                return false
+            case (nil, nil):
+                break
+            }
             let left = lhs.agent.status.consoleSortBucket
             let right = rhs.agent.status.consoleSortBucket
             if left != right { return left < right }

--- a/Sources/Heeler/LiveActivities/HostLiveActivityCoordinator.swift
+++ b/Sources/Heeler/LiveActivities/HostLiveActivityCoordinator.swift
@@ -20,6 +20,7 @@ final class HostLiveActivityCoordinator {
     @ObservationIgnored private let hostDisplayName: @MainActor (Host.ID) -> String
     @ObservationIgnored private let isAwaitingSnapshot: @MainActor (Host.ID) -> Bool
     @ObservationIgnored private let connectionStatus: @MainActor (Host.ID) -> EventsSessionStatus?
+    @ObservationIgnored private let pinnedPaneIDs: @MainActor (Host.ID) -> [String]
     @ObservationIgnored private let settleDuration: Duration
     @ObservationIgnored private let now: @MainActor () -> Date
 
@@ -48,6 +49,7 @@ final class HostLiveActivityCoordinator {
         hostDisplayName: @escaping @MainActor (Host.ID) -> String,
         isAwaitingSnapshot: @escaping @MainActor (Host.ID) -> Bool,
         connectionStatus: @escaping @MainActor (Host.ID) -> EventsSessionStatus?,
+        pinnedPaneIDs: @escaping @MainActor (Host.ID) -> [String] = { _ in [] },
         settleDuration: Duration = .seconds(3),
         now: @escaping @MainActor () -> Date = { Date() }
     ) {
@@ -61,6 +63,7 @@ final class HostLiveActivityCoordinator {
         self.hostDisplayName = hostDisplayName
         self.isAwaitingSnapshot = isAwaitingSnapshot
         self.connectionStatus = connectionStatus
+        self.pinnedPaneIDs = pinnedPaneIDs
         self.settleDuration = settleDuration
         self.now = now
     }
@@ -167,6 +170,22 @@ final class HostLiveActivityCoordinator {
         releaseSnapshotHolds()
     }
 
+    /// Pin set change: rebuild LA content through the existing settle, and
+    /// push `pinned_pane_ids` to Hosts that are connected and already
+    /// showing an activity. Offline Hosts pick up the current set on the
+    /// next live_activity write — no queue.
+    func pinsDidChange() {
+        guard didStart else { return }
+        var hosts = Set(latestAgents.keys)
+        hosts.formUnion(sessions.keys)
+        for hostID in hosts {
+            scheduleSettle(for: hostID)
+            if sessions[hostID] != nil, connectionStatus(hostID) == .connected {
+                enqueue(.setPins, for: hostID)
+            }
+        }
+    }
+
     // MARK: Desire / settle
 
     private func scheduleSettle(for hostID: Host.ID) {
@@ -259,7 +278,9 @@ final class HostLiveActivityCoordinator {
         guard notificationKey(for: hostID) != nil else { return nil }
         let agents = latestAgents[hostID] ?? []
         return AgentActivityContentBuilder.desire(
-            from: agents, hostName: resolvedHostName(hostID, agents: agents))
+            from: agents,
+            hostName: resolvedHostName(hostID, agents: agents),
+            pinnedPaneIDs: pinnedPaneIDs(hostID))
     }
 
     private func isUnchanged(hostID: Host.ID, desired: AgentActivityDesire?) -> Bool {
@@ -385,6 +406,7 @@ final class HostLiveActivityCoordinator {
 
     private enum TokenJob: Equatable {
         case set(hex: String, startedAt: Date)
+        case setPins
         case clear
     }
 
@@ -396,7 +418,14 @@ final class HostLiveActivityCoordinator {
 
     private func enqueue(_ job: TokenJob, for hostID: Host.ID) {
         var pipe = pipes[hostID] ?? TokenPipe()
-        pipe.pending = job
+        switch (pipe.pending, job) {
+        case (.some(.set), .setPins), (.some(.clear), .setPins):
+            // A pending token write already includes current pins at
+            // perform time; a pending clear drops live_activity entirely.
+            break
+        default:
+            pipe.pending = job
+        }
         pipes[hostID] = pipe
         pump(hostID)
     }
@@ -429,13 +458,18 @@ final class HostLiveActivityCoordinator {
 
     private func perform(_ job: TokenJob, hostID: Host.ID) async -> Bool {
         guard let token = deviceToken() else { return false }
+        let pins = pinnedPaneIDs(hostID)
         do {
             try await transports.withNotificationTransport(for: hostID) { [ceremony] transport in
                 switch job {
                 case .set(let hex, let startedAt):
                     try await ceremony.setLiveActivityToken(
                         tokenHex: hex, startedAt: startedAt, deviceToken: token,
+                        pinnedPaneIDs: pins,
                         over: transport)
+                case .setPins:
+                    try await ceremony.setLiveActivityPinnedPaneIDs(
+                        pins, deviceToken: token, over: transport)
                 case .clear:
                     try await ceremony.clearLiveActivityToken(
                         deviceToken: token, over: transport)

--- a/Sources/Heeler/Notifications/NotificationRegistrationCeremony.swift
+++ b/Sources/Heeler/Notifications/NotificationRegistrationCeremony.swift
@@ -87,6 +87,7 @@ struct NotificationRegistrationCeremony: Sendable {
         tokenHex: String,
         startedAt: Date,
         deviceToken: APNSDeviceToken,
+        pinnedPaneIDs: [String] = [],
         over transport: any Transport
     ) async throws {
         let file = try NotificationRegistrationFile.decode(
@@ -96,8 +97,24 @@ struct NotificationRegistrationCeremony: Sendable {
         }
         try await transport.replaceNotificationRegistration(
             try file.settingLiveActivity(
-                token: tokenHex, startedAt: startedAt, forDeviceToken: deviceToken.hex
+                token: tokenHex, startedAt: startedAt, forDeviceToken: deviceToken.hex,
+                pinnedPaneIDs: pinnedPaneIDs
             ).encoded())
+    }
+
+    /// Updates `pinned_pane_ids` on this device's existing `live_activity`
+    /// object. No-op when the device is unregistered or the field is absent.
+    func setLiveActivityPinnedPaneIDs(
+        _ pinnedPaneIDs: [String],
+        deviceToken: APNSDeviceToken,
+        over transport: any Transport
+    ) async throws {
+        guard let data = try await transport.readNotificationRegistration() else { return }
+        let file = try NotificationRegistrationFile.decode(data)
+        let updated = file.settingLiveActivityPinnedPaneIDs(
+            pinnedPaneIDs, forDeviceToken: deviceToken.hex)
+        guard updated != file else { return }
+        try await transport.replaceNotificationRegistration(try updated.encoded())
     }
 
     /// Drops `live_activity` from this device's entry, leaving the rest of

--- a/Sources/Heeler/Notifications/NotificationRegistrationFile.swift
+++ b/Sources/Heeler/Notifications/NotificationRegistrationFile.swift
@@ -161,8 +161,7 @@ struct NotificationRegistrationFile: Sendable, Equatable {
         _ pinnedPaneIDs: [String], forDeviceToken deviceToken: String
     ) -> NotificationRegistrationFile {
         mutatingDevice(token: deviceToken) { entry in
-            guard entry["live_activity"] != nil else { return }
-            var live = objectValue(entry["live_activity"]) ?? .object([:])
+            guard var live = objectValue(entry["live_activity"]) else { return }
             live.setKey("pinned_pane_ids", to: .array(pinnedPaneIDs.map { .string($0) }))
             entry.setKey("live_activity", to: live)
         }

--- a/Sources/Heeler/Notifications/NotificationRegistrationFile.swift
+++ b/Sources/Heeler/Notifications/NotificationRegistrationFile.swift
@@ -66,9 +66,12 @@ struct NotificationDeviceEntry: Sendable, Equatable {
 /// The `live_activity` field of a device entry: the per-activity push token
 /// and when the app started that activity. `startedAt` is the ISO 8601
 /// string as stored, so a rewrite can be compared without re-formatting.
+/// `pinnedPaneIDs` is most-recently-pinned first; a missing or malformed
+/// field reads as empty (docs/agents/live-activity-contract.md).
 struct LiveActivityRegistration: Sendable, Equatable {
     var token: String
     var startedAt: String
+    var pinnedPaneIDs: [String] = []
 }
 
 /// The Notification Registration file v1 (`plugin/README.md`): the whole
@@ -132,18 +135,36 @@ struct NotificationRegistrationFile: Sendable, Equatable {
     }
 
     /// Writes `live_activity` on the matching device entry and leaves every
-    /// other field on that object untouched. An unknown token is a no-op;
-    /// the ceremony refuses that case instead of inventing an entry.
+    /// other field on that object untouched. Merges into an existing
+    /// `live_activity` object so unknown fields and a prior pin list
+    /// survive. An unknown token is a no-op; the ceremony refuses that case
+    /// instead of inventing an entry.
     func settingLiveActivity(
-        token: String, startedAt: Date, forDeviceToken deviceToken: String
+        token: String,
+        startedAt: Date,
+        forDeviceToken deviceToken: String,
+        pinnedPaneIDs: [String] = []
     ) -> NotificationRegistrationFile {
         mutatingDevice(token: deviceToken) { entry in
-            entry.setKey(
-                "live_activity",
-                to: .object([
-                    "token": .string(token),
-                    "started_at": .string(Self.iso8601String(from: startedAt)),
-                ]))
+            var live = objectValue(entry["live_activity"]) ?? .object([:])
+            live.setKey("token", to: .string(token))
+            live.setKey("started_at", to: .string(Self.iso8601String(from: startedAt)))
+            live.setKey("pinned_pane_ids", to: .array(pinnedPaneIDs.map { .string($0) }))
+            entry.setKey("live_activity", to: live)
+        }
+    }
+
+    /// Writes `pinned_pane_ids` on an existing `live_activity` object and
+    /// leaves token, started_at, and unknown fields untouched. No-op when
+    /// the device is missing or has no `live_activity` yet.
+    func settingLiveActivityPinnedPaneIDs(
+        _ pinnedPaneIDs: [String], forDeviceToken deviceToken: String
+    ) -> NotificationRegistrationFile {
+        mutatingDevice(token: deviceToken) { entry in
+            guard entry["live_activity"] != nil else { return }
+            var live = objectValue(entry["live_activity"]) ?? .object([:])
+            live.setKey("pinned_pane_ids", to: .array(pinnedPaneIDs.map { .string($0) }))
+            entry.setKey("live_activity", to: live)
         }
     }
 
@@ -162,7 +183,23 @@ struct NotificationRegistrationFile: Sendable, Equatable {
             let liveToken = entry["live_activity"]?["token"]?.stringValue, !liveToken.isEmpty,
             let startedAt = entry["live_activity"]?["started_at"]?.stringValue, !startedAt.isEmpty
         else { return nil }
-        return LiveActivityRegistration(token: liveToken, startedAt: startedAt)
+        return LiveActivityRegistration(
+            token: liveToken,
+            startedAt: startedAt,
+            pinnedPaneIDs: Self.pinnedPaneIDs(from: entry["live_activity"]?["pinned_pane_ids"]))
+    }
+
+    /// Lenient reader for `live_activity.pinned_pane_ids`. Missing, null, a
+    /// non-array, or any non-string entry yields an empty list — never a throw.
+    static func pinnedPaneIDs(from value: JSONValue?) -> [String] {
+        guard case .array(let items)? = value else { return [] }
+        var ids: [String] = []
+        ids.reserveCapacity(items.count)
+        for item in items {
+            guard case .string(let id) = item else { return [] }
+            ids.append(id)
+        }
+        return ids
     }
 
     /// The notify flags of the entry carrying `token`, nil when that device
@@ -183,6 +220,11 @@ struct NotificationRegistrationFile: Sendable, Equatable {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
         return try encoder.encode(WireFile(v: Self.version, devices: devices))
+    }
+
+    private func objectValue(_ value: JSONValue?) -> JSONValue? {
+        guard let value, case .object = value else { return nil }
+        return value
     }
 
     private func mutatingDevice(

--- a/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
+++ b/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
@@ -108,7 +108,7 @@ final class TerminalAgentSwitcherBar: UIView, UIScrollViewDelegate,
         let selectionChanged = selectedID != self.selectedID
         let previousIDs = chips.map(\.id)
         let previousPinByID = Dictionary(
-            uniqueKeysWithValues: self.items.map { ($0.id, $0.isPinned) })
+            self.items.map { ($0.id, $0.isPinned) }, uniquingKeysWith: { first, _ in first })
         self.items = items
         self.selectedID = selectedID
 
@@ -126,8 +126,11 @@ final class TerminalAgentSwitcherBar: UIView, UIScrollViewDelegate,
         let layoutChanged =
             ordered.map(\.id) != previousIDs
             || items.contains { previousPinByID[$0.id] != $0.isPinned }
+        // Same membership only: an added chip still has a zero frame, and
+        // inserting it inside the animation is the documented grow-in.
         let shouldAnimate =
             layoutChanged
+            && Set(ordered.map(\.id)) == Set(previousIDs)
             && window != nil
             && bounds.width > 0
             && !previousIDs.isEmpty
@@ -141,10 +144,10 @@ final class TerminalAgentSwitcherBar: UIView, UIScrollViewDelegate,
         }
 
         if shouldAnimate {
-            // Commit the frames on screen so the slide interpolates from what
-            // the user sees. Context-menu dismissal has an animation
-            // transaction open; without this, the hole the stack leaves behind
-            // is not in that transaction and snaps shut when the menu ends.
+            // Flush pending layout so the slide interpolates from the frames
+            // already on screen. Context-menu dismissal has a transaction
+            // open; without a committed from-state the restack lands in a
+            // later un-animated pass and the chips teleport.
             UIView.performWithoutAnimation {
                 self.layoutIfNeeded()
             }
@@ -167,23 +170,17 @@ final class TerminalAgentSwitcherBar: UIView, UIScrollViewDelegate,
             applyLayout()
         }
 
-        // Pulse is a repeating layer animation. Adding it inside the layout
-        // UIView.animate above would steal its duration and drop it when
-        // the slide finishes.
-        for chip in ordered {
-            chip.updatePulse()
-        }
-
         if selectionChanged {
             scrollsToSelectionOnLayout = true
             setNeedsLayout()
         }
     }
 
-    /// `insertArrangedSubview` of an already-arranged chip leaves the old
-    /// slot's spacing behind: the chip appears in the new position, a hole
-    /// sits where it left, and a later non-animated layout collapses it.
-    /// Remove then reinsert so the stack has one slot per chip.
+    /// `insertArrangedSubview` of an already-arranged view moves it
+    /// (UIKit's contract). Remove then reinsert is the same move, written
+    /// so the destination index is obvious. The slide still has to wrap
+    /// this in `UIView.animate`: an un-animated layout pass is what used
+    /// to land the new frames after the context menu ended.
     private func syncArrangedSubviews(
         _ ordered: [TerminalAgentChip], removing stale: [TerminalAgentChip]
     ) {
@@ -416,13 +413,10 @@ final class TerminalAgentChip: UIControl {
         label.text = item.title
         label.textColor = selected ? .label : .secondaryLabel
         pinView.isHidden = !item.isPinned
-        // The pin glyph is what changes the chip's width (117→136pt measured).
-        // The outer strip can only animate that resize if Auto Layout knows
-        // the fitting size changed inside the same layout pass.
-        invalidateIntrinsicContentSize()
         dot.backgroundColor = item.status.inkUIColor
         backgroundColor = selected ? .tertiarySystemBackground : .clear
         isWorking = item.status == .working
+        updatePulse()
 
         accessibilityLabel = item.title
         let statusValue = item.status.rawValue.capitalized
@@ -476,9 +470,8 @@ final class TerminalAgentChip: UIControl {
     }
 
     /// Working is the one status worth animating: a still dot cannot tell a
-    /// busy Agent from an idle one at a glance. The strip calls this after
-    /// any layout animation so the pulse is not owned by that transaction.
-    fileprivate func updatePulse() {
+    /// busy Agent from an idle one at a glance.
+    private func updatePulse() {
         guard isWorking, !UIAccessibility.isReduceMotionEnabled else {
             dot.layer.removeAnimation(forKey: Self.pulseKey)
             return

--- a/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
+++ b/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
@@ -207,9 +207,14 @@ final class TerminalAgentSwitcherBar: UIView, UIScrollViewDelegate,
         let image = UIImage(systemName: item.isPinned ? "pin.slash" : "pin")
         return UIMenu(children: [
             UIAction(title: title, image: image) { [weak self] _ in
-                self?.onTogglePin?(item.id)
+                self?.performPinToggle(for: item)
             }
         ])
+    }
+
+    /// The Pin / Unpin action: same path the menu item takes.
+    func performPinToggle(for item: TerminalAgentSwitcherItem) {
+        onTogglePin?(item.id)
     }
 
     /// The item the interaction's chip currently represents. Nil when the

--- a/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
+++ b/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
@@ -67,12 +67,22 @@ final class TerminalAgentSwitcherBar: UIView, UIScrollViewDelegate,
 {
     /// Short on purpose: every point it takes is one the terminal loses.
     static let preferredHeight: CGFloat = 40
+    /// Critically damped slide for a pin reorder: long enough to read, short
+    /// enough that a second pin does not pile up behind it.
+    private static let reorderDuration: TimeInterval = 0.35
 
     var onSelect: (@MainActor (ConsoleAgent.ID) -> Void)?
     var onTogglePin: (@MainActor (ConsoleAgent.ID) -> Void)?
 
     /// The strip as it currently reads, in order.
     private(set) var chips: [TerminalAgentChip] = []
+
+    /// The stack's arranged chips, in layout order. `chips` is the model;
+    /// this is what the stack is actually laying out, so a leftover hole
+    /// after a reorder shows up here.
+    var arrangedChips: [TerminalAgentChip] {
+        row.arrangedSubviews.compactMap { $0 as? TerminalAgentChip }
+    }
 
     /// Gutter between the strip's ends and the first and last chip.
     private static let rowInset: CGFloat = 8
@@ -96,6 +106,9 @@ final class TerminalAgentSwitcherBar: UIView, UIScrollViewDelegate,
     func update(items: [TerminalAgentSwitcherItem], selectedID: ConsoleAgent.ID?) {
         guard items != self.items || selectedID != self.selectedID else { return }
         let selectionChanged = selectedID != self.selectedID
+        let previousIDs = chips.map(\.id)
+        let previousPinByID = Dictionary(
+            uniqueKeysWithValues: self.items.map { ($0.id, $0.isPinned) })
         self.items = items
         self.selectedID = selectedID
 
@@ -105,22 +118,85 @@ final class TerminalAgentSwitcherBar: UIView, UIScrollViewDelegate,
         var ordered: [TerminalAgentChip] = []
         for item in items {
             let chip = reusable.removeValue(forKey: item.id) ?? makeChip(id: item.id)
-            chip.apply(item, selected: item.id == selectedID)
             ordered.append(chip)
         }
-        for stale in reusable.values {
-            row.removeArrangedSubview(stale)
-            stale.removeFromSuperview()
-        }
-        for (index, chip) in ordered.enumerated()
-        where row.arrangedSubviews.firstIndex(of: chip) != index {
-            row.insertArrangedSubview(chip, at: index)
-        }
+        let stale = Array(reusable.values)
         chips = ordered
+
+        let layoutChanged =
+            ordered.map(\.id) != previousIDs
+            || items.contains { previousPinByID[$0.id] != $0.isPinned }
+        let shouldAnimate =
+            layoutChanged
+            && window != nil
+            && bounds.width > 0
+            && !previousIDs.isEmpty
+            && !UIAccessibility.isReduceMotionEnabled
+
+        let applyLayout = {
+            for (item, chip) in zip(items, ordered) {
+                chip.apply(item, selected: item.id == selectedID)
+            }
+            self.syncArrangedSubviews(ordered, removing: stale)
+        }
+
+        if shouldAnimate {
+            // Commit the frames on screen so the slide interpolates from what
+            // the user sees. Context-menu dismissal has an animation
+            // transaction open; without this, the hole the stack leaves behind
+            // is not in that transaction and snaps shut when the menu ends.
+            UIView.performWithoutAnimation {
+                self.layoutIfNeeded()
+            }
+            UIView.animate(
+                withDuration: Self.reorderDuration,
+                delay: 0,
+                usingSpringWithDamping: 1,
+                initialSpringVelocity: 0,
+                options: [
+                    .allowUserInteraction,
+                    .beginFromCurrentState,
+                    .overrideInheritedCurve,
+                    .overrideInheritedDuration,
+                ]
+            ) {
+                applyLayout()
+                self.layoutIfNeeded()
+            }
+        } else {
+            applyLayout()
+        }
+
+        // Pulse is a repeating layer animation. Adding it inside the layout
+        // UIView.animate above would steal its duration and drop it when
+        // the slide finishes.
+        for chip in ordered {
+            chip.updatePulse()
+        }
 
         if selectionChanged {
             scrollsToSelectionOnLayout = true
             setNeedsLayout()
+        }
+    }
+
+    /// `insertArrangedSubview` of an already-arranged chip leaves the old
+    /// slot's spacing behind: the chip appears in the new position, a hole
+    /// sits where it left, and a later non-animated layout collapses it.
+    /// Remove then reinsert so the stack has one slot per chip.
+    private func syncArrangedSubviews(
+        _ ordered: [TerminalAgentChip], removing stale: [TerminalAgentChip]
+    ) {
+        for chip in stale {
+            row.removeArrangedSubview(chip)
+            chip.removeFromSuperview()
+        }
+        for (index, chip) in ordered.enumerated() {
+            if let current = row.arrangedSubviews.firstIndex(of: chip) {
+                if current == index { continue }
+                row.removeArrangedSubview(chip)
+            }
+            row.insertArrangedSubview(chip, at: index)
         }
     }
 
@@ -340,10 +416,13 @@ final class TerminalAgentChip: UIControl {
         label.text = item.title
         label.textColor = selected ? .label : .secondaryLabel
         pinView.isHidden = !item.isPinned
+        // The pin glyph is what changes the chip's width (117→136pt measured).
+        // The outer strip can only animate that resize if Auto Layout knows
+        // the fitting size changed inside the same layout pass.
+        invalidateIntrinsicContentSize()
         dot.backgroundColor = item.status.inkUIColor
         backgroundColor = selected ? .tertiarySystemBackground : .clear
         isWorking = item.status == .working
-        updatePulse()
 
         accessibilityLabel = item.title
         let statusValue = item.status.rawValue.capitalized
@@ -397,8 +476,9 @@ final class TerminalAgentChip: UIControl {
     }
 
     /// Working is the one status worth animating: a still dot cannot tell a
-    /// busy Agent from an idle one at a glance.
-    private func updatePulse() {
+    /// busy Agent from an idle one at a glance. The strip calls this after
+    /// any layout animation so the pulse is not owned by that transaction.
+    fileprivate func updatePulse() {
         guard isWorking, !UIAccessibility.isReduceMotionEnabled else {
             dot.layer.removeAnimation(forKey: Self.pulseKey)
             return

--- a/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
+++ b/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
@@ -146,8 +146,9 @@ final class TerminalAgentSwitcherBar: UIView, UIScrollViewDelegate,
         if shouldAnimate {
             // Flush pending layout so the slide interpolates from the frames
             // already on screen. Context-menu dismissal has a transaction
-            // open; without a committed from-state the restack lands in a
-            // later un-animated pass and the chips teleport.
+            // open; without the flush, layout still pending from an earlier
+            // update gets swept into this animation and the slide starts from
+            // frames the user never saw.
             UIView.performWithoutAnimation {
                 self.layoutIfNeeded()
             }

--- a/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
+++ b/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
@@ -413,7 +413,14 @@ final class TerminalAgentChip: UIControl {
         isSelected = selected
         label.text = item.title
         label.textColor = selected ? .label : .secondaryLabel
-        pinView.isHidden = !item.isPinned
+        // UIStackView balances arranged-subview hidden flips made inside
+        // animation blocks with an internal counter; assigning the value the
+        // view already has unbalances it, after which the opposite
+        // assignment stops taking effect and the glyph sticks. Write only
+        // real changes.
+        if pinView.isHidden != !item.isPinned {
+            pinView.isHidden = !item.isPinned
+        }
         dot.backgroundColor = item.status.inkUIColor
         backgroundColor = selected ? .tertiarySystemBackground : .clear
         isWorking = item.status == .working

--- a/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
+++ b/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
@@ -1,20 +1,35 @@
 import SwiftUI
 import UIKit
 
-/// One chip in the keyboard's Agent switcher: the label it shows and the
-/// status its dot carries.
+/// One chip in the keyboard's Agent switcher: the label it shows, the
+/// status its dot carries, and whether it is pinned.
 struct TerminalAgentSwitcherItem: Equatable, Sendable {
     let id: ConsoleAgent.ID
     let title: String
     let status: AgentStatus
+    let isPinned: Bool
+}
+
+extension TerminalAgentSwitcherItem {
+    /// Maps a Console row through the same pin store the list uses, so a pin
+    /// made on either surface shows up on the other.
+    @MainActor
+    init(agent: ConsoleAgent, pins: PinnedAgentsStore) {
+        self.init(
+            id: agent.id,
+            title: agent.switcherLabel,
+            status: agent.agent.status,
+            isPinned: pins.isPinned(hostID: agent.hostID, paneID: agent.agent.paneID))
+    }
 }
 
 /// What an Agent surface hands its switcher: the Agents to offer, the one
-/// currently on screen, and where a tap goes.
+/// currently on screen, where a tap goes, and where a Pin / Unpin goes.
 struct TerminalAgentSwitcher {
     var items: [TerminalAgentSwitcherItem]
     var selectedID: ConsoleAgent.ID?
     var onSelect: @MainActor (ConsoleAgent.ID) -> Void
+    var onTogglePin: @MainActor (ConsoleAgent.ID) -> Void
 }
 
 /// Carries the user's "I am still typing" intent across the Agent surface
@@ -47,11 +62,14 @@ final class TerminalKeyboardHandoff {
 /// on the keyboard meant UIKit tore the strip down and rebuilt it — losing its
 /// scroll position — every time the keyboard moved.
 @MainActor
-final class TerminalAgentSwitcherBar: UIView, UIScrollViewDelegate {
+final class TerminalAgentSwitcherBar: UIView, UIScrollViewDelegate,
+    UIContextMenuInteractionDelegate
+{
     /// Short on purpose: every point it takes is one the terminal loses.
     static let preferredHeight: CGFloat = 40
 
     var onSelect: (@MainActor (ConsoleAgent.ID) -> Void)?
+    var onTogglePin: (@MainActor (ConsoleAgent.ID) -> Void)?
 
     /// The strip as it currently reads, in order.
     private(set) var chips: [TerminalAgentChip] = []
@@ -177,7 +195,34 @@ final class TerminalAgentSwitcherBar: UIView, UIScrollViewDelegate {
     private func makeChip(id: ConsoleAgent.ID) -> TerminalAgentChip {
         let chip = TerminalAgentChip(id: id)
         chip.addTarget(self, action: #selector(chipTapped), for: .touchUpInside)
+        // Context menu, not a long-press recognizer: the system menu does not
+        // delay the tap that switches Agents.
+        chip.addInteraction(UIContextMenuInteraction(delegate: self))
         return chip
+    }
+
+    /// The chip long-press: one item, Pin or Unpin, matching the Console row.
+    func pinMenu(for item: TerminalAgentSwitcherItem) -> UIMenu {
+        let title = item.isPinned ? "Unpin" : "Pin"
+        let image = UIImage(systemName: item.isPinned ? "pin.slash" : "pin")
+        return UIMenu(children: [
+            UIAction(title: title, image: image) { [weak self] _ in
+                self?.onTogglePin?(item.id)
+            }
+        ])
+    }
+
+    func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        configurationForMenuAtLocation _: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        guard let chip = interaction.view as? TerminalAgentChip,
+            let item = items.first(where: { $0.id == chip.id })
+        else { return nil }
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) {
+            [weak self] _ in
+            self?.pinMenu(for: item)
+        }
     }
 
     @objc private func chipTapped(_ chip: TerminalAgentChip) {
@@ -233,7 +278,7 @@ private final class StripScrollView: UIScrollView {
 }
 
 /// One Agent chip: a status dot and a label in a capsule, filled when it is
-/// the Agent on screen.
+/// the Agent on screen. A pin glyph marks a pinned Agent.
 final class TerminalAgentChip: UIControl {
     static let spacing: CGFloat = 6
     private static let height: CGFloat = 28
@@ -246,9 +291,13 @@ final class TerminalAgentChip: UIControl {
     /// Whether the Working dot is animating. Reads the layer, so it also
     /// answers "did leaving the window strip the animation?".
     var isPulsing: Bool { dot.layer.animation(forKey: Self.pulseKey) != nil }
+    /// The small pin glyph on a pinned chip. Hidden when the Agent is not
+    /// pinned, so an unpinned chip stays a dot and a label.
+    var showsPinIndicator: Bool { !pinView.isHidden }
 
     private let dot = UIView()
     private let label = UILabel()
+    private let pinView = UIImageView()
     private var isWorking = false
 
     override var isHighlighted: Bool {
@@ -278,13 +327,15 @@ final class TerminalAgentChip: UIControl {
         isSelected = selected
         label.text = item.title
         label.textColor = selected ? .label : .secondaryLabel
+        pinView.isHidden = !item.isPinned
         dot.backgroundColor = item.status.inkUIColor
         backgroundColor = selected ? .tertiarySystemBackground : .clear
         isWorking = item.status == .working
         updatePulse()
 
         accessibilityLabel = item.title
-        accessibilityValue = item.status.rawValue.capitalized
+        let statusValue = item.status.rawValue.capitalized
+        accessibilityValue = item.isPinned ? "Pinned, \(statusValue)" : statusValue
         accessibilityTraits = selected ? [.button, .selected] : .button
         accessibilityHint = selected ? nil : "Switches to that Agent"
     }
@@ -303,7 +354,16 @@ final class TerminalAgentChip: UIControl {
         label.lineBreakMode = .byTruncatingTail
         label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
-        let content = UIStackView(arrangedSubviews: [dot, label])
+        pinView.translatesAutoresizingMaskIntoConstraints = false
+        pinView.image = UIImage(systemName: "pin.fill")
+        pinView.preferredSymbolConfiguration = UIImage.SymbolConfiguration(
+            font: .preferredFont(forTextStyle: .caption2))
+        pinView.tintColor = .secondaryLabel
+        pinView.isHidden = true
+        pinView.setContentHuggingPriority(.required, for: .horizontal)
+        pinView.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        let content = UIStackView(arrangedSubviews: [dot, label, pinView])
         content.translatesAutoresizingMaskIntoConstraints = false
         content.axis = .horizontal
         content.alignment = .center
@@ -426,6 +486,7 @@ struct TerminalAgentSwitcherRow: View {
 
         func updateUIView(_ bar: TerminalAgentSwitcherBar, context _: Context) {
             bar.onSelect = switcher.onSelect
+            bar.onTogglePin = switcher.onTogglePin
             bar.update(items: switcher.items, selectedID: switcher.selectedID)
         }
     }

--- a/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
+++ b/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
@@ -212,13 +212,20 @@ final class TerminalAgentSwitcherBar: UIView, UIScrollViewDelegate,
         ])
     }
 
+    /// The item the interaction's chip currently represents. Nil when the
+    /// view is not a chip or that Agent has left the strip.
+    func pinItem(for interaction: UIContextMenuInteraction) -> TerminalAgentSwitcherItem? {
+        guard let chip = interaction.view as? TerminalAgentChip,
+              let item = items.first(where: { $0.id == chip.id })
+        else { return nil }
+        return item
+    }
+
     func contextMenuInteraction(
         _ interaction: UIContextMenuInteraction,
         configurationForMenuAtLocation _: CGPoint
     ) -> UIContextMenuConfiguration? {
-        guard let chip = interaction.view as? TerminalAgentChip,
-            let item = items.first(where: { $0.id == chip.id })
-        else { return nil }
+        guard let item = pinItem(for: interaction) else { return nil }
         return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) {
             [weak self] _ in
             self?.pinMenu(for: item)

--- a/Sources/HeelerActivityCore/AgentActivityEnvelope.swift
+++ b/Sources/HeelerActivityCore/AgentActivityEnvelope.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// Decrypted Live Activity details: the Host's short name plus the capped,
-/// already-sorted agent list carried inside the content-state envelope
+/// Decrypted Live Activity details: the Host's short name plus the capped
+/// agent list in the sender's pin-aware order, rendered as given
 /// (docs/agents/live-activity-contract.md).
 struct AgentActivityDetails: Sendable, Equatable {
     var hostName: String

--- a/Sources/HeelerActivityCore/AgentActivityEnvelope.swift
+++ b/Sources/HeelerActivityCore/AgentActivityEnvelope.swift
@@ -147,10 +147,11 @@ enum AgentActivityEnvelope {
     }
 
     /// Canonical plaintext: compact JSON, keys sorted at every level, agents
-    /// already in contract order and capped at 5. Title is omitted when
-    /// absent or empty.
+    /// in the caller-supplied contract order and capped at 5. Title is
+    /// omitted when absent or empty. This does not re-sort: pin-aware order
+    /// is established by the producer and must survive sealing.
     private static func encodePlaintext(_ details: AgentActivityDetails) throws -> Data {
-        let agents = Array(sorted(details.agents).prefix(5)).map { agent in
+        let agents = Array(details.agents.prefix(5)).map { agent in
             OutgoingAgent(
                 kind: agent.kind, name: nonEmpty(agent.name), pane: agent.paneID,
                 status: agent.status, title: nonEmpty(agent.title))
@@ -159,26 +160,6 @@ enum AgentActivityEnvelope {
         encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
         return try encoder.encode(
             OutgoingPlaintext(agents: agents, host: details.hostName, v: version))
-    }
-
-    private static func sorted(
-        _ agents: [AgentActivityDetails.AgentDetail]
-    ) -> [AgentActivityDetails.AgentDetail] {
-        agents.sorted { lhs, rhs in
-            let left = statusRank(lhs.status)
-            let right = statusRank(rhs.status)
-            if left != right { return left < right }
-            return lhs.paneID.utf8.lexicographicallyPrecedes(rhs.paneID.utf8)
-        }
-    }
-
-    private static func statusRank(_ status: String) -> Int {
-        switch status {
-        case "blocked": 0
-        case "done": 1
-        case "working": 2
-        default: 3
-        }
     }
 
     private static func nonEmpty(_ text: String?) -> String? {

--- a/Sources/HeelerWidgets/AgentActivityDecryptor.swift
+++ b/Sources/HeelerWidgets/AgentActivityDecryptor.swift
@@ -13,7 +13,7 @@ enum AgentActivityPresentation: Equatable, Sendable {
         }
     }
 
-    /// Headline: the most urgent agent's task title (its kind when the
+    /// Headline: the first envelope row's task title (its kind when the
     /// title is missing), or the generic app name when details are
     /// unavailable. Host identity is never rendered.
     var headerTitle: String {
@@ -35,8 +35,8 @@ enum AgentActivityPresentation: Equatable, Sendable {
         }
     }
 
-    /// The agent whose task title is the headline: rows arrive pre-sorted
-    /// blocked > done > working, so this is the most urgent one.
+    /// The agent whose task title is the headline: rows arrive in envelope
+    /// order (pinned eligible first, then status rank).
     var primaryAgent: AgentActivityDetails.AgentDetail? {
         agents.first
     }

--- a/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
+++ b/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
@@ -4,8 +4,8 @@ import WidgetKit
 
 /// Live Activity for one Host. Lock-screen banner is a uniform agent list
 /// under a ~160pt budget: four rows when everything fits, three plus
-/// "+N more" otherwise. Rows arrive pre-sorted most-urgent first; Host
-/// identity is never rendered. Every agent row is a deep link into that
+/// "+N more" otherwise. Rows arrive in the sender's pin-aware order and
+/// are rendered as given; Host identity is never rendered. Every agent row is a deep link into that
 /// agent's detail; taps outside a row land on the Console.
 struct AgentLiveActivityWidget: Widget {
     var body: some WidgetConfiguration {

--- a/Tests/HeelerTests/AgentActivityContentBuilderTests.swift
+++ b/Tests/HeelerTests/AgentActivityContentBuilderTests.swift
@@ -164,6 +164,102 @@ struct AgentActivityContentBuilderTests {
         #expect(details.hostName == "mbp")
     }
 
+    @Test func pinnedEligibleAgentsLeadByPinRecencyThenStatusRank() throws {
+        let agents = [
+            agent("w:p-work", .working),
+            agent("w:p-block", .blocked),
+            agent("w:p-done", .done),
+        ]
+
+        let desire = try #require(
+            AgentActivityContentBuilder.desire(
+                from: agents, hostName: "mbp",
+                pinnedPaneIDs: ["w:p-work", "w:p-done"]))
+
+        #expect(desire.agents.map(\.paneID) == ["w:p-work", "w:p-done", "w:p-block"])
+        #expect(desire.agents.map(\.status) == ["working", "done", "blocked"])
+        #expect(desire.counts == .init(working: 1, blocked: 1, done: 1))
+    }
+
+    @Test func pinnedIneligibleAndUnknownPaneIDsAreIgnored() throws {
+        let agents = [
+            agent("w:p-idle", .idle),
+            agent("w:p-work", .working),
+            agent("w:p-block", .blocked),
+        ]
+
+        let desire = try #require(
+            AgentActivityContentBuilder.desire(
+                from: agents, hostName: "mbp",
+                pinnedPaneIDs: ["w:p-idle", "gone:pane", "w:p-work"]))
+
+        #expect(desire.counts == .init(working: 1, blocked: 1, done: 0))
+        #expect(desire.agents.map(\.paneID) == ["w:p-work", "w:p-block"])
+    }
+
+    @Test func pinOrderCapIsAppliedAfterSortAndCountsStayFull() throws {
+        var agents = [
+            agent("w:p-pin", .working),
+        ]
+        for index in 0..<6 {
+            agents.append(agent(String(format: "w:p%02d", index), .blocked))
+        }
+
+        let desire = try #require(
+            AgentActivityContentBuilder.desire(
+                from: agents, hostName: "mbp",
+                pinnedPaneIDs: ["w:p-pin"]))
+
+        #expect(desire.counts == .init(working: 1, blocked: 6, done: 0))
+        #expect(desire.agents.count == 5)
+        #expect(desire.agents.map(\.paneID) == ["w:p-pin", "w:p00", "w:p01", "w:p02", "w:p03"])
+        #expect(desire.agents.first?.status == "working")
+    }
+
+    @Test func sharedPinOrderVectorsMatchDesire() throws {
+        for vector in LiveActivityVectorFile.shared.valid where !vector.inventory.isEmpty {
+            let agents = vector.inventory.map { item in
+                ConsoleAgent(
+                    hostID: hostID, hostName: vector.payload.host,
+                    agent: Agent(
+                        terminalID: "t",
+                        kind: item.agent ?? "",
+                        title: item.terminalTitleStripped ?? item.terminalTitle ?? "",
+                        status: AgentStatus(rawValue: item.agentStatus),
+                        workspaceID: "w", tabID: "t", paneID: item.paneID,
+                        cwd: "/", revision: 1,
+                        name: nonEmpty(item.displayAgent) ?? nonEmpty(item.name)),
+                    workspaceLabel: nil, repoName: nil)
+            }
+
+            let desire = try #require(
+                AgentActivityContentBuilder.desire(
+                    from: agents, hostName: vector.payload.host,
+                    pinnedPaneIDs: vector.pinnedPaneIDs),
+                "\(vector.name)")
+
+            #expect(desire.hostName == vector.payload.host, "\(vector.name)")
+            #expect(
+                desire.agents.map(\.paneID) == vector.payload.agents.map(\.pane),
+                "\(vector.name)")
+            #expect(
+                desire.agents.map(\.status) == vector.payload.agents.map(\.status),
+                "\(vector.name)")
+            #expect(
+                desire.agents.map(\.title) == vector.payload.agents.map(\.title),
+                "\(vector.name)")
+            #expect(
+                desire.agents.map(\.name) == vector.payload.agents.map(\.name),
+                "\(vector.name)")
+            if let counts = vector.counts {
+                #expect(
+                    desire.counts
+                        == .init(working: counts.working, blocked: counts.blocked, done: counts.done),
+                    "\(vector.name)")
+            }
+        }
+    }
+
     @Test func sealedContentOpensToTheDesiredDetails() throws {
         let agents = [agent("wV:p1", .working, title: "task")]
         let state = try #require(
@@ -180,6 +276,11 @@ struct AgentActivityContentBuilderTests {
     ) throws -> AgentActivityDetails {
         let envelope = try #require(state.envelope)
         return try AgentActivityEnvelope.open(try JSONEncoder().encode(envelope), using: key)
+    }
+
+    private func nonEmpty(_ text: String?) -> String? {
+        guard let text, !text.isEmpty else { return nil }
+        return text
     }
 
     private func agent(

--- a/Tests/HeelerTests/AgentActivityEnvelopeTests.swift
+++ b/Tests/HeelerTests/AgentActivityEnvelopeTests.swift
@@ -62,6 +62,27 @@ struct AgentActivityEnvelopeTests {
         #expect(String(data: sealed, encoding: .utf8) == vector.envelope, "\(vector.name)")
     }
 
+    @Test func sealPreservesCallerSuppliedAgentOrder() throws {
+        let key = Data(0..<32)
+        let nonce = Data(176..<188)
+        let details = AgentActivityDetails(
+            hostName: "mbp",
+            agents: [
+                .init(
+                    paneID: "w1:p-work", kind: "claude", name: "builder",
+                    status: "working", title: "still going"),
+                .init(
+                    paneID: "w1:p-block", kind: "claude", name: "reviewer",
+                    status: "blocked", title: "needs review"),
+            ])
+
+        let sealed = try AgentActivityEnvelope.seal(details, using: key, nonce: nonce)
+        let opened = try AgentActivityEnvelope.open(sealed, using: key)
+
+        #expect(opened.agents.map(\.paneID) == ["w1:p-work", "w1:p-block"])
+        #expect(opened.agents.map(\.status) == ["working", "blocked"])
+    }
+
     @Test(arguments: vectors.invalid)
     func rejectsInvalidVector(vector: LiveActivityVectorFile.Invalid) throws {
         let key = try #require(Data(base64URLEncoded: vector.key))

--- a/Tests/HeelerTests/ConsoleStoreTests.swift
+++ b/Tests/HeelerTests/ConsoleStoreTests.swift
@@ -16,12 +16,21 @@ struct ConsoleStoreTests {
         initialDelay: .milliseconds(10), multiplier: 2, maxDelay: .milliseconds(50))
 
     /// A store whose session factory routes each Host to its scripted
-    /// transport; unknown Hosts fail the connect.
+    /// transport; unknown Hosts fail the connect. Pins default to an isolated
+    /// suite so leftover `UserDefaults.standard` data cannot reorder the list.
     private func makeStore(
         transports: [Host.ID: ScriptedTransport],
-        reconnectPolicy: ReconnectPolicy = Self.fastPolicy
+        reconnectPolicy: ReconnectPolicy = Self.fastPolicy,
+        pins: PinnedAgentsStore? = nil
     ) -> ConsoleStore {
-        ConsoleStore(snapshotRetryDelay: .milliseconds(10)) { host, subscriptions in
+        let resolvedPins =
+            pins
+            ?? PinnedAgentsStore(
+                defaults: UserDefaults(suiteName: "hm-console-pins-\(UUID().uuidString)")
+                    ?? .standard)
+        return ConsoleStore(
+            snapshotRetryDelay: .milliseconds(10), pins: resolvedPins
+        ) { host, subscriptions in
             EventsSession(
                 subscriptions: subscriptions,
                 connect: {
@@ -33,6 +42,27 @@ struct ConsoleStoreTests {
                 reconnectPolicy: reconnectPolicy,
                 keepalive: nil)
         }
+    }
+
+    private func consoleAgent(
+        hostID: UUID,
+        hostName: String,
+        paneID: String,
+        status: AgentStatus,
+        workspaceLabel: String? = "Proj"
+    ) -> ConsoleAgent {
+        ConsoleAgent(
+            hostID: hostID,
+            hostName: hostName,
+            agent: Agent(.fixture(paneID: paneID, status: status)),
+            workspaceLabel: workspaceLabel,
+            repoName: nil)
+    }
+
+    private func makePinDefaults() throws -> (UserDefaults, cleanup: () -> Void) {
+        let suiteName = "hm-console-pins-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        return (defaults, { defaults.removePersistentDomain(forName: suiteName) })
     }
 
     /// Polls until `condition` holds, yielding so the store's tasks progress.
@@ -58,6 +88,45 @@ struct ConsoleStoreTests {
         #expect(
             AgentStatus(rawValue: "haunted").consoleSortBucket
                 == AgentStatus.unknown.consoleSortBucket)
+    }
+
+    @Test func consoleSortedPutsPinnedAgentsFirstByRank() {
+        let hostA = UUID()
+        let hostB = UUID()
+        let idle = consoleAgent(
+            hostID: hostA, hostName: "alpha", paneID: "w1:p1", status: .idle)
+        let working = consoleAgent(
+            hostID: hostA, hostName: "alpha", paneID: "w1:p2", status: .working)
+        let blocked = consoleAgent(
+            hostID: hostB, hostName: "beta", paneID: "w2:p1", status: .blocked)
+        let done = consoleAgent(
+            hostID: hostB, hostName: "beta", paneID: "w2:p2", status: .done)
+        let agents = [idle, working, blocked, done]
+        // Unpinned order is blocked > done > working > idle.
+        #expect(agents.consoleSorted().map(\.agent.paneID) == ["w2:p1", "w2:p2", "w1:p2", "w1:p1"])
+
+        // idle pinned first (rank 1), working pinned more recently (rank 0).
+        // Unpinned blocked/done keep their relative order.
+        let ranks: [ConsoleAgent.ID: Int] = [idle.id: 1, working.id: 0]
+        #expect(
+            agents.consoleSorted { ranks[$0.id] }.map(\.agent.paneID)
+                == ["w1:p2", "w1:p1", "w2:p1", "w2:p2"])
+    }
+
+    @Test func consoleSortedLeavesUnpinnedTiebreaksUnchanged() {
+        let hostA = UUID()
+        let hostB = UUID()
+        // Same status: Host name, then host id, then workspace, then pane id.
+        let laterName = consoleAgent(
+            hostID: hostA, hostName: "zeta", paneID: "w1:p1", status: .working)
+        let earlierName = consoleAgent(
+            hostID: hostB, hostName: "alpha", paneID: "w2:p1", status: .working)
+        let unpinned = [laterName, earlierName].consoleSorted()
+        #expect(unpinned.map(\.agent.paneID) == ["w2:p1", "w1:p1"])
+
+        let ranks: [ConsoleAgent.ID: Int] = [laterName.id: 0]
+        let pinned = [laterName, earlierName].consoleSorted { ranks[$0.id] }
+        #expect(pinned.map(\.agent.paneID) == ["w1:p1", "w2:p1"])
     }
 
     @Test func snapshotsAcrossHostsFlattenIntoOneStatusSortedList() async throws {
@@ -92,6 +161,48 @@ struct ConsoleStoreTests {
         #expect(store.agents.first?.workspaceLabel == "Api")
         #expect(store.agents[1].workspaceLabel == "Api")
         #expect(store.agents.last?.repoName == "proj")
+
+        store.setHosts([])
+    }
+
+    @Test func togglePinResortsThePublishedListImmediately() async throws {
+        let (defaults, cleanup) = try makePinDefaults()
+        defer { cleanup() }
+        let pins = PinnedAgentsStore(defaults: defaults)
+        let hostA = Host.fixture(name: "alpha", address: "a.example")
+        let hostB = Host.fixture(name: "beta", address: "b.example")
+        let transports = [
+            hostA.id: ScriptedTransport(
+                snapshot: .fixture(
+                    agents: [
+                        .fixture(paneID: "w1:p1", status: .idle),
+                        .fixture(paneID: "w1:p2", status: .working),
+                    ],
+                    workspaces: [.fixture(workspaceID: "w1", label: "Proj")])),
+            hostB.id: ScriptedTransport(
+                snapshot: .fixture(
+                    agents: [
+                        .fixture(paneID: "w2:p1", status: .blocked, workspaceID: "w2"),
+                        .fixture(paneID: "w2:p2", status: .done, workspaceID: "w2"),
+                    ],
+                    workspaces: [.fixture(workspaceID: "w2", label: "Api")])),
+        ]
+        let store = makeStore(transports: transports, pins: pins)
+
+        store.setHosts([hostA, hostB])
+        await store.resume()
+        try await waitUntil("all four agents should arrive") { store.agents.count == 4 }
+        #expect(store.agents.map(\.agent.paneID) == ["w2:p1", "w2:p2", "w1:p2", "w1:p1"])
+
+        // Pin the idle agent first, then the working one: working is rank 0.
+        store.togglePin(hostID: hostA.id, paneID: "w1:p1")
+        #expect(store.agents.map(\.agent.paneID) == ["w1:p1", "w2:p1", "w2:p2", "w1:p2"])
+
+        store.togglePin(hostID: hostA.id, paneID: "w1:p2")
+        #expect(store.agents.map(\.agent.paneID) == ["w1:p2", "w1:p1", "w2:p1", "w2:p2"])
+
+        store.togglePin(hostID: hostA.id, paneID: "w1:p2")
+        #expect(store.agents.map(\.agent.paneID) == ["w1:p1", "w2:p1", "w2:p2", "w1:p2"])
 
         store.setHosts([])
     }

--- a/Tests/HeelerTests/HostLiveActivityCoordinatorTests.swift
+++ b/Tests/HeelerTests/HostLiveActivityCoordinatorTests.swift
@@ -568,8 +568,9 @@ struct HostLiveActivityCoordinatorTests {
         world.statuses[host.id] = .connected
         controller.emitToken(id: activityID, Data([0xbb]))
         try await waitUntil("the next live_activity write should carry current pins") {
-            try await liveActivityToken() == "bb"
-                && (try await filePinnedPaneIDs() == ["w:p-work"])
+            let token = try await liveActivityToken()
+            let pins = try await filePinnedPaneIDs()
+            return token == "bb" && pins == ["w:p-work"]
         }
     }
 }

--- a/Tests/HeelerTests/HostLiveActivityCoordinatorTests.swift
+++ b/Tests/HeelerTests/HostLiveActivityCoordinatorTests.swift
@@ -30,10 +30,12 @@ struct HostLiveActivityCoordinatorTests {
 
     private func makeCoordinator(
         defaults: UserDefaults,
-        enable: Bool = true
+        enable: Bool = true,
+        pins: PinnedAgentsStore? = nil
     ) -> HostLiveActivityCoordinator {
         let keys = NotificationKeyStore(secrets: secrets)
         let world = world
+        let pinStore = pins
         let coordinator = HostLiveActivityCoordinator(
             controller: controller,
             preferences: LiveActivityPreferences(defaults: defaults),
@@ -45,6 +47,7 @@ struct HostLiveActivityCoordinatorTests {
             hostDisplayName: { world.hostNames[$0] ?? "" },
             isAwaitingSnapshot: { world.awaitingSnapshot.contains($0) },
             connectionStatus: { world.statuses[$0] },
+            pinnedPaneIDs: { pinStore?.pinnedPaneIDs(for: $0) ?? [] },
             settleDuration: .milliseconds(20))
         if enable {
             coordinator.setEnabled(true, for: host.id)
@@ -100,6 +103,22 @@ struct HostLiveActivityCoordinatorTests {
     private func liveActivityToken() async throws -> String? {
         try NotificationRegistrationFile.decode(await transport.notificationRegistration)
             .liveActivity(forDeviceToken: token.hex)?.token
+    }
+
+    private func filePinnedPaneIDs() async throws -> [String]? {
+        try NotificationRegistrationFile.decode(await transport.notificationRegistration)
+            .liveActivity(forDeviceToken: token.hex)?.pinnedPaneIDs
+    }
+
+    private func notificationKey() throws -> Data {
+        try #require(try NotificationKeyStore(secrets: secrets).record(forHost: host.id)?.key)
+    }
+
+    private func openedPaneIDs(_ state: AgentActivityAttributes.ContentState) throws -> [String] {
+        let envelope = try #require(state.envelope)
+        let details = try AgentActivityEnvelope.open(
+            try JSONEncoder().encode(envelope), using: notificationKey())
+        return details.agents.map(\.paneID)
     }
 
     // MARK: Start / settle / flap
@@ -445,5 +464,112 @@ struct HostLiveActivityCoordinatorTests {
         }
         try await waitPastSettle()
         #expect(controller.requested.count == 1, "the same desire must not restart")
+    }
+
+    // MARK: Pins
+
+    @Test func pinToggleRebuildsOrderAndWritesPinnedPaneIDs() async throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let (pinDefaults, pinCleanup) = try makeDefaults()
+        defer { pinCleanup() }
+        try await registerDevice()
+        armWorld()
+        let pins = PinnedAgentsStore(defaults: pinDefaults)
+        let coordinator = makeCoordinator(defaults: defaults, pins: pins)
+        coordinator.start()
+        coordinator.agentsDidChange([
+            agent("w:p-work", .working),
+            agent("w:p-block", .blocked),
+        ])
+        try await waitUntil("the activity should start") { !controller.requested.isEmpty }
+        #expect(try openedPaneIDs(controller.requested[0]) == ["w:p-block", "w:p-work"])
+        #expect(controller.requested[0].counts == .init(working: 1, blocked: 1, done: 0))
+
+        let activityID = try #require(controller.requestedHandles.first?.id)
+        controller.emitToken(id: activityID, Data([0xab]))
+        try await waitUntil("the token should be written") {
+            try await liveActivityToken() == "ab"
+        }
+        #expect(try await filePinnedPaneIDs() == [])
+
+        pins.togglePin(hostID: host.id, paneID: "w:p-work")
+        coordinator.pinsDidChange()
+        try await waitUntil("a pin toggle should reorder the lock-screen rows") {
+            controller.updates.count == 1
+        }
+        #expect(try openedPaneIDs(controller.updates[0].content) == ["w:p-work", "w:p-block"])
+        #expect(controller.updates[0].content.counts == .init(working: 1, blocked: 1, done: 0))
+        try await waitUntil("the Host should receive the new pin list") {
+            try await filePinnedPaneIDs() == ["w:p-work"]
+        }
+        #expect(controller.requested.count == 1)
+        #expect(controller.ended.isEmpty)
+    }
+
+    @Test func pinningAnIneligibleAgentLeavesRowsAndUpdatesTheFile() async throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let (pinDefaults, pinCleanup) = try makeDefaults()
+        defer { pinCleanup() }
+        try await registerDevice()
+        armWorld()
+        let pins = PinnedAgentsStore(defaults: pinDefaults)
+        let coordinator = makeCoordinator(defaults: defaults, pins: pins)
+        coordinator.start()
+        coordinator.agentsDidChange([
+            agent("w:p-work", .working),
+            agent("w:p-idle", .idle),
+        ])
+        try await waitUntil("the activity should start") { !controller.requestedHandles.isEmpty }
+        let activityID = try #require(controller.requestedHandles.first?.id)
+        controller.emitToken(id: activityID, Data([0x11]))
+        try await waitUntil("the token should be written") {
+            try await liveActivityToken() == "11"
+        }
+
+        pins.togglePin(hostID: host.id, paneID: "w:p-idle")
+        coordinator.pinsDidChange()
+        try await waitPastSettle()
+        #expect(controller.updates.isEmpty, "ineligible pins must not change LA rows")
+        try await waitUntil("the Host should still receive the pin list") {
+            try await filePinnedPaneIDs() == ["w:p-idle"]
+        }
+    }
+
+    @Test func pinToggleWhileOfflineDoesNotWriteUntilTheNextTokenWrite() async throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let (pinDefaults, pinCleanup) = try makeDefaults()
+        defer { pinCleanup() }
+        try await registerDevice()
+        armWorld()
+        let pins = PinnedAgentsStore(defaults: pinDefaults)
+        let coordinator = makeCoordinator(defaults: defaults, pins: pins)
+        coordinator.start()
+        coordinator.agentsDidChange([
+            agent("w:p-work", .working),
+            agent("w:p-block", .blocked),
+        ])
+        try await waitUntil("the activity should start") { !controller.requestedHandles.isEmpty }
+        let activityID = try #require(controller.requestedHandles.first?.id)
+        controller.emitToken(id: activityID, Data([0xaa]))
+        try await waitUntil("the first token should be written") {
+            try await liveActivityToken() == "aa"
+        }
+
+        world.statuses[host.id] = .reconnecting(
+            attempt: 1, delay: .seconds(1), failure: .sshUnreachable(detail: "down"))
+        pins.togglePin(hostID: host.id, paneID: "w:p-work")
+        coordinator.pinsDidChange()
+        try await waitPastSettle()
+        #expect(try await filePinnedPaneIDs() == [])
+
+        world.statuses[host.id] = .connected
+        controller.emitToken(id: activityID, Data([0xbb]))
+        try await waitUntil("the next live_activity write should carry current pins") {
+            try await liveActivityToken() == "bb"
+                && (try await filePinnedPaneIDs() == ["w:p-work"])
+        }
     }
 }

--- a/Tests/HeelerTests/NotificationRegistrationCeremonyTests.swift
+++ b/Tests/HeelerTests/NotificationRegistrationCeremonyTests.swift
@@ -282,4 +282,47 @@ struct NotificationRegistrationCeremonyTests {
         #expect(file.containsDevice(token: token.hex))
         #expect(file.preferences(token: token.hex) != nil)
     }
+
+    @Test func setLiveActivityTokenWritesPinnedPaneIDs() async throws {
+        let transport = ScriptedTransport()
+        try await ceremony.register(
+            hostID: hostID, hostName: "mac-studio", deviceToken: token, over: transport)
+        let started = Date(timeIntervalSince1970: 1_700_000_000)
+
+        try await ceremony.setLiveActivityToken(
+            tokenHex: "deadbeef", startedAt: started, deviceToken: token,
+            pinnedPaneIDs: ["w1:p2", "w1:p1"], over: transport)
+
+        let file = try NotificationRegistrationFile.decode(
+            await transport.notificationRegistration)
+        #expect(file.liveActivity(forDeviceToken: token.hex)?.pinnedPaneIDs == ["w1:p2", "w1:p1"])
+    }
+
+    @Test func setLiveActivityPinnedPaneIDsUpdatesAnExistingField() async throws {
+        let transport = ScriptedTransport()
+        try await ceremony.register(
+            hostID: hostID, hostName: "mac-studio", deviceToken: token, over: transport)
+        try await ceremony.setLiveActivityToken(
+            tokenHex: "deadbeef",
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            deviceToken: token, over: transport)
+
+        try await ceremony.setLiveActivityPinnedPaneIDs(
+            ["w1:p9"], deviceToken: token, over: transport)
+
+        let file = try NotificationRegistrationFile.decode(
+            await transport.notificationRegistration)
+        let live = try #require(file.liveActivity(forDeviceToken: token.hex))
+        #expect(live.token == "deadbeef")
+        #expect(live.pinnedPaneIDs == ["w1:p9"])
+    }
+
+    @Test func setLiveActivityPinnedPaneIDsIsANoOpWhenUnregistered() async throws {
+        let transport = ScriptedTransport()
+
+        try await ceremony.setLiveActivityPinnedPaneIDs(
+            ["w1:p1"], deviceToken: token, over: transport)
+
+        #expect(await transport.replacedNotificationRegistrations.isEmpty)
+    }
 }

--- a/Tests/HeelerTests/NotificationRegistrationFileTests.swift
+++ b/Tests/HeelerTests/NotificationRegistrationFileTests.swift
@@ -139,8 +139,11 @@ struct NotificationRegistrationFileTests {
             try JSONSerialization.jsonObject(with: try file.encoded()) as? [String: Any])
         let devices = try #require(object["devices"] as? [[String: Any]])
         let device = try #require(devices.first)
-        let wire = try #require(device["live_activity"] as? [String: String])
-        #expect(wire == ["token": "deadbeef", "started_at": "2023-11-14T22:13:20Z"])
+        let wire = try #require(device["live_activity"] as? [String: Any])
+        #expect(wire["token"] as? String == "deadbeef")
+        #expect(wire["started_at"] as? String == "2023-11-14T22:13:20Z")
+        #expect(wire["pinned_pane_ids"] as? [String] == [])
+        #expect(live.pinnedPaneIDs.isEmpty)
 
         let cleared = file.clearingLiveActivity(forDeviceToken: entry.token.hex)
         #expect(cleared.liveActivity(forDeviceToken: entry.token.hex) == nil)
@@ -168,6 +171,7 @@ struct NotificationRegistrationFileTests {
         #expect(device["other"]?["nested"] == .bool(true))
         #expect(device["key"]?.stringValue == "kk")
         #expect(file.liveActivity(forDeviceToken: "a1b2c3")?.token == "aabbcc")
+        #expect(file.liveActivity(forDeviceToken: "a1b2c3")?.pinnedPaneIDs == [])
 
         let cleared = file.clearingLiveActivity(forDeviceToken: "a1b2c3")
         let afterClear = try #require(cleared.devices.first)
@@ -193,5 +197,77 @@ struct NotificationRegistrationFileTests {
         #expect(device["key"]?.stringValue == key.base64URLEncodedString())
         #expect(device["notify"]?["blocked"] == .bool(true))
         #expect(device["notify"]?["done"] == .bool(false))
+    }
+
+    @Test func settingLiveActivityWritesPinnedPaneIDsMostRecentFirst() throws {
+        let started = Date(timeIntervalSince1970: 1_700_000_000)
+        let file = NotificationRegistrationFile().upserting(entry)
+            .settingLiveActivity(
+                token: "deadbeef", startedAt: started, forDeviceToken: entry.token.hex,
+                pinnedPaneIDs: ["w1:p2", "w1:p1"])
+
+        let live = try #require(file.liveActivity(forDeviceToken: entry.token.hex))
+        #expect(live.pinnedPaneIDs == ["w1:p2", "w1:p1"])
+
+        let reread = try NotificationRegistrationFile.decode(try file.encoded())
+        #expect(
+            reread.liveActivity(forDeviceToken: entry.token.hex)?.pinnedPaneIDs
+                == ["w1:p2", "w1:p1"])
+
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: try file.encoded()) as? [String: Any])
+        let device = try #require((object["devices"] as? [[String: Any]])?.first)
+        let wire = try #require(device["live_activity"] as? [String: Any])
+        #expect(wire["pinned_pane_ids"] as? [String] == ["w1:p2", "w1:p1"])
+    }
+
+    @Test func settingPinnedPaneIDsMergesWithoutDroppingTokenOrUnknownFields() throws {
+        let existing = Data(
+            (#"{"v":1,"devices":[{"token":"a1b2c3","key":"kk","env":"production","#
+                + #""notify":{"blocked":true,"done":true},"future_field":"kept","#
+                + #""live_activity":{"token":"la","started_at":"2024-01-01T00:00:00Z","#
+                + #""future_la":"kept"}}]}"#).utf8)
+
+        let file = try NotificationRegistrationFile.decode(existing)
+            .settingLiveActivityPinnedPaneIDs(["w1:p9", "w1:p1"], forDeviceToken: "a1b2c3")
+        let device = try #require(file.devices.first)
+        #expect(device["future_field"]?.stringValue == "kept")
+        #expect(device["live_activity"]?["token"]?.stringValue == "la")
+        #expect(device["live_activity"]?["started_at"]?.stringValue == "2024-01-01T00:00:00Z")
+        #expect(device["live_activity"]?["future_la"]?.stringValue == "kept")
+        #expect(file.liveActivity(forDeviceToken: "a1b2c3")?.pinnedPaneIDs == ["w1:p9", "w1:p1"])
+
+        let rewritten = file.settingLiveActivity(
+            token: "aabbcc",
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            forDeviceToken: "a1b2c3",
+            pinnedPaneIDs: ["w1:p1"])
+        let after = try #require(rewritten.devices.first)
+        #expect(after["future_field"]?.stringValue == "kept")
+        #expect(after["live_activity"]?["future_la"]?.stringValue == "kept")
+        #expect(after["live_activity"]?["token"]?.stringValue == "aabbcc")
+        #expect(rewritten.liveActivity(forDeviceToken: "a1b2c3")?.pinnedPaneIDs == ["w1:p1"])
+    }
+
+    @Test func settingPinnedPaneIDsIsANoOpWithoutLiveActivity() throws {
+        let file = NotificationRegistrationFile().upserting(entry)
+        #expect(file.settingLiveActivityPinnedPaneIDs(["w1:p1"], forDeviceToken: entry.token.hex) == file)
+        #expect(file.settingLiveActivityPinnedPaneIDs(["w1:p1"], forDeviceToken: "missing") == file)
+    }
+
+    @Test(arguments: [
+        #"{"v":1,"devices":[{"token":"ffff","live_activity":{"token":"la","started_at":"t"}}]}"#,
+        #"{"v":1,"devices":[{"token":"ffff","live_activity":{"token":"la","started_at":"t","pinned_pane_ids":null}}]}"#,
+        #"{"v":1,"devices":[{"token":"ffff","live_activity":{"token":"la","started_at":"t","pinned_pane_ids":"w1:p1"}}]}"#,
+        #"{"v":1,"devices":[{"token":"ffff","live_activity":{"token":"la","started_at":"t","pinned_pane_ids":["w1:p1",1]}}]}"#,
+        #"{"v":1,"devices":[{"token":"ffff","live_activity":{"token":"la","started_at":"t","pinned_pane_ids":{"pane":"w1:p1"}}}]}"#,
+    ])
+    func malformedPinnedPaneIDsReadAsEmpty(text: String) throws {
+        let file = try NotificationRegistrationFile.decode(Data(text.utf8))
+        #expect(file.liveActivity(forDeviceToken: "ffff")?.pinnedPaneIDs == [])
+        #expect(
+            NotificationRegistrationFile.pinnedPaneIDs(
+                from: file.devices.first?["live_activity"]?["pinned_pane_ids"])
+                == [])
     }
 }

--- a/Tests/HeelerTests/PinnedAgentsStoreTests.swift
+++ b/Tests/HeelerTests/PinnedAgentsStoreTests.swift
@@ -20,6 +20,7 @@ struct PinnedAgentsStoreTests {
         let store = PinnedAgentsStore(defaults: defaults)
         store.togglePin(hostID: hostID, paneID: "w1:p1")
         store.togglePin(hostID: hostID, paneID: "w1:p2")
+        #expect(store.revision == 2)
 
         let reloaded = PinnedAgentsStore(defaults: defaults)
         #expect(reloaded.pinnedPaneIDs(for: hostID) == ["w1:p2", "w1:p1"])

--- a/Tests/HeelerTests/PinnedAgentsStoreTests.swift
+++ b/Tests/HeelerTests/PinnedAgentsStoreTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@MainActor
+@Suite("Pinned agents store")
+struct PinnedAgentsStoreTests {
+    private func makeDefaults() throws -> (UserDefaults, cleanup: () -> Void) {
+        let suiteName = "hm-pins-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        return (defaults, { defaults.removePersistentDomain(forName: suiteName) })
+    }
+
+    @Test func togglePersistsAcrossInstances() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let hostID = UUID()
+
+        let store = PinnedAgentsStore(defaults: defaults)
+        store.togglePin(hostID: hostID, paneID: "w1:p1")
+        store.togglePin(hostID: hostID, paneID: "w1:p2")
+
+        let reloaded = PinnedAgentsStore(defaults: defaults)
+        #expect(reloaded.pinnedPaneIDs(for: hostID) == ["w1:p2", "w1:p1"])
+        #expect(reloaded.isPinned(hostID: hostID, paneID: "w1:p2"))
+        #expect(reloaded.pinRank(hostID: hostID, paneID: "w1:p2") == 0)
+        #expect(reloaded.pinRank(hostID: hostID, paneID: "w1:p1") == 1)
+    }
+
+    @Test func togglePinsThenUnpins() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let hostID = UUID()
+        let store = PinnedAgentsStore(defaults: defaults)
+
+        #expect(!store.isPinned(hostID: hostID, paneID: "w1:p1"))
+        #expect(store.pinRank(hostID: hostID, paneID: "w1:p1") == nil)
+
+        store.togglePin(hostID: hostID, paneID: "w1:p1")
+        #expect(store.isPinned(hostID: hostID, paneID: "w1:p1"))
+        #expect(store.pinRank(hostID: hostID, paneID: "w1:p1") == 0)
+
+        store.togglePin(hostID: hostID, paneID: "w1:p1")
+        #expect(!store.isPinned(hostID: hostID, paneID: "w1:p1"))
+        #expect(store.pinnedPaneIDs(for: hostID).isEmpty)
+        #expect(PinnedAgentsStore(defaults: defaults).pinnedPaneIDs(for: hostID).isEmpty)
+    }
+
+    @Test func rePinMovesTheEntryToMostRecent() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let hostID = UUID()
+        let store = PinnedAgentsStore(defaults: defaults)
+
+        store.togglePin(hostID: hostID, paneID: "w1:p1")
+        store.togglePin(hostID: hostID, paneID: "w1:p2")
+        #expect(store.pinnedPaneIDs(for: hostID) == ["w1:p2", "w1:p1"])
+
+        // Unpin then pin again: the new pin is most-recent, ahead of p2.
+        store.togglePin(hostID: hostID, paneID: "w1:p1")
+        store.togglePin(hostID: hostID, paneID: "w1:p1")
+        #expect(store.pinnedPaneIDs(for: hostID) == ["w1:p1", "w1:p2"])
+        #expect(store.pinRank(hostID: hostID, paneID: "w1:p1") == 0)
+        #expect(store.pinRank(hostID: hostID, paneID: "w1:p2") == 1)
+    }
+
+    @Test func pinsAreIsolatedPerHost() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let hostA = UUID()
+        let hostB = UUID()
+        let store = PinnedAgentsStore(defaults: defaults)
+
+        store.togglePin(hostID: hostA, paneID: "w1:p1")
+        store.togglePin(hostID: hostB, paneID: "w1:p1")
+        store.togglePin(hostID: hostB, paneID: "w2:p9")
+
+        #expect(store.pinnedPaneIDs(for: hostA) == ["w1:p1"])
+        #expect(store.pinnedPaneIDs(for: hostB) == ["w2:p9", "w1:p1"])
+        #expect(store.pinRank(hostID: hostB, paneID: "w2:p9") == 0)
+        #expect(store.pinRank(hostID: hostB, paneID: "w1:p1") == 1)
+        #expect(store.pinRank(hostID: hostA, paneID: "w1:p1") == 2)
+        #expect(!store.isPinned(hostID: hostA, paneID: "w2:p9"))
+        #expect(store.pinnedPaneIDs(for: UUID()).isEmpty)
+    }
+
+    @Test func malformedDataStartsEmptyWithoutCrashing() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        defaults.set(Data("not json".utf8), forKey: "pinned-agents")
+
+        let store = PinnedAgentsStore(defaults: defaults)
+        #expect(store.pinnedPaneIDs(for: UUID()).isEmpty)
+
+        let hostID = UUID()
+        store.togglePin(hostID: hostID, paneID: "w1:p1")
+        #expect(store.isPinned(hostID: hostID, paneID: "w1:p1"))
+        #expect(PinnedAgentsStore(defaults: defaults).isPinned(hostID: hostID, paneID: "w1:p1"))
+    }
+
+    @Test func unknownVersionStartsEmptyWithoutCrashing() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let hostID = UUID()
+        let blob: [String: Any] = [
+            "version": 99,
+            "entries": [
+                ["hostID": hostID.uuidString, "paneID": "w1:p1"]
+            ],
+        ]
+        defaults.set(
+            try JSONSerialization.data(withJSONObject: blob), forKey: "pinned-agents")
+
+        let store = PinnedAgentsStore(defaults: defaults)
+        #expect(!store.isPinned(hostID: hostID, paneID: "w1:p1"))
+        #expect(store.pinnedPaneIDs(for: hostID).isEmpty)
+    }
+
+    @Test func danglingEntriesAreRetainedUntilUnpinned() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let hostID = UUID()
+        let store = PinnedAgentsStore(defaults: defaults)
+        store.togglePin(hostID: hostID, paneID: "gone:pane")
+
+        // The store never sees a live Agent list, so a closed pane cannot
+        // drop its pin. Reload keeps the dangling entry.
+        let reloaded = PinnedAgentsStore(defaults: defaults)
+        #expect(reloaded.isPinned(hostID: hostID, paneID: "gone:pane"))
+        #expect(reloaded.pinnedPaneIDs(for: hostID) == ["gone:pane"])
+        #expect(reloaded.pinRank(hostID: hostID, paneID: "gone:pane") == 0)
+    }
+}

--- a/Tests/HeelerTests/Support/LiveActivityVectorFile.swift
+++ b/Tests/HeelerTests/Support/LiveActivityVectorFile.swift
@@ -16,10 +16,18 @@ struct LiveActivityVectorFile: Decodable, Sendable {
         let envelope: String
         let payload: Payload
         let decodeOnly: Bool
+        /// Most-recently-pinned first. Present on pin-order vectors.
+        let pinnedPaneIDs: [String]
+        /// Full eligible inventory counts when the vector pins the sort rule.
+        let counts: Counts?
+        /// Herdr `agent list` shape used to drive the shared sort rule.
+        let inventory: [InventoryAgent]
         var description: String { name }
 
         enum CodingKeys: String, CodingKey {
             case name, key, keyId, envelope, payload, decodeOnly
+            case pinnedPaneIDs = "pinned_pane_ids"
+            case counts, inventory
         }
 
         init(from decoder: any Decoder) throws {
@@ -30,6 +38,34 @@ struct LiveActivityVectorFile: Decodable, Sendable {
             envelope = try container.decode(String.self, forKey: .envelope)
             payload = try container.decode(Payload.self, forKey: .payload)
             decodeOnly = try container.decodeIfPresent(Bool.self, forKey: .decodeOnly) ?? false
+            pinnedPaneIDs = try container.decodeIfPresent([String].self, forKey: .pinnedPaneIDs) ?? []
+            counts = try container.decodeIfPresent(Counts.self, forKey: .counts)
+            inventory = try container.decodeIfPresent([InventoryAgent].self, forKey: .inventory) ?? []
+        }
+    }
+
+    struct Counts: Decodable, Sendable {
+        let working: Int
+        let blocked: Int
+        let done: Int
+    }
+
+    struct InventoryAgent: Decodable, Sendable {
+        let paneID: String
+        let agentStatus: String
+        let agent: String?
+        let name: String?
+        let displayAgent: String?
+        let terminalTitle: String?
+        let terminalTitleStripped: String?
+
+        enum CodingKeys: String, CodingKey {
+            case paneID = "pane_id"
+            case agentStatus = "agent_status"
+            case agent, name
+            case displayAgent = "display_agent"
+            case terminalTitle = "terminal_title"
+            case terminalTitleStripped = "terminal_title_stripped"
         }
     }
 

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -30,10 +30,11 @@ struct TerminalAgentSwitcherTests {
     }
 
     private static func makeItem(
-        _ agent: ConsoleAgent, status: AgentStatus? = nil
+        _ agent: ConsoleAgent, status: AgentStatus? = nil, isPinned: Bool = false
     ) -> TerminalAgentSwitcherItem {
         TerminalAgentSwitcherItem(
-            id: agent.id, title: agent.switcherLabel, status: status ?? agent.agent.status)
+            id: agent.id, title: agent.switcherLabel,
+            status: status ?? agent.agent.status, isPinned: isPinned)
     }
 
     /// The project is what tells a console full of `claude` apart, so it
@@ -108,7 +109,8 @@ struct TerminalAgentSwitcherTests {
                 // The Agent the user switched to is at the far end of the
                 // strip, so opening it has to scroll — the case that hangs.
                 selectedID: agents[9].id,
-                onSelect: { _ in }),
+                onSelect: { _ in },
+                onTogglePin: { _ in }),
             isKeyboardUp: true,
             toggleKeyboard: {},
             switchKeyboard: {})
@@ -183,6 +185,147 @@ struct TerminalAgentSwitcherTests {
         // would tear down the terminal the user is typing into.
         bar.chips[0].sendActions(for: .touchUpInside)
         #expect(opened == [agents[1].id])
+    }
+
+    /// Switcher chips inherit pin state from the same store the Console list
+    /// uses, so a pin made on one surface shows up on the other.
+    @MainActor
+    @Test func itemsReflectThePinStore() throws {
+        let suiteName = "hm-switcher-pins-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let agent = Self.makeAgent(pane: "p1", workspace: "alpha", status: .blocked)
+        let pins = PinnedAgentsStore(defaults: defaults)
+
+        let unpinned = TerminalAgentSwitcherItem(agent: agent, pins: pins)
+        #expect(unpinned.id == agent.id)
+        #expect(unpinned.title == "alpha")
+        #expect(unpinned.status == .blocked)
+        #expect(!unpinned.isPinned)
+
+        pins.togglePin(hostID: agent.hostID, paneID: agent.agent.paneID)
+        let pinned = TerminalAgentSwitcherItem(agent: agent, pins: pins)
+        #expect(pinned.id == agent.id)
+        #expect(pinned.isPinned)
+    }
+
+    /// Long-press is Pin / Unpin, matching the Console row, so the user can
+    /// mark an Agent without leaving the terminal.
+    @MainActor
+    @Test func thePinMenuSaysPinWhenUnpinnedAndUnpinWhenPinned() throws {
+        let host = UUID()
+        let agents = [
+            Self.makeAgent(pane: "p1", workspace: "alpha", host: host),
+            Self.makeAgent(pane: "p2", workspace: "beta", host: host),
+        ]
+        let items = [
+            Self.makeItem(agents[0]),
+            Self.makeItem(agents[1], isPinned: true),
+        ]
+        let bar = TerminalAgentSwitcherBar()
+        bar.update(items: items, selectedID: agents[0].id)
+
+        for chip in bar.chips {
+            let interaction = try #require(
+                chip.interactions.compactMap { $0 as? UIContextMenuInteraction }.first)
+            #expect(interaction.delegate === bar)
+            #expect(
+                bar.contextMenuInteraction(interaction, configurationForMenuAtLocation: .zero)
+                    != nil)
+        }
+
+        let pinMenu = bar.pinMenu(for: items[0])
+        #expect(pinMenu.children.count == 1)
+        let pin = try #require(pinMenu.children.first as? UIAction)
+        #expect(pin.title == "Pin")
+
+        let unpinMenu = bar.pinMenu(for: items[1])
+        #expect(unpinMenu.children.count == 1)
+        let unpin = try #require(unpinMenu.children.first as? UIAction)
+        #expect(unpin.title == "Unpin")
+    }
+
+    @MainActor
+    @Test func choosingThePinMenuTogglesThatAgent() throws {
+        let host = UUID()
+        let agents = [
+            Self.makeAgent(pane: "p1", workspace: "alpha", host: host),
+            Self.makeAgent(pane: "p2", workspace: "beta", host: host),
+        ]
+        let items = [
+            Self.makeItem(agents[0]),
+            Self.makeItem(agents[1], isPinned: true),
+        ]
+        var toggled: [ConsoleAgent.ID] = []
+        let bar = TerminalAgentSwitcherBar()
+        bar.onTogglePin = { toggled.append($0) }
+        bar.update(items: items, selectedID: agents[0].id)
+
+        let pin = try #require(bar.pinMenu(for: items[0]).children.first as? UIAction)
+        pin.perform(withSender: nil, target: nil)
+        #expect(toggled == [agents[0].id])
+
+        let unpin = try #require(bar.pinMenu(for: items[1]).children.first as? UIAction)
+        unpin.perform(withSender: nil, target: nil)
+        #expect(toggled == [agents[0].id, agents[1].id])
+    }
+
+    /// The pin glyph is how an already-pinned chip reads before a long-press;
+    /// an unpinned chip stays a dot and a label.
+    @MainActor
+    @Test func pinnedChipsShowAPinIndicator() throws {
+        let host = UUID()
+        let agents = [
+            Self.makeAgent(pane: "p1", workspace: "alpha", status: .blocked, host: host),
+            Self.makeAgent(pane: "p2", workspace: "beta", status: .idle, host: host),
+        ]
+        let bar = TerminalAgentSwitcherBar()
+        bar.update(
+            items: [
+                Self.makeItem(agents[0]),
+                Self.makeItem(agents[1], isPinned: true),
+            ],
+            selectedID: agents[0].id)
+
+        #expect(!bar.chips[0].showsPinIndicator)
+        #expect(bar.chips[0].accessibilityValue == "Blocked")
+        #expect(bar.chips[1].showsPinIndicator)
+        #expect(bar.chips[1].accessibilityValue == "Pinned, Idle")
+
+        bar.update(
+            items: [
+                Self.makeItem(agents[0], isPinned: true),
+                Self.makeItem(agents[1]),
+            ],
+            selectedID: agents[0].id)
+        #expect(bar.chips[0].showsPinIndicator)
+        #expect(bar.chips[1].showsPinIndicator == false)
+    }
+
+    /// The context menu must not steal the tap that switches Agents.
+    @MainActor
+    @Test func tappingAChipStillSwitchesWhenTheChipHasAPinMenu() {
+        let host = UUID()
+        let agents = [
+            Self.makeAgent(pane: "p1", workspace: "alpha", host: host),
+            Self.makeAgent(pane: "p2", workspace: "beta", host: host),
+        ]
+        var opened: [ConsoleAgent.ID] = []
+        var toggled: [ConsoleAgent.ID] = []
+        let bar = TerminalAgentSwitcherBar()
+        bar.onSelect = { opened.append($0) }
+        bar.onTogglePin = { toggled.append($0) }
+        bar.update(
+            items: [
+                Self.makeItem(agents[0]),
+                Self.makeItem(agents[1], isPinned: true),
+            ],
+            selectedID: agents[0].id)
+
+        bar.chips[1].sendActions(for: .touchUpInside)
+        #expect(opened == [agents[1].id])
+        #expect(toggled.isEmpty)
     }
 
     /// Status deltas land constantly (`pane.agent_status_changed`). Rebuilding

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -386,8 +386,8 @@ struct TerminalAgentSwitcherTests {
     }
 
     /// Pinning restacks the strip: the same chip views must slide to the
-    /// new order. Recreating them would restart the Working pulse and is
-    /// also why a hole used to sit where the chip left.
+    /// new order, and after layout they sit flush — no gap between
+    /// neighbours, no leftover space where a chip used to be.
     @MainActor
     @Test func reorderingChipsKeepsTheSameViews() {
         let host = UUID()
@@ -408,6 +408,7 @@ struct TerminalAgentSwitcherTests {
         bar.layoutIfNeeded()
         let original = bar.chips
         #expect(original.map(\.id) == agents.map(\.id))
+        expectChipsAreContiguous(bar)
 
         // Pinning gamma sends it to the front; alpha and beta slide closed.
         let pinned = [
@@ -422,7 +423,7 @@ struct TerminalAgentSwitcherTests {
         #expect(bar.chips[0] === original[2])
         #expect(bar.chips[1] === original[0])
         #expect(bar.chips[2] === original[1])
-        expectNoLeftoverChips(bar, matching: pinned, identity: original)
+        expectStripMatches(bar, items: pinned, identity: original)
         #expect(bar.chips[0].showsPinIndicator)
         #expect(!bar.chips[1].showsPinIndicator)
         #expect(!bar.chips[2].showsPinIndicator)
@@ -433,15 +434,14 @@ struct TerminalAgentSwitcherTests {
         #expect(bar.chips[0] === original[0])
         #expect(bar.chips[1] === original[1])
         #expect(bar.chips[2] === original[2])
-        expectNoLeftoverChips(bar, matching: agents.map { Self.makeItem($0) }, identity: original)
+        expectStripMatches(bar, items: agents.map { Self.makeItem($0) }, identity: original)
         #expect(!bar.chips[2].showsPinIndicator)
     }
 
-    /// A leftover arranged slot is the ghost gap: the chip moved, the stack
-    /// still reserved its old place. Pin/unpin cycles must not accumulate
-    /// duplicates or orphans.
+    /// Pin/unpin cycles must leave the strip flush every time: no gap
+    /// between neighbours after layout, and the same chip views throughout.
     @MainActor
-    @Test func repeatedPinCyclesLeaveNoLeftoverChips() {
+    @Test func repeatedPinCyclesLeaveNoGaps() {
         let host = UUID()
         let agents = [
             Self.makeAgent(pane: "p1", workspace: "alpha", host: host),
@@ -460,6 +460,7 @@ struct TerminalAgentSwitcherTests {
         bar.update(items: unpinned, selectedID: agents[0].id)
         bar.layoutIfNeeded()
         let original = bar.chips
+        expectChipsAreContiguous(bar)
 
         for _ in 0..<3 {
             let pinGamma = [
@@ -468,10 +469,12 @@ struct TerminalAgentSwitcherTests {
                 Self.makeItem(agents[1]),
             ]
             bar.update(items: pinGamma, selectedID: agents[0].id)
-            expectNoLeftoverChips(bar, matching: pinGamma, identity: original)
+            bar.layoutIfNeeded()
+            expectStripMatches(bar, items: pinGamma, identity: original)
 
             bar.update(items: unpinned, selectedID: agents[0].id)
-            expectNoLeftoverChips(bar, matching: unpinned, identity: original)
+            bar.layoutIfNeeded()
+            expectStripMatches(bar, items: unpinned, identity: original)
 
             let pinBeta = [
                 Self.makeItem(agents[1], isPinned: true),
@@ -479,30 +482,41 @@ struct TerminalAgentSwitcherTests {
                 Self.makeItem(agents[2]),
             ]
             bar.update(items: pinBeta, selectedID: agents[0].id)
-            expectNoLeftoverChips(bar, matching: pinBeta, identity: original)
+            bar.layoutIfNeeded()
+            expectStripMatches(bar, items: pinBeta, identity: original)
 
             bar.update(items: unpinned, selectedID: agents[0].id)
-            expectNoLeftoverChips(bar, matching: unpinned, identity: original)
+            bar.layoutIfNeeded()
+            expectStripMatches(bar, items: unpinned, identity: original)
         }
     }
 
-    /// Model order, stack order, and object identity all describe one strip.
+    /// After layout, each chip starts where the previous one plus the
+    /// stack spacing ended. A leftover gap is a hole the user can see.
     @MainActor
-    private func expectNoLeftoverChips(
+    private func expectChipsAreContiguous(_ bar: TerminalAgentSwitcherBar) {
+        let chips = bar.chips
+        for index in chips.indices.dropLast() {
+            let actual = chips[index + 1].frame.minX
+            let expected = chips[index].frame.maxX + TerminalAgentChip.spacing
+            #expect(abs(actual - expected) < 0.5)
+        }
+    }
+
+    @MainActor
+    private func expectStripMatches(
         _ bar: TerminalAgentSwitcherBar,
-        matching items: [TerminalAgentSwitcherItem],
+        items: [TerminalAgentSwitcherItem],
         identity: [TerminalAgentChip]
     ) {
         #expect(bar.chips.map(\.id) == items.map(\.id))
         #expect(bar.arrangedChips.map(\.id) == items.map(\.id))
         #expect(bar.arrangedChips.elementsEqual(bar.chips, by: { $0 === $1 }))
-        #expect(
-            Set(bar.arrangedChips.map { ObjectIdentifier($0) }).count
-                == bar.arrangedChips.count)
         let byID = Dictionary(uniqueKeysWithValues: identity.map { ($0.id, $0) })
         for chip in bar.chips {
             #expect(chip === byID[chip.id])
         }
+        expectChipsAreContiguous(bar)
     }
 
     /// A switch builds a new terminal, so the strip that comes back is a new

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -239,11 +239,43 @@ struct TerminalAgentSwitcherTests {
         #expect(pinMenu.children.count == 1)
         let pin = try #require(pinMenu.children.first as? UIAction)
         #expect(pin.title == "Pin")
+        #expect(pin.image == UIImage(systemName: "pin"))
 
         let unpinMenu = bar.pinMenu(for: items[1])
         #expect(unpinMenu.children.count == 1)
         let unpin = try #require(unpinMenu.children.first as? UIAction)
         #expect(unpin.title == "Unpin")
+        #expect(unpin.image == UIImage(systemName: "pin.slash"))
+    }
+
+    /// The long-press must ask the chip under the finger, not the first
+    /// Agent on the strip — otherwise every menu would show the first
+    /// chip's Pin / Unpin state.
+    @MainActor
+    @Test func eachChipResolvesItsOwnPinItem() throws {
+        let host = UUID()
+        let agents = [
+            Self.makeAgent(pane: "p1", workspace: "alpha", host: host),
+            Self.makeAgent(pane: "p2", workspace: "beta", host: host),
+        ]
+        let items = [
+            Self.makeItem(agents[0]),
+            Self.makeItem(agents[1], isPinned: true),
+        ]
+        let bar = TerminalAgentSwitcherBar()
+        bar.update(items: items, selectedID: agents[0].id)
+
+        let firstInteraction = try #require(
+            bar.chips[0].interactions.compactMap { $0 as? UIContextMenuInteraction }.first)
+        let secondInteraction = try #require(
+            bar.chips[1].interactions.compactMap { $0 as? UIContextMenuInteraction }.first)
+
+        let first = try #require(bar.pinItem(for: firstInteraction))
+        let second = try #require(bar.pinItem(for: secondInteraction))
+        #expect(first == items[0])
+        #expect(second == items[1])
+        #expect(!first.isPinned)
+        #expect(second.isPinned)
     }
 
     @MainActor

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -295,11 +295,11 @@ struct TerminalAgentSwitcherTests {
         bar.update(items: items, selectedID: agents[0].id)
 
         let pin = try #require(bar.pinMenu(for: items[0]).children.first as? UIAction)
-        pin.perform(withSender: nil, target: nil)
+        pin.perform(nil, with: nil)
         #expect(toggled == [agents[0].id])
 
         let unpin = try #require(bar.pinMenu(for: items[1]).children.first as? UIAction)
-        unpin.perform(withSender: nil, target: nil)
+        unpin.perform(nil, with: nil)
         #expect(toggled == [agents[0].id, agents[1].id])
     }
 

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -516,7 +516,61 @@ struct TerminalAgentSwitcherTests {
         for chip in bar.chips {
             #expect(chip === byID[chip.id])
         }
+        for (item, chip) in zip(items, bar.chips) {
+            #expect(chip.showsPinIndicator == item.isPinned)
+        }
         expectChipsAreContiguous(bar)
+    }
+
+    /// The glyph write happens inside the reorder animation, and UIStackView
+    /// miscounts hidden flips that re-assign the value already in place. The
+    /// killer sequence is pin → another animated update that keeps the chip
+    /// pinned (the redundant write) → unpin: the glyph must still clear.
+    @MainActor
+    @Test func aPinnedChipsGlyphClearsAfterAnotherAnimatedUpdate() {
+        let host = UUID()
+        let agents = [
+            Self.makeAgent(pane: "p1", workspace: "alpha", host: host),
+            Self.makeAgent(pane: "p2", workspace: "beta", host: host),
+            Self.makeAgent(pane: "p3", workspace: "gamma", host: host),
+        ]
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: 874))
+        let bar = TerminalAgentSwitcherBar()
+        window.addSubview(bar)
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        bar.frame = CGRect(
+            x: 0, y: 0, width: 402, height: TerminalAgentSwitcherBar.preferredHeight)
+
+        let unpinned = agents.map { Self.makeItem($0) }
+        bar.update(items: unpinned, selectedID: agents[0].id)
+        bar.layoutIfNeeded()
+
+        // Pin gamma: its glyph write is a real change, inside the animation.
+        bar.update(
+            items: [
+                Self.makeItem(agents[2], isPinned: true),
+                Self.makeItem(agents[0]),
+                Self.makeItem(agents[1]),
+            ], selectedID: agents[0].id)
+        bar.layoutIfNeeded()
+
+        // Pin beta on top: gamma stays pinned, so its glyph gets the
+        // redundant same-value write inside this second animation.
+        bar.update(
+            items: [
+                Self.makeItem(agents[1], isPinned: true),
+                Self.makeItem(agents[2], isPinned: true),
+                Self.makeItem(agents[0]),
+            ], selectedID: agents[0].id)
+        bar.layoutIfNeeded()
+
+        // Unpin everything: both glyphs must clear.
+        bar.update(items: unpinned, selectedID: agents[0].id)
+        bar.layoutIfNeeded()
+        for chip in bar.chips {
+            #expect(!chip.showsPinIndicator)
+        }
     }
 
     /// A switch builds a new terminal, so the strip that comes back is a new

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -385,6 +385,126 @@ struct TerminalAgentSwitcherTests {
         #expect(working.superview == nil)
     }
 
+    /// Pinning restacks the strip: the same chip views must slide to the
+    /// new order. Recreating them would restart the Working pulse and is
+    /// also why a hole used to sit where the chip left.
+    @MainActor
+    @Test func reorderingChipsKeepsTheSameViews() {
+        let host = UUID()
+        let agents = [
+            Self.makeAgent(pane: "p1", workspace: "alpha", host: host),
+            Self.makeAgent(pane: "p2", workspace: "beta", host: host),
+            Self.makeAgent(pane: "p3", workspace: "gamma", host: host),
+        ]
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: 874))
+        let bar = TerminalAgentSwitcherBar()
+        window.addSubview(bar)
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        bar.frame = CGRect(
+            x: 0, y: 0, width: 402, height: TerminalAgentSwitcherBar.preferredHeight)
+
+        bar.update(items: agents.map { Self.makeItem($0) }, selectedID: agents[0].id)
+        bar.layoutIfNeeded()
+        let original = bar.chips
+        #expect(original.map(\.id) == agents.map(\.id))
+
+        // Pinning gamma sends it to the front; alpha and beta slide closed.
+        let pinned = [
+            Self.makeItem(agents[2], isPinned: true),
+            Self.makeItem(agents[0]),
+            Self.makeItem(agents[1]),
+        ]
+        bar.update(items: pinned, selectedID: agents[0].id)
+        bar.layoutIfNeeded()
+
+        #expect(bar.chips.map(\.id) == pinned.map(\.id))
+        #expect(bar.chips[0] === original[2])
+        #expect(bar.chips[1] === original[0])
+        #expect(bar.chips[2] === original[1])
+        expectNoLeftoverChips(bar, matching: pinned, identity: original)
+        #expect(bar.chips[0].showsPinIndicator)
+        #expect(!bar.chips[1].showsPinIndicator)
+        #expect(!bar.chips[2].showsPinIndicator)
+
+        bar.update(items: agents.map { Self.makeItem($0) }, selectedID: agents[0].id)
+        bar.layoutIfNeeded()
+        #expect(bar.chips.map(\.id) == agents.map(\.id))
+        #expect(bar.chips[0] === original[0])
+        #expect(bar.chips[1] === original[1])
+        #expect(bar.chips[2] === original[2])
+        expectNoLeftoverChips(bar, matching: agents.map { Self.makeItem($0) }, identity: original)
+        #expect(!bar.chips[2].showsPinIndicator)
+    }
+
+    /// A leftover arranged slot is the ghost gap: the chip moved, the stack
+    /// still reserved its old place. Pin/unpin cycles must not accumulate
+    /// duplicates or orphans.
+    @MainActor
+    @Test func repeatedPinCyclesLeaveNoLeftoverChips() {
+        let host = UUID()
+        let agents = [
+            Self.makeAgent(pane: "p1", workspace: "alpha", host: host),
+            Self.makeAgent(pane: "p2", workspace: "beta", host: host),
+            Self.makeAgent(pane: "p3", workspace: "gamma", host: host),
+        ]
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: 874))
+        let bar = TerminalAgentSwitcherBar()
+        window.addSubview(bar)
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+        bar.frame = CGRect(
+            x: 0, y: 0, width: 402, height: TerminalAgentSwitcherBar.preferredHeight)
+
+        let unpinned = agents.map { Self.makeItem($0) }
+        bar.update(items: unpinned, selectedID: agents[0].id)
+        bar.layoutIfNeeded()
+        let original = bar.chips
+
+        for _ in 0..<3 {
+            let pinGamma = [
+                Self.makeItem(agents[2], isPinned: true),
+                Self.makeItem(agents[0]),
+                Self.makeItem(agents[1]),
+            ]
+            bar.update(items: pinGamma, selectedID: agents[0].id)
+            expectNoLeftoverChips(bar, matching: pinGamma, identity: original)
+
+            bar.update(items: unpinned, selectedID: agents[0].id)
+            expectNoLeftoverChips(bar, matching: unpinned, identity: original)
+
+            let pinBeta = [
+                Self.makeItem(agents[1], isPinned: true),
+                Self.makeItem(agents[0]),
+                Self.makeItem(agents[2]),
+            ]
+            bar.update(items: pinBeta, selectedID: agents[0].id)
+            expectNoLeftoverChips(bar, matching: pinBeta, identity: original)
+
+            bar.update(items: unpinned, selectedID: agents[0].id)
+            expectNoLeftoverChips(bar, matching: unpinned, identity: original)
+        }
+    }
+
+    /// Model order, stack order, and object identity all describe one strip.
+    @MainActor
+    private func expectNoLeftoverChips(
+        _ bar: TerminalAgentSwitcherBar,
+        matching items: [TerminalAgentSwitcherItem],
+        identity: [TerminalAgentChip]
+    ) {
+        #expect(bar.chips.map(\.id) == items.map(\.id))
+        #expect(bar.arrangedChips.map(\.id) == items.map(\.id))
+        #expect(bar.arrangedChips.elementsEqual(bar.chips, by: { $0 === $1 }))
+        #expect(
+            Set(bar.arrangedChips.map { ObjectIdentifier($0) }).count
+                == bar.arrangedChips.count)
+        let byID = Dictionary(uniqueKeysWithValues: identity.map { ($0.id, $0) })
+        for chip in bar.chips {
+            #expect(chip === byID[chip.id])
+        }
+    }
+
     /// A switch builds a new terminal, so the strip that comes back is a new
     /// bar sitting at offset zero — and the Agent the user just picked is off
     /// screen whenever the list outruns the row. The chip on screen must be

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -279,7 +279,7 @@ struct TerminalAgentSwitcherTests {
     }
 
     @MainActor
-    @Test func choosingThePinMenuTogglesThatAgent() throws {
+    @Test func choosingThePinMenuTogglesThatAgent() {
         let host = UUID()
         let agents = [
             Self.makeAgent(pane: "p1", workspace: "alpha", host: host),
@@ -294,12 +294,10 @@ struct TerminalAgentSwitcherTests {
         bar.onTogglePin = { toggled.append($0) }
         bar.update(items: items, selectedID: agents[0].id)
 
-        let pin = try #require(bar.pinMenu(for: items[0]).children.first as? UIAction)
-        pin.perform(nil, with: nil)
+        bar.performPinToggle(for: items[0])
         #expect(toggled == [agents[0].id])
 
-        let unpin = try #require(bar.pinMenu(for: items[1]).children.first as? UIAction)
-        unpin.perform(nil, with: nil)
+        bar.performPinToggle(for: items[1])
         #expect(toggled == [agents[0].id, agents[1].id])
     }
 

--- a/docs/agents/live-activity-contract.md
+++ b/docs/agents/live-activity-contract.md
@@ -147,8 +147,9 @@ on the next push.
 `pinned_pane_ids` is this Host's pin recency list: pane-id strings,
 most-recently-pinned first. The app writes it whenever it writes
 `live_activity` and pushes an update when the pin set changes while the
-Host is connected. Missing, null, a non-array, or any non-string entry
-is treated as an empty list (older apps never write the field). Empty
+Host is connected and an activity is running. Missing, null, a
+non-array, or any non-string entry is treated as an empty list (older
+apps never write the field). Empty
 string entries are still strings and are kept. The field is additive v1
 metadata; unknown sibling keys on `live_activity` must survive a rewrite.
 

--- a/docs/agents/live-activity-contract.md
+++ b/docs/agents/live-activity-contract.md
@@ -51,8 +51,14 @@ Decrypted plaintext (canonical form):
   whitespace), object keys in **ascending alphabetical order** at every
   level (Swift: `.sortedKeys, .withoutEscapingSlashes`; Node: construct
   objects with alphabetically ordered keys, then `JSON.stringify`).
-- `agents` sorted `blocked` > `done` > `working`, ties by `pane` ascending
-  (byte order), capped at **5** entries. `counts` still covers everything.
+- `agents` ordered as: eligible agents whose pane id appears in this
+  device's `live_activity.pinned_pane_ids` first, by that array's index
+  (most recently pinned first); remaining eligible agents in the existing
+  order (`blocked` > `done` > `working`, ties by `pane` ascending byte
+  order). Cap at **5** after that sort. `counts` still covers everything.
+  Pins never change eligibility: idle/unknown stay hidden. A pinned
+  working agent may displace an unpinned blocked agent from the visible
+  rows. The widget renders rows in envelope order and does not re-sort.
 - `title` is `terminal_title_stripped ?? terminal_title`, trimmed to ≤80
   graphemes; omitted (not empty) when unavailable. `kind` falls back to
   `"unknown"`.
@@ -71,10 +77,11 @@ The widget renders no Host identity: an agent renders as two lines
 mirroring the herdr sidebar's hierarchy — the task `title` on top with
 the identity (`name`, falling back to `kind` when unnamed, exactly like
 the TUI) indented beneath; a missing title promotes the identity to the
-top line alone. The lock screen draws a uniform list, most urgent first:
-all four rows when the inventory fits, otherwise three rows plus
-"+N more" (the ~160pt banner budget). The `host` field stays in the wire
-for producers but is not displayed.
+top line alone. The lock screen draws a uniform list in envelope order
+(pinned eligible first, then status rank): all four rows when the
+inventory fits, otherwise three rows plus "+N more" (the ~160pt banner
+budget). The `host` field stays in the wire for producers but is not
+displayed.
 
 ## Relay request (plugin → relay)
 
@@ -127,7 +134,8 @@ event:
 
 ```json
 "live_activity": {"token": "<hex per-activity push token>",
-                  "started_at": "<ISO 8601>"}
+                  "started_at": "<ISO 8601>",
+                  "pinned_pane_ids": ["wV:p7X", "wV:p1"]}
 ```
 
 Missing field = send nothing (fail closed; `notify` flags do not gate this
@@ -136,11 +144,21 @@ device entry's alert `token`, `key`, `notify`, and unknown fields. A user
 dismissing the activity while the app is dead self-heals through that 410
 on the next push.
 
+`pinned_pane_ids` is this Host's pin recency list: pane-id strings,
+most-recently-pinned first. The app writes it whenever it writes
+`live_activity` and pushes an update when the pin set changes while the
+Host is connected. Missing, null, a non-array, or any non-string entry
+is treated as an empty list (older apps never write the field). Empty
+string entries are still strings and are kept. The field is additive v1
+metadata; unknown sibling keys on `live_activity` must survive a rewrite.
+
 ## Shared vectors
 
 `plugin/test-vectors/live-activity-content-v1.json`, same schema style as
 `notification-payload-v1.json`: non-`decodeOnly` `valid` vectors must be
 reproduced byte-for-byte by the seal side and opened by the open side;
 `invalid` vectors must fail with the given typed error. Includes the
-cross-AAD case proving domain separation. Consumed by both the Node suite
-and HeelerTests; regenerate only via an independent raw-crypto script.
+cross-AAD case proving domain separation. Pin-order cases also carry
+`inventory`, `pinned_pane_ids`, and `counts` so both suites pin the
+shared sort rule. Consumed by both the Node suite and HeelerTests;
+regenerate only via an independent raw-crypto script.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -293,6 +293,7 @@ revokes that device.
 | `live_activity`  | object  | Optional per-device Live Activity registration. Present while the app is showing this Host's activity. See [Activity hook](#activity-hook). |
 | `live_activity.token` | string | The per-activity APNs push token, lowercase hex. Distinct from the alert `token`. |
 | `live_activity.started_at` | string | ISO 8601 timestamp the app wrote when it started (or rotated) the activity. Ignored by the hook; preserved on rewrite. |
+| `live_activity.pinned_pane_ids` | string[] | Optional. Pane ids the device has pinned, most-recently-pinned first. Reorders Live Activity rows; does not change eligibility or counts. Missing, null, non-array, or any non-string entry is ignored (treated as empty). |
 
 Readers ignore unknown fields (additive v1 metadata); breaking changes bump
 `v`, honored by plugin and app together.

--- a/plugin/src/activity-hook.js
+++ b/plugin/src/activity-hook.js
@@ -84,7 +84,12 @@ function readActivityDevices(configDir) {
     if (!APNS_ENVIRONMENTS.has(env)) continue;
     const key = typeof entry.key === "string" ? Buffer.from(entry.key, "base64url") : null;
     if (key?.length !== KEY_BYTES) continue;
-    devices.push({ token: live.token, env, key });
+    devices.push({
+      token: live.token,
+      env,
+      key,
+      pinnedPaneIds: live.pinned_pane_ids,
+    });
   }
   return devices;
 }
@@ -370,29 +375,30 @@ async function main() {
   const pushEvent = empty ? "end" : "update";
   const priority = hasNewlyBlocked(statuses, previous) ? 10 : 5;
   const timestamp = Math.floor(Date.now() / 1000);
-  const { counts, plaintextObject } = buildActivityState({
-    agents,
-    hostName: shortHostName(),
-  });
-  const content =
-    pushEvent === "end"
-      ? {
-          counts: { working: 0, blocked: 0, done: 0 },
-          plaintextObject: { agents: [], host: plaintextObject.host, v: 1 },
-        }
-      : { counts, plaintextObject };
-
-  const request = {
-    event: pushEvent,
-    priority,
-    timestamp,
-    counts: content.counts,
-  };
+  const hostName = shortHostName();
 
   const pruned = new Set();
   const failures = [];
   let delivered = false;
   for (const device of devices) {
+    const { counts, plaintextObject } = buildActivityState({
+      agents,
+      hostName,
+      pinnedPaneIds: device.pinnedPaneIds,
+    });
+    const content =
+      pushEvent === "end"
+        ? {
+            counts: { working: 0, blocked: 0, done: 0 },
+            plaintextObject: { agents: [], host: plaintextObject.host, v: 1 },
+          }
+        : { counts, plaintextObject };
+    const request = {
+      event: pushEvent,
+      priority,
+      timestamp,
+      counts: content.counts,
+    };
     try {
       const outcome = await deliver(config, device, content.plaintextObject, request);
       if (outcome === "ok") delivered = true;

--- a/plugin/src/activity-state.js
+++ b/plugin/src/activity-state.js
@@ -2,7 +2,9 @@
 //
 // Pure: given a herdr `agent list` inventory and a host label, produce the
 // plaintext counts (full eligible set) and the capped, sorted agents array
-// that goes inside the encrypted envelope.
+// that goes inside the encrypted envelope. An optional `pinnedPaneIds` list
+// (most-recently-pinned first) reorders eligible agents; it never changes
+// eligibility or counts.
 
 import os from "node:os";
 
@@ -59,10 +61,27 @@ export function hasNewlyBlocked(current, previous) {
 }
 
 /**
- * @param {{agents: object[], hostName: string}} input
+ * Lenient reader for `live_activity.pinned_pane_ids`. Missing, null, a
+ * non-array, or any non-string entry becomes an empty list.
+ *
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+export function parsePinnedPaneIds(value) {
+  if (!Array.isArray(value)) return [];
+  const ids = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") return [];
+    ids.push(entry);
+  }
+  return ids;
+}
+
+/**
+ * @param {{agents: object[], hostName: string, pinnedPaneIds?: unknown}} input
  * @returns {{counts: {working: number, blocked: number, done: number}, plaintextObject: object}}
  */
-export function buildActivityState({ agents, hostName }) {
+export function buildActivityState({ agents, hostName, pinnedPaneIds }) {
   const counts = { working: 0, blocked: 0, done: 0 };
   const eligible = [];
   for (const agent of Array.isArray(agents) ? agents : []) {
@@ -71,7 +90,17 @@ export function buildActivityState({ agents, hostName }) {
     counts[parsed.status] += 1;
     eligible.push(parsed);
   }
+  const pinIndex = new Map();
+  for (const [index, pane] of parsePinnedPaneIds(pinnedPaneIds).entries()) {
+    if (!pinIndex.has(pane)) pinIndex.set(pane, index);
+  }
   eligible.sort((left, right) => {
+    const leftPinned = pinIndex.has(left.pane);
+    const rightPinned = pinIndex.has(right.pane);
+    if (leftPinned && rightPinned) {
+      return pinIndex.get(left.pane) - pinIndex.get(right.pane);
+    }
+    if (leftPinned !== rightPinned) return leftPinned ? -1 : 1;
     const rank = STATUS_RANK[left.status] - STATUS_RANK[right.status];
     if (rank !== 0) return rank;
     if (left.pane < right.pane) return -1;

--- a/plugin/test-vectors/live-activity-content-v1.json
+++ b/plugin/test-vectors/live-activity-content-v1.json
@@ -1,5 +1,5 @@
 {
-  "description": "Shared Live Activity content envelope v1 test vectors (docs/agents/live-activity-contract.md). Single source of truth for the encrypted per-Host agent details carried inside a Live Activity content-state, consumed by both the Node plugin tests (seal direction) and the Swift app tests (open direction, plus seal for app-local updates). Envelopes were generated with raw AES-256-GCM calls, independent of all implementations. AAD is HERDR-ACTIVITY:1 (domain-separated from HERDR-NOTIFY:1; see the cross-AAD invalid vector). Canonical plaintext encoding: compact JSON, object keys in ascending alphabetical order at every level; agents sorted blocked > done > working with ties by pane ascending, capped at 5 entries; name (the herdr agent name) and title are each omitted when absent, <=80 graphemes otherwise; agent entry key order kind < name < pane < status < title. Producers keep the base64url ct <= ~2800 bytes by dropping titles first, then sending empty agents. `key` is the 32-byte Notification Key and `keyId` its derived id, both unpadded base64url. Non-`decodeOnly` valid vectors must be reproduced byte-for-byte by the seal side; `decodeOnly: true` envelopes must open to `payload` but are not canonical encodings. Invalid vectors must fail with the given typed error.",
+  "description": "Shared Live Activity content envelope v1 test vectors (docs/agents/live-activity-contract.md). Single source of truth for the encrypted per-Host agent details carried inside a Live Activity content-state, consumed by both the Node plugin tests (seal direction) and the Swift app tests (open direction, plus seal for app-local updates). Envelopes were generated with raw AES-256-GCM calls, independent of all implementations. AAD is HERDR-ACTIVITY:1 (domain-separated from HERDR-NOTIFY:1; see the cross-AAD invalid vector). Canonical plaintext encoding: compact JSON, object keys in ascending alphabetical order at every level; agents ordered pinned-eligible first by pinned_pane_ids index (most recently pinned first), then blocked > done > working with ties by pane ascending, capped at 5 entries after that sort; name (the herdr agent name) and title are each omitted when absent, <=80 graphemes otherwise; agent entry key order kind < name < pane < status < title. Vectors that carry `inventory` (herdr agent-list shape) and `pinned_pane_ids` pin the sort rule: producers must build `payload` from that input. Producers keep the base64url ct <= ~2800 bytes by dropping titles first, then sending empty agents. `key` is the 32-byte Notification Key and `keyId` its derived id, both unpadded base64url. Non-`decodeOnly` valid vectors must be reproduced byte-for-byte by the seal side; `decodeOnly: true` envelopes must open to `payload` but are not canonical encodings. Invalid vectors must fail with the given typed error.",
   "valid": [
     {
       "name": "single working agent",
@@ -88,6 +88,144 @@
       "payload": {
         "agents": [],
         "host": "mbp",
+        "v": 1
+      }
+    },
+    {
+      "name": "pinned working agent precedes unpinned blocked",
+      "key": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+      "keyId": "Yw3NKWbEM2Y",
+      "envelope": "{\"v\":1,\"kid\":\"Yw3NKWbEM2Y\",\"n\":\"sLGys7S1tre4ubq7\",\"ct\":\"4nc7zImjzyxlwszZ7zbhrOAec_B2Qu5AOqug3X7sk3tgaRkYAavP1ME-0mgQm_LUQwg1_TlMc8o9pxtfdvAC05CbStV-yRX4I_7VMexti18hsuWQ3BEBsZDZQrJYLWbTD4AZNKe5UTQjYmH--bOu5C-MlfQfkrheHSXb-3BvQkdrl4X8Znj6SxUwfwQAPUF67dhm6ukUcifB3EGxJqKXtt7wsoheEyBC0iFh0CEriNpXNDKdvpooyDl2abui7ew7OaSEgpBxLe5fFhGEK0JF-rldpEp8W0-0cRpi4-EP2GGsp_QL4MmHMTN38WKWdsfi\"}",
+      "pinned_pane_ids": ["w1:p-work"],
+      "counts": {"working": 1, "blocked": 1, "done": 0},
+      "inventory": [
+        {
+          "pane_id": "w1:p-block",
+          "agent_status": "blocked",
+          "agent": "claude",
+          "name": "reviewer",
+          "terminal_title_stripped": "needs review"
+        },
+        {
+          "pane_id": "w1:p-work",
+          "agent_status": "working",
+          "agent": "claude",
+          "name": "builder",
+          "terminal_title_stripped": "still going"
+        }
+      ],
+      "payload": {
+        "agents": [
+          {
+            "kind": "claude",
+            "name": "builder",
+            "pane": "w1:p-work",
+            "status": "working",
+            "title": "still going"
+          },
+          {
+            "kind": "claude",
+            "name": "reviewer",
+            "pane": "w1:p-block",
+            "status": "blocked",
+            "title": "needs review"
+          }
+        ],
+        "host": "mbp",
+        "v": 1
+      }
+    },
+    {
+      "name": "pin recency first then status rank, cap after, ineligible pins ignored",
+      "key": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+      "keyId": "Yw3NKWbEM2Y",
+      "envelope": "{\"v\":1,\"kid\":\"Yw3NKWbEM2Y\",\"n\":\"wMHCw8TFxsfIycrL\",\"ct\":\"e2pGABIW4i2646bZEMeBOChR2R1fjn7PTqZpJhUNHtjZtK2FBep_c-U6O2uS5kmr_hG-Dqe-giOmUkGiiY5Vei8AqUmAshDJQK86bJ05ceMhZt3AtGZM48QMyT_NbnirruVSnWRvp8l0b_ctdPBmqLQyp01VloKFYwY0E8RexToZB38iLfZp4UpQUQgCetlGjQ1Dw78iqVJv1zdUC2-ekQgxhVVDxcwbgixHcQ-Nh4t9qWwR-q9y9JD6Kc4jfVzA28pN1nLOnItpV9cl6A85t_iP9_oHJTca56lh3JpFZfFMURbQdeZdsA-LfTO6V_9lzJGiIB-22saUug0HaVs44z2BcISk8JflGrEaR2nHW0Vft_86yz50yMjT0EXg1n8xkf0ImxHnyI8rML4ZOIzBjLuQgo6w1x9BiBHbAOrvMhjeQ7-LU7QJPx8Xst6GkDWMKJu6X5fbrv01NmADnxOrCb0aL03NfC0yoUxcT67hdra-WR0RwB3hczf1hru8Awbd2W8aIs75XpKAz7nnEDo6dwXaaiuSwzT0ZL_Z3NvPGHRzdB7m54xAJG0bAdrDeXdVNyawwe2h\"}",
+      "pinned_pane_ids": ["w1:p-work", "w1:p-idle", "w1:missing", "w1:p-done"],
+      "counts": {"working": 3, "blocked": 2, "done": 2},
+      "inventory": [
+        {
+          "pane_id": "w1:p-w3",
+          "agent_status": "working",
+          "agent": "claude",
+          "terminal_title_stripped": "third working"
+        },
+        {
+          "pane_id": "w1:p-b2",
+          "agent_status": "blocked",
+          "agent": "claude",
+          "terminal_title_stripped": "second blocked"
+        },
+        {
+          "pane_id": "w1:p-idle",
+          "agent_status": "idle",
+          "agent": "claude",
+          "terminal_title_stripped": "idle pinned"
+        },
+        {
+          "pane_id": "w1:p-done",
+          "agent_status": "done",
+          "agent": "claude",
+          "terminal_title_stripped": "pinned done"
+        },
+        {
+          "pane_id": "w1:p-w2",
+          "agent_status": "working",
+          "agent": "claude",
+          "terminal_title_stripped": "second working"
+        },
+        {
+          "pane_id": "w1:p-work",
+          "agent_status": "working",
+          "agent": "claude",
+          "terminal_title_stripped": "pinned working"
+        },
+        {
+          "pane_id": "w1:p-b1",
+          "agent_status": "blocked",
+          "agent": "claude",
+          "terminal_title_stripped": "first blocked"
+        },
+        {
+          "pane_id": "w1:p-d2",
+          "agent_status": "done",
+          "agent": "claude",
+          "terminal_title_stripped": "unpinned done"
+        }
+      ],
+      "payload": {
+        "agents": [
+          {
+            "kind": "claude",
+            "pane": "w1:p-work",
+            "status": "working",
+            "title": "pinned working"
+          },
+          {
+            "kind": "claude",
+            "pane": "w1:p-done",
+            "status": "done",
+            "title": "pinned done"
+          },
+          {
+            "kind": "claude",
+            "pane": "w1:p-b1",
+            "status": "blocked",
+            "title": "first blocked"
+          },
+          {
+            "kind": "claude",
+            "pane": "w1:p-b2",
+            "status": "blocked",
+            "title": "second blocked"
+          },
+          {
+            "kind": "claude",
+            "pane": "w1:p-d2",
+            "status": "done",
+            "title": "unpinned done"
+          }
+        ],
+        "host": "studio",
         "v": 1
       }
     },

--- a/plugin/test/activity-hook.test.js
+++ b/plugin/test/activity-hook.test.js
@@ -303,6 +303,48 @@ suite("activity-hook: update and end", () => {
     assert.deepEqual(stubInvocations()[0].args, ["agent", "list"]);
   });
 
+  test("pinned_pane_ids from each device reorder that device's envelope only", async () => {
+    await startFakeRelay();
+    writeConfig();
+    writeRegistration([
+      device({
+        liveActivity: {
+          token: ACTIVITY_TOKEN_A,
+          started_at: "2026-01-01T00:00:00Z",
+          pinned_pane_ids: ["w1:p2"],
+        },
+      }),
+      device({
+        token: "b".repeat(64),
+        key: KEY_B,
+        activityToken: ACTIVITY_TOKEN_B,
+        env: "production",
+      }),
+    ]);
+    writeHerdrStub([
+      listedAgent({ pane: "w1:p1", status: "blocked", title: "need input" }),
+      listedAgent({ pane: "w1:p2", status: "working", title: "coding" }),
+    ]);
+
+    const result = await runHook(statusEvent("working", { paneId: "w1:p2" }));
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(relay.requests.length, 2);
+    const byToken = new Map(relay.requests.map((request) => [request.body.token, request.body]));
+    assert.deepEqual(byToken.get(ACTIVITY_TOKEN_A).counts, { working: 1, blocked: 1, done: 0 });
+    assert.deepEqual(byToken.get(ACTIVITY_TOKEN_B).counts, { working: 1, blocked: 1, done: 0 });
+    const pinned = decryptEnvelope(byToken.get(ACTIVITY_TOKEN_A).envelope, KEY_A);
+    const unpinned = decryptEnvelope(byToken.get(ACTIVITY_TOKEN_B).envelope, KEY_B);
+    assert.deepEqual(
+      pinned.payload.agents.map((entry) => entry.pane),
+      ["w1:p2", "w1:p1"],
+    );
+    assert.deepEqual(
+      unpinned.payload.agents.map((entry) => entry.pane),
+      ["w1:p1", "w1:p2"],
+    );
+  });
+
   test("empty inventory sends end with dismissal_date and empty agents", async () => {
     await startFakeRelay();
     writeConfig();

--- a/plugin/test/activity-state.test.js
+++ b/plugin/test/activity-state.test.js
@@ -125,6 +125,117 @@ suite("buildActivityState", () => {
   });
 });
 
+const MIXED_ELIGIBLE = [
+  agent("w1:p1", "working", { agent: "claude" }),
+  agent("w1:p9", "blocked", { agent: "codex" }),
+  agent("w1:p2", "blocked", { agent: "claude" }),
+  agent("w2:p1", "done", { agent: "droid" }),
+  agent("w3:p4", "working", { agent: "grok" }),
+  agent("w9:p1", "idle", { agent: "claude" }),
+  agent("w9:p2", "unknown", { agent: "claude" }),
+];
+const STATUS_THEN_PANE_ORDER = [
+  "blocked:w1:p2",
+  "blocked:w1:p9",
+  "done:w2:p1",
+  "working:w1:p1",
+  "working:w3:p4",
+];
+
+function rankedPanes(plaintextObject) {
+  return plaintextObject.agents.map((entry) => `${entry.status}:${entry.pane}`);
+}
+
+suite("buildActivityState pin ordering", () => {
+  test("pins float first in recency order, then the existing status rank", () => {
+    const { counts, plaintextObject } = buildActivityState({
+      agents: MIXED_ELIGIBLE,
+      hostName: "studio",
+      pinnedPaneIds: ["w3:p4", "w1:p2"],
+    });
+    assert.deepEqual(counts, { working: 2, blocked: 2, done: 1 });
+    assert.deepEqual(rankedPanes(plaintextObject), [
+      "working:w3:p4",
+      "blocked:w1:p2",
+      "blocked:w1:p9",
+      "done:w2:p1",
+      "working:w1:p1",
+    ]);
+  });
+
+  test("an ineligible pinned agent is ignored", () => {
+    const { counts, plaintextObject } = buildActivityState({
+      agents: MIXED_ELIGIBLE,
+      hostName: "studio",
+      pinnedPaneIds: ["w9:p1", "w3:p4"],
+    });
+    assert.deepEqual(counts, { working: 2, blocked: 2, done: 1 });
+    assert.deepEqual(rankedPanes(plaintextObject), [
+      "working:w3:p4",
+      "blocked:w1:p2",
+      "blocked:w1:p9",
+      "done:w2:p1",
+      "working:w1:p1",
+    ]);
+  });
+
+  test("unknown pane ids in the pin set are ignored", () => {
+    const { counts, plaintextObject } = buildActivityState({
+      agents: MIXED_ELIGIBLE,
+      hostName: "studio",
+      pinnedPaneIds: ["nope", "w1:p1", "also-missing"],
+    });
+    assert.deepEqual(counts, { working: 2, blocked: 2, done: 1 });
+    assert.deepEqual(rankedPanes(plaintextObject), [
+      "working:w1:p1",
+      "blocked:w1:p2",
+      "blocked:w1:p9",
+      "done:w2:p1",
+      "working:w3:p4",
+    ]);
+  });
+
+  test("a missing or malformed pin set keeps today's ordering", () => {
+    const expected = buildActivityState({
+      agents: MIXED_ELIGIBLE,
+      hostName: "studio",
+    });
+    assert.deepEqual(rankedPanes(expected.plaintextObject), STATUS_THEN_PANE_ORDER);
+
+    for (const pinnedPaneIds of [undefined, null, [], "w1:p1", 1, { 0: "w3:p4" }, [1, "w3:p4"], ["w3:p4", null]]) {
+      const { counts, plaintextObject } = buildActivityState({
+        agents: MIXED_ELIGIBLE,
+        hostName: "studio",
+        pinnedPaneIds,
+      });
+      assert.deepEqual(counts, expected.counts, pinnedPaneIds);
+      assert.deepEqual(rankedPanes(plaintextObject), STATUS_THEN_PANE_ORDER, pinnedPaneIds);
+    }
+  });
+
+  test("the agent cap still applies when more than five agents are pinned", () => {
+    const agents = [
+      agent("w1:p1", "blocked", { agent: "a" }),
+      agent("w1:p2", "blocked", { agent: "b" }),
+      agent("w1:p3", "done", { agent: "c" }),
+      agent("w1:p4", "done", { agent: "d" }),
+      agent("w1:p5", "working", { agent: "e" }),
+      agent("w1:p6", "working", { agent: "f" }),
+    ];
+    const { counts, plaintextObject } = buildActivityState({
+      agents,
+      hostName: "mbp",
+      pinnedPaneIds: ["w1:p6", "w1:p5", "w1:p4", "w1:p3", "w1:p2", "w1:p1"],
+    });
+    assert.deepEqual(counts, { working: 2, blocked: 2, done: 2 });
+    assert.equal(plaintextObject.agents.length, 5);
+    assert.deepEqual(
+      plaintextObject.agents.map((entry) => entry.pane),
+      ["w1:p6", "w1:p5", "w1:p4", "w1:p3", "w1:p2"],
+    );
+  });
+});
+
 suite("eligible status helpers", () => {
   test("eligibleStatusMap ignores idle panes and lowercases statuses", () => {
     assert.deepEqual(

--- a/plugin/test/activity-state.test.js
+++ b/plugin/test/activity-state.test.js
@@ -6,6 +6,7 @@ import {
   buildActivityState,
   eligibleStatusMap,
   hasNewlyBlocked,
+  parsePinnedPaneIds,
   sameStatusMap,
 } from "../src/activity-state.js";
 
@@ -233,6 +234,19 @@ suite("buildActivityState pin ordering", () => {
       plaintextObject.agents.map((entry) => entry.pane),
       ["w1:p6", "w1:p5", "w1:p4", "w1:p3", "w1:p2"],
     );
+  });
+});
+
+suite("parsePinnedPaneIds", () => {
+  test("returns a string array as-is", () => {
+    assert.deepEqual(parsePinnedPaneIds(["w3:p4", "w1:p2"]), ["w3:p4", "w1:p2"]);
+    assert.deepEqual(parsePinnedPaneIds([]), []);
+  });
+
+  test("treats missing, null, non-array, or mixed entries as empty", () => {
+    for (const value of [undefined, null, "w1:p1", 1, { 0: "w3:p4" }, [1, "w3:p4"], ["w3:p4", null]]) {
+      assert.deepEqual(parsePinnedPaneIds(value), [], value);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Long-press an agent row in the Console (or a chip in the terminal's agent switcher strip) to pin it. Pinned agents float to the top, most-recently-pinned first; unpinned agents keep the existing attention order. Pins persist locally and the Live Activity honors them end to end, including plugin-built push updates after the app suspends.

- **Console**: `PinnedAgentsStore` (UserDefaults, keyed `(hostID, paneID)`, never pruned so pins survive a herdr server restart), pin-first sort in `consoleSorted()`, row context menu, subdued `pin.fill` indicator.
- **Live Activity (Swift)**: pin-aware ordering in the content builder; the envelope now seals caller order (wire format unchanged); pin set synced to the Host's `notifications.json` as `live_activity.pinned_pane_ids` (additive, lenient parse).
- **Plugin (Node)**: pin-aware ordering in `activity-state.js` reading `pinned_pane_ids` per device; eligibility, counts, and cap semantics unchanged.
- **Switcher strip**: long-press a chip for Pin/Unpin; pinned chips carry the glyph; reorders animate as one transition (same-set guard, Reduce Motion respected); glyph writes guarded against UIStackView's animated-hidden miscount.
- **Contract artifacts**: `docs/agents/live-activity-contract.md` and `plugin/test-vectors/live-activity-content-v1.json` updated in lockstep (two new vector cases, existing cases byte-identical).

## Trade-offs (settled during design)

- Pin dominates status in both the list and the Live Activity: a pinned working agent may displace an unpinned blocked one from the lock screen's visible rows (counts and notifications still surface it).
- Pins are pane-slot scoped: a new conversation in the same pane stays pinned; a closed pane's entry dangles harmlessly.

## Tests

- Swift: new/extended suites for the pin store, console sort, activity builder/envelope, registration file/ceremony, and the switcher (including a regression test that fails without the glyph-write guard). Full `make test` green on the merge base; targeted suites green through every subsequent commit.
- Node: plugin suite 214/214 on the combined tree, including the new shared vectors.
- Manual: simulator UI pass (7/7), frame-by-frame animation verification for pin and unpin, on-device verification of the switcher flow.

## Follow-ups (not in this PR)

- VoiceOver has no path to pin on either surface (custom accessibility action) — worth a small a11y issue together with the context-menu SF Symbol leading-edge clipping papercut.
- `pinsDidChange` fans a cheap read-compare out to every connected Host per toggle; per-Host granularity if it ever matters.