### PR TITLE
feat: manage linked worktrees from the console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Added
+
+- Linked worktrees are now marked on Console cards. Agent detail shows their
+  repository, branch, and checkout path, and can remove the checkout and its
+  workspace after an identity-bound confirmation while keeping the local
+  branch. (#99)
+
 ### Changed
 
 - Host connections now have a distinct Connecting state, separate from

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,7 +71,8 @@ A fresh git checkout of a workspace's repository, created by herdr as its own
 workspace so a new Agent starts on a clean copy of the code. The branch
 defaults to herdr's generated `worktree/<name>` off HEAD; removing the
 Worktree deletes the checkout and closes its workspace, but the branch
-survives.
+survives. Snapshot worktree metadata also describes the main checkout; only
+`is_linked_worktree` makes a workspace eligible for linked-Worktree removal.
 _Avoid_: sandbox, branch copy, checkout folder
 
 **Console**:

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0032AB8CC6C1DFDB893E35C6 /* AgentActivityLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A62B60BB8431BE061FAA21B /* AgentActivityLinkTests.swift */; };
 		00FB65666F7C2E065D94DF2C /* StartAgentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24EF5EA39899292A1907226 /* StartAgentStore.swift */; };
 		03970FA28B8C09C524AF435E /* NotificationPrivacyCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 943C187E6425414801A4734E /* NotificationPrivacyCopyTests.swift */; };
+		03A4895D457152CA4D31FC5A /* WorktreeDetailStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442A5127B47FF6FF8840B0B9 /* WorktreeDetailStoreTests.swift */; };
 		052916002C06699B9F2F1A4B /* AttachTerminalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07A0F64626D74A8EC9A1FE2 /* AttachTerminalStore.swift */; };
 		099CD816C9173740BCE1E64E /* TestWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069388B06CE04D1F3CC24740 /* TestWindow.swift */; };
 		09C7B75B4780E79E3221E9C4 /* TerminalAgentSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8509C4FD5C50A0D7AFEC1A /* TerminalAgentSwitcher.swift */; };
@@ -77,6 +78,7 @@
 		42C86E0D3EFFEA3EEF3FFA96 /* PairingCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA61C2FD4220803AE6D533 /* PairingCode.swift */; };
 		430EDF8111CC397CA9BD2008 /* PairingScanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1674575F15764AB318626947 /* PairingScanView.swift */; };
 		4459AA847D84AE6DB7294306 /* RelayContentStateDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4858DA258C7032AC64AD52 /* RelayContentStateDecodeTests.swift */; };
+		459B7EF40BBAF37071D7539C /* WorktreeRemoval.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71AF3340B0AA8C5F33EF4B7 /* WorktreeRemoval.swift */; };
 		45C187BC7E4A9682CEE6CA7D /* HeelerSSHErrorMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10AE622E38561E17538A561C /* HeelerSSHErrorMappingTests.swift */; };
 		469C32C1704BA67A19BB3AA9 /* EventsSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7625958E48639DCE4F5A8391 /* EventsSession.swift */; };
 		4712E2A7878E4962BDEC7E8C /* TerminalMouseReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6490F9D4A3ECF0F9899D1A /* TerminalMouseReportingTests.swift */; };
@@ -127,12 +129,14 @@
 		6C33AC12CE7ACC5730240A75 /* HeelerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F710C63524E24B79F95A898 /* HeelerApp.swift */; };
 		6CD1D3CCDB58EBFF5350AC7F /* AgentNotificationBannerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A319930B80D42FB33DC8E42 /* AgentNotificationBannerStoreTests.swift */; };
 		6DA75E728052945BC787BBD3 /* AgentComposerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362EF66CE6DA07688C3E5F63 /* AgentComposerStoreTests.swift */; };
+		6DF161C3190C2D5DD0204839 /* WorktreeDetailStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0123607D5AA9F2DD3E26902A /* WorktreeDetailStore.swift */; };
 		6E98D7E8429E2B28B6BDF82D /* AgentTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F234ED041A4A2835A59A7510 /* AgentTerminalView.swift */; };
 		6FB5BA238B79801E1FDA2849 /* ConsoleActivityDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F7218F35AFEB5DCDF8BAF5 /* ConsoleActivityDriver.swift */; };
 		71661C1008468E60B82B74CD /* SSHTransportSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43AE8B2A62473EBA9EA090E /* SSHTransportSettings.swift */; };
 		7238C957097EADD61E823E9D /* NotificationEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61A04DBA56C56925B594FF1 /* NotificationEnvelope.swift */; };
 		72448624659DCDD94EF81DE8 /* AgentNotificationBannerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F85C588963C3CE948AA9E4 /* AgentNotificationBannerStore.swift */; };
 		7254A265BB89A8DAB8176EC9 /* TerminalThemeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90B11BF4D2B2C45635B5EFE /* TerminalThemeSettings.swift */; };
+		728636AA14DAF54406667F6B /* WorktreeRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC4D9448CE3E0CDBBF8F3C2 /* WorktreeRemovalTests.swift */; };
 		72A9243CA6BE664CCBB99EE4 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 86CF5F0136C3ED0B1F7F4EED /* AppIcon.icon */; };
 		74257FA18D6431785BFECE9A /* TerminalInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E30B96F852EFC3C322C9EB /* TerminalInputController.swift */; };
 		745597578F4E92FCC065823A /* GitBranchNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233075006FC2C8907BBFF40F /* GitBranchNameTests.swift */; };
@@ -186,6 +190,7 @@
 		96C9E9E62BB96A66A68570E9 /* TerminalKeysKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CCE32D8F2A1A12B183B3DA5 /* TerminalKeysKeyboardTests.swift */; };
 		97574FEB5FEA14A5776F7B22 /* SecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D2BCB4E4038F510852F71C /* SecretStore.swift */; };
 		97C02BAFE399CE0387CC8163 /* AgentActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E7BAE850794FFCE32E0062 /* AgentActivityAttributes.swift */; };
+		9AA26D72B34CCF2E34C8C675 /* WorktreeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669A53C020B39F9DFAFE005E /* WorktreeDetailView.swift */; };
 		9BF8936D82EC3CC2F41539FF /* NotificationEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7103745D02C07787E49AC70 /* NotificationEnvelopeTests.swift */; };
 		9E7AFEC6FD8926C79DCB9D1D /* HerdrAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F7065C3BE109D2F52AE3BC2 /* HerdrAPITypes.swift */; };
 		A000D3550C034E2978E8B485 /* TerminalAppearancePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAD92008AF144C63F5582E /* TerminalAppearancePane.swift */; };
@@ -346,6 +351,7 @@
 /* Begin PBXFileReference section */
 		00807A3942817BEE9800534F /* ConsoleStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleStoreTests.swift; sourceTree = "<group>"; };
 		00BABBDEFEDCB3D11EF1EFA7 /* AgentNotificationCenterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationCenterDelegate.swift; sourceTree = "<group>"; };
+		0123607D5AA9F2DD3E26902A /* WorktreeDetailStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeDetailStore.swift; sourceTree = "<group>"; };
 		016BA41A48C6D6CCCEB10A47 /* DeviceKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKeyTests.swift; sourceTree = "<group>"; };
 		03E19BDF2824DC34B28A765C /* HostKeyPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostKeyPolicy.swift; sourceTree = "<group>"; };
 		0443F1688BCEC3474F278889 /* HostStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStoreTests.swift; sourceTree = "<group>"; };
@@ -407,6 +413,7 @@
 		414B652A16576BEDEE9AE000 /* ClosePaneStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosePaneStoreTests.swift; sourceTree = "<group>"; };
 		4273AC6F39EB1E015820E614 /* TerminalAppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAppearanceSettingsView.swift; sourceTree = "<group>"; };
 		427512344847A84699F819A0 /* TerminalFontSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalFontSettingsTests.swift; sourceTree = "<group>"; };
+		442A5127B47FF6FF8840B0B9 /* WorktreeDetailStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeDetailStoreTests.swift; sourceTree = "<group>"; };
 		4582B5EA42CFA9C8878E6207 /* HeelerSSH */ = {isa = PBXFileReference; lastKnownFileType = folder; name = HeelerSSH; path = Packages/HeelerSSH; sourceTree = SOURCE_ROOT; };
 		45DB60007029322902FD1AFF /* PairingScanStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScanStore.swift; sourceTree = "<group>"; };
 		4692E780178FDFA1CF9537B1 /* AgentName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentName.swift; sourceTree = "<group>"; };
@@ -446,6 +453,7 @@
 		64D3B8E2EB97A8376B333914 /* AgentNameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNameTests.swift; sourceTree = "<group>"; };
 		651D511E8A282C4CB0214098 /* TerminalTitleGlyphs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTitleGlyphs.swift; sourceTree = "<group>"; };
 		65CFDDFD7A676ECD4EF29BDE /* SSHSourcePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHSourcePolicyTests.swift; sourceTree = "<group>"; };
+		669A53C020B39F9DFAFE005E /* WorktreeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeDetailView.swift; sourceTree = "<group>"; };
 		67AAFD0BF81441DB59EEF7AA /* NotificationRegistrationFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRegistrationFile.swift; sourceTree = "<group>"; };
 		67D6865847B4D827038D1AF0 /* HostOnboardingPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostOnboardingPresentationTests.swift; sourceTree = "<group>"; };
 		6803A0055A861DFCA2A67217 /* AgentCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentCardView.swift; sourceTree = "<group>"; };
@@ -491,6 +499,7 @@
 		88062AE11DDF93EB77A63D6B /* SSHPairingConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPairingConnector.swift; sourceTree = "<group>"; };
 		88E1434C9C39A6419A3A0D79 /* HostConsoleProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostConsoleProjection.swift; sourceTree = "<group>"; };
 		89A4121CF3A5722FE9B3C1E8 /* KnownHostsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStore.swift; sourceTree = "<group>"; };
+		8AC4D9448CE3E0CDBBF8F3C2 /* WorktreeRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRemovalTests.swift; sourceTree = "<group>"; };
 		8B02412C186BA855DFD9379A /* AgentNotificationRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationRoutingTests.swift; sourceTree = "<group>"; };
 		8C5A562F5A01AE08691B8479 /* AttachTerminalStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachTerminalStoreTests.swift; sourceTree = "<group>"; };
 		8D23517AF3A39615725A0ADC /* ComposerStagingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerStagingStore.swift; sourceTree = "<group>"; };
@@ -579,6 +588,7 @@
 		D6EA52B6C673891A3ABBA27E /* AgentNotificationBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationBannerView.swift; sourceTree = "<group>"; };
 		D6F4E5BC2440CFE0FEB3591B /* HeelerSSHHostKeyVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHHostKeyVerifier.swift; sourceTree = "<group>"; };
 		D6F5C337F9BC29D46E48E35E /* HeelerSSHJumpHostGateE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHJumpHostGateE2ETests.swift; sourceTree = "<group>"; };
+		D71AF3340B0AA8C5F33EF4B7 /* WorktreeRemoval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRemoval.swift; sourceTree = "<group>"; };
 		DA5434768FDE9237B7BD721E /* Snippet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snippet.swift; sourceTree = "<group>"; };
 		DA59306306EAEAA6DA78E337 /* TerminalAgentSwitcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAgentSwitcherTests.swift; sourceTree = "<group>"; };
 		DAEAF21DF91A1BCE4C9F79A3 /* AppAppearanceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAppearanceSettings.swift; sourceTree = "<group>"; };
@@ -758,6 +768,8 @@
 				C74CE585C09A319294FB635B /* TransportErrorPresentationTests.swift */,
 				87C2343D5ED9436077682CD1 /* WakeCommandTests.swift */,
 				4AB8C5EA497D1094E86F69C4 /* WeakNetworkE2ETests.swift */,
+				442A5127B47FF6FF8840B0B9 /* WorktreeDetailStoreTests.swift */,
+				8AC4D9448CE3E0CDBBF8F3C2 /* WorktreeRemovalTests.swift */,
 				B62ADE8AB17B60B766C866C1 /* Support */,
 			);
 			path = HeelerTests;
@@ -911,6 +923,9 @@
 				B24EF5EA39899292A1907226 /* StartAgentStore.swift */,
 				CC2E07D2395573D9EF9DE8B9 /* StartAgentView.swift */,
 				0DAC3DCDEF81B14A2019DDBE /* TerminalStatusDialog.swift */,
+				0123607D5AA9F2DD3E26902A /* WorktreeDetailStore.swift */,
+				669A53C020B39F9DFAFE005E /* WorktreeDetailView.swift */,
+				D71AF3340B0AA8C5F33EF4B7 /* WorktreeRemoval.swift */,
 			);
 			path = Console;
 			sourceTree = "<group>";
@@ -1501,6 +1516,9 @@
 				0D88F7CC5BA9BD7CAF4FED62 /* Transport.swift in Sources */,
 				5B0522DF97BC46599DDE4E93 /* TransportConnector.swift in Sources */,
 				ED24AA39EBC4BC6B7341EEFB /* TransportError+Presentation.swift in Sources */,
+				6DF161C3190C2D5DD0204839 /* WorktreeDetailStore.swift in Sources */,
+				9AA26D72B34CCF2E34C8C675 /* WorktreeDetailView.swift in Sources */,
+				459B7EF40BBAF37071D7539C /* WorktreeRemoval.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1639,6 +1657,8 @@
 				BFE02F9C58F080B95770E878 /* WakeCommandTests.swift in Sources */,
 				C6E6E92365F39EDDD50CDE49 /* WeakNetworkE2ETests.swift in Sources */,
 				B253EC25B4FA08551D5E6B4B /* WeakNetworkProxy.swift in Sources */,
