### PR TITLE
test: stabilize keyboard handoff tests against wall-clock stretch

### DIFF
--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		72A9243CA6BE664CCBB99EE4 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 86CF5F0136C3ED0B1F7F4EED /* AppIcon.icon */; };
 		74257FA18D6431785BFECE9A /* TerminalInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E30B96F852EFC3C322C9EB /* TerminalInputController.swift */; };
 		745597578F4E92FCC065823A /* GitBranchNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233075006FC2C8907BBFF40F /* GitBranchNameTests.swift */; };
+		75A8255D9FA3B634C315DBAE /* GridReportSettling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EEA346C23330237A2A79EB /* GridReportSettling.swift */; };
 		76B9105012CFC90972589B87 /* TerminalThemePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9469465EF16322DDC174CD5E /* TerminalThemePickerView.swift */; };
 		76D19F97EA2662895D730A98 /* ConsoleStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14FB8560976CE777FB5A105 /* ConsoleStore.swift */; };
 		76EAFFA9DAD45987F02DC536 /* AsyncDeadline.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25E1DC34365B2E2FA6C5AA8 /* AsyncDeadline.swift */; };
@@ -424,6 +425,7 @@
 		55D2BCB4E4038F510852F71C /* SecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretStore.swift; sourceTree = "<group>"; };
 		578B695DF80C644E2D62060C /* TerminalTouchScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTouchScroll.swift; sourceTree = "<group>"; };
 		57EAD92008AF144C63F5582E /* TerminalAppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAppearancePane.swift; sourceTree = "<group>"; };
+		57EEA346C23330237A2A79EB /* GridReportSettling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridReportSettling.swift; sourceTree = "<group>"; };
 		5870640477FDEB252DEE80B7 /* AttachLinkIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachLinkIndex.swift; sourceTree = "<group>"; };
 		59A749D2AF2390BCACBADED3 /* HeelerNotificationService.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = HeelerNotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		5A3319D35C3BBCD2CB151843 /* TerminalSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSettings.swift; sourceTree = "<group>"; };
@@ -1039,6 +1041,7 @@
 				856A8398D8F0FB87F252D193 /* FakeLiveActivityController.swift */,
 				8273181A2428AD3F78FCC27B /* FakePairingConnector.swift */,
 				696C6905D9D6EEFF77A64E2E /* FakeTransportConnector.swift */,
+				57EEA346C23330237A2A79EB /* GridReportSettling.swift */,
 				51B4AAB6885E0EB9D8C4A131 /* InMemorySecretStore.swift */,
 				C5469F0188E985276A49871C /* LiveActivityVectorFile.swift */,
 				4F172C9E024F73AD2DD96288 /* LocalSSHTestEnvironment.swift */,
@@ -1545,6 +1548,7 @@
 				5789049E3BA965EB057C4577 /* FilePreparerTests.swift in Sources */,
 				297F2EB19960A01651FDA05C /* GeneratedWireTypesTests.swift in Sources */,
 				745597578F4E92FCC065823A /* GitBranchNameTests.swift in Sources */,
+				75A8255D9FA3B634C315DBAE /* GridReportSettling.swift in Sources */,
 				4D0A9B8F7343093907B24788 /* HeelerSSHDirectStreamLocalE2ETests.swift in Sources */,
 				45C187BC7E4A9682CEE6CA7D /* HeelerSSHErrorMappingTests.swift in Sources */,
 				0E50946869DD6FC41373079B /* HeelerSSHHostKeyPolicyTests.swift in Sources */,

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -347,6 +347,11 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     /// change instead.
     private var keyboardTransitionEndsOnFrameChange = false
     private var keyboardTransitionFallbackTask: Task<Void, Never>?
+    /// How long an unsettled handoff may keep the grid frozen before the
+    /// freeze force-ends anyway — a leash for production, where the settle
+    /// signal can fail to arrive. Tests stretch it so a loaded runner cannot
+    /// end a handoff out from under them (#225).
+    var keyboardTransitionFallbackDelay: TimeInterval = 0.5
     private var keyboardGridReportTask: Task<Void, Never>?
     /// How long Ghostty gets to answer a settled layout before its grid is
     /// forwarded to the Host — long enough to coalesce one layout pass's
@@ -990,8 +995,9 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         keyboardTransitionEndsOnFrameChange = endsOnFrameChange
         callbackBridge.beginSizeReportDeferral()
         keyboardTransitionFallbackTask?.cancel()
