### PR TITLE
feat(pairing): copy the Pairing Code on the Host and paste it in the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Added
+
+- Pairing Codes can be copied from the Host popup with `c` and pasted in the
+  app, so pairing no longer depends on scanning a QR that may overflow a
+  small terminal. A failed copy prints the code for manual selection. (#204)
+
 ## [0.1.0] - 2026-08-20
 
 ### Fixed

--- a/Sources/Heeler/Pairing/PairingScanStore.swift
+++ b/Sources/Heeler/Pairing/PairingScanStore.swift
@@ -17,13 +17,13 @@ struct PairingFailure: Equatable, Sendable {
     let canRetry: Bool
 }
 
-/// Drives Scan to Pair (#62, #66): turns strings recognized by the QR
-/// scanner into a parsed Pairing Code, runs the ceremony through the
-/// injected `PairingConnector`, and persists the Host only after the
-/// verified reconnect, with its fingerprint pinned so preflight never
-/// TOFU-prompts. Camera capture stays in the view layer; everything
-/// downstream of the scanned string is testable here with scripted
-/// connector fakes.
+/// Drives Scan to Pair (#62, #66, #204): turns strings recognized by the QR
+/// scanner or pasted from the clipboard into a parsed Pairing Code, runs
+/// the ceremony through the injected `PairingConnector`, and persists the
+/// Host only after the verified reconnect, with its fingerprint pinned so
+/// preflight never TOFU-prompts. Camera capture and pasteboard access stay
+/// in the view layer; everything downstream of the scanned string is
+/// testable here with scripted connector fakes.
 @MainActor
 @Observable
 final class PairingScanStore {
@@ -76,8 +76,11 @@ final class PairingScanStore {
 
     func submit(scannedCode: String) {
         guard pairingCode == nil else { return }
+        // Paste (and a trailing newline from pbcopy/manual selection) is the
+        // same parse path as a scan; trim so the two cannot disagree.
+        let scanned = scannedCode.trimmingCharacters(in: .whitespacesAndNewlines)
         do {
-            let code = try PairingCode.decode(scannedCode)
+            let code = try PairingCode.decode(scanned)
             pairingCode = code
             attemptCode = code
             enrolledViaBootstrap = false

--- a/Sources/Heeler/Pairing/PairingScanView.swift
+++ b/Sources/Heeler/Pairing/PairingScanView.swift
@@ -1,12 +1,14 @@
 import AVFoundation
 import SwiftUI
+import UIKit
 import VisionKit
 
-/// Scan to Pair (#62, #66): the camera entry for Pairing Codes, with the
-/// permission prompt and a usable denied path. Once a code parses, the
-/// pairing ceremony runs immediately — one scan, no confirmation step — and
-/// on success the persisted Host is handed to `onPaired`, entering the same
-/// preflight a manually added Host does.
+/// Scan to Pair (#62, #66, #204): the camera entry for Pairing Codes, with
+/// a paste path for the same string, the permission prompt, and a usable
+/// denied path. Once a code parses, the pairing ceremony runs immediately —
+/// one scan or paste, no confirmation step — and on success the persisted
+/// Host is handed to `onPaired`, entering the same preflight a manually
+/// added Host does.
 struct PairingScanView: View {
     let onPaired: (Host) -> Void
     let onAddManually: () -> Void
@@ -65,12 +67,10 @@ struct PairingScanView: View {
             ContentUnavailableView {
                 Label("Camera Access Needed", systemImage: "camera")
             } description: {
-                Text(
-                    "Scanning a Pairing Code uses the camera. Allow camera access "
-                        + "in Settings, or add the Host manually instead.")
+                Text(store.scanFailureMessage ?? deniedCameraCopy)
             } actions: {
+                pastePairingCodeButton
                 Button("Open Settings") { openSettings() }
-                    .buttonStyle(.borderedProminent)
                 Button("Add Manually") { addManually() }
             }
         case .authorized:
@@ -81,11 +81,12 @@ struct PairingScanView: View {
                     Label("Scanning Unavailable", systemImage: "camera")
                 } description: {
                     Text(
-                        "This device cannot scan QR codes. "
-                            + "Add the Host manually instead.")
+                        store.scanFailureMessage
+                            ?? "This device cannot scan QR codes. "
+                            + "Paste a Pairing Code, or add the Host manually instead.")
                 } actions: {
+                    pastePairingCodeButton
                     Button("Add Manually") { addManually() }
-                        .buttonStyle(.borderedProminent)
                 }
             }
         }
@@ -102,13 +103,38 @@ struct PairingScanView: View {
         PairingCodeScanner { store.submit(scannedCode: $0) }
             .ignoresSafeArea(edges: .bottom)
             .overlay(alignment: .bottom) {
-                Text(store.scanFailureMessage ?? "Point the camera at the Pairing Code shown by herdr.")
-                    .font(.callout)
-                    .multilineTextAlignment(.center)
-                    .padding(12)
-                    .background(.regularMaterial, in: .rect(cornerRadius: 12))
-                    .padding()
+                VStack(spacing: 12) {
+                    pastePairingCodeButton
+                    Text(
+                        store.scanFailureMessage
+                            ?? "Point the camera at the Pairing Code shown by herdr.")
+                        .font(.callout)
+                        .multilineTextAlignment(.center)
+                        .padding(12)
+                        .background(.regularMaterial, in: .rect(cornerRadius: 12))
+                }
+                .padding()
             }
+    }
+
+    /// User-initiated paste so iOS can show its pasteboard prompt against a
+    /// tap, not against a background read (#204). Feeds the same `submit`
+    /// path a scan uses; empty clipboard is a no-op, not a new error.
+    private var pastePairingCodeButton: some View {
+        Button("Paste Pairing Code") { pastePairingCode() }
+            .buttonStyle(.borderedProminent)
+    }
+
+    private var deniedCameraCopy: String {
+        "Scanning a Pairing Code uses the camera. Allow camera access in Settings, "
+            + "paste a Pairing Code, or add the Host manually instead."
+    }
+
+    private func pastePairingCode() {
+        let pasted = UIPasteboard.general.string?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !pasted.isEmpty else { return }
+        store.submit(scannedCode: pasted)
     }
 
     private func resolveCameraAccess() async {

--- a/Tests/HeelerTests/PairingScanStoreTests.swift
+++ b/Tests/HeelerTests/PairingScanStoreTests.swift
@@ -80,6 +80,30 @@ struct PairingScanStoreTests {
         #expect(env.store.scanFailureMessage == nil)
     }
 
+    /// Paste (#204) is not a second decoder: the view feeds the clipboard
+    /// string through `submit(scannedCode:)`, including a trailing newline
+    /// that `pbcopy` / manual selection commonly add.
+    @Test func aPastedPairingCodeUsesTheSameParsePathAsAScan() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+
+        env.store.submit(scannedCode: Self.configOnlyCode + "\n")
+
+        let code = try #require(env.store.pairingCode)
+        #expect(code == (try PairingCode.decode(Self.configOnlyCode)))
+        #expect(env.store.scanFailureMessage == nil)
+    }
+
+    @Test func aPastedMalformedCodeShowsTheExistingParseError() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+
+        env.store.submit(scannedCode: "  not-a-pairing-code  ")
+
+        #expect(env.store.pairingCode == nil)
+        #expect(env.store.scanFailureMessage?.contains("not a herdr Pairing Code") == true)
+    }
+
     @Test func foreignQRCodesAskForTheHerdrPairingCode() throws {
         let env = try makeEnv()
         defer { env.cleanup() }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -56,7 +56,9 @@ Open the Pairing Code popup:
 herdr plugin action invoke heeler.pair
 ```
 
-Scan the code in Heeler to add this machine as a Host. Then open the
+Scan the code in Heeler to add this machine as a Host, or press `c` on the
+QR screen to copy the Pairing Code and paste it in the app (macOS uses
+`pbcopy`; elsewhere the code is printed for manual selection). Then open the
 Heeler settings, enable Agent Notifications, grant the iOS notification
 permission, and enable Notifications for this Host. Leave **Custom Push
 Relay** empty to use the production endpoint at
@@ -80,7 +82,8 @@ herdr plugin action invoke heeler.pair
 
 The popup checklist: arrows or `j`/`k` move, space toggles, `a` toggles all,
 enter mints a Bootstrap Key and renders the QR, `q`/escape closes (revoking
-the key). When the code expires, enter generates a fresh one. Once a device
+the key). On the QR screen, `c` copies the Pairing Code; any other key
+closes. When the code expires, enter generates a fresh one. Once a device
 enrolls, the QR is replaced by a success screen showing the enrolled Device
 Key's fingerprint and label; press `r` there to revoke that key (removing its
 `authorized_keys` line), or any other key to close.

--- a/plugin/src/copy-pairing-code.js
+++ b/plugin/src/copy-pairing-code.js
@@ -1,0 +1,57 @@
+// Clipboard helper for the pairing popup's QR screen (#204).
+//
+// macOS: write the exact Pairing Code string to the pasteboard via pbcopy.
+// Anywhere else, or if pbcopy is missing / fails: the caller prints the code
+// so it can be selected by hand. No format change — the v1 envelope is copied
+// as-is.
+
+import { spawn } from "node:child_process";
+
+/**
+ * What a keypress on the QR screen should do. `c` copies and stays; every
+ * other key (including ctrl+c, which the popup's global handler already
+ * treats as quit) closes. `key` is a readline keypress object.
+ *
+ * @param {{name?: string, ctrl?: boolean} | null | undefined} key
+ * @returns {"copy" | "close"}
+ */
+export function qrKeyAction(key) {
+  if (key?.name === "c" && !key.ctrl) {
+    return "copy";
+  }
+  return "close";
+}
+
+/**
+ * Copy `code` to the macOS pasteboard.
+ *
+ * @param {string} code
+ * @param {{spawnFn?: typeof spawn, platform?: string}} [deps]
+ * @returns {Promise<{copied: boolean}>}
+ */
+export function copyPairingCode(code, { spawnFn = spawn, platform = process.platform } = {}) {
+  if (typeof code !== "string" || code.length === 0 || platform !== "darwin") {
+    return Promise.resolve({ copied: false });
+  }
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (copied) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve({ copied });
+    };
+    let child;
+    try {
+      child = spawnFn("pbcopy", [], { stdio: ["pipe", "ignore", "ignore"] });
+    } catch {
+      finish(false);
+      return;
+    }
+    child.on("error", () => finish(false));
+    child.on("close", (status) => finish(status === 0));
+    child.stdin.on("error", () => finish(false));
+    child.stdin.end(code);
+  });
+}

--- a/plugin/src/pair-popup.js
+++ b/plugin/src/pair-popup.js
@@ -29,6 +29,7 @@ import {
   toggleAll,
   selectedAddresses,
 } from "./select-list.js";
+import { copyPairingCode, qrKeyAction } from "./copy-pairing-code.js";
 
 const DEFAULT_SSH_PORT = 22;
 // How often the QR screen checks whether Enrollment has completed. The pending
@@ -75,7 +76,7 @@ function renderChecklist(state, warning) {
   process.stdout.write(CLEAR + lines.join("\n") + "\n");
 }
 
-async function renderPairingCode(payload) {
+async function renderPairingCode(payload, { copied = false, printedCode = null } = {}) {
   const code = encodePairingCode(payload);
   const qr = await QRCode.toString(code, { type: "terminal", small: true });
   const expires = new Date(payload.expiresAt * 1000).toLocaleTimeString();
@@ -83,9 +84,12 @@ async function renderPairingCode(payload) {
   // scrolls the earliest ones off the top, and with a header above the QR
   // that meant the QR's top edge vanished into scrollback. Clamp to the
   // viewport instead, so any overflow costs trailing text, never the QR.
+  const hint = copied
+    ? `${BOLD}copied${RESET} ${DIM}-- any other key close${RESET}`
+    : `${BOLD}Scan with Heeler${RESET} ${DIM}-- c: copy pairing code, any other key close${RESET}`;
   const lines = [
     ...qr.trimEnd().split("\n"),
-    `${BOLD}Scan with Heeler${RESET} ${DIM}-- press any key to close${RESET}`,
+    hint,
     `${BOLD}${payload.username}${RESET} on port ${BOLD}${payload.port}${RESET}`,
     `Host key ${payload.hostKeyFingerprint}`,
     `Addresses: ${payload.addresses.join(", ")}`,
@@ -94,6 +98,12 @@ async function renderPairingCode(payload) {
   const rows = process.stdout.rows;
   const visible = Number.isInteger(rows) && rows > 0 ? lines.slice(0, rows) : lines;
   process.stdout.write(CLEAR + visible.join("\n"));
+  // pbcopy is macOS-only; when copy fails, print the exact envelope after the
+  // clamped QR so it can be selected by hand even if the footer was trimmed.
+  if (printedCode !== null) {
+    process.stdout.write(`\n${printedCode}`);
+  }
+  return code;
 }
 
 function renderExpired() {
@@ -195,8 +205,15 @@ async function main() {
   let enrollWatch = null;
   let enrolled = null;
   let closing = false;
+  let displayedCode = null;
+  let lastPayload = null;
+  let copiedTimer = null;
 
   async function cleanup() {
+    if (copiedTimer !== null) {
+      clearTimeout(copiedTimer);
+      copiedTimer = null;
+    }
     if (expiryTimer !== null) {
       clearTimeout(expiryTimer);
       expiryTimer = null;
@@ -314,15 +331,42 @@ async function main() {
       }
       void expireCeremony(pairingId);
     }, PAIRING_TTL_SECONDS * 1000);
-    await renderPairingCode({
+    lastPayload = {
       addresses: confirmedAddresses,
       port: DEFAULT_SSH_PORT,
       username: os.userInfo().username,
       hostKeyFingerprint: hostKey.fingerprint,
       bootstrapSeed: session.seed,
       expiresAt: session.expiresAt,
-    });
+    };
+    displayedCode = await renderPairingCode(lastPayload);
     enrollWatch = setInterval(() => onEnrollmentPoll(pairingId), ENROLL_POLL_MS);
+  }
+
+  async function copyDisplayedCode() {
+    if (displayedCode === null || lastPayload === null || closing || phase !== "qr") {
+      return;
+    }
+    const result = await copyPairingCode(displayedCode);
+    if (closing || phase !== "qr") {
+      return;
+    }
+    if (copiedTimer !== null) {
+      clearTimeout(copiedTimer);
+      copiedTimer = null;
+    }
+    if (result.copied) {
+      await renderPairingCode(lastPayload, { copied: true });
+      copiedTimer = setTimeout(() => {
+        copiedTimer = null;
+        if (closing || phase !== "qr" || lastPayload === null) {
+          return;
+        }
+        void renderPairingCode(lastPayload);
+      }, 1500);
+      return;
+    }
+    await renderPairingCode(lastPayload, { printedCode: displayedCode });
   }
 
   function startCeremonyOrDie() {
@@ -362,7 +406,11 @@ async function main() {
       return;
     }
     if (phase === "qr") {
-      void close(0);
+      if (qrKeyAction(key) === "copy") {
+        void copyDisplayedCode();
+      } else {
+        void close(0);
+      }
       return;
     }
     if (phase === "expired") {

--- a/plugin/test/copy-pairing-code.test.js
+++ b/plugin/test/copy-pairing-code.test.js
@@ -1,0 +1,99 @@
+import { EventEmitter } from "node:events";
+import { test, suite } from "node:test";
+import assert from "node:assert/strict";
+
+import { copyPairingCode, qrKeyAction } from "../src/copy-pairing-code.js";
+
+suite("qr key action", () => {
+  test("plain c copies and stays on the QR screen", () => {
+    assert.equal(qrKeyAction({ name: "c" }), "copy");
+    assert.equal(qrKeyAction({ name: "c", ctrl: false }), "copy");
+  });
+
+  test("any other key closes, including ctrl+c and unnamed presses", () => {
+    assert.equal(qrKeyAction({ name: "c", ctrl: true }), "close");
+    assert.equal(qrKeyAction({ name: "q" }), "close");
+    assert.equal(qrKeyAction({ name: "escape" }), "close");
+    assert.equal(qrKeyAction({ name: "return" }), "close");
+    assert.equal(qrKeyAction({}), "close");
+    assert.equal(qrKeyAction(undefined), "close");
+  });
+});
+
+suite("copy pairing code", () => {
+  const code = "HERDR-PAIR:1:exact-bytes-no-newline";
+
+  /** A stdin that records `end` and then fires the child close/error. */
+  function fakePbcopy({ status = 0, failError = null } = {}) {
+    const state = { command: "", written: "" };
+    const spawnFn = (cmd, args, options) => {
+      state.command = cmd;
+      assert.deepEqual(args, []);
+      assert.equal(options.stdio[0], "pipe");
+      const child = new EventEmitter();
+      child.stdin = {
+        on() {
+          return child.stdin;
+        },
+        end(data) {
+          if (data !== undefined && data !== null) {
+            state.written = Buffer.from(data).toString("utf8");
+          }
+          queueMicrotask(() => {
+            if (failError !== null) {
+              child.emit("error", failError);
+              return;
+            }
+            child.emit("close", status);
+          });
+        },
+      };
+      return child;
+    };
+    return { state, spawnFn };
+  }
+
+  test("on darwin, pbcopy receives the exact string and no trailing newline", async () => {
+    const { state, spawnFn } = fakePbcopy();
+    const result = await copyPairingCode(code, { spawnFn, platform: "darwin" });
+    assert.equal(result.copied, true);
+    assert.equal(state.command, "pbcopy");
+    assert.equal(state.written, code);
+  });
+
+  test("a missing pbcopy is a failed copy, not a throw", async () => {
+    const { spawnFn } = fakePbcopy({
+      failError: Object.assign(new Error("spawn pbcopy"), { code: "ENOENT" }),
+    });
+    const result = await copyPairingCode(code, { spawnFn, platform: "darwin" });
+    assert.equal(result.copied, false);
+  });
+
+  test("a non-zero pbcopy exit is a failed copy", async () => {
+    const { spawnFn } = fakePbcopy({ status: 1 });
+    const result = await copyPairingCode(code, { spawnFn, platform: "darwin" });
+    assert.equal(result.copied, false);
+  });
+
+  test("non-darwin platforms do not spawn pbcopy", async () => {
+    let spawned = false;
+    const spawnFn = () => {
+      spawned = true;
+      throw new Error("should not spawn");
+    };
+    const result = await copyPairingCode(code, { spawnFn, platform: "linux" });
+    assert.equal(result.copied, false);
+    assert.equal(spawned, false);
+  });
+
+  test("an empty code is not copied", async () => {
+    let spawned = false;
+    const spawnFn = () => {
+      spawned = true;
+      throw new Error("should not spawn");
+    };
+    const result = await copyPairingCode("", { spawnFn, platform: "darwin" });
+    assert.equal(result.copied, false);
+    assert.equal(spawned, false);
+  });
+});


### PR DESCRIPTION
## Summary

Pairing no longer depends on scanning a QR that may overflow a small terminal. The Host popup copies the existing v1 Pairing Code; the app pastes it into the same ceremony a scan uses.

- Plugin: `c` on the QR screen copies `HERDR-PAIR:1:…` via `pbcopy` (no trailing newline). A failed copy prints the code for manual selection. Any other key still closes.
- App: Scan to Pair offers **Paste Pairing Code**, including when the camera is denied or unavailable. Empty clipboard is a no-op; malformed or expired pastes reuse the existing parse and ceremony copy.
- No envelope change.

Closes #204

## Tests

- `cd plugin && npm test` — 221 passed
- `HeelerTests/PairingScanStoreTests` — 22 passed on the iPhone 17 simulator