+				03A4895D457152CA4D31FC5A /* WorktreeDetailStoreTests.swift in Sources */,
+				728636AA14DAF54406667F6B /* WorktreeRemovalTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Packages/HeelerSSH/Sources/HeelerSSH/PublicTypes.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/PublicTypes.swift
@@ -52,7 +52,6 @@ public enum SSHError: Error, Sendable, Equatable {
     case streamLocalOpenFailed
     case unexpectedEOF
     case responseTooLarge(limit: Int)
-    case requestNotAuthorized
     case sftpUnavailable
     case sftpFailure(status: UInt64)
     case connectionInvalidated

--- a/Packages/HeelerSSH/Sources/HeelerSSH/PublicTypes.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/PublicTypes.swift
@@ -52,6 +52,7 @@ public enum SSHError: Error, Sendable, Equatable {
     case streamLocalOpenFailed
     case unexpectedEOF
     case responseTooLarge(limit: Int)
+    case requestNotAuthorized
     case sftpUnavailable
     case sftpFailure(status: UInt64)
     case connectionInvalidated

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SSHConnection.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SSHConnection.swift
@@ -176,14 +176,15 @@ public final class SSHConnection: Sendable {
     /// Opens one direct-streamlocal channel, writes one request, reads one
     /// newline-terminated response, and closes the channel. Every call owns a
     /// fresh channel to preserve one-request-per-socket protocols.
-    /// `beforeRequestWrite` may veto after the channel opens but before any
-    /// byte is written; `onRequestWritten` runs after the complete request.
+    /// `beforeRequestWrite` may throw after the channel opens but before any
+    /// byte is written; its original error is preserved after channel cleanup.
+    /// `onRequestWritten` runs after the complete request.
     public func exchangeStreamLocal(
         socketPath: String,
         request: Data,
         maximumResponseBytes: Int = 1_048_576,
         timeout: Duration,
-        beforeRequestWrite: (@Sendable () async -> Bool)? = nil,
+        beforeRequestWrite: (@Sendable () async throws -> Void)? = nil,
         onRequestWritten: (@Sendable () async -> Void)? = nil
     ) async throws -> Data {
         try await driver.exchangeStreamLocal(

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SSHConnection.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SSHConnection.swift
@@ -176,17 +176,23 @@ public final class SSHConnection: Sendable {
     /// Opens one direct-streamlocal channel, writes one request, reads one
     /// newline-terminated response, and closes the channel. Every call owns a
     /// fresh channel to preserve one-request-per-socket protocols.
+    /// `beforeRequestWrite` may veto after the channel opens but before any
+    /// byte is written; `onRequestWritten` runs after the complete request.
     public func exchangeStreamLocal(
         socketPath: String,
         request: Data,
         maximumResponseBytes: Int = 1_048_576,
-        timeout: Duration
+        timeout: Duration,
+        beforeRequestWrite: (@Sendable () async -> Bool)? = nil,
+        onRequestWritten: (@Sendable () async -> Void)? = nil
     ) async throws -> Data {
         try await driver.exchangeStreamLocal(
             socketPath: socketPath,
             request: request,
             maximumResponseBytes: maximumResponseBytes,
-            timeout: timeout)
+            timeout: timeout,
+            beforeRequestWrite: beforeRequestWrite,
+            onRequestWritten: onRequestWritten)
     }
 
     /// Opens one long-lived direct-streamlocal channel. The returned handle

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -566,7 +566,7 @@ actor SessionDriver {
         request: Data,
         maximumResponseBytes: Int,
         timeout: Duration,
-        beforeRequestWrite: (@Sendable () async -> Bool)? = nil,
+        beforeRequestWrite: (@Sendable () async throws -> Void)? = nil,
         onRequestWritten: (@Sendable () async -> Void)? = nil
     ) async throws -> Data {
         await acquireOperation()
@@ -609,7 +609,7 @@ actor SessionDriver {
                 cancellable: true)
             return response
         } catch {
-            let normalized = normalize(error)
+            let normalized = (error as? SSHError).map(normalize)
             if let channel {
                 do {
                     try await cleanChannel(
@@ -629,7 +629,10 @@ actor SessionDriver {
                 // — must not admit later work on this session.
                 invalidateResources()
             }
-            throw normalized
+            if let normalized {
+                throw normalized
+            }
+            throw error
         }
     }
 
@@ -2042,7 +2045,7 @@ actor SessionDriver {
         maximumResponseBytes: Int,
         session: OpaquePointer,
         deadline: ContinuousClock.Instant,
-        beforeRequestWrite: (@Sendable () async -> Bool)? = nil,
+        beforeRequestWrite: (@Sendable () async throws -> Void)? = nil,
         onRequestWritten: (@Sendable () async -> Void)? = nil
     ) async throws -> Data {
         var requestOffset = 0
@@ -2050,9 +2053,7 @@ actor SessionDriver {
         var buffer = [UInt8](repeating: 0, count: 16 * 1024)
         var didAnnounceWrite = false
 
-        if let beforeRequestWrite, !(await beforeRequestWrite()) {
-            throw SSHError.requestNotAuthorized
-        }
+        try await beforeRequestWrite?()
 
         while true {
             try checkProgress(deadline: deadline)

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -565,7 +565,9 @@ actor SessionDriver {
         socketPath: String,
         request: Data,
         maximumResponseBytes: Int,
-        timeout: Duration
+        timeout: Duration,
+        beforeRequestWrite: (@Sendable () async -> Bool)? = nil,
+        onRequestWritten: (@Sendable () async -> Void)? = nil
     ) async throws -> Data {
         await acquireOperation()
         defer { releaseOperation() }
@@ -597,7 +599,9 @@ actor SessionDriver {
                 request: request,
                 maximumResponseBytes: maximumResponseBytes,
                 session: session,
-                deadline: deadline)
+                deadline: deadline,
+                beforeRequestWrite: beforeRequestWrite,
+                onRequestWritten: onRequestWritten)
             try await cleanChannel(
                 channel,
                 session: session,
@@ -2037,11 +2041,18 @@ actor SessionDriver {
         request: Data,
         maximumResponseBytes: Int,
         session: OpaquePointer,
-        deadline: ContinuousClock.Instant
+        deadline: ContinuousClock.Instant,
+        beforeRequestWrite: (@Sendable () async -> Bool)? = nil,
+        onRequestWritten: (@Sendable () async -> Void)? = nil
     ) async throws -> Data {
         var requestOffset = 0
         var response = Data()
         var buffer = [UInt8](repeating: 0, count: 16 * 1024)
+        var didAnnounceWrite = false
+
+        if let beforeRequestWrite, !(await beforeRequestWrite()) {
+            throw SSHError.requestNotAuthorized
+        }
 
         while true {
             try checkProgress(deadline: deadline)
@@ -2063,6 +2074,10 @@ actor SessionDriver {
                 } else if written != Int(LIBSSH2_ERROR_EAGAIN) {
                     throw SSHError.channelFailed
                 }
+            }
+            if requestOffset == request.count, !didAnnounceWrite {
+                didAnnounceWrite = true
+                await onRequestWritten?()
             }
 
             let received = try readAvailable(channel: channel, stream: 0, buffer: &buffer)

--- a/Sources/Heeler/Console/AgentCardView.swift
+++ b/Sources/Heeler/Console/AgentCardView.swift
@@ -37,6 +37,15 @@ struct AgentCardView: View {
                     .lineLimit(2)
             }
             HStack(spacing: 6) {
+                if agent.isLinkedWorktree {
+                    Label("Worktree", systemImage: "arrow.triangle.branch")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.quaternary, in: Capsule())
+                        .accessibilityLabel("Linked worktree")
+                }
                 if let kind = agentKindTag {
                     Text(kind)
                         .font(.caption2)
@@ -71,16 +80,7 @@ struct AgentCardView: View {
     /// The workspace context: label, with the worktree repo when it adds
     /// information the label does not already carry.
     private var workspaceContext: String? {
-        switch (agent.workspaceLabel, agent.repoName) {
-        case (nil, nil):
-            return nil
-        case (let label?, nil):
-            return label
-        case (nil, let repo?):
-            return repo
-        case (let label?, let repo?):
-            return label == repo ? label : "\(label) · \(repo)"
-        }
+        agent.workspaceContext
     }
 }
 

--- a/Sources/Heeler/Console/AgentCardView.swift
+++ b/Sources/Heeler/Console/AgentCardView.swift
@@ -118,7 +118,12 @@ struct AgentStatusBadge: View {
                     status: .blocked, workspaceID: "w1", tabID: "w1:t1", paneID: "w1:p1",
                     cwd: "/work/proj", revision: 3),
                 workspaceLabel: "proj",
-                repoName: "proj",
+                repositoryCheckout: RepositoryCheckout(
+                    repoKey: "/work/proj/.git",
+                    repoName: "proj",
+                    repoRoot: "/work/proj",
+                    checkoutPath: "/work/proj-wt",
+                    isLinkedWorktree: true),
                 lastOutputSnippet: "Allow Claude to run rm -rf? 1. Yes 2. No"))
         // No workspace in the snapshot: the agent name takes the lead line
         // and the foot tag drops.
@@ -131,7 +136,7 @@ struct AgentStatusBadge: View {
                     status: .working, workspaceID: "w2", tabID: "w2:t1", paneID: "w2:p1",
                     cwd: "/tmp", revision: 1),
                 workspaceLabel: nil,
-                repoName: nil,
+                repositoryCheckout: nil,
                 lastOutputSnippet: nil))
     }
 }

--- a/Sources/Heeler/Console/AgentComposerView.swift
+++ b/Sources/Heeler/Console/AgentComposerView.swift
@@ -49,6 +49,7 @@ struct AgentComposerActions {
     let showAttachLinks: () -> Void
     let startAgent: () -> Void
     let manageSnippets: () -> Void
+    let showWorktreeDetails: (() -> Void)?
     let renameAgent: () -> Void
     let renameWorkspace: () -> Void
     let closeAgent: () -> Void
@@ -164,6 +165,14 @@ struct AgentComposerView: View {
                                     }
                                 }
                                 Section {
+                                    if let showWorktreeDetails = actions.showWorktreeDetails {
+                                        Button(
+                                            "Worktree Details",
+                                            systemImage: "arrow.triangle.branch"
+                                        ) {
+                                            showWorktreeDetails()
+                                        }
+                                    }
                                     Button("Rename Agent", systemImage: "pencil") {
                                         actions.renameAgent()
                                     }

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -48,6 +48,8 @@ struct AgentTerminalView: View {
     /// pane's long-press menu.
     @State private var viewingSkill: AgentSkill?
     @State private var isRenamingWorkspace = false
+    @State private var isShowingWorktree = false
+    @State private var worktreeStore: WorktreeDetailStore?
     @State private var isShowingAttachLinks = false
     @State private var closeErrorMessage: String?
     @Environment(\.colorScheme) private var colorScheme
@@ -223,6 +225,13 @@ struct AgentTerminalView: View {
                         agent.agent.workspaceID, label: label, on: agent.hostID)
                 })
         }
+        .sheet(isPresented: $isShowingWorktree) {
+            if let worktreeStore {
+                WorktreeDetailView(store: worktreeStore) { _ in
+                    isShowingWorktree = false
+                }
+            }
+        }
         .sheet(
             isPresented: Binding(
                 get: { attach.pendingPaste != nil },
@@ -370,9 +379,42 @@ struct AgentTerminalView: View {
             showAttachLinks: { isShowingAttachLinks = true },
             startAgent: { isStartingAgent = true },
             manageSnippets: { isManagingSnippets = true },
+            showWorktreeDetails: agent.isLinkedWorktree
+                ? {
+                    if let checkout = agent.repositoryCheckout {
+                        worktreeStore = makeWorktreeStore(checkout: checkout)
+                        isShowingWorktree = true
+                    }
+                } : nil,
             renameAgent: { isRenamingAgent = true },
             renameWorkspace: { isRenamingWorkspace = true },
             closeAgent: { isConfirmingClose = true })
+    }
+
+    private func makeWorktreeStore(checkout: RepositoryCheckout) -> WorktreeDetailStore {
+        let hostID = agent.hostID
+        let workspaceID = agent.agent.workspaceID
+        let request = WorktreeRemovalRequest(
+            identity: WorktreeIdentity(
+                hostID: hostID, workspaceID: workspaceID, checkout: checkout))
+        return WorktreeDetailStore(
+            request: request,
+            workspaceLabel: agent.workspaceLabel ?? checkout.repoName,
+            checkout: checkout,
+            list: { [console] workspaceID in
+                try await console.listWorktrees(
+                    forWorkspaceID: workspaceID, on: hostID)
+            },
+            remove: { [console] request in
+                try await console.removeWorktree(request, on: hostID)
+            },
+            hasWorkingAgent: { [console] in
+                console.agents.contains {
+                    $0.hostID == hostID
+                        && $0.agent.workspaceID == workspaceID
+                        && $0.agent.status == .working
+                }
+            })
     }
 
     private var terminalSurface: some View {

--- a/Sources/Heeler/Console/ConsoleAgent.swift
+++ b/Sources/Heeler/Console/ConsoleAgent.swift
@@ -43,27 +43,6 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
         self.lastOutputSnippet = lastOutputSnippet
     }
 
-    /// Compatibility initializer for callers that only need display context,
-    /// not a removable snapshot identity.
-    init(
-        hostID: Host.ID,
-        hostName: String,
-        agent: Agent,
-        workspaceLabel: String?,
-        repoName: String?,
-        checkoutPath: String? = nil,
-        lastOutputSnippet: String? = nil
-    ) {
-        self.init(
-            hostID: hostID,
-            hostName: hostName,
-            agent: agent,
-            workspaceLabel: workspaceLabel,
-            repositoryCheckout: Self.displayOnlyCheckout(
-                repoName: repoName, checkoutPath: checkoutPath),
-            lastOutputSnippet: lastOutputSnippet)
-    }
-
     var repoName: String? { repositoryCheckout?.repoName }
 
     var checkoutPath: String? { repositoryCheckout?.checkoutPath }
@@ -79,16 +58,6 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
         case (nil, let repo?): repo
         case (let label?, let repo?): label == repo ? label : "\(label) · \(repo)"
         }
-    }
-
-    private static func displayOnlyCheckout(
-        repoName: String?, checkoutPath: String?
-    ) -> RepositoryCheckout? {
-        guard let repoName else { return nil }
-        let path = checkoutPath ?? ""
-        return RepositoryCheckout(
-            repoKey: "", repoName: repoName, repoRoot: "",
-            checkoutPath: path, isLinkedWorktree: false)
     }
 
     /// The keyboard switcher's chip label. The project leads, as it does on

--- a/Sources/Heeler/Console/ConsoleAgent.swift
+++ b/Sources/Heeler/Console/ConsoleAgent.swift
@@ -17,13 +17,10 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
     /// Workspace label from the session snapshot; nil when the snapshot did
     /// not carry the workspace.
     let workspaceLabel: String?
-    /// Worktree repo name where the workspace has one — sharper context than
-    /// a raw checkout path.
-    let repoName: String?
-    /// Worktree checkout path where the workspace has one: the directory
-    /// whose files the agent actually sees, which for a linked worktree is
-    /// the checkout rather than the main repository root.
-    let checkoutPath: String?
+    /// Snapshot git metadata when the workspace reported any. Presence does
+    /// not mean this is removable: the main checkout is reported with
+    /// `isLinkedWorktree == false` too.
+    let repositoryCheckout: RepositoryCheckout?
     /// Trailing terminal output (`pane.read`, ANSI stripped), fetched after
     /// snapshots and status changes; nil until the first read lands.
     var lastOutputSnippet: String?
@@ -35,17 +32,63 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
         hostName: String,
         agent: Agent,
         workspaceLabel: String?,
-        repoName: String?,
-        checkoutPath: String? = nil,
+        repositoryCheckout: RepositoryCheckout?,
         lastOutputSnippet: String? = nil
     ) {
         self.hostID = hostID
         self.hostName = hostName
         self.agent = agent
         self.workspaceLabel = workspaceLabel
-        self.repoName = repoName
-        self.checkoutPath = checkoutPath
+        self.repositoryCheckout = repositoryCheckout
         self.lastOutputSnippet = lastOutputSnippet
+    }
+
+    /// Compatibility initializer for callers that only need display context,
+    /// not a removable snapshot identity.
+    init(
+        hostID: Host.ID,
+        hostName: String,
+        agent: Agent,
+        workspaceLabel: String?,
+        repoName: String?,
+        checkoutPath: String? = nil,
+        lastOutputSnippet: String? = nil
+    ) {
+        self.init(
+            hostID: hostID,
+            hostName: hostName,
+            agent: agent,
+            workspaceLabel: workspaceLabel,
+            repositoryCheckout: Self.displayOnlyCheckout(
+                repoName: repoName, checkoutPath: checkoutPath),
+            lastOutputSnippet: lastOutputSnippet)
+    }
+
+    var repoName: String? { repositoryCheckout?.repoName }
+
+    var checkoutPath: String? { repositoryCheckout?.checkoutPath }
+
+    /// Console badge and destructive-action eligibility come only from the
+    /// latest session snapshot's explicit linkage bit.
+    var isLinkedWorktree: Bool { repositoryCheckout?.isLinkedWorktree == true }
+
+    var workspaceContext: String? {
+        switch (workspaceLabel, repoName) {
+        case (nil, nil): nil
+        case (let label?, nil): label
+        case (nil, let repo?): repo
+        case (let label?, let repo?): label == repo ? label : "\(label) · \(repo)"
+        }
+    }
+
+    private static func displayOnlyCheckout(
+        repoName: String?, checkoutPath: String?
+    ) -> RepositoryCheckout? {
+        guard let repoName else { return nil }
+        let path = checkoutPath ?? ""
+        return RepositoryCheckout(
+            repoKey: "", repoName: repoName, repoRoot: "",
+            checkoutPath: path, isLinkedWorktree: false)
     }
 
     /// The keyboard switcher's chip label. The project leads, as it does on
@@ -63,6 +106,39 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
     var skillsProjectRoot: String? {
         if let checkoutPath, !checkoutPath.isEmpty { return checkoutPath }
         return agent.cwd.isEmpty ? nil : agent.cwd
+    }
+}
+
+/// The snapshot's exact git checkout identity for one workspace. Workspace
+/// ids are reusable slots, so destructive actions match this tuple too.
+struct RepositoryCheckout: Sendable, Equatable, Hashable {
+    let repoKey: String
+    let repoName: String
+    let repoRoot: String
+    let checkoutPath: String
+    let isLinkedWorktree: Bool
+
+    init(
+        repoKey: String,
+        repoName: String,
+        repoRoot: String,
+        checkoutPath: String,
+        isLinkedWorktree: Bool
+    ) {
+        self.repoKey = repoKey
+        self.repoName = repoName
+        self.repoRoot = repoRoot
+        self.checkoutPath = checkoutPath
+        self.isLinkedWorktree = isLinkedWorktree
+    }
+
+    init(_ info: WorkspaceWorktreeInfo) {
+        self.init(
+            repoKey: info.repoKey,
+            repoName: info.repoName,
+            repoRoot: info.repoRoot,
+            checkoutPath: info.checkoutPath,
+            isLinkedWorktree: info.isLinkedWorktree)
     }
 }
 

--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -445,8 +445,11 @@ final class ConsoleStore {
         if workspacesByHost != nextWorkspacesByHost {
             workspacesByHost = nextWorkspacesByHost
         }
-        removedWorktreesByAgent = current.reduce(into: [:]) { result, projection in
+        let nextRemovedWorktreesByAgent = current.reduce(into: [:]) { result, projection in
             result.merge(projection.removedWorktreesByAgent) { _, latest in latest }
+        }
+        if removedWorktreesByAgent != nextRemovedWorktreesByAgent {
+            removedWorktreesByAgent = nextRemovedWorktreesByAgent
         }
         publishAgentStatuses()
     }

--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -26,6 +26,12 @@ final class ConsoleStore {
     /// than a projection lookup so an open New Agent picker refreshes when a
     /// snapshot arrives or a workspace membership event resyncs the Host.
     private(set) var workspacesByHost: [Host.ID: [ConsoleWorkspace]] = [:]
+    /// Successful or snapshot-reconciled removals keyed by the exact Agents
+    /// that belonged to the validated worktree. This survives their rows
+    /// disappearing so Agent detail can show a stable result.
+    private(set) var removedWorktreesByAgent: [
+        ConsoleAgent.ID: WorktreeRemovalReceipt
+    ] = [:]
 
     @ObservationIgnored private var projections: [
         Host.ID: HostConsoleProjection
@@ -363,6 +369,18 @@ final class ConsoleStore {
         try await projection(for: hostID).closePane(paneID)
     }
 
+    func listWorktrees(
+        forWorkspaceID workspaceID: String, on hostID: Host.ID
+    ) async throws -> WorktreeListResponse {
+        try await projection(for: hostID).listWorktrees(forWorkspaceID: workspaceID)
+    }
+
+    func removeWorktree(
+        _ request: WorktreeRemovalRequest, on hostID: Host.ID
+    ) async throws -> WorktreeRemovalReceipt {
+        try await projection(for: hostID).removeWorktree(request)
+    }
+
     func renameAgent(
         _ paneID: String, name: String?, on hostID: Host.ID
     ) async throws {
@@ -426,6 +444,9 @@ final class ConsoleStore {
             })
         if workspacesByHost != nextWorkspacesByHost {
             workspacesByHost = nextWorkspacesByHost
+        }
+        removedWorktreesByAgent = current.reduce(into: [:]) { result, projection in
+            result.merge(projection.removedWorktreesByAgent) { _, latest in latest }
         }
         publishAgentStatuses()
     }

--- a/Sources/Heeler/Console/ConsoleView.swift
+++ b/Sources/Heeler/Console/ConsoleView.swift
@@ -185,7 +185,9 @@ struct ConsoleView: View {
     @ViewBuilder
     private var detail: some View {
         if let id = notificationRouter.path.last {
-            if let agent = console.agents.first(where: { $0.id == id }) {
+            if let receipt = matchingRemovedWorktreeReceipt(for: id) {
+                removedWorktreeSurface(receipt)
+            } else if let agent = console.agents.first(where: { $0.id == id }) {
                 AgentDetailView(
                     agent: agent,
                     console: console,
@@ -223,6 +225,33 @@ struct ConsoleView: View {
             ContentUnavailableView(
                 "No Agent Selected", systemImage: "rectangle.on.rectangle",
                 description: Text("Choose an Agent to view its live terminal."))
+        }
+    }
+
+    /// A receipt is keyed by the Agent set captured at the authorized write.
+    /// If the same pane id has already returned, require the live row to match
+    /// the exact removed workspace/worktree identity before showing it.
+    private func matchingRemovedWorktreeReceipt(
+        for id: ConsoleAgent.ID
+    ) -> WorktreeRemovalReceipt? {
+        RemovedWorktreeSelection.receipt(
+            for: id,
+            agents: console.agents,
+            receipts: console.removedWorktreesByAgent)
+    }
+
+    private func removedWorktreeSurface(
+        _ receipt: WorktreeRemovalReceipt
+    ) -> some View {
+        ContentUnavailableView {
+            Label("Worktree Removed", systemImage: "checkmark.circle")
+        } description: {
+            Text(
+                "The checkout at \(receipt.request.identity.checkoutPath) was removed and its workspace was closed. No branch was deleted."
+            )
+        } actions: {
+            Button("Back to Console") { notificationRouter.path = [] }
+                .buttonStyle(.borderedProminent)
         }
     }
 

--- a/Sources/Heeler/Console/HostConsoleProjection.swift
+++ b/Sources/Heeler/Console/HostConsoleProjection.swift
@@ -23,6 +23,23 @@ final class HostConsoleProjection {
     /// snapshot. `.connected` arrives before that request completes, so an
     /// empty projection in this window means "unknown", not "no Agents".
     private(set) var isAwaitingSnapshot = true
+    /// Stable success surfaces keyed by every Agent that belonged to the
+    /// exact validated worktree at dispatch.
+    private(set) var removedWorktreesByAgent: [
+        ConsoleAgent.ID: WorktreeRemovalReceipt
+    ] = [:]
+
+    private struct WorktreeRemovalOperation {
+        enum Phase {
+            case preparing
+            case dispatched(snapshotRequestGeneration: UInt64)
+            case unconfirmed(snapshotRequestGeneration: UInt64)
+        }
+
+        let request: WorktreeRemovalRequest
+        var affectedAgentIDs: Set<ConsoleAgent.ID> = []
+        var phase: Phase = .preparing
+    }
 
     private let snapshotRetryDelay: Duration
     private let onChange: @MainActor @Sendable () -> Void
@@ -35,6 +52,11 @@ final class HostConsoleProjection {
     /// already in flight may still return after its Host drops, but its stale
     /// rows must never repopulate the Console.
     private var snapshotEpoch: UInt64 = 0
+    /// Request-start order, used only after a complete remove request line was
+    /// written. A snapshot already in flight cannot resolve its outcome.
+    private var snapshotRequestGeneration: UInt64 = 0
+    private var workspacesByID: [String: WorkspaceInfo] = [:]
+    private var worktreeRemovalOperations: [UUID: WorktreeRemovalOperation] = [:]
     private var statusChangeRevision: UInt64 = 0
     private var latestStatusChanges: [
         String: (revision: UInt64, status: AgentStatus)
@@ -217,6 +239,152 @@ final class HostConsoleProjection {
         scheduleResync()
     }
 
+    func listWorktrees(forWorkspaceID workspaceID: String) async throws -> WorktreeListResponse {
+        try await session.withTransport { transport in
+            try await transport.listWorktrees(forWorkspaceID: workspaceID)
+        }
+    }
+
+    /// One operation record per immutable request prevents repeated taps and
+    /// concurrent removals from replacing one another. Exact identity is
+    /// checked again inside the Transport's write boundary, after channel
+    /// admission and immediately before the first request byte.
+    func removeWorktree(
+        _ request: WorktreeRemovalRequest
+    ) async throws -> WorktreeRemovalReceipt {
+        guard request.identity.hostID == host.id else {
+            throw WorktreeRemovalError.staleIdentity
+        }
+        guard worktreeRemovalOperations[request.id] == nil else {
+            throw WorktreeRemovalError.alreadyInProgress
+        }
+        guard !worktreeRemovalOperations.values.contains(where: {
+            $0.request.identity == request.identity
+        }) else {
+            throw WorktreeRemovalError.alreadyInProgress
+        }
+        worktreeRemovalOperations[request.id] = WorktreeRemovalOperation(request: request)
+
+        do {
+            let response = try await session.withTransport { transport in
+                try await transport.removeWorktree(
+                    request,
+                    authorize: { request in
+                        try await self.authorizeWorktreeRemoval(request)
+                    },
+                    onDispatched: { request in
+                        await self.worktreeRemovalWasDispatched(request)
+                    })
+            }
+            guard
+                response.workspaceID == request.identity.workspaceID,
+                response.path == request.identity.checkoutPath
+            else {
+                try markWorktreeRemovalUnconfirmed(request)
+                scheduleResync()
+                throw WorktreeRemovalError.outcomeUnconfirmed
+            }
+            let receipt = try finishSuccessfulWorktreeRemoval(request)
+            scheduleResync()
+            publish()
+            return receipt
+        } catch let error as WorktreeRemovalError {
+            if error != .outcomeUnconfirmed {
+                worktreeRemovalOperations[request.id] = nil
+            }
+            publish()
+            throw error
+        } catch {
+            if Self.isDefiniteWorktreeRejection(error) {
+                worktreeRemovalOperations[request.id] = nil
+                publish()
+                throw error
+            }
+            guard let operation = worktreeRemovalOperations[request.id],
+                case .dispatched = operation.phase
+            else {
+                worktreeRemovalOperations[request.id] = nil
+                publish()
+                throw error
+            }
+            try markWorktreeRemovalUnconfirmed(request)
+            scheduleResync()
+            publish()
+            throw WorktreeRemovalError.outcomeUnconfirmed
+        }
+    }
+
+    private func authorizeWorktreeRemoval(_ request: WorktreeRemovalRequest) throws {
+        guard
+            var operation = worktreeRemovalOperations[request.id],
+            operation.request == request,
+            case .preparing = operation.phase,
+            let workspace = workspacesByID[request.identity.workspaceID],
+            let checkout = workspace.worktree.map(RepositoryCheckout.init),
+            request.identity.matches(checkout)
+        else {
+            throw WorktreeRemovalError.staleIdentity
+        }
+        operation.affectedAgentIDs = Set(
+            agentsByPane.values.lazy
+                .filter {
+                    $0.agent.workspaceID == request.identity.workspaceID
+                        && $0.repositoryCheckout.map(request.identity.matches) == true
+                }
+                .map(\.id))
+        worktreeRemovalOperations[request.id] = operation
+    }
+
+    private func worktreeRemovalWasDispatched(_ request: WorktreeRemovalRequest) {
+        guard var operation = worktreeRemovalOperations[request.id],
+            operation.request == request,
+            case .preparing = operation.phase
+        else { return }
+        operation.phase = .dispatched(
+            snapshotRequestGeneration: snapshotRequestGeneration)
+        worktreeRemovalOperations[request.id] = operation
+    }
+
+    private func markWorktreeRemovalUnconfirmed(
+        _ request: WorktreeRemovalRequest
+    ) throws {
+        guard var operation = worktreeRemovalOperations[request.id],
+            operation.request == request,
+            case .dispatched(let generation) = operation.phase
+        else { throw WorktreeRemovalError.staleIdentity }
+        operation.phase = .unconfirmed(snapshotRequestGeneration: generation)
+        worktreeRemovalOperations[request.id] = operation
+    }
+
+    private func finishSuccessfulWorktreeRemoval(
+        _ request: WorktreeRemovalRequest
+    ) throws -> WorktreeRemovalReceipt {
+        guard let operation = worktreeRemovalOperations.removeValue(forKey: request.id),
+            operation.request == request
+        else { throw WorktreeRemovalError.staleIdentity }
+        let receipt = WorktreeRemovalReceipt(
+            request: request, affectedAgentIDs: operation.affectedAgentIDs)
+        record(receipt)
+        return receipt
+    }
+
+    private func record(_ receipt: WorktreeRemovalReceipt) {
+        for agentID in receipt.affectedAgentIDs {
+            removedWorktreesByAgent[agentID] = receipt
+        }
+    }
+
+    private static func isDefiniteWorktreeRejection(_ error: any Error) -> Bool {
+        switch error {
+        case is HerdrAPIError:
+            true
+        case TransportError.apiRejected(_, _):
+            true
+        default:
+            false
+        }
+    }
+
     /// Renames an Agent (#98); a nil name clears back to the detected kind.
     /// The new name lands via the post-RPC resync, not an event delta:
     /// `pane.updated` does not carry the agent name and fires on every
@@ -310,6 +478,8 @@ final class HostConsoleProjection {
     }
 
     private func runResync() async {
+        snapshotRequestGeneration &+= 1
+        let requestGeneration = snapshotRequestGeneration
         let epochBeforeSnapshot = snapshotEpoch
         let statusRevisionBeforeSnapshot = statusChangeRevision
         do {
@@ -326,7 +496,8 @@ final class HostConsoleProjection {
             syncError = nil
             apply(
                 snapshot,
-                preservingStatusChangesAfter: statusRevisionBeforeSnapshot)
+                preservingStatusChangesAfter: statusRevisionBeforeSnapshot,
+                requestGeneration: requestGeneration)
             await session.updateSubscriptions(
                 Self.subscriptions(paneIDs: agentsByPane.keys))
             refreshSnippets()
@@ -368,11 +539,13 @@ final class HostConsoleProjection {
         pendingSnippetRefreshes.removeAll(keepingCapacity: true)
         agentsByPane.removeAll(keepingCapacity: true)
         workspaces.removeAll(keepingCapacity: true)
+        workspacesByID.removeAll(keepingCapacity: true)
     }
 
     private func apply(
         _ snapshot: SessionSnapshot,
-        preservingStatusChangesAfter snapshotStartRevision: UInt64
+        preservingStatusChangesAfter snapshotStartRevision: UInt64,
+        requestGeneration: UInt64
     ) {
         let workspaceByID = Dictionary(
             snapshot.workspaces.map { ($0.workspaceID, $0) }) { first, _ in first }
@@ -385,8 +558,7 @@ final class HostConsoleProjection {
                 hostName: host.displayName,
                 agent: agent,
                 workspaceLabel: workspace?.label,
-                repoName: workspace?.worktree?.repoName,
-                checkoutPath: workspace?.worktree?.checkoutPath,
+                repositoryCheckout: workspace?.worktree.map(RepositoryCheckout.init),
                 lastOutputSnippet: agentsByPane[agent.paneID]?.lastOutputSnippet)
         }
         for (paneID, change) in latestStatusChanges
@@ -398,10 +570,31 @@ final class HostConsoleProjection {
         latestStatusChanges.removeAll(keepingCapacity: true)
         isAwaitingSnapshot = false
         agentsByPane = nextAgents
+        workspacesByID = workspaceByID
         workspaces = snapshot.workspaces
             .map { ConsoleWorkspace(id: $0.workspaceID, label: $0.label) }
             .sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
+        reconcileUnconfirmedWorktreeRemovals(requestGeneration: requestGeneration)
         publish()
+    }
+
+    private func reconcileUnconfirmedWorktreeRemovals(requestGeneration: UInt64) {
+        for (id, operation) in worktreeRemovalOperations {
+            guard case .unconfirmed(let dispatchGeneration) = operation.phase,
+                requestGeneration > dispatchGeneration
+            else { continue }
+            let stillPresent = workspacesByID[operation.request.identity.workspaceID]
+                .flatMap(\.worktree)
+                .map(RepositoryCheckout.init)
+                .map(operation.request.identity.matches) == true
+            worktreeRemovalOperations[id] = nil
+            if !stillPresent {
+                record(
+                    WorktreeRemovalReceipt(
+                        request: operation.request,
+                        affectedAgentIDs: operation.affectedAgentIDs))
+            }
+        }
     }
 
     private func applyStatusChange(_ data: JSONValue) -> AgentStatus? {

--- a/Sources/Heeler/Console/HostConsoleProjection.swift
+++ b/Sources/Heeler/Console/HostConsoleProjection.swift
@@ -25,9 +25,14 @@ final class HostConsoleProjection {
     private(set) var isAwaitingSnapshot = true
     /// Stable success surfaces keyed by every Agent that belonged to the
     /// exact validated worktree at dispatch.
-    private(set) var removedWorktreesByAgent: [
-        ConsoleAgent.ID: WorktreeRemovalReceipt
-    ] = [:]
+    var removedWorktreesByAgent: [ConsoleAgent.ID: WorktreeRemovalReceipt] {
+        worktreeRemovalReceiptsByAgent.mapValues(\.receipt)
+    }
+
+    private struct WorktreeRemovalReceiptRecord {
+        let receipt: WorktreeRemovalReceipt
+        let snapshotRequestGeneration: UInt64
+    }
 
     private struct WorktreeRemovalOperation {
         enum Phase {
@@ -57,6 +62,9 @@ final class HostConsoleProjection {
     private var snapshotRequestGeneration: UInt64 = 0
     private var workspacesByID: [String: WorkspaceInfo] = [:]
     private var worktreeRemovalOperations: [UUID: WorktreeRemovalOperation] = [:]
+    private var worktreeRemovalReceiptsByAgent: [
+        ConsoleAgent.ID: WorktreeRemovalReceiptRecord
+    ] = [:]
     private var statusChangeRevision: UInt64 = 0
     private var latestStatusChanges: [
         String: (revision: UInt64, status: AgentStatus)
@@ -361,13 +369,19 @@ final class HostConsoleProjection {
         else { throw WorktreeRemovalError.staleIdentity }
         let receipt = WorktreeRemovalReceipt(
             request: request, affectedAgentIDs: operation.affectedAgentIDs)
-        record(receipt)
+        record(receipt, atSnapshotRequestGeneration: snapshotRequestGeneration)
         return receipt
     }
 
-    private func record(_ receipt: WorktreeRemovalReceipt) {
+    private func record(
+        _ receipt: WorktreeRemovalReceipt,
+        atSnapshotRequestGeneration generation: UInt64
+    ) {
+        let record = WorktreeRemovalReceiptRecord(
+            receipt: receipt,
+            snapshotRequestGeneration: generation)
         for agentID in receipt.affectedAgentIDs {
-            removedWorktreesByAgent[agentID] = receipt
+            worktreeRemovalReceiptsByAgent[agentID] = record
         }
     }
 
@@ -571,7 +585,8 @@ final class HostConsoleProjection {
         workspaces = snapshot.workspaces
             .map { ConsoleWorkspace(id: $0.workspaceID, label: $0.label) }
             .sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
-        pruneReceiptsReintroducedByCurrentSnapshot()
+        pruneReceiptsReintroducedByCurrentSnapshot(
+            requestGeneration: requestGeneration)
         reconcileUnconfirmedWorktreeRemovals(requestGeneration: requestGeneration)
         publish()
     }
@@ -579,12 +594,18 @@ final class HostConsoleProjection {
     /// A later snapshot is the source of truth for existence. If the exact
     /// removed identity appears again, it is a recreated/live worktree and
     /// must not inherit an older success surface.
-    private func pruneReceiptsReintroducedByCurrentSnapshot() {
-        removedWorktreesByAgent = removedWorktreesByAgent.filter { agentID, receipt in
+    private func pruneReceiptsReintroducedByCurrentSnapshot(
+        requestGeneration: UInt64
+    ) {
+        worktreeRemovalReceiptsByAgent = worktreeRemovalReceiptsByAgent.filter {
+            agentID, record in
+            guard requestGeneration > record.snapshotRequestGeneration else {
+                return true
+            }
             guard let agent = agentsByPane[agentID.paneID], agent.id == agentID else {
                 return true
             }
-            let identity = receipt.request.identity
+            let identity = record.receipt.request.identity
             return agent.agent.workspaceID != identity.workspaceID
                 || agent.repositoryCheckout.map(identity.matches) != true
         }
@@ -604,7 +625,8 @@ final class HostConsoleProjection {
                 record(
                     WorktreeRemovalReceipt(
                         request: operation.request,
-                        affectedAgentIDs: operation.affectedAgentIDs))
+                        affectedAgentIDs: operation.affectedAgentIDs),
+                    atSnapshotRequestGeneration: requestGeneration)
             }
         }
     }

--- a/Sources/Heeler/Console/HostConsoleProjection.swift
+++ b/Sources/Heeler/Console/HostConsoleProjection.swift
@@ -276,10 +276,7 @@ final class HostConsoleProjection {
                         await self.worktreeRemovalWasDispatched(request)
                     })
             }
-            guard
-                response.workspaceID == request.identity.workspaceID,
-                response.path == request.identity.checkoutPath
-            else {
+            guard response.workspaceID == request.identity.workspaceID else {
                 try markWorktreeRemovalUnconfirmed(request)
                 scheduleResync()
                 throw WorktreeRemovalError.outcomeUnconfirmed
@@ -574,8 +571,23 @@ final class HostConsoleProjection {
         workspaces = snapshot.workspaces
             .map { ConsoleWorkspace(id: $0.workspaceID, label: $0.label) }
             .sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
+        pruneReceiptsReintroducedByCurrentSnapshot()
         reconcileUnconfirmedWorktreeRemovals(requestGeneration: requestGeneration)
         publish()
+    }
+
+    /// A later snapshot is the source of truth for existence. If the exact
+    /// removed identity appears again, it is a recreated/live worktree and
+    /// must not inherit an older success surface.
+    private func pruneReceiptsReintroducedByCurrentSnapshot() {
+        removedWorktreesByAgent = removedWorktreesByAgent.filter { agentID, receipt in
+            guard let agent = agentsByPane[agentID.paneID], agent.id == agentID else {
+                return true
+            }
+            let identity = receipt.request.identity
+            return agent.agent.workspaceID != identity.workspaceID
+                || agent.repositoryCheckout.map(identity.matches) != true
+        }
     }
 
     private func reconcileUnconfirmedWorktreeRemovals(requestGeneration: UInt64) {

--- a/Sources/Heeler/Console/WorktreeDetailStore.swift
+++ b/Sources/Heeler/Console/WorktreeDetailStore.swift
@@ -33,7 +33,9 @@ final class WorktreeDetailStore {
     private let remove: (WorktreeRemovalRequest) async throws -> WorktreeRemovalReceipt
     private let hasWorkingAgent: () -> Bool
     private var didLoadBranch = false
-    private var isConfirming = false
+    /// A token captured synchronously by the confirmation action and consumed
+    /// exactly once when its asynchronous removal task starts.
+    private var pendingRemovalRequestID: UUID?
 
     init(
         request: WorktreeRemovalRequest,
@@ -52,7 +54,7 @@ final class WorktreeDetailStore {
     }
 
     var canRemove: Bool {
-        checkout.isLinkedWorktree && !isConfirming && removalPhase == .idle
+        checkout.isLinkedWorktree && removalPhase == .idle
     }
 
     func loadBranchIfNeeded() async {
@@ -84,6 +86,9 @@ final class WorktreeDetailStore {
         } catch is CancellationError {
             didLoadBranch = false
             branch = .loading
+        } catch TransportError.cancelled {
+            didLoadBranch = false
+            branch = .loading
         } catch {
             branch = .unavailable
         }
@@ -109,14 +114,22 @@ final class WorktreeDetailStore {
         confirmation = nil
     }
 
-    func confirmRemoval() async {
-        guard !isConfirming, let confirmation else { return }
-        isConfirming = true
+    /// Captures and transitions the exact confirmed request synchronously.
+    /// SwiftUI may clear the dialog binding immediately after this returns;
+    /// the asynchronous dispatch no longer reads that mutable dialog state.
+    func beginRemoval() -> WorktreeRemovalRequest? {
+        guard canRemove, let confirmation else { return nil }
         removalPhase = .removing
         self.confirmation = nil
-        defer { isConfirming = false }
+        pendingRemovalRequestID = confirmation.request.id
+        return confirmation.request
+    }
+
+    func finishRemoval(_ request: WorktreeRemovalRequest) async {
+        guard pendingRemovalRequestID == request.id, request == self.request else { return }
+        pendingRemovalRequestID = nil
         do {
-            removalPhase = .removed(try await remove(confirmation.request))
+            removalPhase = .removed(try await remove(request))
         } catch WorktreeRemovalError.staleIdentity {
             removalPhase = .stale(WorktreeRemovalError.staleIdentity.message)
             showsFeedback = true
@@ -124,6 +137,8 @@ final class WorktreeDetailStore {
             removalPhase = .unconfirmed
             showsFeedback = true
         } catch is CancellationError {
+            removalPhase = .idle
+        } catch TransportError.cancelled {
             removalPhase = .idle
         } catch {
             removalPhase = .failed(WorktreeRemovalRefusal.message(for: error))

--- a/Sources/Heeler/Console/WorktreeDetailStore.swift
+++ b/Sources/Heeler/Console/WorktreeDetailStore.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class WorktreeDetailStore {
+    enum BranchPresentation: Equatable {
+        case loading
+        case named(String)
+        case detached
+        case unavailable
+    }
+
+    enum RemovalPhase: Equatable {
+        case idle
+        case removing
+        case removed(WorktreeRemovalReceipt)
+        case failed(String)
+        case stale(String)
+        case unconfirmed
+    }
+
+    let request: WorktreeRemovalRequest
+    let workspaceLabel: String
+    let checkout: RepositoryCheckout
+
+    private(set) var branch: BranchPresentation = .loading
+    private(set) var confirmation: WorktreeRemovalConfirmation?
+    private(set) var removalPhase: RemovalPhase = .idle
+    private(set) var showsFeedback = false
+
+    private let list: (String) async throws -> WorktreeListResponse
+    private let remove: (WorktreeRemovalRequest) async throws -> WorktreeRemovalReceipt
+    private let hasWorkingAgent: () -> Bool
+    private var didLoadBranch = false
+    private var isConfirming = false
+
+    init(
+        request: WorktreeRemovalRequest,
+        workspaceLabel: String,
+        checkout: RepositoryCheckout,
+        list: @escaping (String) async throws -> WorktreeListResponse,
+        remove: @escaping (WorktreeRemovalRequest) async throws -> WorktreeRemovalReceipt,
+        hasWorkingAgent: @escaping () -> Bool
+    ) {
+        self.request = request
+        self.workspaceLabel = workspaceLabel
+        self.checkout = checkout
+        self.list = list
+        self.remove = remove
+        self.hasWorkingAgent = hasWorkingAgent
+    }
+
+    var canRemove: Bool {
+        checkout.isLinkedWorktree && !isConfirming && removalPhase == .idle
+    }
+
+    func loadBranchIfNeeded() async {
+        guard !didLoadBranch else { return }
+        didLoadBranch = true
+        branch = .loading
+        do {
+            let response = try await list(request.identity.workspaceID)
+            guard response.source.repoKey == request.identity.repoKey else {
+                branch = .unavailable
+                return
+            }
+            let entry = response.worktrees.first {
+                $0.openWorkspaceID == request.identity.workspaceID
+                    && $0.path == request.identity.checkoutPath
+                    && $0.isLinkedWorktree
+            }
+            guard let entry else {
+                branch = .unavailable
+                return
+            }
+            if let name = entry.branch, !name.isEmpty {
+                branch = .named(name)
+            } else if entry.isDetached {
+                branch = .detached
+            } else {
+                branch = .unavailable
+            }
+        } catch is CancellationError {
+            didLoadBranch = false
+            branch = .loading
+        } catch {
+            branch = .unavailable
+        }
+    }
+
+    func retryBranch() async {
+        didLoadBranch = false
+        await loadBranchIfNeeded()
+    }
+
+    /// Captures one immutable request in the dialog. Final authorization is
+    /// deliberately later, immediately before the wire begins writing.
+    func prepareConfirmation() {
+        guard canRemove else { return }
+        confirmation = WorktreeRemovalConfirmation.make(
+            request: request,
+            workspaceLabel: workspaceLabel,
+            branch: confirmationBranch,
+            hasWorkingAgent: hasWorkingAgent())
+    }
+
+    func cancelConfirmation() {
+        confirmation = nil
+    }
+
+    func confirmRemoval() async {
+        guard !isConfirming, let confirmation else { return }
+        isConfirming = true
+        removalPhase = .removing
+        self.confirmation = nil
+        defer { isConfirming = false }
+        do {
+            removalPhase = .removed(try await remove(confirmation.request))
+        } catch WorktreeRemovalError.staleIdentity {
+            removalPhase = .stale(WorktreeRemovalError.staleIdentity.message)
+            showsFeedback = true
+        } catch WorktreeRemovalError.outcomeUnconfirmed {
+            removalPhase = .unconfirmed
+            showsFeedback = true
+        } catch is CancellationError {
+            removalPhase = .idle
+        } catch {
+            removalPhase = .failed(WorktreeRemovalRefusal.message(for: error))
+            showsFeedback = true
+        }
+    }
+
+    func dismissFeedback() {
+        showsFeedback = false
+        if case .failed = removalPhase {
+            removalPhase = .idle
+        }
+    }
+
+    private var confirmationBranch: WorktreeRemovalConfirmation.Branch {
+        switch branch {
+        case .named(let name): .named(name)
+        case .detached: .detached
+        case .loading, .unavailable: .unavailable
+        }
+    }
+}

--- a/Sources/Heeler/Console/WorktreeDetailView.swift
+++ b/Sources/Heeler/Console/WorktreeDetailView.swift
@@ -30,7 +30,7 @@ struct WorktreeDetailView: View {
                 }
 
                 Section {
-                    Button("Remove Worktree…", role: .destructive) {
+                    Button("Remove Worktree", role: .destructive) {
                         store.prepareConfirmation()
                     }
                     .disabled(!store.canRemove)
@@ -62,7 +62,8 @@ struct WorktreeDetailView: View {
                 titleVisibility: .visible
             ) {
                 Button("Remove Worktree", role: .destructive) {
-                    Task { await store.confirmRemoval() }
+                    guard let request = store.beginRemoval() else { return }
+                    Task { await store.finishRemoval(request) }
                 }
                 Button("Cancel", role: .cancel) { store.cancelConfirmation() }
             } message: {
@@ -130,6 +131,7 @@ struct WorktreeDetailView: View {
             case .unavailable:
                 Text("Unavailable").foregroundStyle(.secondary)
                 Button("Retry") { Task { await store.retryBranch() } }
+                    .buttonStyle(.borderless)
             }
         }
     }

--- a/Sources/Heeler/Console/WorktreeDetailView.swift
+++ b/Sources/Heeler/Console/WorktreeDetailView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+struct WorktreeDetailView: View {
+    @State private var store: WorktreeDetailStore
+    let onRemoved: (WorktreeRemovalReceipt) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    init(
+        store: WorktreeDetailStore,
+        onRemoved: @escaping (WorktreeRemovalReceipt) -> Void
+    ) {
+        _store = State(initialValue: store)
+        self.onRemoved = onRemoved
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Linked Worktree") {
+                    LabeledContent("Repository", value: store.checkout.repoName)
+                    branchRow
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Checkout Path")
+                            .foregroundStyle(.secondary)
+                        Text(store.checkout.checkoutPath)
+                            .font(.body.monospaced())
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                Section {
+                    Button("Remove Worktree…", role: .destructive) {
+                        store.prepareConfirmation()
+                    }
+                    .disabled(!store.canRemove)
+                    if store.removalPhase == .removing {
+                        ProgressView("Removing worktree")
+                    }
+                } footer: {
+                    if store.removalPhase == .unconfirmed {
+                        Text(WorktreeRemovalError.outcomeUnconfirmed.message)
+                    } else if case .stale(let message) = store.removalPhase {
+                        Text(message)
+                    } else {
+                        Text(
+                            "Deletes this checkout and closes its workspace. No branch is deleted."
+                        )
+                    }
+                }
+            }
+            .navigationTitle("Worktree")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .confirmationDialog(
+                store.confirmation?.title ?? "Remove worktree?",
+                isPresented: confirmationPresented,
+                titleVisibility: .visible
+            ) {
+                Button("Remove Worktree", role: .destructive) {
+                    Task { await store.confirmRemoval() }
+                }
+                Button("Cancel", role: .cancel) { store.cancelConfirmation() }
+            } message: {
+                Text(store.confirmation?.message ?? "")
+            }
+            .alert(
+                feedbackTitle,
+                isPresented: feedbackPresented
+            ) {
+                Button("OK", role: .cancel) { store.dismissFeedback() }
+            } message: {
+                Text(feedbackMessage)
+            }
+            .onChange(of: store.removalPhase) { _, phase in
+                guard case .removed(let receipt) = phase else { return }
+                onRemoved(receipt)
+                dismiss()
+            }
+            .task { await store.loadBranchIfNeeded() }
+        }
+    }
+
+    private var confirmationPresented: Binding<Bool> {
+        Binding(
+            get: { store.confirmation != nil },
+            set: { if !$0 { store.cancelConfirmation() } })
+    }
+
+    private var feedbackPresented: Binding<Bool> {
+        Binding(
+            get: { store.showsFeedback },
+            set: { presented in
+                if !presented { store.dismissFeedback() }
+            })
+    }
+
+    private var feedbackTitle: String {
+        switch store.removalPhase {
+        case .unconfirmed: "Removal Unconfirmed"
+        default: "Couldn't Remove Worktree"
+        }
+    }
+
+    private var feedbackMessage: String {
+        switch store.removalPhase {
+        case .failed(let message): message
+        case .stale(let message): message
+        case .unconfirmed: WorktreeRemovalError.outcomeUnconfirmed.message
+        default: ""
+        }
+    }
+
+    @ViewBuilder
+    private var branchRow: some View {
+        HStack {
+            Text("Branch")
+            Spacer()
+            switch store.branch {
+            case .loading:
+                Text("Loading…").foregroundStyle(.secondary)
+            case .named(let name):
+                Text(name).font(.body.monospaced())
+            case .detached:
+                Text("Detached HEAD")
+            case .unavailable:
+                Text("Unavailable").foregroundStyle(.secondary)
+                Button("Retry") { Task { await store.retryBranch() } }
+            }
+        }
+    }
+}

--- a/Sources/Heeler/Console/WorktreeRemoval.swift
+++ b/Sources/Heeler/Console/WorktreeRemoval.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// Exact linked-worktree identity shown to the user. The workspace id alone
+/// cannot authorize a destructive request because herdr may reuse it.
+struct WorktreeIdentity: Equatable, Hashable, Sendable {
+    let hostID: Host.ID
+    let workspaceID: String
+    let repoKey: String
+    let checkoutPath: String
+
+    init(hostID: Host.ID, workspaceID: String, checkout: RepositoryCheckout) {
+        self.hostID = hostID
+        self.workspaceID = workspaceID
+        repoKey = checkout.repoKey
+        checkoutPath = checkout.checkoutPath
+    }
+
+    func matches(_ checkout: RepositoryCheckout) -> Bool {
+        checkout.isLinkedWorktree
+            && checkout.repoKey == repoKey
+            && checkout.checkoutPath == checkoutPath
+    }
+}
+
+/// Immutable request carried from confirmation through the Transport seam.
+/// `id` keeps concurrent operations distinct even when their timing overlaps.
+struct WorktreeRemovalRequest: Equatable, Hashable, Sendable {
+    let id: UUID
+    let identity: WorktreeIdentity
+
+    init(id: UUID = UUID(), identity: WorktreeIdentity) {
+        self.id = id
+        self.identity = identity
+    }
+}
+
+/// Stable post-removal state. The affected Agent ids are captured from the
+/// validated snapshot, so a later missing selection is never matched by Host
+/// or workspace id alone.
+struct WorktreeRemovalReceipt: Equatable, Sendable {
+    let request: WorktreeRemovalRequest
+    let affectedAgentIDs: Set<ConsoleAgent.ID>
+}
+
+enum RemovedWorktreeSelection {
+    static func receipt(
+        for selectedID: ConsoleAgent.ID,
+        agents: [ConsoleAgent],
+        receipts: [ConsoleAgent.ID: WorktreeRemovalReceipt]
+    ) -> WorktreeRemovalReceipt? {
+        guard let receipt = receipts[selectedID] else { return nil }
+        guard let live = agents.first(where: { $0.id == selectedID }) else {
+            return receipt
+        }
+        let identity = receipt.request.identity
+        guard live.agent.workspaceID == identity.workspaceID,
+            live.repositoryCheckout.map(identity.matches) == true
+        else { return nil }
+        return receipt
+    }
+}
+
+enum WorktreeRemovalError: Error, Equatable, Sendable {
+    case staleIdentity
+    case alreadyInProgress
+    case outcomeUnconfirmed
+
+    var message: String {
+        switch self {
+        case .staleIdentity:
+            "This is no longer the same linked worktree. Nothing was removed."
+        case .alreadyInProgress:
+            "This worktree already has a removal in progress."
+        case .outcomeUnconfirmed:
+            "The Host did not confirm whether removal completed. To avoid removing a reused workspace, close this sheet and reopen Worktree Details after the Console refreshes."
+        }
+    }
+}
+
+struct WorktreeRemovalConfirmation: Equatable, Sendable {
+    enum Branch: Equatable, Sendable {
+        case named(String)
+        case detached
+        case unavailable
+    }
+
+    let request: WorktreeRemovalRequest
+    let title: String
+    let message: String
+
+    static func make(
+        request: WorktreeRemovalRequest,
+        workspaceLabel: String,
+        branch: Branch,
+        hasWorkingAgent: Bool
+    ) -> WorktreeRemovalConfirmation {
+        var sentences = [
+            "This deletes \(request.identity.checkoutPath) and closes the whole workspace, ending every Agent and closing every Pane in it."
+        ]
+        switch branch {
+        case .named(let name):
+            sentences.append("The local branch \(name) is kept.")
+        case .detached:
+            break
+        case .unavailable:
+            sentences.append("Any local branch is kept.")
+        }
+        sentences.append("This can't be undone.")
+        if hasWorkingAgent {
+            sentences.append("An Agent is still working in this worktree.")
+        }
+        return WorktreeRemovalConfirmation(
+            request: request,
+            title: "Remove \(workspaceLabel) worktree?",
+            message: sentences.joined(separator: " "))
+    }
+}
+
+enum WorktreeRemovalRefusal {
+    static func message(for error: any Error) -> String {
+        switch error {
+        case let removal as WorktreeRemovalError:
+            removal.message
+        case let api as HerdrAPIError:
+            apiMessage(code: api.code, serverMessage: api.message)
+        case let TransportError.apiRejected(code, message):
+            apiMessage(code: code, serverMessage: message)
+        case TransportError.sshUnreachable:
+            "The Host is not connected."
+        case TransportError.timedOut:
+            "The Host did not answer in time."
+        default:
+            "Removing the worktree failed: \(error)"
+        }
+    }
+
+    private static func apiMessage(code: String, serverMessage: String) -> String {
+        switch code {
+        case "dirty_worktree_requires_force":
+            "herdr couldn't remove this worktree because it has modified or untracked files. Commit or discard those changes on the Host, then retry."
+        case "not_linked_worktree":
+            "herdr couldn't remove this worktree because the workspace is not a linked worktree."
+        case "workspace_not_found":
+            "herdr couldn't remove this worktree because the workspace is no longer on the Host."
+        case "worktree_operation_in_progress":
+            "herdr is already changing a worktree on this Host. Wait a moment, then retry."
+        default:
+            "herdr couldn't remove this worktree: \(serverMessage)"
+        }
+    }
+}

--- a/Sources/Heeler/Console/WorktreeRemoval.swift
+++ b/Sources/Heeler/Console/WorktreeRemoval.swift
@@ -72,7 +72,7 @@ enum WorktreeRemovalError: Error, Equatable, Sendable {
         case .alreadyInProgress:
             "This worktree already has a removal in progress."
         case .outcomeUnconfirmed:
-            "The Host did not confirm whether removal completed. To avoid removing a reused workspace, close this sheet and reopen Worktree Details after the Console refreshes."
+            "The Host did not confirm whether removal completed. Close this sheet, wait for the Console to refresh, then reopen Worktree Details."
         }
     }
 }
@@ -105,10 +105,10 @@ struct WorktreeRemovalConfirmation: Equatable, Sendable {
         case .unavailable:
             sentences.append("Any local branch is kept.")
         }
-        sentences.append("This can't be undone.")
         if hasWorkingAgent {
             sentences.append("An Agent is still working in this worktree.")
         }
+        sentences.append("This can't be undone.")
         return WorktreeRemovalConfirmation(
             request: request,
             title: "Remove \(workspaceLabel) worktree?",
@@ -129,6 +129,8 @@ enum WorktreeRemovalRefusal {
             "The Host is not connected."
         case TransportError.timedOut:
             "The Host did not answer in time."
+        case TransportError.cancelled:
+            "Worktree removal was cancelled."
         default:
             "Removing the worktree failed: \(error)"
         }

--- a/Sources/Heeler/Demo/DemoScreenshotMode.swift
+++ b/Sources/Heeler/Demo/DemoScreenshotMode.swift
@@ -189,7 +189,9 @@
                             cwd: "/workspace/heeler"),
                     ],
                     workspaces: [
-                        workspace(id: "mobile", label: "iOS App", repo: "heeler"),
+                        workspace(
+                            id: "mobile", label: "iOS App", repo: "heeler",
+                            isLinkedWorktree: true),
                         workspace(id: "docs", label: "Product Docs", repo: "docs-site"),
                     ]),
                 paneSnippets: [
@@ -313,9 +315,11 @@
         private static func workspace(
             id: String,
             label: String,
-            repo: String
+            repo: String,
+            isLinkedWorktree: Bool = false
         ) -> WorkspaceInfo {
-            WorkspaceInfo(
+            let repoRoot = isLinkedWorktree ? "/source/\(repo)" : "/workspace/\(repo)"
+            return WorkspaceInfo(
                 activeTabID: "\(id):t1",
                 agentStatus: .unknown,
                 focused: false,
@@ -326,10 +330,10 @@
                 workspaceID: id,
                 worktree: WorkspaceWorktreeInfo(
                     checkoutPath: "/workspace/\(repo)",
-                    isLinkedWorktree: false,
-                    repoKey: "/workspace/\(repo)/.git",
+                    isLinkedWorktree: isLinkedWorktree,
+                    repoKey: "\(repoRoot)/.git",
                     repoName: repo,
-                    repoRoot: "/workspace/\(repo)"))
+                    repoRoot: repoRoot))
         }
     }
 

--- a/Sources/Heeler/Transport/Generated/HerdrAPITypes.swift
+++ b/Sources/Heeler/Transport/Generated/HerdrAPITypes.swift
@@ -1062,6 +1062,33 @@ struct WorktreeInfo: Codable, Equatable, Sendable {
     }
 }
 
+/// herdr schema `$defs/WorktreeListParams`.
+struct WorktreeListParams: Codable, Equatable, Sendable {
+    let cwd: String?
+    let workspaceID: String?
+
+    init(cwd: String? = nil, workspaceID: String? = nil) {
+        self.cwd = cwd
+        self.workspaceID = workspaceID
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case cwd
+        case workspaceID = "workspace_id"
+    }
+}
+
+/// The `"type":"worktree_list"` result payload of herdr's success_response schema.
+struct WorktreeListResponse: Codable, Equatable, Sendable {
+    let source: WorktreeSourceInfo
+    let worktrees: [WorktreeInfo]
+
+    init(source: WorktreeSourceInfo, worktrees: [WorktreeInfo]) {
+        self.source = source
+        self.worktrees = worktrees
+    }
+}
+
 /// herdr schema `$defs/WorktreeRemoveParams`.
 struct WorktreeRemoveParams: Codable, Equatable, Sendable {
     let force: Bool?
@@ -1094,5 +1121,36 @@ struct WorktreeRemovedResponse: Codable, Equatable, Sendable {
         case forced
         case path
         case workspaceID = "workspace_id"
+    }
+}
+
+/// herdr schema `$defs/WorktreeSourceInfo`.
+struct WorktreeSourceInfo: Codable, Equatable, Sendable {
+    let repoKey: String
+    let repoName: String
+    let repoRoot: String
+    let sourceCheckoutPath: String
+    let sourceWorkspaceID: String?
+
+    init(
+        repoKey: String,
+        repoName: String,
+        repoRoot: String,
+        sourceCheckoutPath: String,
+        sourceWorkspaceID: String? = nil
+    ) {
+        self.repoKey = repoKey
+        self.repoName = repoName
+        self.repoRoot = repoRoot
+        self.sourceCheckoutPath = sourceCheckoutPath
+        self.sourceWorkspaceID = sourceWorkspaceID
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case repoKey = "repo_key"
+        case repoName = "repo_name"
+        case repoRoot = "repo_root"
+        case sourceCheckoutPath = "source_checkout_path"
+        case sourceWorkspaceID = "source_workspace_id"
     }
 }

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -500,7 +500,7 @@ actor HeelerSSHTransport: Transport {
             .algorithmNegotiationFailed, .connectionInvalidated:
             return .sshUnreachable(detail: String(describing: error))
         case .channelFailed, .streamLocalOpenFailed, .unexpectedEOF,
-            .responseTooLarge, .sftpUnavailable, .sftpFailure:
+            .responseTooLarge, .requestNotAuthorized, .sftpUnavailable, .sftpFailure:
             return .channelFailed(detail: String(describing: error))
         case .authenticationFailed, .timedOut, .cancelled, .forwardingDenied:
             // Exhaustiveness only: `sharedClassification` is total over these.
@@ -659,12 +659,46 @@ actor HeelerSSHTransport: Transport {
                 paneID: created.rootPane.paneID)
             return Agent(response.agent)
         } catch let error as HerdrAPIError {
-            try? await removeWorktree(workspaceID: created.workspace.workspaceID)
+            try? await removeCreatedWorktree(workspaceID: created.workspace.workspaceID)
             throw error
         }
     }
 
-    private func removeWorktree(workspaceID: String) async throws {
+    func listWorktrees(forWorkspaceID workspaceID: String) async throws -> WorktreeListResponse {
+        try await request(
+            method: "worktree.list",
+            params: WorktreeListParams(workspaceID: workspaceID),
+            decoding: WorktreeListResponse.self)
+    }
+
+    func removeWorktree(
+        _ removal: WorktreeRemovalRequest,
+        authorize: @escaping @Sendable (WorktreeRemovalRequest) async throws -> Void,
+        onDispatched: @escaping @Sendable (WorktreeRemovalRequest) async -> Void
+    ) async throws -> WorktreeRemovedResponse {
+        do {
+            return try await request(
+                method: "worktree.remove",
+                params: WorktreeRemoveParams(
+                    workspaceID: removal.identity.workspaceID,
+                    force: false),
+                decoding: WorktreeRemovedResponse.self,
+                beforeDispatch: {
+                    do {
+                        try await authorize(removal)
+                        return true
+                    } catch {
+                        return false
+                    }
+                },
+                onDispatched: { await onDispatched(removal) })
+        } catch TransportError.channelFailed(let detail)
+        where detail == Self.requestNotAuthorizedDetail {
+            throw WorktreeRemovalError.staleIdentity
+        }
+    }
+
+    private func removeCreatedWorktree(workspaceID: String) async throws {
         _ = try await request(
             method: "worktree.remove",
             params: WorktreeRemoveParams(workspaceID: workspaceID),
@@ -1442,20 +1476,26 @@ actor HeelerSSHTransport: Transport {
     private func request<P: Encodable & Sendable, R: Decodable & Sendable>(
         method: String,
         params: P,
-        decoding type: R.Type
+        decoding type: R.Type,
+        beforeDispatch: (@Sendable () async -> Bool)? = nil,
+        onDispatched: (@Sendable () async -> Void)? = nil
     ) async throws -> R {
         try await withColdStartWake {
             try await self.performRequest(
                 method: method,
                 params: params,
-                decoding: type)
+                decoding: type,
+                beforeDispatch: beforeDispatch,
+                onDispatched: onDispatched)
         }
     }
 
     private func performRequest<P: Encodable & Sendable, R: Decodable & Sendable>(
         method: String,
         params: P,
-        decoding type: R.Type
+        decoding type: R.Type,
+        beforeDispatch: (@Sendable () async -> Bool)? = nil,
+        onDispatched: (@Sendable () async -> Void)? = nil
     ) async throws -> R {
         guard connected else {
             throw TransportError.sshUnreachable(
@@ -1474,7 +1514,9 @@ actor HeelerSSHTransport: Transport {
                         socketPath: socketPath,
                         request: Data(line.utf8),
                         maximumResponseBytes: Self.maximumResponseBytes,
-                        timeout: self.requestTimeout)
+                        timeout: self.requestTimeout,
+                        beforeRequestWrite: beforeDispatch,
+                        onRequestWritten: onDispatched)
                 } catch SSHError.streamLocalOpenFailed {
                     throw try await self.classifyStreamLocalOpenFailure(
                         socketPath: socketPath)
@@ -1639,6 +1681,8 @@ actor HeelerSSHTransport: Transport {
             return .malformedResponse("stream-local channel closed before a response line")
         case .responseTooLarge(let limit):
             return .malformedResponse("response line exceeds \(limit) bytes")
+        case .requestNotAuthorized:
+            return .channelFailed(detail: Self.requestNotAuthorizedDetail)
         case .connectionInvalidated:
             return .sshUnreachable(detail: "The SSH connection is no longer reusable.")
         // `.streamLocalOpenFailed` falls here on purpose. Only
@@ -1673,11 +1717,13 @@ actor HeelerSSHTransport: Transport {
             return .tcpForwardingUnavailable
         case .invalidEndpoint, .connectionFailed, .algorithmNegotiationFailed,
             .channelFailed, .streamLocalOpenFailed, .unexpectedEOF,
-            .responseTooLarge, .connectionInvalidated, .targetUnreachable,
-            .sftpUnavailable, .sftpFailure:
+            .responseTooLarge, .requestNotAuthorized, .connectionInvalidated,
+            .targetUnreachable, .sftpUnavailable, .sftpFailure:
             return nil
         }
     }
+
+    private static let requestNotAuthorizedDetail = "request not authorized"
 
     #if DEBUG
     /// Test surface for the real connect-time mapper; not a second taxonomy.

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -500,7 +500,7 @@ actor HeelerSSHTransport: Transport {
             .algorithmNegotiationFailed, .connectionInvalidated:
             return .sshUnreachable(detail: String(describing: error))
         case .channelFailed, .streamLocalOpenFailed, .unexpectedEOF,
-            .responseTooLarge, .requestNotAuthorized, .sftpUnavailable, .sftpFailure:
+            .responseTooLarge, .sftpUnavailable, .sftpFailure:
             return .channelFailed(detail: String(describing: error))
         case .authenticationFailed, .timedOut, .cancelled, .forwardingDenied:
             // Exhaustiveness only: `sharedClassification` is total over these.
@@ -676,26 +676,14 @@ actor HeelerSSHTransport: Transport {
         authorize: @escaping @Sendable (WorktreeRemovalRequest) async throws -> Void,
         onDispatched: @escaping @Sendable (WorktreeRemovalRequest) async -> Void
     ) async throws -> WorktreeRemovedResponse {
-        do {
-            return try await request(
-                method: "worktree.remove",
-                params: WorktreeRemoveParams(
-                    workspaceID: removal.identity.workspaceID,
-                    force: false),
-                decoding: WorktreeRemovedResponse.self,
-                beforeDispatch: {
-                    do {
-                        try await authorize(removal)
-                        return true
-                    } catch {
-                        return false
-                    }
-                },
-                onDispatched: { await onDispatched(removal) })
-        } catch TransportError.channelFailed(let detail)
-        where detail == Self.requestNotAuthorizedDetail {
-            throw WorktreeRemovalError.staleIdentity
-        }
+        try await request(
+            method: "worktree.remove",
+            params: WorktreeRemoveParams(
+                workspaceID: removal.identity.workspaceID,
+                force: false),
+            decoding: WorktreeRemovedResponse.self,
+            beforeDispatch: { try await authorize(removal) },
+            onDispatched: { await onDispatched(removal) })
     }
 
     private func removeCreatedWorktree(workspaceID: String) async throws {
@@ -1477,7 +1465,7 @@ actor HeelerSSHTransport: Transport {
         method: String,
         params: P,
         decoding type: R.Type,
-        beforeDispatch: (@Sendable () async -> Bool)? = nil,
+        beforeDispatch: (@Sendable () async throws -> Void)? = nil,
         onDispatched: (@Sendable () async -> Void)? = nil
     ) async throws -> R {
         try await withColdStartWake {
@@ -1494,7 +1482,7 @@ actor HeelerSSHTransport: Transport {
         method: String,
         params: P,
         decoding type: R.Type,
-        beforeDispatch: (@Sendable () async -> Bool)? = nil,
+        beforeDispatch: (@Sendable () async throws -> Void)? = nil,
         onDispatched: (@Sendable () async -> Void)? = nil
     ) async throws -> R {
         guard connected else {
@@ -1520,8 +1508,10 @@ actor HeelerSSHTransport: Transport {
                 } catch SSHError.streamLocalOpenFailed {
                     throw try await self.classifyStreamLocalOpenFailure(
                         socketPath: socketPath)
-                } catch {
+                } catch let error as SSHError {
                     throw await self.mapOperationError(error)
+                } catch {
+                    throw error
                 }
             }
         }
@@ -1681,8 +1671,6 @@ actor HeelerSSHTransport: Transport {
             return .malformedResponse("stream-local channel closed before a response line")
         case .responseTooLarge(let limit):
             return .malformedResponse("response line exceeds \(limit) bytes")
-        case .requestNotAuthorized:
-            return .channelFailed(detail: Self.requestNotAuthorizedDetail)
         case .connectionInvalidated:
             return .sshUnreachable(detail: "The SSH connection is no longer reusable.")
         // `.streamLocalOpenFailed` falls here on purpose. Only
@@ -1717,13 +1705,11 @@ actor HeelerSSHTransport: Transport {
             return .tcpForwardingUnavailable
         case .invalidEndpoint, .connectionFailed, .algorithmNegotiationFailed,
             .channelFailed, .streamLocalOpenFailed, .unexpectedEOF,
-            .responseTooLarge, .requestNotAuthorized, .connectionInvalidated,
+            .responseTooLarge, .connectionInvalidated,
             .targetUnreachable, .sftpUnavailable, .sftpFailure:
             return nil
         }
     }
-
-    private static let requestNotAuthorizedDetail = "request not authorized"
 
     #if DEBUG
     /// Test surface for the real connect-time mapper; not a second taxonomy.

--- a/Sources/Heeler/Transport/Transport.swift
+++ b/Sources/Heeler/Transport/Transport.swift
@@ -76,6 +76,21 @@ protocol Transport: Sendable {
     /// id; returns once the server acknowledges.
     func closePane(_ params: PaneTarget) async throws
 
+    /// Lists git worktrees for the repository containing `workspaceID`.
+    /// Console detail uses this only to obtain branch presentation because
+    /// `session.snapshot` already carries repository and checkout identity.
+    func listWorktrees(forWorkspaceID workspaceID: String) async throws -> WorktreeListResponse
+
+    /// Removes one exact confirmed linked Worktree. `authorize` is invoked
+    /// after the stream-local channel opens but before its first request byte;
+    /// `onDispatched` runs only after the complete request line is written.
+    /// Both receive the immutable request that crosses this Transport seam.
+    func removeWorktree(
+        _ request: WorktreeRemovalRequest,
+        authorize: @escaping @Sendable (WorktreeRemovalRequest) async throws -> Void,
+        onDispatched: @escaping @Sendable (WorktreeRemovalRequest) async -> Void
+    ) async throws -> WorktreeRemovedResponse
+
     /// Renames an Agent (`agent.rename`): the Console management action
     /// (#98). A nil name clears the custom name back to the detected kind
     /// (verified live against herdr 0.7.5: omitting the key clears). The
@@ -227,6 +242,20 @@ extension Transport {
 
     func replaceNotificationConfig(_ contents: Data) async throws {
         throw NotificationRegistrationError.pluginNotInstalled
+    }
+
+    func listWorktrees(forWorkspaceID workspaceID: String) async throws -> WorktreeListResponse {
+        throw TransportError.channelFailed(
+            detail: "This transport cannot list worktrees.")
+    }
+
+    func removeWorktree(
+        _ request: WorktreeRemovalRequest,
+        authorize: @escaping @Sendable (WorktreeRemovalRequest) async throws -> Void,
+        onDispatched: @escaping @Sendable (WorktreeRemovalRequest) async -> Void
+    ) async throws -> WorktreeRemovedResponse {
+        throw TransportError.channelFailed(
+            detail: "This transport cannot remove worktrees.")
     }
 }
 

--- a/Tests/HeelerTests/AgentActivityContentBuilderTests.swift
+++ b/Tests/HeelerTests/AgentActivityContentBuilderTests.swift
@@ -133,7 +133,7 @@ struct AgentActivityContentBuilderTests {
         let agents = [
             ConsoleAgent(
                 hostID: hostID, hostName: "mbp", agent: blankKind,
-                workspaceLabel: nil, repoName: nil)
+                workspaceLabel: nil, repositoryCheckout: nil)
         ]
 
         let desire = try #require(
@@ -233,7 +233,7 @@ struct AgentActivityContentBuilderTests {
                         workspaceID: "w", tabID: "t", paneID: item.paneID,
                         cwd: "/", revision: 1,
                         name: nonEmpty(item.displayAgent) ?? nonEmpty(item.name)),
-                    workspaceLabel: nil, repoName: nil)
+                    workspaceLabel: nil, repositoryCheckout: nil)
             }
 
             let desire = try #require(
@@ -295,6 +295,6 @@ struct AgentActivityContentBuilderTests {
             hostID: hostID, hostName: "mbp",
             agent: Agent(
                 .fixture(paneID: paneID, status: status, kind: kind, title: title, name: name)),
-            workspaceLabel: nil, repoName: nil)
+            workspaceLabel: nil, repositoryCheckout: nil)
     }
 }

--- a/Tests/HeelerTests/AgentComposerStoreTests.swift
+++ b/Tests/HeelerTests/AgentComposerStoreTests.swift
@@ -498,7 +498,13 @@ struct AgentComposerStoreTests {
                 terminalID: "term-1", kind: "claude", title: "Task",
                 status: status, workspaceID: "w1", tabID: "w1:t1", paneID: "w1:p1",
                 cwd: "/work", revision: 1),
-            workspaceLabel: "Project", repoName: "Project")
+            workspaceLabel: "Project",
+            repositoryCheckout: RepositoryCheckout(
+                repoKey: "/work/Project/.git",
+                repoName: "Project",
+                repoRoot: "/work/Project",
+                checkoutPath: "/work/Project",
+                isLinkedWorktree: false))
     }
 }
 

--- a/Tests/HeelerTests/AgentNotificationBannerStoreTests.swift
+++ b/Tests/HeelerTests/AgentNotificationBannerStoreTests.swift
@@ -47,7 +47,9 @@ struct AgentNotificationBannerStoreTests {
         ConsoleAgent(
             hostID: hostID ?? self.hostID, hostName: "mac-studio",
             agent: Agent(.fixture(paneID: paneID, status: status, kind: kind)),
-            workspaceLabel: workspaceLabel, repoName: nil, lastOutputSnippet: nil)
+            workspaceLabel: workspaceLabel,
+            repositoryCheckout: nil,
+            lastOutputSnippet: nil)
     }
 
     /// Polls until `condition` holds, yielding so the store's tasks progress.

--- a/Tests/HeelerTests/AgentNotificationRouterTests.swift
+++ b/Tests/HeelerTests/AgentNotificationRouterTests.swift
@@ -18,7 +18,7 @@ struct AgentNotificationRouterTests {
         ConsoleAgent(
             hostID: hostID, hostName: "mac-studio",
             agent: Agent(.fixture(paneID: paneID)),
-            workspaceLabel: nil, repoName: nil, lastOutputSnippet: nil)
+            workspaceLabel: nil, repositoryCheckout: nil, lastOutputSnippet: nil)
     }
 
     /// Polls until `condition` holds, yielding so the router's tasks progress.

--- a/Tests/HeelerTests/AgentSurfaceReplacementTests.swift
+++ b/Tests/HeelerTests/AgentSurfaceReplacementTests.swift
@@ -654,7 +654,7 @@ struct AgentSurfaceReplacementTests {
                 status: .idle, workspaceID: "w", tabID: "w:t", paneID: pane,
                 cwd: "/work", revision: 1, name: nil),
             workspaceLabel: nil,
-            repoName: nil,
+            repositoryCheckout: nil,
             lastOutputSnippet: nil)
     }
 

--- a/Tests/HeelerTests/ConsoleStoreTests.swift
+++ b/Tests/HeelerTests/ConsoleStoreTests.swift
@@ -1414,6 +1414,175 @@ struct ConsoleStoreTests {
         store.setHosts([])
     }
 
+    @Test func linkedWorktreeRemovalRecordsOnlyItsAffectedAgents() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: linkedWorktreeSnapshot(
+                workspaces: [
+                    ("w1", "one", "/work/one-wt"),
+                    ("w2", "two", "/work/two-wt"),
+                ]))
+        let store = makeStore(transports: [host.id: transport])
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("both linked-worktree Agents should arrive") {
+            store.agents.count == 2
+        }
+        let first = try #require(store.agents.first { $0.agent.workspaceID == "w1" })
+        let checkout = try #require(first.repositoryCheckout)
+        let request = WorktreeRemovalRequest(
+            identity: WorktreeIdentity(
+                hostID: host.id, workspaceID: "w1", checkout: checkout))
+
+        let receipt = try await store.removeWorktree(request, on: host.id)
+
+        #expect(await transport.removedWorktreeRequests == [request])
+        #expect(receipt.affectedAgentIDs == [first.id])
+        #expect(store.removedWorktreesByAgent[first.id] == receipt)
+        let unaffected = try #require(store.agents.first { $0.agent.workspaceID == "w2" })
+        #expect(store.removedWorktreesByAgent[unaffected.id] == nil)
+        store.setHosts([])
+    }
+
+    @Test func staleIdentityAtTheWriteBoundarySendsNoRemoval() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: linkedWorktreeSnapshot(workspaces: [("w1", "one", "/work/one-wt")]))
+        let gate = ScriptedTransportCallGate()
+        await transport.gateNextWorktreeAuthorization(using: gate)
+        let store = makeStore(transports: [host.id: transport])
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the linked-worktree Agent should arrive") {
+            store.agents.first?.isLinkedWorktree == true
+        }
+        let agent = try #require(store.agents.first)
+        let checkout = try #require(agent.repositoryCheckout)
+        let request = WorktreeRemovalRequest(
+            identity: WorktreeIdentity(
+                hostID: host.id, workspaceID: "w1", checkout: checkout))
+        let removal = Task { try await store.removeWorktree(request, on: host.id) }
+
+        try await waitUntil("remove should be waiting immediately before authorization") {
+            await gate.entryCount == 1
+        }
+        await transport.setSnapshot(
+            linkedWorktreeSnapshot(workspaces: [("w1", "replacement", "/work/reused-wt")]))
+        #expect(
+            await transport.emit(
+                HerdrEvent(
+                    kind: GlobalEventKind.workspaceMetadataUpdated.kind,
+                    data: .object([:]))) == true)
+        try await waitUntil("the replacement identity should become the latest snapshot") {
+            store.agents.first?.checkoutPath == "/work/reused-wt"
+        }
+        await gate.open()
+
+        await #expect(throws: WorktreeRemovalError.staleIdentity) {
+            try await removal.value
+        }
+        #expect(await transport.removedWorktreeRequests.isEmpty)
+        #expect(store.removedWorktreesByAgent.isEmpty)
+        store.setHosts([])
+    }
+
+    @Test func repeatedAndConcurrentRemovalRequestsStayDistinct() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: linkedWorktreeSnapshot(
+                workspaces: [
+                    ("w1", "one", "/work/one-wt"),
+                    ("w2", "two", "/work/two-wt"),
+                ]))
+        let gate = ScriptedTransportCallGate()
+        await transport.gateNextWorktreeAuthorization(using: gate)
+        let store = makeStore(transports: [host.id: transport])
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("both Agents should arrive") { store.agents.count == 2 }
+        let one = try #require(store.agents.first { $0.agent.workspaceID == "w1" })
+        let two = try #require(store.agents.first { $0.agent.workspaceID == "w2" })
+        let requestOne = WorktreeRemovalRequest(
+            identity: WorktreeIdentity(
+                hostID: host.id,
+                workspaceID: "w1",
+                checkout: try #require(one.repositoryCheckout)))
+        let requestTwo = WorktreeRemovalRequest(
+            identity: WorktreeIdentity(
+                hostID: host.id,
+                workspaceID: "w2",
+                checkout: try #require(two.repositoryCheckout)))
+        let first = Task { try await store.removeWorktree(requestOne, on: host.id) }
+        try await waitUntil("the first request should wait at authorization") {
+            await gate.entryCount == 1
+        }
+
+        await #expect(throws: WorktreeRemovalError.alreadyInProgress) {
+            try await store.removeWorktree(requestOne, on: host.id)
+        }
+        let second = Task { try await store.removeWorktree(requestTwo, on: host.id) }
+        await gate.open()
+        _ = try await first.value
+        _ = try await second.value
+
+        let requests = await transport.removedWorktreeRequests
+        #expect(requests.count == 2)
+        #expect(Set(requests) == [requestOne, requestTwo])
+        store.setHosts([])
+    }
+
+    @Test func serverAndTransportFailuresHaveDeterministicOutcomes() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: linkedWorktreeSnapshot(workspaces: [("w1", "one", "/work/one-wt")]))
+        let store = makeStore(transports: [host.id: transport])
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the Agent should arrive") { store.agents.count == 1 }
+        let agent = try #require(store.agents.first)
+        let checkout = try #require(agent.repositoryCheckout)
+
+        await transport.setWorktreeRemoveFailure(
+            HerdrAPIError(code: "dirty_worktree_requires_force", message: "dirty"))
+        let rejected = WorktreeRemovalRequest(
+            identity: WorktreeIdentity(
+                hostID: host.id, workspaceID: "w1", checkout: checkout))
+        await #expect(throws: HerdrAPIError.self) {
+            try await store.removeWorktree(rejected, on: host.id)
+        }
+        #expect(store.removedWorktreesByAgent.isEmpty)
+
+        await transport.setWorktreeRemoveFailure(TransportError.timedOut)
+        await transport.setSnapshot(.fixture())
+        let uncertain = WorktreeRemovalRequest(
+            identity: WorktreeIdentity(
+                hostID: host.id, workspaceID: "w1", checkout: checkout))
+        await #expect(throws: WorktreeRemovalError.outcomeUnconfirmed) {
+            try await store.removeWorktree(uncertain, on: host.id)
+        }
+        try await waitUntil("a newer absent snapshot should resolve the exact removal") {
+            store.removedWorktreesByAgent[agent.id]?.request == uncertain
+        }
+        store.setHosts([])
+    }
+
+    private func linkedWorktreeSnapshot(
+        workspaces: [(id: String, name: String, path: String)]
+    ) -> SessionSnapshot {
+        .fixture(
+            agents: workspaces.map {
+                .fixture(paneID: "\($0.id):p1", workspaceID: $0.id)
+            },
+            workspaces: workspaces.map {
+                .fixture(
+                    workspaceID: $0.id,
+                    label: $0.name,
+                    repoName: $0.name,
+                    checkoutPath: $0.path,
+                    isLinkedWorktree: true)
+            })
+    }
+
     /// A store whose session factory hands each Host the next transport in
     /// its scripted sequence, so tests can drive SSH-level replacement.
     private func makeStore(transportQueues: [Host.ID: TransportQueue]) -> ConsoleStore {

--- a/Tests/HeelerTests/ConsoleStoreTests.swift
+++ b/Tests/HeelerTests/ConsoleStoreTests.swift
@@ -1433,14 +1433,19 @@ struct ConsoleStoreTests {
         let request = WorktreeRemovalRequest(
             identity: WorktreeIdentity(
                 hostID: host.id, workspaceID: "w1", checkout: checkout))
+        let unaffected = try #require(store.agents.first { $0.agent.workspaceID == "w2" })
+        await transport.setSnapshot(
+            linkedWorktreeSnapshot(workspaces: [("w2", "two", "/work/two-wt")]))
 
         let receipt = try await store.removeWorktree(request, on: host.id)
 
         #expect(await transport.removedWorktreeRequests == [request])
         #expect(receipt.affectedAgentIDs == [first.id])
-        #expect(store.removedWorktreesByAgent[first.id] == receipt)
-        let unaffected = try #require(store.agents.first { $0.agent.workspaceID == "w2" })
-        #expect(store.removedWorktreesByAgent[unaffected.id] == nil)
+        try await waitUntil("the post-removal snapshot should retain only the unaffected Agent") {
+            store.agents.map(\.id) == [unaffected.id]
+                && store.removedWorktreesByAgent[first.id] == receipt
+                && store.removedWorktreesByAgent[unaffected.id] == nil
+        }
         store.setHosts([])
     }
 
@@ -1545,6 +1550,66 @@ struct ConsoleStoreTests {
             store.agents.first?.repositoryCheckout == agent.repositoryCheckout
                 && store.removedWorktreesByAgent[agent.id] == nil
         }
+        store.setHosts([])
+    }
+
+    @Test func staleInflightSnapshotCannotPruneNewRemovalReceipt() async throws {
+        let host = Host.fixture()
+        let linked = linkedWorktreeSnapshot(
+            workspaces: [("w1", "one", "/work/one-wt")])
+        let transport = ScriptedTransport(snapshot: linked)
+        let store = makeStore(transports: [host.id: transport])
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the pane subscription should settle") {
+            await transport.capturedSubscriptions.last?.contains(
+                .pane(.agentStatusChanged, paneID: "w1:p1")) == true
+        }
+        let agent = try #require(store.agents.first)
+        let request = WorktreeRemovalRequest(
+            identity: WorktreeIdentity(
+                hostID: host.id,
+                workspaceID: "w1",
+                checkout: try #require(agent.repositoryCheckout)))
+
+        let staleSnapshotGate = ScriptedTransportCallGate()
+        await transport.gateNextSnapshot(using: staleSnapshotGate)
+        #expect(
+            await transport.emit(
+                HerdrEvent(
+                    kind: GlobalEventKind.workspaceMetadataUpdated.kind,
+                    data: .object([:]))) == true)
+        try await waitUntil("the pre-removal snapshot should be in flight") {
+            await staleSnapshotGate.entryCount == 1
+        }
+
+        let convergenceSnapshotGate = ScriptedTransportCallGate()
+        await transport.setSnapshot(.fixture())
+        await transport.gateNextSnapshot(using: convergenceSnapshotGate)
+        let receipt = try await store.removeWorktree(request, on: host.id)
+        #expect(store.removedWorktreesByAgent[agent.id] == receipt)
+
+        await staleSnapshotGate.open()
+        try await waitUntil("the post-removal convergence snapshot should start") {
+            await convergenceSnapshotGate.entryCount == 1
+        }
+        #expect(store.agents.first?.repositoryCheckout == agent.repositoryCheckout)
+        #expect(store.removedWorktreesByAgent[agent.id] == receipt)
+        #expect(
+            RemovedWorktreeSelection.receipt(
+                for: agent.id,
+                agents: store.agents,
+                receipts: store.removedWorktreesByAgent) == receipt)
+
+        await convergenceSnapshotGate.open()
+        try await waitUntil("the post-removal snapshot should converge") {
+            store.agents.isEmpty && store.removedWorktreesByAgent[agent.id] == receipt
+        }
+        #expect(
+            RemovedWorktreeSelection.receipt(
+                for: agent.id,
+                agents: store.agents,
+                receipts: store.removedWorktreesByAgent) == receipt)
         store.setHosts([])
     }
 

--- a/Tests/HeelerTests/ConsoleStoreTests.swift
+++ b/Tests/HeelerTests/ConsoleStoreTests.swift
@@ -56,7 +56,7 @@ struct ConsoleStoreTests {
             hostName: hostName,
             agent: Agent(.fixture(paneID: paneID, status: status)),
             workspaceLabel: workspaceLabel,
-            repoName: nil)
+            repositoryCheckout: nil)
     }
 
     private func makePinDefaults() throws -> (UserDefaults, cleanup: () -> Void) {
@@ -1483,6 +1483,68 @@ struct ConsoleStoreTests {
         }
         #expect(await transport.removedWorktreeRequests.isEmpty)
         #expect(store.removedWorktreesByAgent.isEmpty)
+        store.setHosts([])
+    }
+
+    @Test func canonicalizedRemovalPathDoesNotOverrideWorkspaceIdentity() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(
+            snapshot: linkedWorktreeSnapshot(workspaces: [("w1", "one", "/var/work/one-wt")]))
+        await transport.setWorktreeRemoveResponsePath("/private/var/work/one-wt")
+        let store = makeStore(transports: [host.id: transport])
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the linked-worktree Agent should arrive") {
+            store.agents.first?.isLinkedWorktree == true
+        }
+        let agent = try #require(store.agents.first)
+        let request = WorktreeRemovalRequest(
+            identity: WorktreeIdentity(
+                hostID: host.id,
+                workspaceID: "w1",
+                checkout: try #require(agent.repositoryCheckout)))
+
+        let receipt = try await store.removeWorktree(request, on: host.id)
+
+        #expect(receipt.request == request)
+        #expect(await transport.removedWorktreeRequests == [request])
+        store.setHosts([])
+    }
+
+    @Test func laterSnapshotPrunesReceiptForRecreatedExactIdentity() async throws {
+        let host = Host.fixture()
+        let linked = linkedWorktreeSnapshot(
+            workspaces: [("w1", "one", "/work/one-wt")])
+        let transport = ScriptedTransport(snapshot: linked)
+        let store = makeStore(transports: [host.id: transport])
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the original linked-worktree Agent should arrive") {
+            store.agents.first?.isLinkedWorktree == true
+        }
+        let agent = try #require(store.agents.first)
+        let request = WorktreeRemovalRequest(
+            identity: WorktreeIdentity(
+                hostID: host.id,
+                workspaceID: "w1",
+                checkout: try #require(agent.repositoryCheckout)))
+        await transport.setSnapshot(.fixture())
+
+        _ = try await store.removeWorktree(request, on: host.id)
+        try await waitUntil("the absent snapshot should retain the removal receipt") {
+            store.agents.isEmpty && store.removedWorktreesByAgent[agent.id]?.request == request
+        }
+
+        await transport.setSnapshot(linked)
+        #expect(
+            await transport.emit(
+                HerdrEvent(
+                    kind: GlobalEventKind.workspaceMetadataUpdated.kind,
+                    data: .object([:]))) == true)
+        try await waitUntil("the recreated exact identity should clear the old receipt") {
+            store.agents.first?.repositoryCheckout == agent.repositoryCheckout
+                && store.removedWorktreesByAgent[agent.id] == nil
+        }
         store.setHosts([])
     }
 

--- a/Tests/HeelerTests/GeneratedWireTypesTests.swift
+++ b/Tests/HeelerTests/GeneratedWireTypesTests.swift
@@ -177,6 +177,18 @@ import Testing
         #expect(response.forced == false)
     }
 
+    @Test func worktreeListResponseRoundTripsNamedAndDetachedEntries() throws {
+        let json = #"{"type":"worktree_list","source":{"repo_key":"/Users/u/Heeler/.git","repo_name":"Heeler","repo_root":"/Users/u/Heeler","source_checkout_path":"/Users/u/Heeler","source_workspace_id":"wV"},"worktrees":[{"path":"/Users/u/Heeler","branch":"main","is_bare":false,"is_detached":false,"is_prunable":false,"is_linked_worktree":false,"label":"Heeler","open_workspace_id":"wV"},{"path":"/Users/u/wt/Heeler/feat-x","branch":null,"is_bare":false,"is_detached":true,"is_prunable":false,"is_linked_worktree":true,"label":"Heeler","open_workspace_id":"w15"}]}"#
+
+        let response = try roundTrip(WorktreeListResponse.self, json)
+
+        #expect(response.source.repoKey == "/Users/u/Heeler/.git")
+        #expect(response.worktrees[0].branch == "main")
+        #expect(response.worktrees[1].branch == nil)
+        #expect(response.worktrees[1].isDetached)
+        #expect(response.worktrees[1].openWorkspaceID == "w15")
+    }
+
     @Test func okResponseDecodes() throws {
         // The bare-acknowledgement result shape (`pane.close`).
         _ = try roundTrip(OkResponse.self, #"{"type":"ok"}"#)

--- a/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
@@ -697,6 +697,75 @@ struct HeelerSSHTransportBehaviorE2ETests {
         #expect(recorded[2] == #"worktree.remove {"workspace_id":"workspace:\#(token)"}"#)
     }
 
+    @Test("confirmed worktree removal crosses the real wire dispatch seam")
+    func confirmedWorktreeRemovalCrossesTheRealWireDispatchSeam() async throws {
+        let environment = try #require(HeelerSSHTransportBehaviorEnvironment.current)
+        let transport = try await HeelerSSHTransport.connect(
+            settings: environment.directSettings())
+        defer { Task { try? await transport.close() } }
+
+        let token = Self.scriptToken("remove")
+        let checkout = RepositoryCheckout(
+            repoKey: "/tmp/repo/.git",
+            repoName: "repo",
+            repoRoot: "/tmp/repo",
+            checkoutPath: "/tmp/worktree/\(token)",
+            isLinkedWorktree: true)
+        let request = WorktreeRemovalRequest(
+            identity: WorktreeIdentity(
+                hostID: UUID(),
+                workspaceID: "workspace:\(token)",
+                checkout: checkout))
+        let boundary = WorktreeWireBoundaryRecorder()
+
+        let response = try await transport.removeWorktree(
+            request,
+            authorize: { candidate in await boundary.authorize(candidate) },
+            onDispatched: { candidate in await boundary.recordDispatch(candidate) })
+
+        #expect(response.workspaceID == request.identity.workspaceID)
+        #expect(response.path == request.identity.checkoutPath)
+        #expect(await boundary.authorized == [request])
+        #expect(await boundary.dispatched == [request])
+        let recorded = try await Self.recordedRequests(from: transport, token: token)
+        #expect(
+            recorded == [
+                #"worktree.remove {"force":false,"workspace_id":"workspace:\#(token)"}"#
+            ])
+    }
+
+    @Test("stale worktree authorization writes no request bytes")
+    func staleWorktreeAuthorizationWritesNoRequestBytes() async throws {
+        let environment = try #require(HeelerSSHTransportBehaviorEnvironment.current)
+        let transport = try await HeelerSSHTransport.connect(
+            settings: environment.directSettings())
+        defer { Task { try? await transport.close() } }
+
+        let token = Self.scriptToken("stale")
+        let checkout = RepositoryCheckout(
+            repoKey: "/tmp/repo/.git",
+            repoName: "repo",
+            repoRoot: "/tmp/repo",
+            checkoutPath: "/tmp/worktree/\(token)",
+            isLinkedWorktree: true)
+        let request = WorktreeRemovalRequest(
+            identity: WorktreeIdentity(
+                hostID: UUID(),
+                workspaceID: "workspace:\(token)",
+                checkout: checkout))
+        let boundary = WorktreeWireBoundaryRecorder()
+
+        await #expect(throws: WorktreeRemovalError.staleIdentity) {
+            _ = try await transport.removeWorktree(
+                request,
+                authorize: { _ in throw WorktreeRemovalError.staleIdentity },
+                onDispatched: { candidate in await boundary.recordDispatch(candidate) })
+        }
+
+        #expect(await boundary.dispatched.isEmpty)
+        #expect(try await Self.recordedRequests(from: transport, token: token).isEmpty)
+    }
+
     /// A launch started from another agent's screen carries that agent's
     /// directory. Dropping the cwd is invisible in the reply — herdr answers
     /// with a healthy tab either way — so only the request proves it went.
@@ -1356,6 +1425,19 @@ struct HeelerSSHTransportBehaviorE2ETests {
     private func connectionCount(from transport: HeelerSSHTransport) async throws -> Int {
         let session = try #require(try await transport.listSessions().first)
         return try #require(Int(session.name.dropFirst("count-".count)))
+    }
+}
+
+private actor WorktreeWireBoundaryRecorder {
+    private(set) var authorized: [WorktreeRemovalRequest] = []
+    private(set) var dispatched: [WorktreeRemovalRequest] = []
+
+    func authorize(_ request: WorktreeRemovalRequest) {
+        authorized.append(request)
+    }
+
+    func recordDispatch(_ request: WorktreeRemovalRequest) {
+        dispatched.append(request)
     }
 }
 

--- a/Tests/HeelerTests/HostLiveActivityCoordinatorTests.swift
+++ b/Tests/HeelerTests/HostLiveActivityCoordinatorTests.swift
@@ -87,7 +87,7 @@ struct HostLiveActivityCoordinatorTests {
         ConsoleAgent(
             hostID: host.id, hostName: "mbp",
             agent: Agent(.fixture(paneID: paneID, status: status, title: title)),
-            workspaceLabel: nil, repoName: nil)
+            workspaceLabel: nil, repositoryCheckout: nil)
     }
 
     private func waitUntil(

--- a/Tests/HeelerTests/Support/ScriptedTransport.swift
+++ b/Tests/HeelerTests/Support/ScriptedTransport.swift
@@ -31,6 +31,7 @@ final actor ScriptedTransport: Transport {
     private var worktreeListResponse: WorktreeListResponse?
     private var worktreeListFailure: (any Error)?
     private var worktreeRemoveFailure: (any Error)?
+    private var worktreeRemoveResponsePath: String?
     private var nextWorktreeAuthorizationGate: ScriptedTransportCallGate?
     /// Every `agent.rename` / `workspace.rename` received, in order; the
     /// rename flows (#98) assert on the params they forwarded.
@@ -179,6 +180,10 @@ final actor ScriptedTransport: Transport {
 
     func setWorktreeRemoveFailure(_ failure: (any Error)?) {
         worktreeRemoveFailure = failure
+    }
+
+    func setWorktreeRemoveResponsePath(_ path: String?) {
+        worktreeRemoveResponsePath = path
     }
 
     func gateNextWorktreeAuthorization(using gate: ScriptedTransportCallGate) {
@@ -430,7 +435,7 @@ final actor ScriptedTransport: Transport {
         if let worktreeRemoveFailure { throw worktreeRemoveFailure }
         return WorktreeRemovedResponse(
             forced: false,
-            path: request.identity.checkoutPath,
+            path: worktreeRemoveResponsePath ?? request.identity.checkoutPath,
             workspaceID: request.identity.workspaceID)
     }
 

--- a/Tests/HeelerTests/Support/ScriptedTransport.swift
+++ b/Tests/HeelerTests/Support/ScriptedTransport.swift
@@ -26,6 +26,12 @@ final actor ScriptedTransport: Transport {
     /// appends here).
     private(set) var closedPanes: [PaneTarget] = []
     private var closeFailure: TransportError?
+    private(set) var listedWorktreeWorkspaceIDs: [String] = []
+    private(set) var removedWorktreeRequests: [WorktreeRemovalRequest] = []
+    private var worktreeListResponse: WorktreeListResponse?
+    private var worktreeListFailure: (any Error)?
+    private var worktreeRemoveFailure: (any Error)?
+    private var nextWorktreeAuthorizationGate: ScriptedTransportCallGate?
     /// Every `agent.rename` / `workspace.rename` received, in order; the
     /// rename flows (#98) assert on the params they forwarded.
     private(set) var agentRenames: [AgentRenameParams] = []
@@ -162,6 +168,21 @@ final actor ScriptedTransport: Transport {
     /// Makes every subsequent `closePane` throw `failure`.
     func setCloseFailure(_ failure: TransportError?) {
         closeFailure = failure
+    }
+
+    func configureWorktreeList(
+        _ response: WorktreeListResponse?, failure: (any Error)? = nil
+    ) {
+        worktreeListResponse = response
+        worktreeListFailure = failure
+    }
+
+    func setWorktreeRemoveFailure(_ failure: (any Error)?) {
+        worktreeRemoveFailure = failure
+    }
+
+    func gateNextWorktreeAuthorization(using gate: ScriptedTransportCallGate) {
+        nextWorktreeAuthorizationGate = gate
     }
 
     /// Makes every subsequent rename (agent or workspace) throw `failure`.
@@ -384,6 +405,33 @@ final actor ScriptedTransport: Transport {
     func closePane(_ params: PaneTarget) async throws {
         if let closeFailure { throw closeFailure }
         closedPanes.append(params)
+    }
+
+    func listWorktrees(forWorkspaceID workspaceID: String) async throws -> WorktreeListResponse {
+        listedWorktreeWorkspaceIDs.append(workspaceID)
+        if let worktreeListFailure { throw worktreeListFailure }
+        guard let worktreeListResponse else {
+            throw TransportError.channelFailed(detail: "no worktree list scripted")
+        }
+        return worktreeListResponse
+    }
+
+    func removeWorktree(
+        _ request: WorktreeRemovalRequest,
+        authorize: @escaping @Sendable (WorktreeRemovalRequest) async throws -> Void,
+        onDispatched: @escaping @Sendable (WorktreeRemovalRequest) async -> Void
+    ) async throws -> WorktreeRemovedResponse {
+        let gate = nextWorktreeAuthorizationGate
+        nextWorktreeAuthorizationGate = nil
+        await gate?.waitUntilOpen()
+        try await authorize(request)
+        removedWorktreeRequests.append(request)
+        await onDispatched(request)
+        if let worktreeRemoveFailure { throw worktreeRemoveFailure }
+        return WorktreeRemovedResponse(
+            forced: false,
+            path: request.identity.checkoutPath,
+            workspaceID: request.identity.workspaceID)
     }
 
     func renameAgent(_ params: AgentRenameParams) async throws {
@@ -636,14 +684,19 @@ extension AgentInfo {
 
 extension WorkspaceInfo {
     static func fixture(
-        workspaceID: String, label: String, repoName: String? = nil
+        workspaceID: String,
+        label: String,
+        repoName: String? = nil,
+        checkoutPath: String? = nil,
+        isLinkedWorktree: Bool = false
     ) -> WorkspaceInfo {
         WorkspaceInfo(
             activeTabID: "\(workspaceID):t1", agentStatus: .unknown, focused: false,
             label: label, number: 1, paneCount: 1, tabCount: 1, workspaceID: workspaceID,
             worktree: repoName.map { name in
                 WorkspaceWorktreeInfo(
-                    checkoutPath: "/work/\(name)", isLinkedWorktree: false,
+                    checkoutPath: checkoutPath ?? "/work/\(name)",
+                    isLinkedWorktree: isLinkedWorktree,
                     repoKey: "/work/\(name)/.git", repoName: name, repoRoot: "/work/\(name)")
             })
     }

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -25,7 +25,14 @@ struct TerminalAgentSwitcherTests {
                 status: status, workspaceID: "w", tabID: "w:t", paneID: pane,
                 cwd: "/work", revision: 1, name: name),
             workspaceLabel: workspace,
-            repoName: repo,
+            repositoryCheckout: repo.map {
+                RepositoryCheckout(
+                    repoKey: "/work/\($0)/.git",
+                    repoName: $0,
+                    repoRoot: "/work/\($0)",
+                    checkoutPath: "/work/\($0)",
+                    isLinkedWorktree: false)
+            },
             lastOutputSnippet: nil)
     }
 

--- a/Tests/HeelerTests/WorktreeDetailStoreTests.swift
+++ b/Tests/HeelerTests/WorktreeDetailStoreTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@MainActor
+@Suite("Worktree detail store")
+struct WorktreeDetailStoreTests {
+    @Test func snapshotMetadataAndScopedListPresentTheBranch() async {
+        let recorder = WorktreeRemoveRecorder()
+        let store = makeStore(
+            list: { workspaceID in
+                #expect(workspaceID == "w1")
+                return Self.list(branch: "feat/issue-99")
+            },
+            remove: { request in
+                await recorder.record(request)
+                return WorktreeRemovalReceipt(
+                    request: request, affectedAgentIDs: [])
+            })
+
+        await store.loadBranchIfNeeded()
+
+        #expect(store.checkout.repoName == "Heeler")
+        #expect(store.checkout.checkoutPath == "/work/Heeler-wt")
+        #expect(store.branch == .named("feat/issue-99"))
+    }
+
+    @Test func cancelLeavesStateUnchangedAndSendsNoRemoval() async {
+        let recorder = WorktreeRemoveRecorder()
+        let store = makeStore(
+            list: { _ in Self.list(branch: "feat/issue-99") },
+            remove: { request in
+                await recorder.record(request)
+                return WorktreeRemovalReceipt(request: request, affectedAgentIDs: [])
+            })
+
+        store.prepareConfirmation()
+        store.cancelConfirmation()
+
+        #expect(store.confirmation == nil)
+        #expect(store.removalPhase == .idle)
+        #expect(await recorder.requests.isEmpty)
+    }
+
+    @Test func rapidRepeatedConfirmationDispatchesExactlyOnce() async throws {
+        let gate = ScriptedTransportCallGate()
+        let recorder = WorktreeRemoveRecorder()
+        let store = makeStore(
+            list: { _ in Self.list(branch: "feat/issue-99") },
+            remove: { request in
+                await recorder.record(request)
+                await gate.waitUntilOpen()
+                return WorktreeRemovalReceipt(request: request, affectedAgentIDs: [])
+            })
+        store.prepareConfirmation()
+
+        let first = Task { await store.confirmRemoval() }
+        try await waitUntil("the first removal should start") {
+            await recorder.requests.count == 1
+        }
+        await store.confirmRemoval()
+        #expect(await recorder.requests.count == 1)
+        await gate.open()
+        await first.value
+        guard case .removed = store.removalPhase else {
+            Issue.record("removal should succeed")
+            return
+        }
+    }
+
+    @Test func serverFailureStaysOnTheDetailAndCanRetry() async {
+        let store = makeStore(
+            list: { _ in Self.list(branch: "feat/issue-99") },
+            remove: { _ in
+                throw HerdrAPIError(
+                    code: "dirty_worktree_requires_force",
+                    message: "dirty")
+            })
+        store.prepareConfirmation()
+
+        await store.confirmRemoval()
+
+        guard case .failed(let message) = store.removalPhase else {
+            Issue.record("server rejection should be a stable failure")
+            return
+        }
+        #expect(message.contains("modified or untracked files"))
+        store.dismissFeedback()
+        #expect(store.removalPhase == .idle)
+    }
+
+    @Test func transportUncertaintyIsNotReportedAsSuccess() async {
+        let store = makeStore(
+            list: { _ in Self.list(branch: nil, detached: true) },
+            remove: { _ in throw WorktreeRemovalError.outcomeUnconfirmed })
+        store.prepareConfirmation()
+
+        await store.confirmRemoval()
+
+        #expect(store.removalPhase == .unconfirmed)
+    }
+
+    @Test func staleConfirmationFailsClosedUntilTheDetailIsReopened() async {
+        let store = makeStore(
+            list: { _ in Self.list(branch: "feat/old") },
+            remove: { _ in throw WorktreeRemovalError.staleIdentity })
+        store.prepareConfirmation()
+
+        await store.confirmRemoval()
+
+        #expect(store.removalPhase == .stale(WorktreeRemovalError.staleIdentity.message))
+        store.dismissFeedback()
+        #expect(!store.canRemove)
+    }
+
+    private func makeStore(
+        list: @escaping (String) async throws -> WorktreeListResponse,
+        remove: @escaping (WorktreeRemovalRequest) async throws -> WorktreeRemovalReceipt
+    ) -> WorktreeDetailStore {
+        let checkout = RepositoryCheckout(
+            repoKey: "/work/Heeler/.git",
+            repoName: "Heeler",
+            repoRoot: "/work/Heeler",
+            checkoutPath: "/work/Heeler-wt",
+            isLinkedWorktree: true)
+        return WorktreeDetailStore(
+            request: WorktreeRemovalRequest(
+                identity: WorktreeIdentity(
+                    hostID: UUID(), workspaceID: "w1", checkout: checkout)),
+            workspaceLabel: "issue-99",
+            checkout: checkout,
+            list: list,
+            remove: remove,
+            hasWorkingAgent: { true })
+    }
+
+    private static func list(
+        branch: String?, detached: Bool = false
+    ) -> WorktreeListResponse {
+        WorktreeListResponse(
+            source: WorktreeSourceInfo(
+                repoKey: "/work/Heeler/.git",
+                repoName: "Heeler",
+                repoRoot: "/work/Heeler",
+                sourceCheckoutPath: "/work/Heeler"),
+            worktrees: [
+                WorktreeInfo(
+                    isBare: false,
+                    isDetached: detached,
+                    isLinkedWorktree: true,
+                    isPrunable: false,
+                    label: "issue-99",
+                    path: "/work/Heeler-wt",
+                    branch: branch,
+                    openWorkspaceID: "w1")
+            ])
+    }
+
+    private func waitUntil(
+        _ comment: Comment,
+        condition: () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await condition(), comment)
+    }
+}
+
+private actor WorktreeRemoveRecorder {
+    private(set) var requests: [WorktreeRemovalRequest] = []
+
+    func record(_ request: WorktreeRemovalRequest) {
+        requests.append(request)
+    }
+}

--- a/Tests/HeelerTests/WorktreeDetailStoreTests.swift
+++ b/Tests/HeelerTests/WorktreeDetailStoreTests.swift
@@ -54,12 +54,14 @@ struct WorktreeDetailStoreTests {
                 return WorktreeRemovalReceipt(request: request, affectedAgentIDs: [])
             })
         store.prepareConfirmation()
+        let request = try #require(store.beginRemoval())
+        #expect(store.beginRemoval() == nil)
 
-        let first = Task { await store.confirmRemoval() }
+        let first = Task { await store.finishRemoval(request) }
         try await waitUntil("the first removal should start") {
             await recorder.requests.count == 1
         }
-        await store.confirmRemoval()
+        await store.finishRemoval(request)
         #expect(await recorder.requests.count == 1)
         await gate.open()
         await first.value
@@ -69,7 +71,28 @@ struct WorktreeDetailStoreTests {
         }
     }
 
-    @Test func serverFailureStaysOnTheDetailAndCanRetry() async {
+    @Test func dialogDismissalAfterActionCannotClearCapturedRemoval() async throws {
+        let recorder = WorktreeRemoveRecorder()
+        let store = makeStore(
+            list: { _ in Self.list(branch: "feat/issue-99") },
+            remove: { request in
+                await recorder.record(request)
+                return WorktreeRemovalReceipt(request: request, affectedAgentIDs: [])
+            })
+        store.prepareConfirmation()
+
+        // The button action runs synchronously, then SwiftUI may dismiss the
+        // dialog through its binding before the queued Task begins.
+        let request = try #require(store.beginRemoval())
+        store.cancelConfirmation()
+        await store.finishRemoval(request)
+
+        #expect(await recorder.requests == [request])
+        #expect(store.removalPhase == .removed(
+            WorktreeRemovalReceipt(request: request, affectedAgentIDs: [])))
+    }
+
+    @Test func serverFailureStaysOnTheDetailAndCanRetry() async throws {
         let store = makeStore(
             list: { _ in Self.list(branch: "feat/issue-99") },
             remove: { _ in
@@ -78,8 +101,9 @@ struct WorktreeDetailStoreTests {
                     message: "dirty")
             })
         store.prepareConfirmation()
+        let request = try #require(store.beginRemoval())
 
-        await store.confirmRemoval()
+        await store.finishRemoval(request)
 
         guard case .failed(let message) = store.removalPhase else {
             Issue.record("server rejection should be a stable failure")
@@ -90,28 +114,46 @@ struct WorktreeDetailStoreTests {
         #expect(store.removalPhase == .idle)
     }
 
-    @Test func transportUncertaintyIsNotReportedAsSuccess() async {
+    @Test func transportUncertaintyIsNotReportedAsSuccess() async throws {
         let store = makeStore(
             list: { _ in Self.list(branch: nil, detached: true) },
             remove: { _ in throw WorktreeRemovalError.outcomeUnconfirmed })
         store.prepareConfirmation()
+        let request = try #require(store.beginRemoval())
 
-        await store.confirmRemoval()
+        await store.finishRemoval(request)
 
         #expect(store.removalPhase == .unconfirmed)
     }
 
-    @Test func staleConfirmationFailsClosedUntilTheDetailIsReopened() async {
+    @Test func staleConfirmationFailsClosedUntilTheDetailIsReopened() async throws {
         let store = makeStore(
             list: { _ in Self.list(branch: "feat/old") },
             remove: { _ in throw WorktreeRemovalError.staleIdentity })
         store.prepareConfirmation()
+        let request = try #require(store.beginRemoval())
 
-        await store.confirmRemoval()
+        await store.finishRemoval(request)
 
         #expect(store.removalPhase == .stale(WorktreeRemovalError.staleIdentity.message))
         store.dismissFeedback()
         #expect(!store.canRemove)
+    }
+
+    @Test func transportCancellationRestoresIdleWithoutFailureFeedback() async throws {
+        let store = makeStore(
+            list: { _ in throw TransportError.cancelled },
+            remove: { _ in throw TransportError.cancelled })
+
+        await store.loadBranchIfNeeded()
+        #expect(store.branch == .loading)
+
+        store.prepareConfirmation()
+        let request = try #require(store.beginRemoval())
+        await store.finishRemoval(request)
+
+        #expect(store.removalPhase == .idle)
+        #expect(!store.showsFeedback)
     }
 
     private func makeStore(

--- a/Tests/HeelerTests/WorktreeRemovalTests.swift
+++ b/Tests/HeelerTests/WorktreeRemovalTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@Suite("Worktree removal value model")
+struct WorktreeRemovalTests {
+    @Test func identityRequiresRepositoryAndCheckoutPath() {
+        let hostID = UUID()
+        let checkout = RepositoryCheckout(
+            repoKey: "/repo/.git", repoName: "repo", repoRoot: "/repo",
+            checkoutPath: "/wt/one", isLinkedWorktree: true)
+        let identity = WorktreeIdentity(
+            hostID: hostID, workspaceID: "w1", checkout: checkout)
+
+        #expect(identity.matches(checkout))
+        #expect(
+            !identity.matches(
+                RepositoryCheckout(
+                    repoKey: "/repo/.git", repoName: "repo", repoRoot: "/repo",
+                    checkoutPath: "/wt/two", isLinkedWorktree: true)))
+        #expect(
+            !identity.matches(
+                RepositoryCheckout(
+                    repoKey: "/repo/.git", repoName: "repo", repoRoot: "/repo",
+                    checkoutPath: "/wt/one", isLinkedWorktree: false)))
+    }
+
+    @Test func onlySnapshotLinkedCheckoutsAreEligibleForTheBadgeAndAction() {
+        let hostID = UUID()
+        let agent = Agent(
+            terminalID: "term", kind: "codex", title: "task", status: .idle,
+            workspaceID: "w1", tabID: "w1:t1", paneID: "w1:p1",
+            cwd: "/repo", revision: 1)
+        let mainCheckout = ConsoleAgent(
+            hostID: hostID,
+            hostName: "host",
+            agent: agent,
+            workspaceLabel: "repo",
+            repositoryCheckout: RepositoryCheckout(
+                repoKey: "/repo/.git", repoName: "repo", repoRoot: "/repo",
+                checkoutPath: "/repo", isLinkedWorktree: false))
+        let linked = ConsoleAgent(
+            hostID: hostID,
+            hostName: "host",
+            agent: agent,
+            workspaceLabel: "repo-wt",
+            repositoryCheckout: RepositoryCheckout(
+                repoKey: "/repo/.git", repoName: "repo", repoRoot: "/repo",
+                checkoutPath: "/wt/repo", isLinkedWorktree: true))
+
+        #expect(!mainCheckout.isLinkedWorktree)
+        #expect(linked.isLinkedWorktree)
+    }
+
+    @Test func confirmationNamesBlastRadiusAndPreservedBranch() {
+        let checkout = RepositoryCheckout(
+            repoKey: "/repo/.git", repoName: "repo", repoRoot: "/repo",
+            checkoutPath: "/wt/one", isLinkedWorktree: true)
+        let request = WorktreeRemovalRequest(
+            identity: WorktreeIdentity(
+                hostID: UUID(), workspaceID: "w1", checkout: checkout))
+
+        let confirmation = WorktreeRemovalConfirmation.make(
+            request: request,
+            workspaceLabel: "issue-99",
+            branch: .named("feat/issue-99"),
+            hasWorkingAgent: true)
+
+        #expect(confirmation.request == request)
+        #expect(confirmation.message.contains("ending every Agent and closing every Pane"))
+        #expect(confirmation.message.contains("local branch feat/issue-99 is kept"))
+        #expect(confirmation.message.contains("An Agent is still working"))
+    }
+
+    @Test func resultSurfaceMatchesAffectedAbsentSelectionExactly() {
+        let hostID = UUID()
+        let selectedID = ConsoleAgent.ID(hostID: hostID, paneID: "w1:p1")
+        let otherID = ConsoleAgent.ID(hostID: hostID, paneID: "w2:p1")
+        let checkout = RepositoryCheckout(
+            repoKey: "/repo/.git", repoName: "repo", repoRoot: "/repo",
+            checkoutPath: "/wt/one", isLinkedWorktree: true)
+        let receipt = WorktreeRemovalReceipt(
+            request: WorktreeRemovalRequest(
+                identity: WorktreeIdentity(
+                    hostID: hostID, workspaceID: "w1", checkout: checkout)),
+            affectedAgentIDs: [selectedID])
+
+        #expect(
+            RemovedWorktreeSelection.receipt(
+                for: selectedID, agents: [], receipts: [selectedID: receipt]) == receipt)
+        #expect(
+            RemovedWorktreeSelection.receipt(
+                for: otherID, agents: [], receipts: [selectedID: receipt]) == nil)
+
+        let stillProjected = ConsoleAgent(
+            hostID: hostID,
+            hostName: "host",
+            agent: Agent(
+                terminalID: "term", kind: "codex", title: "task", status: .idle,
+                workspaceID: "w1", tabID: "w1:t1", paneID: "w1:p1",
+                cwd: "/wt/one", revision: 1),
+            workspaceLabel: "one",
+            repositoryCheckout: checkout)
+        #expect(
+            RemovedWorktreeSelection.receipt(
+                for: selectedID,
+                agents: [stillProjected],
+                receipts: [selectedID: receipt]) == receipt)
+    }
+
+    @Test func reusedPaneSelectionDoesNotInheritAnOldRemovalResult() {
+        let hostID = UUID()
+        let selectedID = ConsoleAgent.ID(hostID: hostID, paneID: "w1:p1")
+        let removedCheckout = RepositoryCheckout(
+            repoKey: "/repo/.git", repoName: "repo", repoRoot: "/repo",
+            checkoutPath: "/wt/old", isLinkedWorktree: true)
+        let receipt = WorktreeRemovalReceipt(
+            request: WorktreeRemovalRequest(
+                identity: WorktreeIdentity(
+                    hostID: hostID, workspaceID: "w1", checkout: removedCheckout)),
+            affectedAgentIDs: [selectedID])
+        let replacement = ConsoleAgent(
+            hostID: hostID,
+            hostName: "host",
+            agent: Agent(
+                terminalID: "term", kind: "codex", title: "replacement",
+                status: .idle, workspaceID: "w1", tabID: "w1:t1", paneID: "w1:p1",
+                cwd: "/wt/new", revision: 1),
+            workspaceLabel: "new",
+            repositoryCheckout: RepositoryCheckout(
+                repoKey: "/repo/.git", repoName: "repo", repoRoot: "/repo",
+                checkoutPath: "/wt/new", isLinkedWorktree: true))
+
+        #expect(
+            RemovedWorktreeSelection.receipt(
+                for: selectedID,
+                agents: [replacement],
+                receipts: [selectedID: receipt]) == nil)
+    }
+}

--- a/scripts/generate-wire-types.py
+++ b/scripts/generate-wire-types.py
@@ -63,6 +63,7 @@ METHODS = [
     "session.snapshot",
     "workspace.rename",
     "worktree.create",
+    "worktree.list",
     "worktree.remove",
 ]
 
@@ -94,6 +95,7 @@ RESULT_TAGS = [
     "ok",  # pane.close
     "workspace_info",  # workspace.rename
     "worktree_created",  # worktree.create
+    "worktree_list",  # worktree.list
     "worktree_removed",  # worktree.remove
 ]
 

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -1616,7 +1616,7 @@ fi
 run_suite HeelerSSHPTYE2ETests 3 1
 run_suite HeelerSSHDirectStreamLocalE2ETests 11 1
 run_suite HeelerSSHJumpHostGateE2ETests 9 1
-run_suite HeelerSSHTransportBehaviorE2ETests 46 1
+run_suite HeelerSSHTransportBehaviorE2ETests 48 1
 run_suite ImageStagingE2ETests 8 1
 run_suite WeakNetworkE2ETests 8 1
 run_suite PairingCeremonyE2ETests 11 1
@@ -1654,6 +1654,11 @@ assert_behavior "workspace rename params" HeelerSSHTransportBehaviorE2ETests \
     '"workspace rename sends its label and workspace id exactly"'
 assert_behavior "pane read params and result" HeelerSSHTransportBehaviorE2ETests \
     '"pane read sends exact params and round trips the result"'
+assert_behavior "worktree remove params" HeelerSSHTransportBehaviorE2ETests \
+    '"confirmed worktree removal crosses the real wire dispatch seam"'
+assert_behavior "worktree remove stale authorization writes nothing" \
+    HeelerSSHTransportBehaviorE2ETests \
+    '"stale worktree authorization writes no request bytes"'
 assert_behavior "herdr API rejection" HeelerSSHTransportBehaviorE2ETests \
     '"a herdr error envelope surfaces as a typed API rejection"'
 assert_behavior "session API rejection mapping" HeelerSSHTransportBehaviorE2ETests \


### PR DESCRIPTION
## Summary

- mark linked-worktree Agents in the Console and show repository, branch, and checkout details
- add explicit-confirmation worktree removal with exact identity revalidation at the wire boundary
- keep removal feedback deterministic across concurrent requests, stale snapshots, cancellation, and convergence

## Testing

- `make test`
- focused `ConsoleStoreTests` (55 tests)
- `python3 scripts/generate-wire-types.py --check --schema scripts/herdr-schema.json`
- `git diff --check`

`make test` also ran the HeelerSSH package suite: 9 tests passed and 17 disposable-sshd tests skipped as designed.

Closes #99