+        let fallbackDelay = keyboardTransitionFallbackDelay
         keyboardTransitionFallbackTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .milliseconds(500))
+            try? await Task.sleep(for: .seconds(fallbackDelay))
             guard !Task.isCancelled else { return }
             self?.finishKeyboardTransitionLayout()
         }

--- a/Tests/HeelerTests/Support/GridReportSettling.swift
+++ b/Tests/HeelerTests/Support/GridReportSettling.swift
@@ -1,0 +1,29 @@
+import Testing
+
+/// The settle wait ran out of polls with the reports still absent or
+/// still churning; the caller's assertions cannot trust the state.
+struct GridReportsNeverSettledError: Error {}
+
+/// Waits until grid reports have arrived *and* gone quiet. Quiet alone is
+/// not settlement: the report a thaw schedules rides two timers, so on a
+/// loaded machine 200ms of silence can elapse before it lands — quiet
+/// counting must not start until a report the caller is about to assert
+/// on exists (#225). Only proven quiet returns; exhausting the poll cap
+/// throws, so a report that never comes or never stops churning fails
+/// loud instead of handing the caller a state it cannot trust.
+@MainActor
+func waitForGridReportsToSettle(count: () -> Int) async throws {
+    var stablePolls = 0
+    var previousCount = count()
+    for _ in 0..<1000 {
+        try await Task.sleep(for: .milliseconds(10))
+        if count() == previousCount, count() > 0 {
+            stablePolls += 1
+            if stablePolls >= 20 { return }
+        } else {
+            previousCount = count()
+            stablePolls = 0
+        }
+    }
+    throw GridReportsNeverSettledError()
+}

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -756,33 +756,6 @@ struct TerminalAgentSwitcherTests {
         var description: String { "\(columns)x\(rows)" }
     }
 
-    /// Ghostty answers one layout with several viewport reports, arriving on
-    /// the main actor a beat behind the layout that provoked them, so a grid
-    /// only means anything once they have stopped coming.
-    @MainActor
-    /// Waits until grid reports have arrived *and* gone quiet. Quiet alone
-    /// is not settlement: the report a thaw schedules rides two timers, so
-    /// on a loaded machine 200ms of silence can elapse before it lands —
-    /// counting must not start until the report the caller is about to
-    /// assert on exists (#225). The poll cap turns a report that never
-    /// comes into a loud assertion failure downstream instead of a hang.
-    private static func waitForGridReportsToStop(
-        _ reportedGrids: () -> [TerminalGrid]
-    ) async throws {
-        var stablePolls = 0
-        var previousCount = reportedGrids().count
-        for _ in 0..<1000 {
-            try await Task.sleep(for: .milliseconds(10))
-            if reportedGrids().count == previousCount, !reportedGrids().isEmpty {
-                stablePolls += 1
-                if stablePolls >= 20 { return }
-            } else {
-                previousCount = reportedGrids().count
-                stablePolls = 0
-            }
-        }
-    }
-
     /// Ghostty's first viewport report on a fresh surface carries a zero cell
     /// size. Measuring the surface against that half-built grid — which is
     /// what happens when the view shrinks for the keyboard right after the
@@ -844,7 +817,7 @@ struct TerminalAgentSwitcherTests {
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
                 x: 0, y: 400, width: 390, height: 300)])
-        try await Self.waitForGridReportsToStop { reportedGrids }
+        try await waitForGridReportsToSettle { reportedGrids.count }
         let escaped = reportedGrids
         #expect(!escaped.isEmpty, "the settled grid never made it past the freeze")
 
@@ -862,7 +835,7 @@ struct TerminalAgentSwitcherTests {
             terminal.layoutIfNeeded()
             try await Task.sleep(for: .milliseconds(30))
         }
-        try await Self.waitForGridReportsToStop { reportedGrids }
+        try await waitForGridReportsToSettle { reportedGrids.count }
         let settled = try #require(
             reportedGrids.last, "the terminal never measured its settled bounds")
 
@@ -1008,7 +981,7 @@ struct TerminalAgentSwitcherTests {
             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
                 x: 0, y: 400, width: 390, height: 300)])
         #expect(terminal.inputViewRebuildCount > rebuildsBeforeForeignEvent)
-        try await Self.waitForGridReportsToStop { reportedGrids }
+        try await waitForGridReportsToSettle { reportedGrids.count }
         #expect(
             !reportedGrids.isEmpty,
             "the terminal's own settle never made it past the freeze")

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -760,15 +760,22 @@ struct TerminalAgentSwitcherTests {
     /// the main actor a beat behind the layout that provoked them, so a grid
     /// only means anything once they have stopped coming.
     @MainActor
+    /// Waits until grid reports have arrived *and* gone quiet. Quiet alone
+    /// is not settlement: the report a thaw schedules rides two timers, so
+    /// on a loaded machine 200ms of silence can elapse before it lands —
+    /// counting must not start until the report the caller is about to
+    /// assert on exists (#225). The poll cap turns a report that never
+    /// comes into a loud assertion failure downstream instead of a hang.
     private static func waitForGridReportsToStop(
         _ reportedGrids: () -> [TerminalGrid]
     ) async throws {
         var stablePolls = 0
         var previousCount = reportedGrids().count
-        while stablePolls < 20 {
+        for _ in 0..<1000 {
             try await Task.sleep(for: .milliseconds(10))
-            if reportedGrids().count == previousCount {
+            if reportedGrids().count == previousCount, !reportedGrids().isEmpty {
                 stablePolls += 1
+                if stablePolls >= 20 { return }
             } else {
                 previousCount = reportedGrids().count
                 stablePolls = 0
@@ -804,6 +811,10 @@ struct TerminalAgentSwitcherTests {
             window.isHidden = true
         }
 
+        // This test thaws the freeze explicitly below, so the wall-clock
+        // fallback must stay out of it: the sleeps inside the handoff window
+        // can stretch past its 500ms on a loaded runner (#225).
+        terminal.keyboardTransitionFallbackDelay = 60
         terminal.raisesKeyboardWhenReady = true
         terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 600)
         host.view.addSubview(terminal)

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -1209,7 +1209,7 @@ struct TerminalAttachTests {
         host.view.addSubview(terminal)
         window.layoutIfNeeded()
 
-        try await waitForGridReportsToSettle(&reportedGrids)
+        try await waitForGridReportsToSettle { reportedGrids.count }
         let initialRows = try #require(reportedGrids.last?.rows)
         reportedGrids.removeAll()
 
@@ -1232,7 +1232,7 @@ struct TerminalAttachTests {
 
         #expect(reportedGrids.isEmpty)
         terminal.finishKeyboardTransitionLayout()
-        try await waitForGridReportsToSettle(&reportedGrids)
+        try await waitForGridReportsToSettle { reportedGrids.count }
 
         #expect(reportedGrids.count == 1)
         #expect(reportedGrids.last?.rows ?? 0 > initialRows)
@@ -1263,7 +1263,7 @@ struct TerminalAttachTests {
         host.view.addSubview(terminal)
         window.layoutIfNeeded()
 
-        try await waitForGridReportsToSettle(&reportedGrids)
+        try await waitForGridReportsToSettle { reportedGrids.count }
         let initialRows = try #require(reportedGrids.last?.rows)
         reportedGrids.removeAll()
 
@@ -1285,7 +1285,7 @@ struct TerminalAttachTests {
 
         #expect(reportedGrids.isEmpty)
         terminal.finishKeyboardTransitionLayout()
-        try await waitForGridReportsToSettle(&reportedGrids)
+        try await waitForGridReportsToSettle { reportedGrids.count }
 
         #expect(reportedGrids.count == 1)
         #expect(reportedGrids.last?.rows ?? 0 > initialRows)
@@ -1316,7 +1316,7 @@ struct TerminalAttachTests {
         host.view.addSubview(terminal)
         window.layoutIfNeeded()
 
-        try await waitForGridReportsToSettle(&reportedGrids)
+        try await waitForGridReportsToSettle { reportedGrids.count }
         let initialRows = try #require(reportedGrids.last?.rows)
         reportedGrids.removeAll()
 
@@ -1330,7 +1330,7 @@ struct TerminalAttachTests {
         terminal.layoutIfNeeded()
 
         // No settle signal, no explicit finish — only the fallback ends this.
-        try await waitForGridReportsToSettle(&reportedGrids)
+        try await waitForGridReportsToSettle { reportedGrids.count }
 
         #expect(reportedGrids.count == 1)
         #expect(reportedGrids.last?.rows ?? 0 > initialRows)
@@ -1624,30 +1624,6 @@ struct TerminalAttachTests {
         let keyboard = try #require(terminal.inputView as? TerminalKeysKeyboardView)
         #expect(keyboard.intrinsicContentSize.height == 288)
         #expect(keyboard.frame.height == 288)
-    }
-
-    /// Waits until grid reports have arrived *and* gone quiet. Quiet alone
-    /// is not settlement: the report a thaw schedules rides two timers, so
-    /// on a loaded machine 200ms of silence can elapse before it lands —
-    /// counting must not start until the report the caller is about to
-    /// assert on exists (#225). The poll cap turns a report that never
-    /// comes into a loud assertion failure downstream instead of a hang.
-    @MainActor
-    private func waitForGridReportsToSettle(
-        _ reports: inout [(columns: Int, rows: Int)]
-    ) async throws {
-        var stablePolls = 0
-        var previousCount = reports.count
-        for _ in 0..<1000 {
-            try await Task.sleep(for: .milliseconds(10))
-            if reports.count == previousCount, !reports.isEmpty {
-                stablePolls += 1
-                if stablePolls >= 20 { return }
-            } else {
-                previousCount = reports.count
-                stablePolls = 0
-            }
-        }
     }
 
     @Test func terminalControlKeyboardContainsOnlyUsefulMobileKeys() {

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -1626,16 +1626,23 @@ struct TerminalAttachTests {
         #expect(keyboard.frame.height == 288)
     }
 
+    /// Waits until grid reports have arrived *and* gone quiet. Quiet alone
+    /// is not settlement: the report a thaw schedules rides two timers, so
+    /// on a loaded machine 200ms of silence can elapse before it lands —
+    /// counting must not start until the report the caller is about to
+    /// assert on exists (#225). The poll cap turns a report that never
+    /// comes into a loud assertion failure downstream instead of a hang.
     @MainActor
     private func waitForGridReportsToSettle(
         _ reports: inout [(columns: Int, rows: Int)]
     ) async throws {
         var stablePolls = 0
         var previousCount = reports.count
-        while stablePolls < 20 {
+        for _ in 0..<1000 {
             try await Task.sleep(for: .milliseconds(10))
-            if reports.count == previousCount {
+            if reports.count == previousCount, !reports.isEmpty {
                 stablePolls += 1
+                if stablePolls >= 20 { return }
             } else {
                 previousCount = reports.count
                 stablePolls = 0

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -1215,6 +1215,10 @@ struct TerminalAttachTests {
 
         // The handoff itself: the replacement surface claims the keyboard as
         // it reaches the window, and freezes its grid until that settles.
+        // This test drives the settle explicitly, so the wall-clock fallback
+        // must stay out of it: on a loaded runner the steps below stretched
+        // past its 500ms and it thawed the freeze mid-handoff (#225).
+        terminal.keyboardTransitionFallbackDelay = 60
         terminal.removeFromSuperview()
         terminal.raisesKeyboardWhenReady = true
         host.view.addSubview(terminal)
@@ -1228,6 +1232,104 @@ struct TerminalAttachTests {
 
         #expect(reportedGrids.isEmpty)
         terminal.finishKeyboardTransitionLayout()
+        try await waitForGridReportsToSettle(&reportedGrids)
+
+        #expect(reportedGrids.count == 1)
+        #expect(reportedGrids.last?.rows ?? 0 > initialRows)
+    }
+
+    /// The freeze must hold for as long as the handoff actually takes — a
+    /// loaded CI runner stretched one past half a second and the transient
+    /// grids escaped (#225). The stall here is the deterministic version of
+    /// that runner.
+    @MainActor
+    @Test func aSlowKeyboardHandoffStillCoalescesIntoOneResize() async throws {
+        var reportedGrids: [(columns: Int, rows: Int)] = []
+        let center = NotificationCenter()
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            onSizeChanged: { columns, rows in
+                reportedGrids.append((columns, rows))
+            },
+            notificationCenter: center)
+        let host = UIViewController()
+        let window = try await makeTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 390, height: 700),
+            rootViewController: host)
+        defer {
+            terminal.removeFromSuperview()
+            window.isHidden = true
+        }
+        terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 360)
+        host.view.addSubview(terminal)
+        window.layoutIfNeeded()
+
+        try await waitForGridReportsToSettle(&reportedGrids)
+        let initialRows = try #require(reportedGrids.last?.rows)
+        reportedGrids.removeAll()
+
+        terminal.keyboardTransitionFallbackDelay = 60
+        terminal.removeFromSuperview()
+        terminal.raisesKeyboardWhenReady = true
+        host.view.addSubview(terminal)
+
+        // A transient height, then a stall longer than the production
+        // fallback, then another — the shape of the handoff on the runner
+        // that leaked.
+        terminal.frame.size.height = 440
+        terminal.setNeedsLayout()
+        terminal.layoutIfNeeded()
+        try await Task.sleep(for: .milliseconds(600))
+        terminal.frame.size.height = 600
+        terminal.setNeedsLayout()
+        terminal.layoutIfNeeded()
+
+        #expect(reportedGrids.isEmpty)
+        terminal.finishKeyboardTransitionLayout()
+        try await waitForGridReportsToSettle(&reportedGrids)
+
+        #expect(reportedGrids.count == 1)
+        #expect(reportedGrids.last?.rows ?? 0 > initialRows)
+    }
+
+    /// The freeze's other edge: a handoff whose settle signal never arrives
+    /// must not stay frozen forever. The fallback thaws it after its delay,
+    /// and the thaw itself still coalesces — one report, not one per
+    /// transient.
+    @MainActor
+    @Test func anUnsettledHandoffThawsThroughTheFallbackInOneResize() async throws {
+        var reportedGrids: [(columns: Int, rows: Int)] = []
+        let center = NotificationCenter()
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            onSizeChanged: { columns, rows in
+                reportedGrids.append((columns, rows))
+            },
+            notificationCenter: center)
+        let host = UIViewController()
+        let window = try await makeTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 390, height: 700),
+            rootViewController: host)
+        defer {
+            terminal.removeFromSuperview()
+            window.isHidden = true
+        }
+        terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 360)
+        host.view.addSubview(terminal)
+        window.layoutIfNeeded()
+
+        try await waitForGridReportsToSettle(&reportedGrids)
+        let initialRows = try #require(reportedGrids.last?.rows)
+        reportedGrids.removeAll()
+
+        terminal.keyboardTransitionFallbackDelay = 0.1
+        terminal.removeFromSuperview()
+        terminal.raisesKeyboardWhenReady = true
+        host.view.addSubview(terminal)
+
+        terminal.frame.size.height = 600
+        terminal.setNeedsLayout()
+        terminal.layoutIfNeeded()
+
+        // No settle signal, no explicit finish — only the fallback ends this.
         try await waitForGridReportsToSettle(&reportedGrids)
 
         #expect(reportedGrids.count == 1)


### PR DESCRIPTION
Fixes #225.

## Root cause

`aKeyboardHandoffCoalescesItsTransientGridsIntoOneResize` held the handoff freeze open with real layout passes and sleeps, implicitly promising to finish inside the 500ms wall-clock fallback that force-thaws an unsettled handoff (`beginKeyboardTransitionLayoutDeferral`). On a loaded CI runner the steps stretched past that leash, the fallback ended the size-report deferral mid-handoff, and the transient grids it exists to swallow leaked out — reproduced deterministically by stalling the freeze window past 500ms, with the exact failure signature from the issue.

## Fix

- `keyboardTransitionFallbackDelay` becomes an injectable instance var (production default unchanged at 0.5s); the settle-driven tests stretch it to 60s so a slow runner can no longer thaw a handoff out from under them. Same pin applied to `aClaimedHandoffFreezesTheGridUntilTheKeyboardSettles`, which carried the identical latent exposure.
- New regression test `aSlowKeyboardHandoffStillCoalescesIntoOneResize`: the deterministic stand-in for the loaded runner (600ms stall inside the freeze); red before the fix with the CI failure signature.
- New test `anUnsettledHandoffThawsThroughTheFallbackInOneResize`: locks the fallback safety net itself, which previously had no coverage.
- The two suites' settle helpers merged into one shared `waitForGridReportsToSettle(count:)` (`Tests/HeelerTests/Support/GridReportSettling.swift`) that starts quiet counting only once a report exists, and throws `GridReportsNeverSettledError` on poll-cap exhaustion instead of returning an unproven state — both were further wall-clock races found in review.

## Validation

- Terminal attach + Agent switcher suites (104 tests): repeated runs all green, including 5× repeats of the timing-sensitive tests.
- CI count assertions unaffected: exact pins cover only the SSH/E2E lanes; the full lane asserts a floor (769).
- Reviewed over three rounds by a codex agent (findings: zero-report early-return race, silent cap exhaustion, duplicated polling contract — all addressed); final verdict accept with no findings.