### PR TITLE
fix: prevent SSH RPC head-of-line blocking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,9 @@ __pycache__/
 # Local-only notes and experiments
 .local/
 
-# testloop scratch artifacts
-.testloop/
+# testloop scratch artifacts; keep concise run reports as repository history
+.testloop/*
+!.testloop/reports/
 
 # Agent workspace (research reports, scratch)
 .claude/

--- a/.testloop/reports/2026-08-24-broad.md
+++ b/.testloop/reports/2026-08-24-broad.md
@@ -1,0 +1,20 @@
+# testloop — 2026-08-24 — broad
+
+**Verdict:** pass · **Rounds:** 2
+
+## Covered
+
+- Built, installed, and launched Heeler on the dedicated iOS 27.0 Simulator.
+- Exercised the Agents console, Hosts list, and Add Host form without saving.
+- Exercised Settings, Terminal Appearance, and the disabled New Agent flow.
+- Verified the disconnected-Host and no-Agent branches without mutating live data.
+
+## Found & fixed
+
+- None.
+
+## Still open
+
+- None. Computer Use could not reproduce the standard sheet-dismiss drag, but
+  the user confirmed the same Hosts sheet dismisses manually; this was treated
+  as a test-driver limitation rather than a product failure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Entries reference the issue that motivated them.
   authentication failure names the Jump Host rather than the Host, and an
   incompatible herdr protocol tells the user to update herdr. (#163)
 
+### Fixed
+
+- A slow ordinary Host request no longer freezes a live Attach session. (#130)
+
 ## [0.1.1] - 2026-08-20
 
 ### Added

--- a/Packages/HeelerSSH/README.md
+++ b/Packages/HeelerSSH/README.md
@@ -95,9 +95,11 @@ packet-producing `EAGAIN` is the public signal for it, and `send_existing` runs
 before `_libssh2_transport_send` clears that bit, so the report is conservative
 rather than falsely clear.
 
-Only two things end that ownership: the **exact** owning call returning a
-non-`EAGAIN` result after outbound state is clear, or completed whole-session
-invalidation, which frees
+The **exact** owning call decides how ownership ends. A successful
+non-`EAGAIN` result clears ownership even if libssh2's direction bit is stale.
+A negative result clears only when no outbound block remains; with outbound
+still reported, the caller first reads any native error status it needs and
+then invalidates the whole session. Completed invalidation frees
 `session->packet` along with the session. A cancelled or timed-out Swift task
 is not one of them — the native packet outlives it. `_libssh2_channel_write`
 leaves `write_state` at `libssh2_NB_state_created` on `EAGAIN`, so re-calling
@@ -113,11 +115,13 @@ budget expires. A negative non-`EAGAIN` result while libssh2 still reports
 outbound state also invalidates: clearing the owner in that state would admit
 a foreign producer while the native packet may still be pending.
 
-Channel teardown has its own resource transition. As soon as PTY or
-direct-streamlocal close begins, the registry entry stops accepting reads,
-writes, and resizes. Cleanup may still re-resolve that entry across yielded
-turns, but user I/O cannot interleave with close/free on the same native
-channel.
+Channel teardown has its own resource transition. As soon as PTY exit-status,
+PTY close, or direct-streamlocal close begins, the registry entry stops
+accepting reads, writes, and resizes. Cleanup may still re-resolve that entry
+across yielded turns, but user I/O cannot interleave with close/free on the
+same native channel. PTY close waits for an in-flight exit-status handshake;
+if that handshake fails, ordinary PTY I/O is enabled again so the caller can
+retry or close explicitly.
 
 SFTP is a second exception and a stronger one. `struct _LIBSSH2_SFTP`
 (`src/sftp.h`) carries one continuation slot per operation kind —
@@ -159,7 +163,7 @@ display names exactly:
 - `cancelling a yielded one-shot distinguishes cleanup outcomes`
 - `timing out a yielded one-shot distinguishes cleanup outcomes`
 - `invalidation during a yielding wait does not touch a stale native pointer`
-- `yielded channel teardown rejects same-id I/O`
+- `yielded channel teardown rejects same-id I/O and preserves close`
 - `repeated invalidation reclaims every file descriptor`
 - `measurement: Attach throughput with concurrent RPCs`
 - `SFTP operations and close wait out an in-flight handle use`

--- a/Packages/HeelerSSH/README.md
+++ b/Packages/HeelerSSH/README.md
@@ -41,6 +41,108 @@ and signature switches disabled; the small reviewed patch in `Patches/`
 removes SHA-1 key exchange and MAC methods that libssh2 1.11.1 otherwise has no
 build switch for.
 
+## Session scheduling
+
+`SessionDriver` owns one `LIBSSH2_SESSION` and serializes every call into it
+behind one operation mutex. What may release that mutex mid-operation is fixed
+by where libssh2 keeps its non-blocking continuation state, so re-check this
+section against `Sources.lock` whenever libssh2 is bumped.
+
+In 1.11.1 an unfinished channel open is **session** state: `open_state`,
+`open_channel`, `open_packet`, `open_data` and `open_packet_requirev_state`
+drive `_libssh2_channel_open`, and `direct_state` with `direct_message` drives
+both `channel_direct_tcpip` and `channel_direct_streamlocal` — one state
+machine for the two, despite the declaring comment naming only the first. All
+of them are fields of `LIBSSH2_SESSION` in
+`src/libssh2_priv.h`. `_libssh2_channel_open` only builds its request while
+`open_state` is idle, so a second open entered during another's `EAGAIN`
+resumes the first state machine and hands the first call's channel to the
+second caller. Channel opens must not interleave.
+
+Waiting for that serialized open slot is not itself an open attempt. A task
+cancelled or timed out while queued has no uncertain native channel state, so
+it leaves the connection reusable; once its own open call has started, the
+existing whole-session invalidation rule still applies to an interrupted open.
+
+Most of what follows open is **channel** state — `process_state`, `read_state`,
+`write_state`, `close_state`, `wait_eof_state`, `wait_closed_state`,
+`free_state` and `reqPTY_state` all live on `LIBSSH2_CHANNEL` — which is why
+the PTY and long-lived stream-local paths can take one short turn per call.
+Any operation that means to release the mutex between turns has to re-resolve
+its channel by id from a driver registry afterwards: invalidation frees the
+session, `libssh2_session_free` destroys every channel attached to it, and a
+pointer captured before the release would dangle.
+
+Sending is the exception, and it cuts across every channel. The pending
+outbound packet is **session** state: `odata`, `olen`, `osent` and `ototal_num`
+on `struct transportpacket` (`src/libssh2_priv.h`), reached through
+`session->packet`. `_libssh2_transport_send` records them whenever a send could
+not flush the whole packet — including when it sent nothing — and
+`send_existing` refuses any retry whose `data` pointer or length differs, with
+the comment "Address is different, returning EAGAIN" (`src/transport.c`). It
+returns `EAGAIN` without advancing the packet, so a foreign producer can never
+drain it.
+
+The consequence is a livelock, not a slowdown. `_libssh2_channel_write` sends
+from the channel's own `write_packet` buffer, so the owning channel can resume
+across a mutex release; anyone else cannot. If a caller holds the operation
+mutex across its own `EAGAIN` loop while another channel owns a pending packet,
+it spins until its deadline and the owner never gets a turn. Channel open is
+such a caller. Any call that loops on `EAGAIN` while holding the mutex must
+therefore first establish that no other operation is the transport-send owner;
+`libssh2_session_block_directions` reporting an outbound block after a
+packet-producing `EAGAIN` is the public signal for it, and `send_existing` runs
+before `_libssh2_transport_send` clears that bit, so the report is conservative
+rather than falsely clear.
+
+Only two things end that ownership: the **exact** owning call returning
+non-`EAGAIN`, or completed whole-session invalidation, which frees
+`session->packet` along with the session. A cancelled or timed-out Swift task
+is not one of them — the native packet outlives it. `_libssh2_channel_write`
+leaves `write_state` at `libssh2_NB_state_created` on `EAGAIN`, so re-calling
+`libssh2_channel_write_ex` on the same channel resends the same
+`write_packet`/`write_packet_len` and is the only call that can drain it;
+`send_existing` sanity-checks `data` and `data_len` alone and never the payload,
+so a caller that resumes with a different payload buffer gets no diagnostic.
+Before #130, `writePTY` and `writeStreamLocal` threw directly out of their wait,
+so cancellation could strand a packet for the rest of the session's life.
+Cleanup now drives the exact owning call non-cancellably to a non-`EAGAIN`
+result within its reclamation budget, and invalidates the session if that
+budget expires.
+
+SFTP is a second exception and a stronger one. `struct _LIBSSH2_SFTP`
+(`src/sftp.h`) carries one continuation slot per operation kind —
+`mkdir_state`/`mkdir_packet`/`mkdir_request_id`, `stat_*`, `unlink_*`,
+`rename_*`, `fstat_*` and the rest — plus one shared inbound parser
+(`packet_state`, `partial_packet`, `partial_len`, `partial_received`). A second
+call of the same kind resumes the first call's state instead of starting its
+own, so it can combine one request's packet with another's length or deliver
+one call's result into another's output buffer. Re-resolving the handle by id
+does not isolate this, because the id resolves to the same shared state. Every
+call on one SFTP handle stays mutually exclusive for its whole logical
+operation, waits included, and `libssh2_sftp_init` stays serialized on its own
+session-owned `open_state`.
+
+Waits are released session-wide rather than per channel. libssh2 buffers what
+it decrypts, so an operation reading its own channel consumes the packets the
+others are blocked on and the socket keeps no edge to report; `SessionActivity`
+therefore counts receives and wakes every wait armed before the last one. The
+number of wakeups per inbound packet grows with the number of channels parked
+at once, so turn bodies stay small.
+
+## Test lanes
+
+`make test` runs the app suites and then `scripts/run-heelerssh-package-tests.sh`
+for this package's own suites, including `SessionDriverE2ETests`. The local
+package runner asserts only that something executed, not an exact count, so
+machines without the disposable sshd fixture can skip the E2E suite cleanly.
+
+Merge CI runs `scripts/run-ci-ios-tests.sh`, which now also drives the
+`HeelerSSH` package scheme after the app lanes. That package lane pins an
+exact executed count and named tests, including the #130 scheduling
+invariants. Driver-level regressions cannot hide behind the local runner's
+`executed > 0` floor.
+
 ## Direct-streamlocal acceptance
 
 `scripts/run-ci-ios-tests.sh` provisions disposable OpenSSH endpoints and a

--- a/Packages/HeelerSSH/README.md
+++ b/Packages/HeelerSSH/README.md
@@ -151,7 +151,7 @@ package runner asserts only that something executed, not an exact count, so
 machines without the disposable sshd fixture can skip the E2E suite cleanly.
 
 The E2E integration package must update `scripts/run-ci-ios-tests.sh` before
-merge so its package lane expects **42** executed tests and pins these new
+merge so its package lane expects **43** executed tests and pins these new
 display names exactly:
 
 - `outbound backpressure does not livelock a channel open`
@@ -170,6 +170,7 @@ display names exactly:
 - `a serialized channel-open wait honors deadline and cancellation`
 - `an invalidation generation rejects a watch armed before it`
 - `a transport-send owner error with outbound pending invalidates`
+- `a bridge write to a closed peer reports peerClosed`
 
 This core package intentionally does not edit that integration script.
 

--- a/Packages/HeelerSSH/README.md
+++ b/Packages/HeelerSSH/README.md
@@ -95,8 +95,9 @@ packet-producing `EAGAIN` is the public signal for it, and `send_existing` runs
 before `_libssh2_transport_send` clears that bit, so the report is conservative
 rather than falsely clear.
 
-Only two things end that ownership: the **exact** owning call returning
-non-`EAGAIN`, or completed whole-session invalidation, which frees
+Only two things end that ownership: the **exact** owning call returning a
+non-`EAGAIN` result after outbound state is clear, or completed whole-session
+invalidation, which frees
 `session->packet` along with the session. A cancelled or timed-out Swift task
 is not one of them — the native packet outlives it. `_libssh2_channel_write`
 leaves `write_state` at `libssh2_NB_state_created` on `EAGAIN`, so re-calling
@@ -108,7 +109,15 @@ Before #130, `writePTY` and `writeStreamLocal` threw directly out of their wait,
 so cancellation could strand a packet for the rest of the session's life.
 Cleanup now drives the exact owning call non-cancellably to a non-`EAGAIN`
 result within its reclamation budget, and invalidates the session if that
-budget expires.
+budget expires. A negative non-`EAGAIN` result while libssh2 still reports
+outbound state also invalidates: clearing the owner in that state would admit
+a foreign producer while the native packet may still be pending.
+
+Channel teardown has its own resource transition. As soon as PTY or
+direct-streamlocal close begins, the registry entry stops accepting reads,
+writes, and resizes. Cleanup may still re-resolve that entry across yielded
+turns, but user I/O cannot interleave with close/free on the same native
+channel.
 
 SFTP is a second exception and a stronger one. `struct _LIBSSH2_SFTP`
 (`src/sftp.h`) carries one continuation slot per operation kind —
@@ -137,11 +146,28 @@ for this package's own suites, including `SessionDriverE2ETests`. The local
 package runner asserts only that something executed, not an exact count, so
 machines without the disposable sshd fixture can skip the E2E suite cleanly.
 
-Merge CI runs `scripts/run-ci-ios-tests.sh`, which now also drives the
-`HeelerSSH` package scheme after the app lanes. That package lane pins an
-exact executed count and named tests, including the #130 scheduling
-invariants. Driver-level regressions cannot hide behind the local runner's
-`executed > 0` floor.
+The E2E integration package must update `scripts/run-ci-ios-tests.sh` before
+merge so its package lane expects **42** executed tests and pins these new
+display names exactly:
+
+- `outbound backpressure does not livelock a channel open`
+- `cancelling a transport-send owner drains`
+- `cancelling a transport-send owner invalidates`
+- `timing out a transport-send owner at loop-top drains`
+- `timing out a transport-send owner at loop-top invalidates`
+- `one-shot RPCs yield so a live PTY can progress`
+- `cancelling a yielded one-shot distinguishes cleanup outcomes`
+- `timing out a yielded one-shot distinguishes cleanup outcomes`
+- `invalidation during a yielding wait does not touch a stale native pointer`
+- `yielded channel teardown rejects same-id I/O`
+- `repeated invalidation reclaims every file descriptor`
+- `measurement: Attach throughput with concurrent RPCs`
+- `SFTP operations and close wait out an in-flight handle use`
+- `a serialized channel-open wait honors deadline and cancellation`
+- `an invalidation generation rejects a watch armed before it`
+- `a transport-send owner error with outbound pending invalidates`
+
+This core package intentionally does not edit that integration script.
 
 ## Direct-streamlocal acceptance
 

--- a/Packages/HeelerSSH/Sources/CHeelerSSHSupport/SessionAbandon.c
+++ b/Packages/HeelerSSH/Sources/CHeelerSSHSupport/SessionAbandon.c
@@ -2,7 +2,7 @@
 
 #include <errno.h>
 
-static ssize_t heeler_abandoned_send(
+static ssize_t heeler_discarded_send(
     libssh2_socket_t socket,
     const void *buffer,
     size_t length,
@@ -11,11 +11,9 @@ static ssize_t heeler_abandoned_send(
 ) {
     (void)socket;
     (void)buffer;
-    (void)length;
     (void)flags;
     (void)abstract;
-    errno = EPIPE;
-    return -1;
+    return (ssize_t)length;
 }
 
 static ssize_t heeler_abandoned_receive(
@@ -30,8 +28,31 @@ static ssize_t heeler_abandoned_receive(
     (void)length;
     (void)flags;
     (void)abstract;
-    errno = ECONNRESET;
-    return -1;
+    return -ECONNRESET;
+}
+
+void heeler_libssh2_prepare_session_abandonment(LIBSSH2_SESSION *session) {
+    if (session == NULL) {
+        return;
+    }
+
+    /*
+     * A pending transport packet must first be completed by the exact owning
+     * libssh2 call: send_existing rejects a different data pointer with EAGAIN
+     * before invoking this callback. Reporting the owner's remaining bytes as
+     * consumed clears that packet without peer I/O. Fatal receives then keep
+     * channel teardown from waiting for remote close acknowledgements.
+     */
+    libssh2_session_callback_set2(
+        session,
+        LIBSSH2_CALLBACK_SEND,
+        (libssh2_cb_generic *)heeler_discarded_send
+    );
+    libssh2_session_callback_set2(
+        session,
+        LIBSSH2_CALLBACK_RECV,
+        (libssh2_cb_generic *)heeler_abandoned_receive
+    );
 }
 
 int heeler_libssh2_abandon_session(LIBSSH2_SESSION *session) {
@@ -39,22 +60,6 @@ int heeler_libssh2_abandon_session(LIBSSH2_SESSION *session) {
         return LIBSSH2_ERROR_BAD_USE;
     }
 
-    /*
-     * In pinned libssh2 1.11.1, session_free can propagate EAGAIN only while
-     * freeing channels or listeners. Those paths obtain EAGAIN from transport
-     * send or receive callbacks. Replacing both callbacks with fatal I/O makes
-     * abandonment a one-shot local reclamation with no peer-readiness wait.
-     */
-    libssh2_session_callback_set2(
-        session,
-        LIBSSH2_CALLBACK_SEND,
-        (libssh2_cb_generic *)heeler_abandoned_send
-    );
-    libssh2_session_callback_set2(
-        session,
-        LIBSSH2_CALLBACK_RECV,
-        (libssh2_cb_generic *)heeler_abandoned_receive
-    );
-
+    heeler_libssh2_prepare_session_abandonment(session);
     return libssh2_session_free(session);
 }

--- a/Packages/HeelerSSH/Sources/CHeelerSSHSupport/include/CHeelerSSHSupport.h
+++ b/Packages/HeelerSSH/Sources/CHeelerSSHSupport/include/CHeelerSSHSupport.h
@@ -4,6 +4,7 @@
 #include <CLibSSH2/libssh2.h>
 
 int heeler_libssh2_abandon_session(LIBSSH2_SESSION *session);
+void heeler_libssh2_prepare_session_abandonment(LIBSSH2_SESSION *session);
 
 typedef ssize_t (*heeler_libssh2_receive_callback)(
     libssh2_socket_t socket,

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SSHConnection.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SSHConnection.swift
@@ -178,7 +178,7 @@ public final class SSHConnection: Sendable {
     /// fresh channel to preserve one-request-per-socket protocols.
     /// `beforeRequestWrite` may throw after the channel opens but before any
     /// byte is written; its original error is preserved after channel cleanup.
-    /// `onRequestWritten` runs after the complete request.
+    /// `onRequestWritten` runs exactly once after the complete request.
     public func exchangeStreamLocal(
         socketPath: String,
         request: Data,
@@ -231,7 +231,7 @@ public final class SSHConnection: Sendable {
     }
 
     public func holdNextSessionWaitForTesting(
-        _ hold: @escaping @Sendable () async -> Void
+        _ hold: @escaping @Sendable () async throws -> Void
     ) async {
         await driver.holdNextSessionWaitForTesting(hold)
     }
@@ -268,6 +268,88 @@ public final class SSHConnection: Sendable {
 
     public func failNextSFTPInitBeforeEAGAINForTesting() async {
         await driver.failNextSFTPInitBeforeEAGAINForTesting()
+    }
+
+    public func holdNextOutboundWriteParkForTesting(
+        _ hold: @escaping @Sendable () async -> Void
+    ) async {
+        await driver.holdNextOutboundWriteParkForTesting(hold)
+    }
+
+    public func holdNextOneShotEstablishedForTesting(
+        _ hold: @escaping @Sendable () async throws -> Void
+    ) async {
+        await driver.holdNextOneShotEstablishedForTesting(hold)
+    }
+
+    public func holdEachOneShotEstablishedForTesting(
+        _ hold: @escaping @Sendable () async throws -> Void
+    ) async {
+        await driver.holdEachOneShotEstablishedForTesting(hold)
+    }
+
+    public func clearEachOneShotEstablishedHoldForTesting() async {
+        await driver.clearEachOneShotEstablishedHoldForTesting()
+    }
+
+    public func holdNextOwnedLoopTopForTesting(
+        _ hold: @escaping @Sendable () async throws -> Void
+    ) async {
+        await driver.holdNextOwnedLoopTopForTesting(hold)
+    }
+
+    public func holdNextOwnedDrainForTesting(
+        _ hold: @escaping @Sendable () async throws -> Void
+    ) async {
+        await driver.holdNextOwnedDrainForTesting(hold)
+    }
+
+    public func holdNextChannelOpenSlotForTesting(
+        _ hold: @escaping @Sendable () async throws -> Void
+    ) async {
+        await driver.holdNextChannelOpenSlotForTesting(hold)
+    }
+
+    public func holdEachSessionWaitForTesting(
+        _ hold: @escaping @Sendable () async -> Void
+    ) async {
+        await driver.holdEachSessionWaitForTesting(hold)
+    }
+
+    public func clearEachSessionWaitForTesting() async {
+        await driver.clearEachSessionWaitForTesting()
+    }
+
+    public func sftpUseCountForTesting() async -> Int {
+        await driver.sftpUseCountForTesting()
+    }
+
+    public func sftpIdleWaiterCountForTesting() async -> Int {
+        await driver.sftpIdleWaiterCountForTesting()
+    }
+
+    public func channelOpenWaiterCountForTesting() async -> Int {
+        await driver.channelOpenWaiterCountForTesting()
+    }
+
+    public func startSamplingTransportSendOwnerForTesting() async {
+        await driver.startSamplingTransportSendOwnerForTesting()
+    }
+
+    public func transportSendOwnerSamplesForTesting() async -> [TransportSendOwnerSample] {
+        await driver.transportSendOwnerSamplesForTesting()
+    }
+
+    public func oneShotRegistryCountForTesting() async -> Int {
+        await driver.oneShotRegistryCountForTesting()
+    }
+
+    public func shrinkSendBufferForTesting(bytes: Int) async throws {
+        try await driver.shrinkSendBufferForTesting(bytes: bytes)
+    }
+
+    public func resourceStateForTesting() async -> SessionDriverResourceState {
+        await driver.resourceStateForTesting()
     }
 
     public var operationWaiterCountForTesting: Int {

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SSHConnection.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SSHConnection.swift
@@ -310,6 +310,16 @@ public final class SSHConnection: Sendable {
         await driver.holdNextChannelOpenSlotForTesting(hold)
     }
 
+    func holdNextChannelTeardownForTesting(
+        _ hold: @escaping @Sendable () async -> Void
+    ) async {
+        await driver.holdNextChannelTeardownForTesting(hold)
+    }
+
+    func failNextResumedChannelOpenWaiterForTesting(_ error: SSHError) async {
+        await driver.failNextResumedChannelOpenWaiterForTesting(error)
+    }
+
     public func holdEachSessionWaitForTesting(
         _ hold: @escaping @Sendable () async -> Void
     ) async {
@@ -336,7 +346,7 @@ public final class SSHConnection: Sendable {
         await driver.startSamplingTransportSendOwnerForTesting()
     }
 
-    public func transportSendOwnerSamplesForTesting() async -> [TransportSendOwnerSample] {
+    func transportSendOwnerSamplesForTesting() async -> [TransportSendOwnerSample] {
         await driver.transportSendOwnerSamplesForTesting()
     }
 
@@ -348,7 +358,7 @@ public final class SSHConnection: Sendable {
         try await driver.shrinkSendBufferForTesting(bytes: bytes)
     }
 
-    public func resourceStateForTesting() async -> SessionDriverResourceState {
+    func resourceStateForTesting() async -> SessionDriverResourceState {
         await driver.resourceStateForTesting()
     }
 

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SSHConnection.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SSHConnection.swift
@@ -282,16 +282,6 @@ public final class SSHConnection: Sendable {
         await driver.holdNextOneShotEstablishedForTesting(hold)
     }
 
-    public func holdEachOneShotEstablishedForTesting(
-        _ hold: @escaping @Sendable () async throws -> Void
-    ) async {
-        await driver.holdEachOneShotEstablishedForTesting(hold)
-    }
-
-    public func clearEachOneShotEstablishedHoldForTesting() async {
-        await driver.clearEachOneShotEstablishedHoldForTesting()
-    }
-
     public func holdNextOwnedLoopTopForTesting(
         _ hold: @escaping @Sendable () async throws -> Void
     ) async {
@@ -324,16 +314,6 @@ public final class SSHConnection: Sendable {
         _ hold: @escaping @Sendable () async -> Void
     ) async {
         await driver.holdNextChannelOpenWaiterRegistrationForTesting(hold)
-    }
-
-    public func holdEachSessionWaitForTesting(
-        _ hold: @escaping @Sendable () async -> Void
-    ) async {
-        await driver.holdEachSessionWaitForTesting(hold)
-    }
-
-    public func clearEachSessionWaitForTesting() async {
-        await driver.clearEachSessionWaitForTesting()
     }
 
     public func sftpUseCountForTesting() async -> Int {

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SSHConnection.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SSHConnection.swift
@@ -320,6 +320,12 @@ public final class SSHConnection: Sendable {
         await driver.failNextResumedChannelOpenWaiterForTesting(error)
     }
 
+    func holdNextChannelOpenWaiterRegistrationForTesting(
+        _ hold: @escaping @Sendable () async -> Void
+    ) async {
+        await driver.holdNextChannelOpenWaiterRegistrationForTesting(hold)
+    }
+
     public func holdEachSessionWaitForTesting(
         _ hold: @escaping @Sendable () async -> Void
     ) async {
@@ -340,6 +346,14 @@ public final class SSHConnection: Sendable {
 
     public func channelOpenWaiterCountForTesting() async -> Int {
         await driver.channelOpenWaiterCountForTesting()
+    }
+
+    func ptyTeardownWaiterCountForTesting() async -> Int {
+        await driver.ptyTeardownWaiterCountForTesting()
+    }
+
+    func ptyChannelCountForTesting() async -> Int {
+        await driver.ptyChannelCountForTesting()
     }
 
     public func startSamplingTransportSendOwnerForTesting() async {

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SSHPTYChannel.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SSHPTYChannel.swift
@@ -52,6 +52,12 @@ public final class SSHPTYChannel: Sendable {
         try await driver.closePTY(id: id, timeout: timeout)
     }
 
+#if DEBUG
+    func acceptsIOForTesting() async -> Bool {
+        await driver.ptyAcceptsIOForTesting(id: id)
+    }
+#endif
+
     deinit {
         let id = id
         let driver = driver

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SSHPTYChannel.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SSHPTYChannel.swift
@@ -7,12 +7,11 @@ import Foundation
 /// take short turns on the driver so the live terminal does not monopolize the
 /// SSH session while other channels make progress.
 ///
-/// That holds in one direction only. An ordinary RPC — `execute`,
-/// `executeResponseLine`, `exchangeStreamLocal` — takes the same operation
-/// mutex and holds it for its entire round trip, so terminal output,
-/// keystrokes and resizes queue behind one until it completes or its own
-/// deadline ends it. The effect is delay rather than failure: the terminal is
-/// not torn down, it simply stops moving meanwhile. See #130.
+/// Ordinary RPCs — `execute`, `executeResponseLine`, `exchangeStreamLocal` —
+/// take the same turns after the channel is established. A live terminal keeps
+/// moving while one of those waits for its remote response; a cancelled or
+/// timed-out write either drains the packet it owns or invalidates the session
+/// rather than leaving the next caller spun on a stranded send. See #130.
 public final class SSHPTYChannel: Sendable {
     private let id: UInt64
     private let driver: SessionDriver

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SSHStreamLocalChannel.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SSHStreamLocalChannel.swift
@@ -6,12 +6,11 @@ import Foundation
 /// short turn on that driver, so an idle stream never monopolizes the SSH
 /// session while ordinary channels make progress.
 ///
-/// That holds in one direction only. An ordinary RPC — `execute`,
-/// `executeResponseLine`, `exchangeStreamLocal` — takes the same operation
-/// mutex and holds it for its entire round trip, so a read here queues behind
-/// one until it completes or its own deadline ends it. The effect is delay
-/// rather than failure: the stream is not torn down, it simply makes no
-/// progress meanwhile. See #130.
+/// Ordinary RPCs — `execute`, `executeResponseLine`, `exchangeStreamLocal` —
+/// take the same turns after the channel is established. A live stream keeps
+/// moving while one of those waits for its remote response; a cancelled or
+/// timed-out write either drains the packet it owns or invalidates the session
+/// rather than leaving the next caller spun on a stranded send. See #130.
 public final class SSHStreamLocalChannel: Sendable {
     private let id: UInt64
     private let driver: SessionDriver

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionActivity.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionActivity.swift
@@ -26,13 +26,20 @@ final class SessionActivity: @unchecked Sendable {
 
     private let lock = NSLock()
     private var receiveCount: UInt64 = 0
+    private var generation: UInt64 = 0
     private var registrations: [ObjectIdentifier: Registration] = [:]
 
-    /// Records the current receive count so a later wait can tell whether the
-    /// session moved while it was arming. Callers must capture this before
-    /// they release the session to the next operation.
+    /// Records the current receive count and invalidation generation so a
+    /// later wait can tell whether the session moved or was invalidated while
+    /// it was arming. Callers must capture this before they release the
+    /// session to the next operation.
     func watch() -> SessionActivityWatch {
-        SessionActivityWatch(activity: self, token: lock.withLock { receiveCount })
+        lock.withLock {
+            SessionActivityWatch(
+                activity: self,
+                token: receiveCount,
+                generation: generation)
+        }
     }
 
     /// Installs the counting receive callback on `session`.
@@ -53,8 +60,13 @@ final class SessionActivity: @unchecked Sendable {
     /// Parks `waiter` until the receive count moves past `token`, and reports
     /// whether it did so. False means bytes already moved, so the caller must
     /// retry immediately rather than wait for an edge that will never come.
-    func register(_ waiter: DispatchWaiter, since token: UInt64) -> Bool {
+    func register(
+        _ waiter: DispatchWaiter,
+        since token: UInt64,
+        generation: UInt64
+    ) -> Bool {
         lock.withLock {
+            guard self.generation == generation else { return false }
             guard receiveCount == token else { return false }
             registrations[ObjectIdentifier(waiter)] = Registration(
                 waiter: waiter,
@@ -83,21 +95,35 @@ final class SessionActivity: @unchecked Sendable {
         for waiter in stale { waiter.finish(.success(())) }
     }
 
+    /// Releases every parked wait before the session descriptor is closed.
+    /// Invalidation does not move the receive count, so a waiter armed around
+    /// that moment would otherwise sleep out its own deadline.
+    func releaseAllWaiters() {
+        let waiters: [DispatchWaiter] = lock.withLock {
+            generation &+= 1
+            let current = Array(registrations.values.map(\.waiter))
+            registrations.removeAll()
+            return current
+        }
+        for waiter in waiters { waiter.finish(.success(())) }
+    }
+
     fileprivate func recordReceive() {
         lock.withLock { receiveCount &+= 1 }
     }
 }
 
-/// The receive count one operation observed, paired with the session it
-/// observed it on.
+/// The receive count and invalidation generation one operation observed,
+/// paired with the session it observed them on.
 struct SessionActivityWatch: Sendable {
     let activity: SessionActivity
     let token: UInt64
+    let generation: UInt64
 
-    /// Reports false when the session already moved on, meaning the caller
-    /// must retry now instead of waiting.
+    /// Reports false when the session already moved on or was invalidated,
+    /// meaning the caller must retry now instead of waiting.
     func register(_ waiter: DispatchWaiter) -> Bool {
-        activity.register(waiter, since: token)
+        activity.register(waiter, since: token, generation: generation)
     }
 
     func unregister(_ waiter: DispatchWaiter) {

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -10,6 +10,11 @@ actor SessionDriver {
         case invalidate
     }
 
+    private struct PacketOperationResult {
+        let code: Int32
+        let disposition: TransportSendOwnerDisposition
+    }
+
     static let hostKeyAlgorithms = [
         "ssh-ed25519",
         "ecdsa-sha2-nistp384",
@@ -112,7 +117,13 @@ actor SessionDriver {
         let continuation: CheckedContinuation<Void, any Error>
         let deadlineTask: Task<Void, Never>
     }
+    private struct PTYTeardownWaiter {
+        let ptyID: UInt64
+        let waiter: DriverWaiter
+    }
     private var channelOpenWaiters: [UInt64: DriverWaiter] = [:]
+    private var nextPTYTeardownWaiterID: UInt64 = 0
+    private var ptyTeardownWaiters: [UInt64: PTYTeardownWaiter] = [:]
     private var sftpUses: [UInt64: Int] = [:]
     private var nextSFTPIdleWaiterID: UInt64 = 0
     private var sftpIdleWaiters: [UInt64: DriverWaiter] = [:]
@@ -134,6 +145,7 @@ actor SessionDriver {
     private var nextChannelOpenSlotHoldForTesting: (@Sendable () async throws -> Void)?
     private var nextChannelTeardownHoldForTesting: (@Sendable () async -> Void)?
     private var nextResumedChannelOpenWaiterErrorForTesting: SSHError?
+    private var nextChannelOpenWaiterRegistrationHoldForTesting: (@Sendable () async -> Void)?
     private var eachSessionWaitHoldForTesting: (@Sendable () async -> Void)?
     private var ownerSamplesForTesting: [TransportSendOwnerSample]?
     private var shouldFailNextSFTPInitBeforeEAGAINForTesting = false
@@ -494,7 +506,11 @@ actor SessionDriver {
                 let session = try requireSession()
                 let channel = try resolveChannel(.pty(id))
                 let written = writeChannel(channel, data: data, offset: offset)
-                notePacketProducingWrite(written, owner: owner, session: session)
+                let disposition = notePacketProducingWrite(
+                    written,
+                    owner: owner,
+                    session: session)
+                applyTransportSendOwnerDisposition(disposition)
                 guard written >= 0 || written == Int(LIBSSH2_ERROR_EAGAIN) else {
                     throw SSHError.channelFailed
                 }
@@ -645,9 +661,12 @@ actor SessionDriver {
                 allowClosing: true)
             ptyChannels[id]?.closed = true
             ptyChannels[id]?.teardownInProgress = false
+            wakePTYTeardownWaiters(for: id)
             return exitStatus
         } catch {
+            ptyChannels[id]?.acceptsIO = true
             ptyChannels[id]?.teardownInProgress = false
+            wakePTYTeardownWaiters(for: id)
             throw error
         }
     }
@@ -656,12 +675,24 @@ actor SessionDriver {
         await acquireOperation()
         defer { releaseOperation() }
 
+        guard ptyChannels[id] != nil else { return }
+        guard valid, session != nil else {
+            ptyChannels.removeValue(forKey: id)
+            wakePTYTeardownWaiters(for: id)
+            return
+        }
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        do {
+            try await waitUntilPTYTeardownCompletes(id: id, deadline: deadline)
+        } catch {
+            throw normalize(error)
+        }
         guard var state = ptyChannels[id] else { return }
         guard valid, session != nil else {
             ptyChannels.removeValue(forKey: id)
+            wakePTYTeardownWaiters(for: id)
             return
         }
-        guard !state.teardownInProgress else { return }
         state.acceptsIO = false
         state.teardownInProgress = true
         ptyChannels[id] = state
@@ -669,7 +700,6 @@ actor SessionDriver {
         await holdChannelTeardownForTestingIfNeeded()
 #endif
         do {
-            let deadline = ContinuousClock.now.advanced(by: timeout)
             if ptyChannels[id]?.closed == true {
                 let freeResult = try await repeatUntilCompleteYielding(
                     deadline: deadline,
@@ -688,8 +718,10 @@ actor SessionDriver {
                     allowClosing: true)
             }
             ptyChannels.removeValue(forKey: id)
+            wakePTYTeardownWaiters(for: id)
         } catch {
             ptyChannels.removeValue(forKey: id)
+            wakePTYTeardownWaiters(for: id)
             throw teardownFailure(error)
         }
     }
@@ -852,7 +884,11 @@ actor SessionDriver {
                 let session = try requireSession()
                 let channel = try resolveChannel(.streamLocal(id))
                 let written = writeChannel(channel, data: data, offset: offset)
-                notePacketProducingWrite(written, owner: owner, session: session)
+                let disposition = notePacketProducingWrite(
+                    written,
+                    owner: owner,
+                    session: session)
+                applyTransportSendOwnerDisposition(disposition)
                 guard written >= 0 || written == Int(LIBSSH2_ERROR_EAGAIN) else {
                     throw SSHError.channelFailed
                 }
@@ -1006,14 +1042,22 @@ actor SessionDriver {
 #endif
                 let session = try requireSession()
                 if let sftp = libssh2_sftp_init(session) {
-                    notePacketProducingResult(0, owner: owner, session: session)
+                    let disposition = notePacketProducingResult(
+                        0,
+                        owner: owner,
+                        session: session)
+                    applyTransportSendOwnerDisposition(disposition)
                     nextSFTPID &+= 1
                     let id = nextSFTPID
                     sftpClients[id] = SFTPState(handle: sftp)
                     return SSHSFTPClient(id: id, driver: self)
                 }
                 let error = libssh2_session_last_errno(session)
-                notePacketProducingResult(error, owner: owner, session: session)
+                let disposition = notePacketProducingResult(
+                    error,
+                    owner: owner,
+                    session: session)
+                applyTransportSendOwnerDisposition(disposition)
                 if error == LIBSSH2_ERROR_EAGAIN {
                     initWasPending = true
                     try await waitForSession(session, deadline: deadline)
@@ -1198,7 +1242,11 @@ actor SessionDriver {
                     Int32(LIBSSH2_SFTP_OPENFILE))
             }
             if let file {
-                notePacketProducingResult(0, owner: owner, session: session)
+                let disposition = notePacketProducingResult(
+                    0,
+                    owner: owner,
+                    session: session)
+                applyTransportSendOwnerDisposition(disposition)
                 nextSFTPFileID &+= 1
                 let fileID = nextSFTPFileID
                 sftpClients[sftpID]?.files[fileID] = file
@@ -1206,10 +1254,10 @@ actor SessionDriver {
             }
 
             let error = libssh2_session_last_errno(session)
-            let openFailure = error == LIBSSH2_ERROR_EAGAIN
-                ? nil
-                : classifyDirectTCPIPOpenFailure(session)
-            notePacketProducingResult(error, owner: owner, session: session)
+            let disposition = notePacketProducingResult(
+                error,
+                owner: owner,
+                session: session)
             if error == LIBSSH2_ERROR_EAGAIN {
                 try await waitForSession(session, deadline: deadline)
                 continue
@@ -1219,6 +1267,8 @@ actor SessionDriver {
                 throw SSHError.connectionInvalidated
             }
             let status = UInt64(libssh2_sftp_last_error(sftp))
+            applyTransportSendOwnerDisposition(disposition)
+            if disposition == .invalidate { throw SSHError.connectionInvalidated }
             if status == UInt64(LIBSSH2_FX_NO_SUCH_FILE) { return nil }
             throw SSHError.sftpFailure(status: status)
         }
@@ -1261,10 +1311,18 @@ actor SessionDriver {
                         baseAddress.assumingMemoryBound(to: CChar.self),
                         bytes.count)
                 }
-                notePacketProducingWrite(read, owner: owner, session: session)
+                let disposition = notePacketProducingWrite(
+                    read,
+                    owner: owner,
+                    session: session)
                 if read < 0, read != Int(LIBSSH2_ERROR_EAGAIN) {
-                    throw mappedSFTPError(sftp: state.handle, code: Int32(read))
+                    let mappedError = mappedSFTPError(
+                        sftp: state.handle,
+                        code: Int32(read))
+                    applyTransportSendOwnerDisposition(disposition)
+                    throw mappedError
                 }
+                applyTransportSendOwnerDisposition(disposition)
                 progress = (
                     read > 0 ? Data(buffer.prefix(read)) : Data(),
                     read == 0,
@@ -1343,18 +1401,27 @@ actor SessionDriver {
                     Int32(LIBSSH2_SFTP_OPENFILE))
             }
             if let file {
-                notePacketProducingResult(0, owner: owner, session: session)
+                let disposition = notePacketProducingResult(
+                    0,
+                    owner: owner,
+                    session: session)
+                applyTransportSendOwnerDisposition(disposition)
                 nextSFTPFileID &+= 1
                 let fileID = nextSFTPFileID
                 sftpClients[sftpID]?.files[fileID] = file
                 return SSHSFTPFile(sftpID: sftpID, fileID: fileID, driver: self)
             }
             let error = libssh2_session_last_errno(session)
-            notePacketProducingResult(error, owner: owner, session: session)
+            let disposition = notePacketProducingResult(
+                error,
+                owner: owner,
+                session: session)
             if error == LIBSSH2_ERROR_EAGAIN {
                 try await waitForSession(session, deadline: deadline)
             } else {
-                throw mappedSFTPError(sftp: sftp, code: error)
+                let mappedError = mappedSFTPError(sftp: sftp, code: error)
+                applyTransportSendOwnerDisposition(disposition)
+                throw mappedError
             }
         }
         } catch {
@@ -1412,10 +1479,18 @@ actor SessionDriver {
                             baseAddress.advanced(by: offset).assumingMemoryBound(to: CChar.self),
                             data.count - offset)
                     }
-                    notePacketProducingWrite(written, owner: owner, session: session)
+                    let disposition = notePacketProducingWrite(
+                        written,
+                        owner: owner,
+                        session: session)
                     if written < 0, written != Int(LIBSSH2_ERROR_EAGAIN) {
-                        throw mappedSFTPError(sftp: state.handle, code: Int32(written))
+                        let mappedError = mappedSFTPError(
+                            sftp: state.handle,
+                            code: Int32(written))
+                        applyTransportSendOwnerDisposition(disposition)
+                        throw mappedError
                     }
+                    applyTransportSendOwnerDisposition(disposition)
                     progress = (written, sessionWaitPlan(session))
                     releaseOperation()
                 } catch {
@@ -1628,16 +1703,21 @@ actor SessionDriver {
                 libssh2_sftp_unlink_ex(sftp, pathPointer, UInt32(path.utf8.count))
             }
         }
-        if result != 0 {
-            if Self.isConnectionLoss(result) { throw SSHError.connectionInvalidated }
-            let status = UInt64(libssh2_sftp_last_error(sftp))
-            guard verifyAbsence, status == UInt64(LIBSSH2_FX_NO_SUCH_FILE) else {
-                try checkSFTPResult(result, sftp: sftp, session: session)
-                return
+        if result.code != 0 {
+            if Self.isConnectionLoss(result.code) {
+                applyTransportSendOwnerDisposition(result.disposition)
+                throw SSHError.connectionInvalidated
             }
+            let status = UInt64(libssh2_sftp_last_error(sftp))
+            applyTransportSendOwnerDisposition(result.disposition)
+            if result.disposition == .invalidate { throw SSHError.connectionInvalidated }
+            guard verifyAbsence, status == UInt64(LIBSSH2_FX_NO_SUCH_FILE) else {
+                throw SSHError.sftpFailure(status: status)
+            }
+        } else {
+            applyTransportSendOwnerDisposition(result.disposition)
         }
         guard verifyAbsence else {
-            try checkSFTPResult(result, sftp: sftp, session: session)
             return
         }
 
@@ -1656,12 +1736,19 @@ actor SessionDriver {
                     &attributes)
             }
         }
-        if statResult == 0 { throw SSHError.channelFailed }
-        if Self.isConnectionLoss(statResult) { throw SSHError.connectionInvalidated }
+        if statResult.code == 0 {
+            applyTransportSendOwnerDisposition(statResult.disposition)
+            throw SSHError.channelFailed
+        }
+        if Self.isConnectionLoss(statResult.code) {
+            applyTransportSendOwnerDisposition(statResult.disposition)
+            throw SSHError.connectionInvalidated
+        }
         let status = UInt64(libssh2_sftp_last_error(sftp))
+        applyTransportSendOwnerDisposition(statResult.disposition)
+        if statResult.disposition == .invalidate { throw SSHError.connectionInvalidated }
         guard status == UInt64(LIBSSH2_FX_NO_SUCH_FILE) else {
-            try checkSFTPResult(statResult, sftp: sftp, session: session)
-            return
+            throw SSHError.sftpFailure(status: status)
         }
         guard valid, self.session == session else {
             throw SSHError.connectionInvalidated
@@ -1859,6 +1946,12 @@ actor SessionDriver {
         nextResumedChannelOpenWaiterErrorForTesting = error
     }
 
+    func holdNextChannelOpenWaiterRegistrationForTesting(
+        _ hold: @escaping @Sendable () async -> Void
+    ) {
+        nextChannelOpenWaiterRegistrationHoldForTesting = hold
+    }
+
     func holdEachSessionWaitForTesting(
         _ hold: @escaping @Sendable () async -> Void
     ) {
@@ -1879,6 +1972,18 @@ actor SessionDriver {
 
     func channelOpenWaiterCountForTesting() -> Int {
         channelOpenWaiters.count
+    }
+
+    func ptyTeardownWaiterCountForTesting() -> Int {
+        ptyTeardownWaiters.count
+    }
+
+    func ptyChannelCountForTesting() -> Int {
+        ptyChannels.count
+    }
+
+    func ptyAcceptsIOForTesting(id: UInt64) -> Bool {
+        ptyChannels[id]?.acceptsIO == true
     }
 
     func startSamplingTransportSendOwnerForTesting() {
@@ -2068,12 +2173,22 @@ actor SessionDriver {
                     0)
             }
             if let channel {
-                notePacketProducingResult(0, owner: owner, session: session)
+                let disposition = notePacketProducingResult(
+                    0,
+                    owner: owner,
+                    session: session)
+                applyTransportSendOwnerDisposition(disposition)
                 return channel
             }
 
             let error = libssh2_session_last_errno(session)
-            notePacketProducingResult(error, owner: owner, session: session)
+            let openFailure = error == LIBSSH2_ERROR_EAGAIN
+                ? nil
+                : classifyDirectTCPIPOpenFailure(session)
+            let disposition = notePacketProducingResult(
+                error,
+                owner: owner,
+                session: session)
             if error == LIBSSH2_ERROR_EAGAIN {
                 do {
                     try await waitForSession(session, deadline: deadline)
@@ -2082,6 +2197,7 @@ actor SessionDriver {
                     throw error
                 }
             } else {
+                applyTransportSendOwnerDisposition(disposition)
                 throw openFailure ?? SSHError.channelFailed
             }
         }
@@ -2330,25 +2446,20 @@ actor SessionDriver {
         _ result: Int32,
         owner: UInt64,
         session: OpaquePointer
-    ) {
+    ) -> TransportSendOwnerDisposition {
         if result == LIBSSH2_ERROR_EAGAIN {
             if sessionReportsOutbound(session), transportSendOwner == nil {
                 transportSendOwner = owner
             }
-        } else {
-            switch Self.transportSendOwnerDisposition(
-                result: result,
-                isCurrentOwner: transportSendOwner == owner,
-                hasOutbound: sessionReportsOutbound(session))
-            {
-            case .unchanged:
-                break
-            case .clear:
-                transportSendOwner = nil
-            case .invalidate:
-                invalidateResources()
-            }
+            return .unchanged
         }
+        guard transportSendOwner == owner else { return .unchanged }
+        let disposition = Self.transportSendOwnerDisposition(
+            result: result,
+            isCurrentOwner: true,
+            hasOutbound: sessionReportsOutbound(session))
+        if disposition == .clear { transportSendOwner = nil }
+        return disposition
     }
 
     static func transportSendOwnerDisposition(
@@ -2361,17 +2472,29 @@ actor SessionDriver {
         return .clear
     }
 
+    private func applyTransportSendOwnerDisposition(
+        _ disposition: TransportSendOwnerDisposition
+    ) {
+        if disposition == .invalidate { invalidateResources() }
+    }
+
     private func notePacketProducingWrite(
         _ written: Int,
         owner: UInt64,
         session: OpaquePointer
-    ) {
+    ) -> TransportSendOwnerDisposition {
         if written == Int(LIBSSH2_ERROR_EAGAIN) {
-            notePacketProducingResult(LIBSSH2_ERROR_EAGAIN, owner: owner, session: session)
+            return notePacketProducingResult(
+                LIBSSH2_ERROR_EAGAIN,
+                owner: owner,
+                session: session)
         } else if written >= 0 {
-            notePacketProducingResult(0, owner: owner, session: session)
+            return notePacketProducingResult(0, owner: owner, session: session)
         } else {
-            notePacketProducingResult(Int32(clamping: written), owner: owner, session: session)
+            return notePacketProducingResult(
+                Int32(clamping: written),
+                owner: owner,
+                session: session)
         }
     }
 
@@ -2449,7 +2572,11 @@ actor SessionDriver {
                     return
                 }
                 let session = try requireSession()
-                notePacketProducingResult(result, owner: owner, session: session)
+                let disposition = notePacketProducingResult(
+                    result,
+                    owner: owner,
+                    session: session)
+                applyTransportSendOwnerDisposition(disposition)
                 if result != LIBSSH2_ERROR_EAGAIN { return }
                 try await waitForSession(
                     session,
@@ -2511,6 +2638,9 @@ actor SessionDriver {
     ) async throws {
         if cancellable {
             try await withTaskCancellationHandler {
+#if DEBUG
+                await holdChannelOpenWaiterRegistrationForTestingIfNeeded()
+#endif
                 try await parkChannelOpenWaiterUntilDeadline(
                     id: id,
                     deadline: deadline,
@@ -2543,7 +2673,7 @@ actor SessionDriver {
                 } catch {
                     return
                 }
-                await self.resumeChannelOpenWaiter(id: id, .failure(SSHError.timedOut))
+                self.resumeChannelOpenWaiter(id: id, .failure(SSHError.timedOut))
             }
             channelOpenWaiters[id] = DriverWaiter(
                 continuation: continuation,
@@ -2560,10 +2690,7 @@ actor SessionDriver {
 
     private func releaseChannelOpenSlot() {
         channelOpenInProgress = false
-        let ids = Array(channelOpenWaiters.keys)
-        for id in ids {
-            resumeChannelOpenWaiter(id: id, .success(()))
-        }
+        resumeAllChannelOpenWaiters()
     }
 
     private func resumeAllChannelOpenWaiters() {
@@ -2571,6 +2698,76 @@ actor SessionDriver {
         for id in ids {
             resumeChannelOpenWaiter(id: id, .success(()))
         }
+    }
+
+    private func waitUntilPTYTeardownCompletes(
+        id: UInt64,
+        deadline: ContinuousClock.Instant
+    ) async throws {
+        while ptyChannels[id]?.teardownInProgress == true {
+            guard ContinuousClock.now < deadline else { throw SSHError.timedOut }
+            nextPTYTeardownWaiterID &+= 1
+            let waiterID = nextPTYTeardownWaiterID
+            do {
+                try await parkPTYTeardownWaiter(
+                    id: waiterID,
+                    ptyID: id,
+                    deadline: deadline)
+            } catch {
+                await acquireOperation()
+                throw error
+            }
+            await acquireOperation()
+            guard ContinuousClock.now < deadline else { throw SSHError.timedOut }
+            guard valid else { throw SSHError.connectionInvalidated }
+        }
+    }
+
+    private func parkPTYTeardownWaiter(
+        id: UInt64,
+        ptyID: UInt64,
+        deadline: ContinuousClock.Instant
+    ) async throws {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, any Error>) in
+            let deadlineTask = Task {
+                do {
+                    try await Task.sleep(until: deadline, clock: .continuous)
+                } catch {
+                    return
+                }
+                self.resumePTYTeardownWaiter(
+                    id: id,
+                    .failure(SSHError.timedOut))
+            }
+            ptyTeardownWaiters[id] = PTYTeardownWaiter(
+                ptyID: ptyID,
+                waiter: DriverWaiter(
+                    continuation: continuation,
+                    deadlineTask: deadlineTask))
+            releaseOperation()
+        }
+    }
+
+    private func resumePTYTeardownWaiter(
+        id: UInt64,
+        _ result: Result<Void, any Error>
+    ) {
+        guard let entry = ptyTeardownWaiters.removeValue(forKey: id) else { return }
+        entry.waiter.deadlineTask.cancel()
+        entry.waiter.continuation.resume(with: result)
+    }
+
+    private func wakePTYTeardownWaiters(for ptyID: UInt64) {
+        let ids = ptyTeardownWaiters.compactMap { id, entry in
+            entry.ptyID == ptyID ? id : nil
+        }
+        for id in ids { resumePTYTeardownWaiter(id: id, .success(())) }
+    }
+
+    private func resumeAllPTYTeardownWaiters() {
+        let ids = Array(ptyTeardownWaiters.keys)
+        for id in ids { resumePTYTeardownWaiter(id: id, .success(())) }
     }
 
     private func registerOneShot(
@@ -2756,12 +2953,22 @@ actor SessionDriver {
                 nil,
                 0)
             {
-                notePacketProducingResult(0, owner: owner, session: session)
+                let disposition = notePacketProducingResult(
+                    0,
+                    owner: owner,
+                    session: session)
+                applyTransportSendOwnerDisposition(disposition)
                 return channel
             }
             let error = libssh2_session_last_errno(session)
-            notePacketProducingResult(error, owner: owner, session: session)
-            guard error == LIBSSH2_ERROR_EAGAIN else { throw SSHError.channelFailed }
+            let disposition = notePacketProducingResult(
+                error,
+                owner: owner,
+                session: session)
+            guard error == LIBSSH2_ERROR_EAGAIN else {
+                applyTransportSendOwnerDisposition(disposition)
+                throw SSHError.channelFailed
+            }
             do {
                 try await waitForSession(session, deadline: deadline)
             } catch {
@@ -2802,12 +3009,19 @@ actor SessionDriver {
                     0)
             }
             if let channel {
-                notePacketProducingResult(0, owner: owner, session: session)
+                let disposition = notePacketProducingResult(
+                    0,
+                    owner: owner,
+                    session: session)
+                applyTransportSendOwnerDisposition(disposition)
                 return channel
             }
 
             let error = libssh2_session_last_errno(session)
-            notePacketProducingResult(error, owner: owner, session: session)
+            let disposition = notePacketProducingResult(
+                error,
+                owner: owner,
+                session: session)
             if error == LIBSSH2_ERROR_EAGAIN {
                 do {
                     try await waitForSession(session, deadline: deadline)
@@ -2816,6 +3030,7 @@ actor SessionDriver {
                     throw error
                 }
             } else {
+                applyTransportSendOwnerDisposition(disposition)
                 throw Self.mappedStreamLocalOpenError(error)
             }
         }
@@ -2944,7 +3159,11 @@ actor SessionDriver {
                     let channel = try resolveChannel(identity)
                     let session = try requireSession()
                     let written = writeChannel(channel, data: input, offset: inputOffset)
-                    notePacketProducingWrite(written, owner: writeOwner, session: session)
+                    let disposition = notePacketProducingWrite(
+                        written,
+                        owner: writeOwner,
+                        session: session)
+                    applyTransportSendOwnerDisposition(disposition)
                     if written > 0 {
                         inputOffset += written
                         madeProgress = true
@@ -2961,7 +3180,11 @@ actor SessionDriver {
                     let channel = try resolveChannel(identity)
                     let session = try requireSession()
                     let result = libssh2_channel_send_eof(channel)
-                    notePacketProducingResult(result, owner: eofOwner, session: session)
+                    let disposition = notePacketProducingResult(
+                        result,
+                        owner: eofOwner,
+                        session: session)
+                    applyTransportSendOwnerDisposition(disposition)
                     if result == 0 {
                         sentEOF = true
                         madeProgress = true
@@ -3086,7 +3309,11 @@ actor SessionDriver {
                     let channel = try resolveChannel(identity)
                     let session = try requireSession()
                     let written = writeChannel(channel, data: request, offset: requestOffset)
-                    notePacketProducingWrite(written, owner: writeOwner, session: session)
+                    let disposition = notePacketProducingWrite(
+                        written,
+                        owner: writeOwner,
+                        session: session)
+                    applyTransportSendOwnerDisposition(disposition)
                     if written > 0 {
                         requestOffset += written
                         madeProgress = true
@@ -3178,7 +3405,11 @@ actor SessionDriver {
         session: OpaquePointer
     ) throws -> Data {
         let count = rawChannelRead(channel: channel, stream: stream, buffer: &buffer)
-        notePacketProducingWrite(count, owner: owner, session: session)
+        let disposition = notePacketProducingWrite(
+            count,
+            owner: owner,
+            session: session)
+        applyTransportSendOwnerDisposition(disposition)
         if count > 0 { return Data(buffer.prefix(count)) }
         if count == 0 || count == Int(LIBSSH2_ERROR_EAGAIN) { return Data() }
         throw SSHError.channelFailed
@@ -3418,7 +3649,7 @@ actor SessionDriver {
                 } catch {
                     return
                 }
-                await self.resumeSFTPIdleWaiter(id: id, .failure(SSHError.timedOut))
+                self.resumeSFTPIdleWaiter(id: id, .failure(SSHError.timedOut))
             }
             sftpIdleWaiters[id] = DriverWaiter(
                 continuation: continuation,
@@ -3514,8 +3745,14 @@ actor SessionDriver {
                 drive: operation)
             let session = try requireSession()
             let result = operation()
-            notePacketProducingResult(result, owner: owner, session: session)
-            if result != LIBSSH2_ERROR_EAGAIN { return result }
+            let disposition = notePacketProducingResult(
+                result,
+                owner: owner,
+                session: session)
+            if result != LIBSSH2_ERROR_EAGAIN {
+                applyTransportSendOwnerDisposition(disposition)
+                return result
+            }
             do {
                 try await waitForSession(
                     session,
@@ -3534,7 +3771,7 @@ actor SessionDriver {
         deadline: ContinuousClock.Instant,
         cancellable: Bool = true,
         _ operation: (OpaquePointer) -> Int32
-    ) async throws -> Int32 {
+    ) async throws -> PacketOperationResult {
         try await waitUntilSFTPIdle(
             id: id,
             deadline: deadline,
@@ -3566,8 +3803,15 @@ actor SessionDriver {
             }
             let session = try requireSession()
             let result = operation(sftp)
-            notePacketProducingResult(result, owner: owner, session: session)
-            if result != LIBSSH2_ERROR_EAGAIN { return result }
+            let disposition = notePacketProducingResult(
+                result,
+                owner: owner,
+                session: session)
+            if result != LIBSSH2_ERROR_EAGAIN {
+                return PacketOperationResult(
+                    code: result,
+                    disposition: disposition)
+            }
             do {
                 try await waitForSession(
                     session,
@@ -3604,8 +3848,14 @@ actor SessionDriver {
             }
             let session = try requireSession()
             let result = operation()
-            notePacketProducingResult(result, owner: owner, session: session)
-            if result != LIBSSH2_ERROR_EAGAIN { return result }
+            let disposition = notePacketProducingResult(
+                result,
+                owner: owner,
+                session: session)
+            if result != LIBSSH2_ERROR_EAGAIN {
+                applyTransportSendOwnerDisposition(disposition)
+                return result
+            }
             do {
                 try await waitForSession(
                     session,
@@ -3651,8 +3901,14 @@ actor SessionDriver {
             let channel = try resolveChannel(identity, allowClosing: allowClosing)
             let session = try requireSession()
             let result = operation(channel)
-            notePacketProducingResult(result, owner: owner, session: session)
-            if result != LIBSSH2_ERROR_EAGAIN { return result }
+            let disposition = notePacketProducingResult(
+                result,
+                owner: owner,
+                session: session)
+            if result != LIBSSH2_ERROR_EAGAIN {
+                applyTransportSendOwnerDisposition(disposition)
+                return result
+            }
             let plan = sessionWaitPlan(session)
             releaseOperation()
             do {
@@ -3674,7 +3930,7 @@ actor SessionDriver {
         deadline: ContinuousClock.Instant,
         cancellable: Bool,
         _ operation: () -> Int32
-    ) async throws -> Int32 {
+    ) async throws -> PacketOperationResult {
         let owner = allocateTransportSendOwner()
         while true {
             try await checkProgressFinishingOwnedSend(
@@ -3687,8 +3943,15 @@ actor SessionDriver {
 #if DEBUG
             try await runCompensationPhaseHookForTestingIfNeeded(phase)
 #endif
-            notePacketProducingResult(result, owner: owner, session: session)
-            if result != LIBSSH2_ERROR_EAGAIN { return result }
+            let disposition = notePacketProducingResult(
+                result,
+                owner: owner,
+                session: session)
+            if result != LIBSSH2_ERROR_EAGAIN {
+                return PacketOperationResult(
+                    code: result,
+                    disposition: disposition)
+            }
             do {
                 try await waitForSession(
                     session,
@@ -3702,6 +3965,12 @@ actor SessionDriver {
     }
 
 #if DEBUG
+    private func holdChannelOpenWaiterRegistrationForTestingIfNeeded() async {
+        guard let hold = nextChannelOpenWaiterRegistrationHoldForTesting else { return }
+        nextChannelOpenWaiterRegistrationHoldForTesting = nil
+        await hold()
+    }
+
     private func holdChannelTeardownForTestingIfNeeded() async {
         guard let hold = nextChannelTeardownHoldForTesting else { return }
         nextChannelTeardownHoldForTesting = nil
@@ -3817,6 +4086,19 @@ actor SessionDriver {
         try checkSFTPResult(result, sftp: sftp, session: session)
     }
 
+    private func checkSFTPResult(
+        _ result: PacketOperationResult,
+        sftpID: UInt64
+    ) throws {
+        do {
+            try checkSFTPResult(result.code, sftpID: sftpID)
+        } catch {
+            applyTransportSendOwnerDisposition(result.disposition)
+            throw error
+        }
+        applyTransportSendOwnerDisposition(result.disposition)
+    }
+
     private func mappedSFTPError(sftp: OpaquePointer, code: Int32) -> SSHError {
         if Self.isConnectionLoss(code) { return .connectionInvalidated }
         return .sftpFailure(status: UInt64(libssh2_sftp_last_error(sftp)))
@@ -3886,6 +4168,7 @@ actor SessionDriver {
         oneShotChannels.removeAll()
         channelOpenInProgress = false
         resumeAllChannelOpenWaiters()
+        resumeAllPTYTeardownWaiters()
         wakeSFTPIdleWaiters()
         activity.releaseAllWaiters()
         InvalidatedSessionTeardown.reclaim(&session)

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -139,14 +139,12 @@ actor SessionDriver {
     private var nextCompensationShutdownHoldForTesting: (@Sendable () async throws -> Void)?
     private var nextOutboundWriteParkHoldForTesting: (@Sendable () async -> Void)?
     private var nextOneShotEstablishedHoldForTesting: (@Sendable () async throws -> Void)?
-    private var eachOneShotEstablishedHoldForTesting: (@Sendable () async throws -> Void)?
     private var nextOwnedLoopTopHoldForTesting: (@Sendable () async throws -> Void)?
     private var nextOwnedDrainHoldForTesting: (@Sendable () async throws -> Void)?
     private var nextChannelOpenSlotHoldForTesting: (@Sendable () async throws -> Void)?
     private var nextChannelTeardownHoldForTesting: (@Sendable () async -> Void)?
     private var nextResumedChannelOpenWaiterErrorForTesting: SSHError?
     private var nextChannelOpenWaiterRegistrationHoldForTesting: (@Sendable () async -> Void)?
-    private var eachSessionWaitHoldForTesting: (@Sendable () async -> Void)?
     private var ownerSamplesForTesting: [TransportSendOwnerSample]?
     private var shouldFailNextSFTPInitBeforeEAGAINForTesting = false
 #endif
@@ -1908,16 +1906,6 @@ actor SessionDriver {
         nextOneShotEstablishedHoldForTesting = hold
     }
 
-    func holdEachOneShotEstablishedForTesting(
-        _ hold: @escaping @Sendable () async throws -> Void
-    ) {
-        eachOneShotEstablishedHoldForTesting = hold
-    }
-
-    func clearEachOneShotEstablishedHoldForTesting() {
-        eachOneShotEstablishedHoldForTesting = nil
-    }
-
     func holdNextOwnedLoopTopForTesting(
         _ hold: @escaping @Sendable () async throws -> Void
     ) {
@@ -1950,16 +1938,6 @@ actor SessionDriver {
         _ hold: @escaping @Sendable () async -> Void
     ) {
         nextChannelOpenWaiterRegistrationHoldForTesting = hold
-    }
-
-    func holdEachSessionWaitForTesting(
-        _ hold: @escaping @Sendable () async -> Void
-    ) {
-        eachSessionWaitHoldForTesting = hold
-    }
-
-    func clearEachSessionWaitForTesting() {
-        eachSessionWaitHoldForTesting = nil
     }
 
     func sftpUseCountForTesting() -> Int {
@@ -2403,8 +2381,6 @@ actor SessionDriver {
         if let hold = nextSessionWaitHoldForTesting {
             nextSessionWaitHoldForTesting = nil
             try await hold()
-        } else if let hold = eachSessionWaitHoldForTesting {
-            await hold()
         }
 #endif
         try await SocketReadiness.wait(
@@ -2896,14 +2872,9 @@ actor SessionDriver {
     }
 
     private func holdOneShotEstablishedForTestingIfNeeded() async throws {
-        if let hold = nextOneShotEstablishedHoldForTesting {
-            nextOneShotEstablishedHoldForTesting = nil
-            try await hold()
-            return
-        }
-        if let hold = eachOneShotEstablishedHoldForTesting {
-            try await hold()
-        }
+        guard let hold = nextOneShotEstablishedHoldForTesting else { return }
+        nextOneShotEstablishedHoldForTesting = nil
+        try await hold()
     }
 #endif
 

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -69,15 +69,54 @@ actor SessionDriver {
     private var nextSFTPFileID: UInt64 = 0
     private var sftpClients: [UInt64: SFTPState] = [:]
 
+    private struct ChannelOpenAdmissionError: Error, Sendable {
+        let underlying: SSHError
+    }
+
+    private struct OneShotChannel {
+        let channel: OpaquePointer
+        let session: OpaquePointer
+    }
+
+    private enum ChannelIdentity: Equatable {
+        case oneShot(UInt64)
+        case pty(UInt64)
+        case streamLocal(UInt64)
+    }
+
+    private var nextOneShotID: UInt64 = 0
+    private var oneShotChannels: [UInt64: OneShotChannel] = [:]
+    private var nextTransportSendIdentity: UInt64 = 0
+    /// The logical libssh2 call that last returned `EAGAIN` with an outbound
+    /// block. Cleared only by that same call returning non-`EAGAIN`, or by
+    /// completed whole-session invalidation. Cancellation does not clear it.
+    private var transportSendOwner: UInt64?
+    /// Session-owned channel opens must not interleave, even when the opener
+    /// releases the operation mutex to wait for a foreign send owner.
+    private var channelOpenInProgress = false
+    private var nextChannelOpenWaiterID: UInt64 = 0
+    private var channelOpenWaiters: [UInt64: CheckedContinuation<Void, any Error>] = [:]
+    private var sftpUses: [UInt64: Int] = [:]
+    private var nextSFTPIdleWaiterID: UInt64 = 0
+    private var sftpIdleWaiters: [UInt64: CheckedContinuation<Void, any Error>] = [:]
+
 #if DEBUG
     private var nextSFTPWriteDelayForTesting: Duration?
     private var sftpWriteDelayIsActiveForTesting = false
-    private var nextSessionWaitHoldForTesting: (@Sendable () async -> Void)?
+    private var nextSessionWaitHoldForTesting: (@Sendable () async throws -> Void)?
     private var nextExecChannelAllocatedHoldForTesting: (@Sendable () async throws -> Void)?
     private var nextExecCleanupHoldForTesting: (@Sendable () async throws -> Void)?
     private var nextCompensationUnlinkPhaseHookForTesting: (@Sendable () async throws -> Void)?
     private var nextCompensationStatPhaseHookForTesting: (@Sendable () async throws -> Void)?
     private var nextCompensationShutdownHoldForTesting: (@Sendable () async throws -> Void)?
+    private var nextOutboundWriteParkHoldForTesting: (@Sendable () async -> Void)?
+    private var nextOneShotEstablishedHoldForTesting: (@Sendable () async throws -> Void)?
+    private var eachOneShotEstablishedHoldForTesting: (@Sendable () async throws -> Void)?
+    private var nextOwnedLoopTopHoldForTesting: (@Sendable () async throws -> Void)?
+    private var nextOwnedDrainHoldForTesting: (@Sendable () async throws -> Void)?
+    private var nextChannelOpenSlotHoldForTesting: (@Sendable () async throws -> Void)?
+    private var eachSessionWaitHoldForTesting: (@Sendable () async -> Void)?
+    private var ownerSamplesForTesting: [TransportSendOwnerSample]?
     private var shouldFailNextSFTPInitBeforeEAGAINForTesting = false
 #endif
 
@@ -215,55 +254,60 @@ actor SessionDriver {
         await acquireOperation()
         defer { releaseOperation() }
 
-        guard valid, !forwarding, authenticated, let session else {
+        guard valid, !forwarding, authenticated, session != nil else {
             throw SSHError.connectionInvalidated
         }
         guard !command.isEmpty else { throw SSHError.channelFailed }
         let deadline = ContinuousClock.now.advanced(by: timeout)
-        var channel: OpaquePointer?
+        var oneShotID: UInt64?
 
         do {
-            channel = try await openSessionChannel(session: session, deadline: deadline)
-            guard let channel else { throw SSHError.channelFailed }
+            let channel = try await openSessionChannel(deadline: deadline)
+            let session = try requireSession()
+            let id = registerOneShot(channel: channel, session: session)
+            oneShotID = id
 #if DEBUG
             try await holdExecChannelAllocationForTestingIfNeeded()
+            try await holdOneShotEstablishedForTestingIfNeeded()
 #endif
             try await startExec(
-                channel: channel,
+                identity: .oneShot(id),
                 command: command,
-                session: session,
                 deadline: deadline)
 
             let result = try await exchange(
-                channel: channel,
+                identity: .oneShot(id),
                 input: input,
-                session: session,
                 deadline: deadline)
-            let freeResult = try await repeatUntilComplete(deadline: deadline) {
-                libssh2_channel_free(channel)
+            let freeResult = try await repeatUntilCompleteYielding(
+                deadline: deadline,
+                identity: .oneShot(id)
+            ) {
+                libssh2_channel_free($0)
             }
             guard freeResult == 0 else { throw SSHError.channelFailed }
+            removeOneShot(id)
             return result
         } catch {
             let normalized = normalize(error)
-            if let channel {
+            if let id = oneShotID {
                 do {
                     let cleanupDeadline = ContinuousClock.now.advanced(by: .seconds(2))
 #if DEBUG
                     try await holdExecCleanupForTestingIfNeeded()
 #endif
                     try await cleanChannel(
-                        channel,
-                        session: session,
+                        identity: .oneShot(id),
                         deadline: cleanupDeadline,
                         cancellable: false)
+                    removeOneShot(id)
                 } catch {
                     // This is the last owner of the allocated exec channel.
                     // If cleanup cannot finish, only session teardown can
                     // reclaim its native channel and server session slot.
                     invalidateResources()
                 }
-            } else {
+            } else if !(error is ChannelOpenAdmissionError) {
                 // A channel-open outcome is uncertain, so the session must not
                 // admit later work even if the underlying TCP socket survives.
                 invalidateResources()
@@ -281,7 +325,7 @@ actor SessionDriver {
         await acquireOperation()
         defer { releaseOperation() }
 
-        guard valid, !forwarding, authenticated, let session else {
+        guard valid, !forwarding, authenticated, session != nil else {
             throw SSHError.connectionInvalidated
         }
         guard
@@ -294,51 +338,52 @@ actor SessionDriver {
             throw SSHError.channelFailed
         }
         let deadline = ContinuousClock.now.advanced(by: timeout)
-        var channel: OpaquePointer?
+        var oneShotID: UInt64?
 
         do {
-            channel = try await openSessionChannel(session: session, deadline: deadline)
-            guard let channel else { throw SSHError.channelFailed }
+            let channel = try await openSessionChannel(deadline: deadline)
+            let session = try requireSession()
+            let id = registerOneShot(channel: channel, session: session)
+            oneShotID = id
 #if DEBUG
             try await holdExecChannelAllocationForTestingIfNeeded()
+            try await holdOneShotEstablishedForTestingIfNeeded()
 #endif
             try await startExec(
-                channel: channel,
+                identity: .oneShot(id),
                 command: command,
-                session: session,
                 deadline: deadline)
             let response = try await exchangeResponseLine(
-                channel: channel,
+                identity: .oneShot(id),
                 request: input,
                 maximumResponseBytes: maximumResponseBytes,
-                session: session,
                 deadline: deadline)
             try await cleanChannel(
-                channel,
-                session: session,
+                identity: .oneShot(id),
                 deadline: deadline,
                 cancellable: true)
+            removeOneShot(id)
             return response
         } catch {
             let normalized = normalize(error)
-            if let channel {
+            if let id = oneShotID {
                 do {
                     let cleanupDeadline = ContinuousClock.now.advanced(by: .seconds(2))
 #if DEBUG
                     try await holdExecCleanupForTestingIfNeeded()
 #endif
                     try await cleanChannel(
-                        channel,
-                        session: session,
+                        identity: .oneShot(id),
                         deadline: cleanupDeadline,
                         cancellable: false)
+                    removeOneShot(id)
                 } catch {
                     // The response-line channel has no owner after this scope.
                     // A failed cleanup therefore requires session teardown to
                     // reclaim the native channel and its server session slot.
                     invalidateResources()
                 }
-            } else {
+            } else if !(error is ChannelOpenAdmissionError) {
                 invalidateResources()
             }
             throw normalized
@@ -355,7 +400,7 @@ actor SessionDriver {
         await acquireOperation()
         defer { releaseOperation() }
 
-        guard valid, !forwarding, authenticated, let session else {
+        guard valid, !forwarding, authenticated, session != nil else {
             throw SSHError.connectionInvalidated
         }
         guard
@@ -373,40 +418,38 @@ actor SessionDriver {
             throw SSHError.channelFailed
         }
         let deadline = ContinuousClock.now.advanced(by: timeout)
-        var channel: OpaquePointer?
+        var registeredID: UInt64?
 
         do {
-            channel = try await openSessionChannel(session: session, deadline: deadline)
-            guard let channel else { throw SSHError.channelFailed }
+            let channel = try await openSessionChannel(deadline: deadline)
+            nextPTYChannelID &+= 1
+            let id = nextPTYChannelID
+            ptyChannels[id] = PTYChannelState(channel: channel)
+            registeredID = id
             try await configurePTY(
-                channel: channel,
+                identity: .pty(id),
                 terminal: terminal,
                 columns: columns,
                 rows: rows,
                 deadline: deadline)
             try await startExec(
-                channel: channel,
+                identity: .pty(id),
                 command: command,
-                session: session,
                 deadline: deadline)
-
-            nextPTYChannelID &+= 1
-            let id = nextPTYChannelID
-            ptyChannels[id] = PTYChannelState(channel: channel)
             return SSHPTYChannel(id: id, driver: self)
         } catch {
             let normalized = normalize(error)
-            if let channel {
+            if let id = registeredID {
                 do {
                     try await cleanChannel(
-                        channel,
-                        session: session,
+                        identity: .pty(id),
                         deadline: ContinuousClock.now.advanced(by: .seconds(2)),
                         cancellable: false)
+                    ptyChannels.removeValue(forKey: id)
                 } catch {
                     invalidateResources()
                 }
-            } else {
+            } else if !(error is ChannelOpenAdmissionError) {
                 invalidateResources()
             }
             throw normalized
@@ -417,30 +460,34 @@ actor SessionDriver {
         guard !data.isEmpty else { return }
         let deadline = ContinuousClock.now.advanced(by: timeout)
         var offset = 0
+        let owner = allocateTransportSendOwner()
 
         while offset < data.count {
             await acquireOperation()
-            let progress: (written: Int, wait: SessionWaitPlan)
+            let progress: (written: Int, wait: SessionWaitPlan, parkedOutbound: Bool)
             do {
+                try await holdOwnedLoopTopForTestingIfNeeded(owner: owner)
                 try checkProgress(deadline: deadline)
-                guard valid, let session else { throw SSHError.connectionInvalidated }
-                guard let channel = ptyChannels[id]?.channel else {
-                    throw SSHError.channelFailed
-                }
-                let written = data.withUnsafeBytes { bytes -> Int in
-                    guard let baseAddress = bytes.baseAddress else { return 0 }
-                    return libssh2_channel_write_ex(
-                        channel,
-                        0,
-                        baseAddress.advanced(by: offset).assumingMemoryBound(to: CChar.self),
-                        data.count - offset)
-                }
+                try await waitForTransportSendAdmission(
+                    owner: owner,
+                    deadline: deadline,
+                    cancellable: true)
+                let session = try requireSession()
+                let channel = try resolveChannel(.pty(id))
+                let written = writeChannel(channel, data: data, offset: offset)
+                notePacketProducingWrite(written, owner: owner, session: session)
                 guard written >= 0 || written == Int(LIBSSH2_ERROR_EAGAIN) else {
                     throw SSHError.channelFailed
                 }
-                progress = (written, sessionWaitPlan(session))
+                progress = (
+                    written,
+                    sessionWaitPlan(session),
+                    written == Int(LIBSSH2_ERROR_EAGAIN) && transportSendOwner == owner)
                 releaseOperation()
             } catch {
+                await finishOwnedSendIfNeeded(owner: owner) {
+                    writeChannelOnce(identity: .pty(id), data: data, offset: offset)
+                }
                 releaseOperation()
                 throw normalize(error)
             }
@@ -449,7 +496,21 @@ actor SessionDriver {
                 offset += progress.written
                 await Task.yield()
             } else {
-                try await awaitSessionProgress(progress.wait, until: deadline)
+#if DEBUG
+                if progress.parkedOutbound {
+                    await holdOutboundWriteParkForTestingIfNeeded()
+                }
+#endif
+                do {
+                    try await awaitSessionProgress(progress.wait, until: deadline)
+                } catch {
+                    await acquireOperation()
+                    await finishOwnedSendIfNeeded(owner: owner) {
+                        writeChannelOnce(identity: .pty(id), data: data, offset: offset)
+                    }
+                    releaseOperation()
+                    throw normalize(error)
+                }
             }
         }
     }
@@ -462,29 +523,53 @@ actor SessionDriver {
         guard maximumBytes > 0 else { throw SSHError.channelFailed }
         let deadline = ContinuousClock.now.advanced(by: timeout)
 
+        let owner = allocateTransportSendOwner()
         while true {
             await acquireOperation()
             let progress: (data: Data, eof: Bool, wait: SessionWaitPlan)
             do {
                 try checkProgress(deadline: deadline)
-                guard valid, let session else { throw SSHError.connectionInvalidated }
-                guard let channel = ptyChannels[id]?.channel else {
-                    throw SSHError.channelFailed
-                }
+                try await waitForTransportSendAdmission(
+                    owner: owner,
+                    deadline: deadline,
+                    cancellable: true)
+                let session = try requireSession()
+                let channel = try resolveChannel(.pty(id))
                 var buffer = [UInt8](repeating: 0, count: maximumBytes)
-                let data = try readAvailable(channel: channel, stream: 0, buffer: &buffer)
+                let data = try readAvailableNoting(
+                    channel: channel,
+                    stream: 0,
+                    buffer: &buffer,
+                    owner: owner,
+                    session: session)
                 let eof = libssh2_channel_eof(channel) == 1
                 if eof { ptyChannels[id]?.reachedEOF = true }
                 progress = (data, eof, sessionWaitPlan(session))
                 releaseOperation()
             } catch {
+                await finishOwnedSendIfNeeded(owner: owner) {
+                    guard let channel = try? resolveChannel(.pty(id)) else { return nil }
+                    var scratch = [UInt8](repeating: 0, count: maximumBytes)
+                    return readOnce(channel: channel, stream: 0, buffer: &scratch)
+                }
                 releaseOperation()
                 throw normalize(error)
             }
 
             if !progress.data.isEmpty { return progress.data }
             if progress.eof { return nil }
-            try await awaitSessionProgress(progress.wait, until: deadline)
+            do {
+                try await awaitSessionProgress(progress.wait, until: deadline)
+            } catch {
+                await acquireOperation()
+                await finishOwnedSendIfNeeded(owner: owner) {
+                    guard let channel = try? resolveChannel(.pty(id)) else { return nil }
+                    var scratch = [UInt8](repeating: 0, count: maximumBytes)
+                    return readOnce(channel: channel, stream: 0, buffer: &scratch)
+                }
+                releaseOperation()
+                throw normalize(error)
+            }
         }
     }
 
@@ -506,11 +591,12 @@ actor SessionDriver {
         defer { releaseOperation() }
 
         guard valid, session != nil else { throw SSHError.connectionInvalidated }
-        guard let channel = ptyChannels[id]?.channel else { throw SSHError.channelFailed }
-        let result = try await repeatUntilComplete(
-            deadline: ContinuousClock.now.advanced(by: timeout)
+        guard ptyChannels[id] != nil else { throw SSHError.channelFailed }
+        let result = try await repeatUntilCompleteYielding(
+            deadline: ContinuousClock.now.advanced(by: timeout),
+            identity: .pty(id)
         ) {
-            libssh2_channel_request_pty_size_ex(channel, Int32(columns), Int32(rows), 0, 0)
+            libssh2_channel_request_pty_size_ex($0, Int32(columns), Int32(rows), 0, 0)
         }
         guard result == 0 else { throw SSHError.channelFailed }
     }
@@ -527,7 +613,7 @@ actor SessionDriver {
         }
 
         let exitStatus = try await exitStatusAfterChannelClose(
-            channel: state.channel,
+            identity: .pty(id),
             deadline: deadline)
         ptyChannels[id]?.closed = true
         return exitStatus
@@ -537,26 +623,31 @@ actor SessionDriver {
         await acquireOperation()
         defer { releaseOperation() }
 
-        guard let state = ptyChannels.removeValue(forKey: id) else { return }
-        guard valid, let session else { return }
+        guard ptyChannels[id] != nil else { return }
+        guard valid, session != nil else {
+            ptyChannels.removeValue(forKey: id)
+            return
+        }
         do {
             let deadline = ContinuousClock.now.advanced(by: timeout)
-            if state.closed {
-                let freeResult = try await repeatUntilComplete(
+            if ptyChannels[id]?.closed == true {
+                let freeResult = try await repeatUntilCompleteYielding(
                     deadline: deadline,
-                    cancellable: false
+                    cancellable: false,
+                    identity: .pty(id)
                 ) {
-                    libssh2_channel_free(state.channel)
+                    libssh2_channel_free($0)
                 }
                 guard freeResult == 0 else { throw SSHError.channelFailed }
             } else {
                 try await cleanChannel(
-                    state.channel,
-                    session: session,
+                    identity: .pty(id),
                     deadline: deadline,
                     cancellable: false)
             }
+            ptyChannels.removeValue(forKey: id)
         } catch {
+            ptyChannels.removeValue(forKey: id)
             throw teardownFailure(error)
         }
     }
@@ -572,7 +663,7 @@ actor SessionDriver {
         await acquireOperation()
         defer { releaseOperation() }
 
-        guard valid, !forwarding, authenticated, let session else {
+        guard valid, !forwarding, authenticated, session != nil else {
             throw SSHError.connectionInvalidated
         }
         guard
@@ -586,41 +677,48 @@ actor SessionDriver {
         }
 
         let deadline = ContinuousClock.now.advanced(by: timeout)
-        var channel: OpaquePointer?
+        var oneShotID: UInt64?
 
         do {
-            channel = try await openStreamLocalChannel(
+            let channel = try await openStreamLocalChannel(
                 socketPath: socketPath,
-                session: session,
                 deadline: deadline)
-            guard let channel else { throw SSHError.streamLocalOpenFailed }
-            let response = try await exchangeResponseLine(
+            let session = try requireSession()
+            let id = registerOneShot(
                 channel: channel,
+                session: session)
+            oneShotID = id
+#if DEBUG
+            try await holdOneShotEstablishedForTestingIfNeeded()
+#endif
+            let response = try await exchangeResponseLine(
+                identity: .oneShot(id),
                 request: request,
                 maximumResponseBytes: maximumResponseBytes,
-                session: session,
                 deadline: deadline,
                 beforeRequestWrite: beforeRequestWrite,
                 onRequestWritten: onRequestWritten)
             try await cleanChannel(
-                channel,
-                session: session,
+                identity: .oneShot(id),
                 deadline: deadline,
                 cancellable: true)
+            removeOneShot(id)
             return response
         } catch {
             let normalized = (error as? SSHError).map(normalize)
-            if let channel {
+            if let id = oneShotID {
                 do {
                     try await cleanChannel(
-                        channel,
-                        session: session,
+                        identity: .oneShot(id),
                         deadline: ContinuousClock.now.advanced(by: .seconds(2)),
                         cancellable: false)
+                    removeOneShot(id)
                 } catch {
                     invalidateResources()
                 }
-            } else if normalized != .streamLocalOpenFailed {
+            } else if !(error is ChannelOpenAdmissionError),
+                normalized != .streamLocalOpenFailed
+            {
                 // `.streamLocalOpenFailed` now means only what it says: the
                 // server refused this one channel and the session is intact.
                 // Everything else — a timeout or cancellation with an uncertain
@@ -643,7 +741,7 @@ actor SessionDriver {
         await acquireOperation()
         defer { releaseOperation() }
 
-        guard valid, !forwarding, authenticated, let session else {
+        guard valid, !forwarding, authenticated, session != nil else {
             throw SSHError.connectionInvalidated
         }
         guard socketPath.hasPrefix("/"), !socketPath.utf8.contains(0) else {
@@ -655,7 +753,6 @@ actor SessionDriver {
         do {
             channel = try await openStreamLocalChannel(
                 socketPath: socketPath,
-                session: session,
                 deadline: deadline)
             guard let channel else { throw SSHError.streamLocalOpenFailed }
             nextStreamLocalChannelID &+= 1
@@ -668,13 +765,15 @@ actor SessionDriver {
                 do {
                     try await cleanChannel(
                         channel,
-                        session: session,
+                        session: try requireSession(),
                         deadline: ContinuousClock.now.advanced(by: .seconds(2)),
                         cancellable: false)
                 } catch {
                     invalidateResources()
                 }
-            } else if normalized != .streamLocalOpenFailed {
+            } else if !(error is ChannelOpenAdmissionError),
+                normalized != .streamLocalOpenFailed
+            {
                 // The same rule `exchangeStreamLocal` states above: only a
                 // refusal of this one channel leaves the session usable.
                 invalidateResources()
@@ -691,33 +790,34 @@ actor SessionDriver {
         guard !data.isEmpty else { return }
         let deadline = ContinuousClock.now.advanced(by: timeout)
         var offset = 0
+        let owner = allocateTransportSendOwner()
 
         while offset < data.count {
             await acquireOperation()
-            let progress: (written: Int, wait: SessionWaitPlan)
+            let progress: (written: Int, wait: SessionWaitPlan, parkedOutbound: Bool)
             do {
+                try await holdOwnedLoopTopForTestingIfNeeded(owner: owner)
                 try checkProgress(deadline: deadline)
-                guard
-                    valid,
-                    let session,
-                    let channel = streamLocalChannels[id]
-                else {
-                    throw SSHError.connectionInvalidated
-                }
-                let written = data.withUnsafeBytes { bytes -> Int in
-                    guard let baseAddress = bytes.baseAddress else { return 0 }
-                    return libssh2_channel_write_ex(
-                        channel,
-                        0,
-                        baseAddress.advanced(by: offset).assumingMemoryBound(to: CChar.self),
-                        data.count - offset)
-                }
+                try await waitForTransportSendAdmission(
+                    owner: owner,
+                    deadline: deadline,
+                    cancellable: true)
+                let session = try requireSession()
+                let channel = try resolveChannel(.streamLocal(id))
+                let written = writeChannel(channel, data: data, offset: offset)
+                notePacketProducingWrite(written, owner: owner, session: session)
                 guard written >= 0 || written == Int(LIBSSH2_ERROR_EAGAIN) else {
                     throw SSHError.channelFailed
                 }
-                progress = (written, sessionWaitPlan(session))
+                progress = (
+                    written,
+                    sessionWaitPlan(session),
+                    written == Int(LIBSSH2_ERROR_EAGAIN) && transportSendOwner == owner)
                 releaseOperation()
             } catch {
+                await finishOwnedSendIfNeeded(owner: owner) {
+                    writeChannelOnce(identity: .streamLocal(id), data: data, offset: offset)
+                }
                 releaseOperation()
                 throw normalize(error)
             }
@@ -726,7 +826,21 @@ actor SessionDriver {
                 offset += progress.written
                 await Task.yield()
             } else {
-                try await awaitSessionProgress(progress.wait, until: deadline)
+#if DEBUG
+                if progress.parkedOutbound {
+                    await holdOutboundWriteParkForTestingIfNeeded()
+                }
+#endif
+                do {
+                    try await awaitSessionProgress(progress.wait, until: deadline)
+                } catch {
+                    await acquireOperation()
+                    await finishOwnedSendIfNeeded(owner: owner) {
+                        writeChannelOnce(identity: .streamLocal(id), data: data, offset: offset)
+                    }
+                    releaseOperation()
+                    throw normalize(error)
+                }
             }
         }
     }
@@ -738,34 +852,55 @@ actor SessionDriver {
     ) async throws -> Data? {
         guard maximumBytes > 0 else { throw SSHError.channelFailed }
         let deadline = ContinuousClock.now.advanced(by: timeout)
+        let owner = allocateTransportSendOwner()
 
         while true {
             await acquireOperation()
             let progress: (data: Data, eof: Bool, wait: SessionWaitPlan)
             do {
                 try checkProgress(deadline: deadline)
-                guard
-                    valid,
-                    let session,
-                    let channel = streamLocalChannels[id]
-                else {
-                    throw SSHError.connectionInvalidated
-                }
+                try await waitForTransportSendAdmission(
+                    owner: owner,
+                    deadline: deadline,
+                    cancellable: true)
+                let session = try requireSession()
+                let channel = try resolveChannel(.streamLocal(id))
                 var buffer = [UInt8](repeating: 0, count: maximumBytes)
-                let data = try readAvailable(channel: channel, stream: 0, buffer: &buffer)
+                let data = try readAvailableNoting(
+                    channel: channel,
+                    stream: 0,
+                    buffer: &buffer,
+                    owner: owner,
+                    session: session)
                 progress = (
                     data,
                     libssh2_channel_eof(channel) == 1,
                     sessionWaitPlan(session))
                 releaseOperation()
             } catch {
+                await finishOwnedSendIfNeeded(owner: owner) {
+                    guard let channel = try? resolveChannel(.streamLocal(id)) else { return nil }
+                    var scratch = [UInt8](repeating: 0, count: maximumBytes)
+                    return readOnce(channel: channel, stream: 0, buffer: &scratch)
+                }
                 releaseOperation()
                 throw normalize(error)
             }
 
             if !progress.data.isEmpty { return progress.data }
             if progress.eof { return nil }
-            try await awaitSessionProgress(progress.wait, until: deadline)
+            do {
+                try await awaitSessionProgress(progress.wait, until: deadline)
+            } catch {
+                await acquireOperation()
+                await finishOwnedSendIfNeeded(owner: owner) {
+                    guard let channel = try? resolveChannel(.streamLocal(id)) else { return nil }
+                    var scratch = [UInt8](repeating: 0, count: maximumBytes)
+                    return readOnce(channel: channel, stream: 0, buffer: &scratch)
+                }
+                releaseOperation()
+                throw normalize(error)
+            }
         }
     }
 
@@ -773,15 +908,19 @@ actor SessionDriver {
         await acquireOperation()
         defer { releaseOperation() }
 
-        guard let channel = streamLocalChannels.removeValue(forKey: id) else { return }
-        guard valid, let session else { return }
+        guard streamLocalChannels[id] != nil else { return }
+        guard valid, session != nil else {
+            streamLocalChannels.removeValue(forKey: id)
+            return
+        }
         do {
             try await cleanChannel(
-                channel,
-                session: session,
+                identity: .streamLocal(id),
                 deadline: ContinuousClock.now.advanced(by: timeout),
                 cancellable: false)
+            streamLocalChannels.removeValue(forKey: id)
         } catch {
+            streamLocalChannels.removeValue(forKey: id)
             throw teardownFailure(error)
         }
     }
@@ -790,28 +929,36 @@ actor SessionDriver {
         await acquireOperation()
         defer { releaseOperation() }
 
-        guard valid, !forwarding, authenticated, let session else {
+        guard valid, !forwarding, authenticated, session != nil else {
             throw SSHError.connectionInvalidated
         }
         let deadline = ContinuousClock.now.advanced(by: timeout)
         var initWasPending = false
+        let owner = allocateTransportSendOwner()
 
         do {
             while true {
                 try checkProgress(deadline: deadline)
+                try await waitForTransportSendAdmission(
+                    owner: owner,
+                    deadline: deadline,
+                    cancellable: true)
 #if DEBUG
                 if shouldFailNextSFTPInitBeforeEAGAINForTesting {
                     shouldFailNextSFTPInitBeforeEAGAINForTesting = false
                     throw SSHError.sftpUnavailable
                 }
 #endif
+                let session = try requireSession()
                 if let sftp = libssh2_sftp_init(session) {
+                    notePacketProducingResult(0, owner: owner, session: session)
                     nextSFTPID &+= 1
                     let id = nextSFTPID
                     sftpClients[id] = SFTPState(handle: sftp)
                     return SSHSFTPClient(id: id, driver: self)
                 }
                 let error = libssh2_session_last_errno(session)
+                notePacketProducingResult(error, owner: owner, session: session)
                 if error == LIBSSH2_ERROR_EAGAIN {
                     initWasPending = true
                     try await waitForSession(session, deadline: deadline)
@@ -822,6 +969,7 @@ actor SessionDriver {
                 }
             }
         } catch {
+            if transportSendOwner == owner { invalidateResources() }
             let normalized = normalize(error)
             // libssh2 1.11.1 keeps one in-progress SFTP-init state per session,
             // including its channel and allocation. Any failure after EAGAIN
@@ -847,12 +995,10 @@ actor SessionDriver {
         }
         await acquireOperation()
         defer { releaseOperation() }
-        guard valid, let session, let sftp = sftpClients[id]?.handle else {
-            throw SSHError.connectionInvalidated
-        }
-        let result = try await repeatUntilComplete(
+        let result = try await repeatUntilCompleteHoldingSFTP(
+            id: id,
             deadline: ContinuousClock.now.advanced(by: timeout)
-        ) {
+        ) { sftp in
             path.withCString { pathPointer in
                 libssh2_sftp_mkdir_ex(
                     sftp,
@@ -861,7 +1007,7 @@ actor SessionDriver {
                     Int(permissions))
             }
         }
-        try checkSFTPResult(result, sftp: sftp, session: session)
+        try checkSFTPResult(result, sftpID: id)
     }
 
     func sftpAttributes(
@@ -872,13 +1018,11 @@ actor SessionDriver {
         guard Self.isValidSFTPPath(path) else { throw SSHError.channelFailed }
         await acquireOperation()
         defer { releaseOperation() }
-        guard valid, let session, let sftp = sftpClients[id]?.handle else {
-            throw SSHError.connectionInvalidated
-        }
         var attributes = LIBSSH2_SFTP_ATTRIBUTES()
-        let result = try await repeatUntilComplete(
+        let result = try await repeatUntilCompleteHoldingSFTP(
+            id: id,
             deadline: ContinuousClock.now.advanced(by: timeout)
-        ) {
+        ) { sftp in
             path.withCString { pathPointer in
                 libssh2_sftp_stat_ex(
                     sftp,
@@ -888,7 +1032,7 @@ actor SessionDriver {
                     &attributes)
             }
         }
-        try checkSFTPResult(result, sftp: sftp, session: session)
+        try checkSFTPResult(result, sftpID: id)
         let hasSize = attributes.flags & UInt(LIBSSH2_SFTP_ATTR_SIZE) != 0
         let hasPermissions = attributes.flags & UInt(LIBSSH2_SFTP_ATTR_PERMISSIONS) != 0
         return SSHSFTPAttributes(
@@ -909,15 +1053,13 @@ actor SessionDriver {
         }
         await acquireOperation()
         defer { releaseOperation() }
-        guard valid, let session, let sftp = sftpClients[id]?.handle else {
-            throw SSHError.connectionInvalidated
-        }
         var attributes = LIBSSH2_SFTP_ATTRIBUTES()
         attributes.flags = UInt(LIBSSH2_SFTP_ATTR_PERMISSIONS)
         attributes.permissions = UInt(permissions)
-        let result = try await repeatUntilComplete(
+        let result = try await repeatUntilCompleteHoldingSFTP(
+            id: id,
             deadline: ContinuousClock.now.advanced(by: timeout)
-        ) {
+        ) { sftp in
             path.withCString { pathPointer in
                 libssh2_sftp_stat_ex(
                     sftp,
@@ -927,7 +1069,7 @@ actor SessionDriver {
                     &attributes)
             }
         }
-        try checkSFTPResult(result, sftp: sftp, session: session)
+        try checkSFTPResult(result, sftpID: id)
     }
 
     func readSFTPFileIfPresent(
@@ -937,32 +1079,34 @@ actor SessionDriver {
     ) async throws -> Data? {
         guard Self.isValidSFTPPath(path) else { throw SSHError.channelFailed }
         let deadline = ContinuousClock.now.advanced(by: timeout)
-        guard let fileID = try await openSFTPFileForReadingIfPresent(
-            sftpID: id,
-            path: path,
-            deadline: deadline)
-        else { return nil }
-
-        do {
-            var contents = Data()
-            while let chunk = try await readSFTPFileChunk(
+        return try await withSFTPUse(id: id, deadline: deadline) {
+            guard let fileID = try await openSFTPFileForReadingIfPresent(
                 sftpID: id,
-                fileID: fileID,
+                path: path,
                 deadline: deadline)
-            {
-                contents.append(chunk)
+            else { return nil }
+
+            do {
+                var contents = Data()
+                while let chunk = try await readSFTPFileChunk(
+                    sftpID: id,
+                    fileID: fileID,
+                    deadline: deadline)
+                {
+                    contents.append(chunk)
+                }
+                try await closeSFTPFileWithinUse(
+                    sftpID: id,
+                    fileID: fileID,
+                    timeout: timeout)
+                return contents
+            } catch {
+                try? await closeSFTPFileWithinUse(
+                    sftpID: id,
+                    fileID: fileID,
+                    timeout: .seconds(2))
+                throw normalize(error)
             }
-            try await closeSFTPFile(
-                sftpID: id,
-                fileID: fileID,
-                timeout: timeout)
-            return contents
-        } catch {
-            try? await closeSFTPFile(
-                sftpID: id,
-                fileID: fileID,
-                timeout: .seconds(2))
-            throw normalize(error)
         }
     }
 
@@ -973,12 +1117,22 @@ actor SessionDriver {
     ) async throws -> UInt64? {
         await acquireOperation()
         defer { releaseOperation() }
-        guard valid, let session, let sftp = sftpClients[sftpID]?.handle else {
+        guard valid, session != nil, sftpClients[sftpID]?.handle != nil else {
             throw SSHError.connectionInvalidated
         }
+        let owner = allocateTransportSendOwner()
 
+        do {
         while true {
             try checkProgress(deadline: deadline)
+            try await waitForTransportSendAdmission(
+                owner: owner,
+                deadline: deadline,
+                cancellable: true)
+            let session = try requireSession()
+            guard let sftp = sftpClients[sftpID]?.handle else {
+                throw SSHError.connectionInvalidated
+            }
             let file = path.withCString { pathPointer in
                 libssh2_sftp_open_ex(
                     sftp,
@@ -989,6 +1143,7 @@ actor SessionDriver {
                     Int32(LIBSSH2_SFTP_OPENFILE))
             }
             if let file {
+                notePacketProducingResult(0, owner: owner, session: session)
                 nextSFTPFileID &+= 1
                 let fileID = nextSFTPFileID
                 sftpClients[sftpID]?.files[fileID] = file
@@ -996,6 +1151,7 @@ actor SessionDriver {
             }
 
             let error = libssh2_session_last_errno(session)
+            notePacketProducingResult(error, owner: owner, session: session)
             if error == LIBSSH2_ERROR_EAGAIN {
                 try await waitForSession(session, deadline: deadline)
                 continue
@@ -1008,6 +1164,10 @@ actor SessionDriver {
             if status == UInt64(LIBSSH2_FX_NO_SUCH_FILE) { return nil }
             throw SSHError.sftpFailure(status: status)
         }
+        } catch {
+            if transportSendOwner == owner { invalidateResources() }
+            throw error
+        }
     }
 
     private func readSFTPFileChunk(
@@ -1016,12 +1176,17 @@ actor SessionDriver {
         deadline: ContinuousClock.Instant
     ) async throws -> Data? {
         let maximumChunkBytes = 64 * 1_024
+        let owner = allocateTransportSendOwner()
 
         while true {
             await acquireOperation()
             let progress: (data: Data, reachedEOF: Bool, wait: SessionWaitPlan)
             do {
                 try checkProgress(deadline: deadline)
+                try await waitForTransportSendAdmission(
+                    owner: owner,
+                    deadline: deadline,
+                    cancellable: true)
                 guard
                     valid,
                     let session,
@@ -1038,6 +1203,7 @@ actor SessionDriver {
                         baseAddress.assumingMemoryBound(to: CChar.self),
                         bytes.count)
                 }
+                notePacketProducingWrite(read, owner: owner, session: session)
                 if read < 0, read != Int(LIBSSH2_ERROR_EAGAIN) {
                     throw mappedSFTPError(sftp: state.handle, code: Int32(read))
                 }
@@ -1049,13 +1215,27 @@ actor SessionDriver {
             } catch {
                 let normalized = normalize(error)
                 if normalized == .connectionInvalidated { invalidateResources() }
+                await finishOwnedSendIfNeeded(owner: owner) {
+                    readSFTPOnce(sftpID: sftpID, fileID: fileID)
+                }
                 releaseOperation()
                 throw normalized
             }
 
             if !progress.data.isEmpty { return progress.data }
             if progress.reachedEOF { return nil }
-            try await awaitSessionProgress(progress.wait, until: deadline)
+            do {
+                try await awaitSessionProgress(progress.wait, until: deadline)
+            } catch {
+                let normalized = normalize(error)
+                if normalized == .connectionInvalidated { invalidateResources() }
+                await acquireOperation()
+                await finishOwnedSendIfNeeded(owner: owner) {
+                    readSFTPOnce(sftpID: sftpID, fileID: fileID)
+                }
+                releaseOperation()
+                throw normalized
+            }
         }
     }
 
@@ -1070,15 +1250,31 @@ actor SessionDriver {
         }
         await acquireOperation()
         defer { releaseOperation() }
-        guard valid, let session, let sftp = sftpClients[sftpID]?.handle else {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        guard valid, session != nil, sftpClients[sftpID]?.handle != nil else {
             throw SSHError.connectionInvalidated
         }
-        let deadline = ContinuousClock.now.advanced(by: timeout)
+        try await waitUntilSFTPIdle(
+            id: sftpID,
+            deadline: deadline,
+            cancellable: true)
+        try beginSFTPUse(sftpID)
+        defer { endSFTPUse(sftpID) }
         let flags = UInt(
             LIBSSH2_FXF_WRITE | LIBSSH2_FXF_CREAT | LIBSSH2_FXF_TRUNC | LIBSSH2_FXF_EXCL)
+        let owner = allocateTransportSendOwner()
 
+        do {
         while true {
             try checkProgress(deadline: deadline)
+            try await waitForTransportSendAdmission(
+                owner: owner,
+                deadline: deadline,
+                cancellable: true)
+            let session = try requireSession()
+            guard let sftp = sftpClients[sftpID]?.handle else {
+                throw SSHError.connectionInvalidated
+            }
             let file = path.withCString { pathPointer in
                 libssh2_sftp_open_ex(
                     sftp,
@@ -1089,17 +1285,23 @@ actor SessionDriver {
                     Int32(LIBSSH2_SFTP_OPENFILE))
             }
             if let file {
+                notePacketProducingResult(0, owner: owner, session: session)
                 nextSFTPFileID &+= 1
                 let fileID = nextSFTPFileID
                 sftpClients[sftpID]?.files[fileID] = file
                 return SSHSFTPFile(sftpID: sftpID, fileID: fileID, driver: self)
             }
             let error = libssh2_session_last_errno(session)
+            notePacketProducingResult(error, owner: owner, session: session)
             if error == LIBSSH2_ERROR_EAGAIN {
                 try await waitForSession(session, deadline: deadline)
             } else {
                 throw mappedSFTPError(sftp: sftp, code: error)
             }
+        }
+        } catch {
+            if transportSendOwner == owner { invalidateResources() }
+            throw error
         }
     }
 
@@ -1124,45 +1326,67 @@ actor SessionDriver {
         }
 #endif
         let deadline = ContinuousClock.now.advanced(by: timeout)
-        var offset = 0
+        try await withSFTPUse(id: sftpID, deadline: deadline) {
+            var offset = 0
+            let owner = allocateTransportSendOwner()
 
-        while offset < data.count {
-            await acquireOperation()
-            let progress: (written: Int, wait: SessionWaitPlan)
-            do {
-                try checkProgress(deadline: deadline)
-                guard
-                    valid,
-                    let session,
-                    let state = sftpClients[sftpID],
-                    let file = state.files[fileID]
-                else {
-                    throw SSHError.connectionInvalidated
+            while offset < data.count {
+                await acquireOperation()
+                let progress: (written: Int, wait: SessionWaitPlan)
+                do {
+                    try checkProgress(deadline: deadline)
+                    try await waitForTransportSendAdmission(
+                        owner: owner,
+                        deadline: deadline,
+                        cancellable: true)
+                    guard
+                        valid,
+                        let session,
+                        let state = sftpClients[sftpID],
+                        let file = state.files[fileID]
+                    else {
+                        throw SSHError.connectionInvalidated
+                    }
+                    let written = data.withUnsafeBytes { bytes -> Int in
+                        guard let baseAddress = bytes.baseAddress else { return 0 }
+                        return libssh2_sftp_write(
+                            file,
+                            baseAddress.advanced(by: offset).assumingMemoryBound(to: CChar.self),
+                            data.count - offset)
+                    }
+                    notePacketProducingWrite(written, owner: owner, session: session)
+                    if written < 0, written != Int(LIBSSH2_ERROR_EAGAIN) {
+                        throw mappedSFTPError(sftp: state.handle, code: Int32(written))
+                    }
+                    progress = (written, sessionWaitPlan(session))
+                    releaseOperation()
+                } catch {
+                    let normalized = normalize(error)
+                    if normalized == .connectionInvalidated { invalidateResources() }
+                    await finishOwnedSendIfNeeded(owner: owner) {
+                        writeSFTPOnce(sftpID: sftpID, fileID: fileID, data: data, offset: offset)
+                    }
+                    releaseOperation()
+                    throw normalized
                 }
-                let written = data.withUnsafeBytes { bytes -> Int in
-                    guard let baseAddress = bytes.baseAddress else { return 0 }
-                    return libssh2_sftp_write(
-                        file,
-                        baseAddress.advanced(by: offset).assumingMemoryBound(to: CChar.self),
-                        data.count - offset)
-                }
-                if written < 0, written != Int(LIBSSH2_ERROR_EAGAIN) {
-                    throw mappedSFTPError(sftp: state.handle, code: Int32(written))
-                }
-                progress = (written, sessionWaitPlan(session))
-                releaseOperation()
-            } catch {
-                let normalized = normalize(error)
-                if normalized == .connectionInvalidated { invalidateResources() }
-                releaseOperation()
-                throw normalized
-            }
 
-            if progress.written > 0 {
-                offset += progress.written
-                await Task.yield()
-            } else {
-                try await awaitSessionProgress(progress.wait, until: deadline)
+                if progress.written > 0 {
+                    offset += progress.written
+                    await Task.yield()
+                } else {
+                    do {
+                        try await awaitSessionProgress(progress.wait, until: deadline)
+                    } catch {
+                        let normalized = normalize(error)
+                        if normalized == .connectionInvalidated { invalidateResources() }
+                        await acquireOperation()
+                        await finishOwnedSendIfNeeded(owner: owner) {
+                            writeSFTPOnce(sftpID: sftpID, fileID: fileID, data: data, offset: offset)
+                        }
+                        releaseOperation()
+                        throw normalized
+                    }
+                }
             }
         }
     }
@@ -1174,20 +1398,62 @@ actor SessionDriver {
     ) async throws {
         await acquireOperation()
         defer { releaseOperation() }
-        guard let state = sftpClients[sftpID], let file = state.files[fileID] else { return }
+        guard sftpClients[sftpID]?.files[fileID] != nil else { return }
         guard valid, session != nil else { return }
         do {
-            let result = try await repeatUntilComplete(
-                deadline: ContinuousClock.now.advanced(by: timeout),
-                cancellable: false
-            ) {
-                libssh2_sftp_close_handle(file)
-            }
-            guard result == 0 else { throw SSHError.channelFailed }
-            sftpClients[sftpID]?.files[fileID] = nil
+            let deadline = ContinuousClock.now.advanced(by: timeout)
+            try await waitUntilSFTPIdle(
+                id: sftpID,
+                deadline: deadline,
+                cancellable: false)
+            try beginSFTPUse(sftpID)
+            defer { endSFTPUse(sftpID) }
+            try await closeSFTPFileHoldingOperation(
+                sftpID: sftpID,
+                fileID: fileID,
+                deadline: deadline)
         } catch {
             throw teardownFailure(error)
         }
+    }
+
+    private func closeSFTPFileWithinUse(
+        sftpID: UInt64,
+        fileID: UInt64,
+        timeout: Duration
+    ) async throws {
+        await acquireOperation()
+        defer { releaseOperation() }
+        guard sftpClients[sftpID]?.files[fileID] != nil else { return }
+        guard valid, session != nil else { return }
+        do {
+            try await closeSFTPFileHoldingOperation(
+                sftpID: sftpID,
+                fileID: fileID,
+                deadline: ContinuousClock.now.advanced(by: timeout))
+        } catch {
+            throw teardownFailure(error)
+        }
+    }
+
+    private func closeSFTPFileHoldingOperation(
+        sftpID: UInt64,
+        fileID: UInt64,
+        deadline: ContinuousClock.Instant
+    ) async throws {
+        try await waitForTransportSendAdmission(
+            owner: allocateTransportSendOwner(),
+            deadline: deadline,
+            cancellable: false)
+        guard let file = sftpClients[sftpID]?.files[fileID] else { return }
+        let result = try await repeatUntilCompleteHolding(
+            deadline: deadline,
+            cancellable: false
+        ) {
+            libssh2_sftp_close_handle(file)
+        }
+        guard result == 0 else { throw SSHError.channelFailed }
+        sftpClients[sftpID]?.files[fileID] = nil
     }
 
     func removeSFTPFile(
@@ -1262,7 +1528,7 @@ actor SessionDriver {
             try await hold()
         }
 #endif
-        let result = try await repeatUntilComplete(
+        let result = try await repeatUntilCompleteHolding(
             deadline: deadline,
             cancellable: false
         ) {
@@ -1281,10 +1547,20 @@ actor SessionDriver {
         cancellable: Bool,
         verifyAbsence: Bool
     ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        try await waitUntilSFTPIdle(
+            id: id,
+            deadline: deadline,
+            cancellable: cancellable)
+        try beginSFTPUse(id)
+        defer { endSFTPUse(id) }
+        try await waitForTransportSendAdmission(
+            owner: allocateTransportSendOwner(),
+            deadline: deadline,
+            cancellable: cancellable)
         guard valid, let session, let sftp = sftpClients[id]?.handle else {
             throw SSHError.connectionInvalidated
         }
-        let deadline = ContinuousClock.now.advanced(by: timeout)
         let result = try await repeatCompensationOperation(
             phase: .unlink,
             deadline: deadline,
@@ -1348,12 +1624,10 @@ actor SessionDriver {
         }
         await acquireOperation()
         defer { releaseOperation() }
-        guard valid, let session, let sftp = sftpClients[id]?.handle else {
-            throw SSHError.connectionInvalidated
-        }
-        let result = try await repeatUntilComplete(
+        let result = try await repeatUntilCompleteHoldingSFTP(
+            id: id,
             deadline: ContinuousClock.now.advanced(by: timeout)
-        ) {
+        ) { sftp in
             sourcePath.withCString { sourcePointer in
                 destinationPath.withCString { destinationPointer in
                     libssh2_sftp_posix_rename_ex(
@@ -1365,17 +1639,27 @@ actor SessionDriver {
                 }
             }
         }
-        try checkSFTPResult(result, sftp: sftp, session: session)
+        try checkSFTPResult(result, sftpID: id)
     }
 
     func closeSFTP(id: UInt64, timeout: Duration) async throws {
         await acquireOperation()
         defer { releaseOperation() }
-        guard let state = sftpClients.removeValue(forKey: id) else { return }
-        guard valid, session != nil else { return }
+        guard sftpClients[id] != nil else { return }
+        let deadline = ContinuousClock.now.advanced(by: timeout)
         do {
-            let result = try await repeatUntilComplete(
-                deadline: ContinuousClock.now.advanced(by: timeout),
+            try await waitUntilSFTPIdle(
+                id: id,
+                deadline: deadline,
+                cancellable: false)
+            guard let state = sftpClients.removeValue(forKey: id) else { return }
+            guard valid, session != nil else { return }
+            try await waitForTransportSendAdmission(
+                owner: allocateTransportSendOwner(),
+                deadline: deadline,
+                cancellable: false)
+            let result = try await repeatUntilCompleteHolding(
+                deadline: deadline,
                 cancellable: false
             ) {
                 libssh2_sftp_shutdown(state.handle)
@@ -1414,8 +1698,14 @@ actor SessionDriver {
             }
             try await freeSession(session, deadline: deadline, cancellable: true)
             self.session = nil
-            closeDescriptor()
             valid = false
+            oneShotChannels.removeAll()
+            streamLocalChannels.removeAll()
+            ptyChannels.removeAll()
+            sftpClients.removeAll()
+            transportSendOwner = nil
+            activity.releaseAllWaiters()
+            closeDescriptor()
         } catch {
             invalidateResources()
             throw normalize(error)
@@ -1443,7 +1733,9 @@ actor SessionDriver {
     /// naturally passes through: released to the next operation, not yet
     /// watching the socket. Widening that window turns the race this driver
     /// has to survive into something a test can drive.
-    func holdNextSessionWaitForTesting(_ hold: @escaping @Sendable () async -> Void) {
+    func holdNextSessionWaitForTesting(
+        _ hold: @escaping @Sendable () async throws -> Void
+    ) {
         nextSessionWaitHoldForTesting = hold
     }
 
@@ -1457,6 +1749,92 @@ actor SessionDriver {
         _ hold: @escaping @Sendable () async throws -> Void
     ) {
         nextExecCleanupHoldForTesting = hold
+    }
+
+    func holdNextOutboundWriteParkForTesting(
+        _ hold: @escaping @Sendable () async -> Void
+    ) {
+        nextOutboundWriteParkHoldForTesting = hold
+    }
+
+    func holdNextOneShotEstablishedForTesting(
+        _ hold: @escaping @Sendable () async throws -> Void
+    ) {
+        nextOneShotEstablishedHoldForTesting = hold
+    }
+
+    func holdEachOneShotEstablishedForTesting(
+        _ hold: @escaping @Sendable () async throws -> Void
+    ) {
+        eachOneShotEstablishedHoldForTesting = hold
+    }
+
+    func clearEachOneShotEstablishedHoldForTesting() {
+        eachOneShotEstablishedHoldForTesting = nil
+    }
+
+    func holdNextOwnedLoopTopForTesting(
+        _ hold: @escaping @Sendable () async throws -> Void
+    ) {
+        nextOwnedLoopTopHoldForTesting = hold
+    }
+
+    func holdNextOwnedDrainForTesting(
+        _ hold: @escaping @Sendable () async throws -> Void
+    ) {
+        nextOwnedDrainHoldForTesting = hold
+    }
+
+    func holdNextChannelOpenSlotForTesting(
+        _ hold: @escaping @Sendable () async throws -> Void
+    ) {
+        nextChannelOpenSlotHoldForTesting = hold
+    }
+
+    func holdEachSessionWaitForTesting(
+        _ hold: @escaping @Sendable () async -> Void
+    ) {
+        eachSessionWaitHoldForTesting = hold
+    }
+
+    func clearEachSessionWaitForTesting() {
+        eachSessionWaitHoldForTesting = nil
+    }
+
+    func sftpUseCountForTesting() -> Int {
+        sftpUses.values.reduce(0, +)
+    }
+
+    func sftpIdleWaiterCountForTesting() -> Int {
+        sftpIdleWaiters.count
+    }
+
+    func channelOpenWaiterCountForTesting() -> Int {
+        channelOpenWaiters.count
+    }
+
+    func startSamplingTransportSendOwnerForTesting() {
+        ownerSamplesForTesting = []
+    }
+
+    func transportSendOwnerSamplesForTesting() -> [TransportSendOwnerSample] {
+        ownerSamplesForTesting ?? []
+    }
+
+    func oneShotRegistryCountForTesting() -> Int {
+        oneShotChannels.count
+    }
+
+    func shrinkSendBufferForTesting(bytes: Int) throws {
+        guard descriptor >= 0 else { throw SSHError.connectionInvalidated }
+        var size = Int32(clamping: bytes)
+        let result = setsockopt(
+            descriptor,
+            SOL_SOCKET,
+            SO_SNDBUF,
+            &size,
+            socklen_t(MemoryLayout<Int32>.size))
+        guard result == 0 else { throw SSHError.connectionInvalidated }
     }
 
     func runNextCompensationUnlinkPhaseHookForTesting(
@@ -1556,7 +1934,6 @@ actor SessionDriver {
         do {
             channel = try await openDirectTCPIPChannel(
                 endpoint: endpoint,
-                session: session,
                 deadline: deadline)
             guard let channel else { throw SSHError.channelFailed }
             let transport = try DirectTCPIPByteTransport()
@@ -1582,7 +1959,9 @@ actor SessionDriver {
                 } catch {
                     invalidateResources()
                 }
-            } else if normalized == .timedOut || normalized == .cancelled {
+            } else if !(error is ChannelOpenAdmissionError),
+                normalized == .timedOut || normalized == .cancelled
+            {
                 invalidateResources()
             }
             throw normalized
@@ -1591,11 +1970,27 @@ actor SessionDriver {
 
     private func openDirectTCPIPChannel(
         endpoint: SSHEndpoint,
-        session: OpaquePointer,
         deadline: ContinuousClock.Instant
     ) async throws -> OpaquePointer {
+        do {
+            try await claimChannelOpenSlot(deadline: deadline, cancellable: true)
+        } catch {
+            throw ChannelOpenAdmissionError(underlying: normalize(error))
+        }
+        defer { releaseChannelOpenSlot() }
+        let owner = allocateTransportSendOwner()
         while true {
             try checkProgress(deadline: deadline)
+            do {
+                try await waitForTransportSendAdmission(
+                    owner: owner,
+                    deadline: deadline,
+                    cancellable: true)
+            } catch {
+                if transportSendOwner == owner { invalidateResources() }
+                throw error
+            }
+            let session = try requireSession()
             let channel = endpoint.host.withCString { hostPointer in
                 libssh2_channel_direct_tcpip_ex(
                     session,
@@ -1604,11 +1999,20 @@ actor SessionDriver {
                     "127.0.0.1",
                     0)
             }
-            if let channel { return channel }
+            if let channel {
+                notePacketProducingResult(0, owner: owner, session: session)
+                return channel
+            }
 
             let error = libssh2_session_last_errno(session)
+            notePacketProducingResult(error, owner: owner, session: session)
             if error == LIBSSH2_ERROR_EAGAIN {
-                try await waitForSession(session, deadline: deadline)
+                do {
+                    try await waitForSession(session, deadline: deadline)
+                } catch {
+                    if transportSendOwner == owner { invalidateResources() }
+                    throw error
+                }
             } else {
                 throw classifyDirectTCPIPOpenFailure(session)
             }
@@ -1814,6 +2218,8 @@ actor SessionDriver {
 #if DEBUG
         if let hold = nextSessionWaitHoldForTesting {
             nextSessionWaitHoldForTesting = nil
+            try await hold()
+        } else if let hold = eachSessionWaitHoldForTesting {
             await hold()
         }
 #endif
@@ -1838,6 +2244,352 @@ actor SessionDriver {
         return directions
     }
 
+    private func sessionReportsOutbound(_ session: OpaquePointer) -> Bool {
+        libssh2_session_block_directions(session) & LIBSSH2_SESSION_BLOCK_OUTBOUND != 0
+    }
+
+    private func requireSession() throws -> OpaquePointer {
+        guard valid, let session else { throw SSHError.connectionInvalidated }
+        return session
+    }
+
+    private func allocateTransportSendOwner() -> UInt64 {
+        nextTransportSendIdentity &+= 1
+        return nextTransportSendIdentity
+    }
+
+    private func notePacketProducingResult(
+        _ result: Int32,
+        owner: UInt64,
+        session: OpaquePointer
+    ) {
+        if result == LIBSSH2_ERROR_EAGAIN {
+            if sessionReportsOutbound(session), transportSendOwner == nil {
+                transportSendOwner = owner
+            }
+        } else if transportSendOwner == owner {
+            transportSendOwner = nil
+        }
+    }
+
+    private func notePacketProducingWrite(
+        _ written: Int,
+        owner: UInt64,
+        session: OpaquePointer
+    ) {
+        if written == Int(LIBSSH2_ERROR_EAGAIN) {
+            notePacketProducingResult(LIBSSH2_ERROR_EAGAIN, owner: owner, session: session)
+        } else if written >= 0 {
+            notePacketProducingResult(0, owner: owner, session: session)
+        } else {
+            notePacketProducingResult(Int32(clamping: written), owner: owner, session: session)
+        }
+    }
+
+    /// Caller holds the operation mutex. Releases it while a foreign owner
+    /// occupies the send, then re-acquires before returning or throwing so a
+    /// matching `releaseOperation()` stays balanced.
+    private func waitForTransportSendAdmission(
+        owner: UInt64,
+        deadline: ContinuousClock.Instant,
+        cancellable: Bool
+    ) async throws {
+        while let existing = transportSendOwner, existing != owner {
+            let session = try requireSession()
+            let plan = sessionWaitPlan(session)
+            releaseOperation()
+            do {
+                try await awaitSessionProgress(
+                    plan,
+                    until: deadline,
+                    cancellable: cancellable)
+            } catch {
+                await acquireOperation()
+                throw error
+            }
+            await acquireOperation()
+            if cancellable {
+                try checkProgress(deadline: deadline)
+            } else if ContinuousClock.now >= deadline {
+                throw SSHError.timedOut
+            }
+        }
+    }
+
+    /// Drives the exact owning libssh2 call to a non-`EAGAIN` result, or
+    /// invalidates. Cancellation and timeout never clear ownership by themselves.
+    private func finishOwnedSendIfNeeded(
+        owner: UInt64,
+        drive: () -> Int32
+    ) async {
+        await finishOwnedSendIfNeeded(owner: owner, drive: { drive() as Int32? })
+    }
+
+    private func finishOwnedSendIfNeeded(
+        owner: UInt64,
+        drive: () -> Int32?
+    ) async {
+        guard transportSendOwner == owner else { return }
+#if DEBUG
+        if let hold = nextOwnedDrainHoldForTesting {
+            nextOwnedDrainHoldForTesting = nil
+            do {
+                try await hold()
+            } catch {
+                invalidateResources()
+                return
+            }
+        }
+#endif
+        let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+        do {
+            while transportSendOwner == owner {
+                if ContinuousClock.now >= deadline {
+                    invalidateResources()
+                    return
+                }
+                guard valid else { return }
+                guard let result = drive() else {
+                    invalidateResources()
+                    return
+                }
+                let session = try requireSession()
+                notePacketProducingResult(result, owner: owner, session: session)
+                if result != LIBSSH2_ERROR_EAGAIN { return }
+                try await waitForSession(
+                    session,
+                    deadline: deadline,
+                    cancellable: false)
+            }
+        } catch {
+            invalidateResources()
+        }
+    }
+
+    private func claimChannelOpenSlot(
+        deadline: ContinuousClock.Instant,
+        cancellable: Bool
+    ) async throws {
+        while channelOpenInProgress {
+            if cancellable {
+                try checkProgress(deadline: deadline)
+            } else if ContinuousClock.now >= deadline {
+                throw SSHError.timedOut
+            }
+            nextChannelOpenWaiterID &+= 1
+            let waiterID = nextChannelOpenWaiterID
+            do {
+                try await waitForChannelOpenSlot(
+                    id: waiterID,
+                    deadline: deadline,
+                    cancellable: cancellable)
+            } catch {
+                await acquireOperation()
+                throw error
+            }
+            await acquireOperation()
+            if cancellable {
+                try checkProgress(deadline: deadline)
+            } else if ContinuousClock.now >= deadline {
+                throw SSHError.timedOut
+            }
+            guard valid else { throw SSHError.connectionInvalidated }
+        }
+        channelOpenInProgress = true
+#if DEBUG
+        if let hold = nextChannelOpenSlotHoldForTesting {
+            nextChannelOpenSlotHoldForTesting = nil
+            do {
+                try await hold()
+            } catch {
+                releaseChannelOpenSlot()
+                throw error
+            }
+        }
+#endif
+    }
+
+    private func waitForChannelOpenSlot(
+        id: UInt64,
+        deadline: ContinuousClock.Instant,
+        cancellable: Bool
+    ) async throws {
+        if cancellable {
+            try await withTaskCancellationHandler {
+                try await parkChannelOpenWaiterUntilDeadline(id: id, deadline: deadline)
+            } onCancel: {
+                Task { await self.resumeChannelOpenWaiter(id: id, .failure(SSHError.cancelled)) }
+            }
+        } else {
+            try await parkChannelOpenWaiterUntilDeadline(id: id, deadline: deadline)
+        }
+    }
+
+    private func parkChannelOpenWaiterUntilDeadline(
+        id: UInt64,
+        deadline: ContinuousClock.Instant
+    ) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            channelOpenWaiters[id] = continuation
+            releaseOperation()
+            Task {
+                try? await Task.sleep(until: deadline, clock: .continuous)
+                await self.resumeChannelOpenWaiter(id: id, .failure(SSHError.timedOut))
+            }
+        }
+    }
+
+    private func resumeChannelOpenWaiter(id: UInt64, _ result: Result<Void, any Error>) {
+        guard let continuation = channelOpenWaiters.removeValue(forKey: id) else { return }
+        continuation.resume(with: result)
+    }
+
+    private func releaseChannelOpenSlot() {
+        channelOpenInProgress = false
+        if let id = channelOpenWaiters.keys.sorted().first {
+            resumeChannelOpenWaiter(id: id, .success(()))
+        }
+    }
+
+    private func resumeAllChannelOpenWaiters() {
+        let ids = Array(channelOpenWaiters.keys)
+        for id in ids {
+            resumeChannelOpenWaiter(id: id, .success(()))
+        }
+    }
+
+    private func registerOneShot(
+        channel: OpaquePointer,
+        session: OpaquePointer
+    ) -> UInt64 {
+        nextOneShotID &+= 1
+        let id = nextOneShotID
+        oneShotChannels[id] = OneShotChannel(
+            channel: channel,
+            session: session)
+        return id
+    }
+
+    private func removeOneShot(_ id: UInt64) {
+        oneShotChannels.removeValue(forKey: id)
+    }
+
+    private func resolveChannel(_ identity: ChannelIdentity) throws -> OpaquePointer {
+        let session = try requireSession()
+        switch identity {
+        case .oneShot(let id):
+            guard let entry = oneShotChannels[id], entry.session == session else {
+                throw SSHError.channelFailed
+            }
+            return entry.channel
+        case .pty(let id):
+            guard let state = ptyChannels[id] else { throw SSHError.channelFailed }
+            return state.channel
+        case .streamLocal(let id):
+            guard let channel = streamLocalChannels[id] else {
+                throw SSHError.connectionInvalidated
+            }
+            return channel
+        }
+    }
+
+    private func writeChannel(
+        _ channel: OpaquePointer,
+        data: Data,
+        offset: Int
+    ) -> Int {
+        data.withUnsafeBytes { bytes -> Int in
+            guard let baseAddress = bytes.baseAddress else { return 0 }
+            return libssh2_channel_write_ex(
+                channel,
+                0,
+                baseAddress.advanced(by: offset).assumingMemoryBound(to: CChar.self),
+                data.count - offset)
+        }
+    }
+
+    private func writeChannelOnce(
+        identity: ChannelIdentity,
+        data: Data,
+        offset: Int
+    ) -> Int32? {
+        guard let channel = try? resolveChannel(identity) else { return nil }
+        let written = writeChannel(channel, data: data, offset: offset)
+        if written == Int(LIBSSH2_ERROR_EAGAIN) { return LIBSSH2_ERROR_EAGAIN }
+        if written >= 0 { return 0 }
+        return Int32(clamping: written)
+    }
+
+    private func readSFTPOnce(sftpID: UInt64, fileID: UInt64) -> Int32? {
+        guard let file = sftpClients[sftpID]?.files[fileID] else { return nil }
+        var scratch = [UInt8](repeating: 0, count: 64 * 1_024)
+        let read = scratch.withUnsafeMutableBytes { bytes -> Int in
+            guard let baseAddress = bytes.baseAddress else { return 0 }
+            return libssh2_sftp_read(
+                file,
+                baseAddress.assumingMemoryBound(to: CChar.self),
+                bytes.count)
+        }
+        if read == Int(LIBSSH2_ERROR_EAGAIN) { return LIBSSH2_ERROR_EAGAIN }
+        if read >= 0 { return 0 }
+        return Int32(clamping: read)
+    }
+
+    private func writeSFTPOnce(
+        sftpID: UInt64,
+        fileID: UInt64,
+        data: Data,
+        offset: Int
+    ) -> Int32? {
+        guard let file = sftpClients[sftpID]?.files[fileID] else { return nil }
+        let written = data.withUnsafeBytes { bytes -> Int in
+            guard let baseAddress = bytes.baseAddress else { return 0 }
+            return libssh2_sftp_write(
+                file,
+                baseAddress.advanced(by: offset).assumingMemoryBound(to: CChar.self),
+                data.count - offset)
+        }
+        if written == Int(LIBSSH2_ERROR_EAGAIN) { return LIBSSH2_ERROR_EAGAIN }
+        if written >= 0 { return 0 }
+        return Int32(clamping: written)
+    }
+
+    private func sampleTransportSendOwnerIfNeeded() {
+#if DEBUG
+        guard ownerSamplesForTesting != nil else { return }
+        let outboundPending: Bool
+        if let session {
+            outboundPending = sessionReportsOutbound(session)
+        } else {
+            outboundPending = false
+        }
+        ownerSamplesForTesting?.append(
+            TransportSendOwnerSample(
+                hasOwner: transportSendOwner != nil,
+                isValid: valid,
+                outboundPending: outboundPending))
+#endif
+    }
+
+#if DEBUG
+    private func holdOutboundWriteParkForTestingIfNeeded() async {
+        guard let hold = nextOutboundWriteParkHoldForTesting else { return }
+        nextOutboundWriteParkHoldForTesting = nil
+        await hold()
+    }
+
+    private func holdOneShotEstablishedForTestingIfNeeded() async throws {
+        if let hold = nextOneShotEstablishedHoldForTesting {
+            nextOneShotEstablishedHoldForTesting = nil
+            try await hold()
+            return
+        }
+        if let hold = eachOneShotEstablishedHoldForTesting {
+            try await hold()
+        }
+    }
+#endif
+
     private func extractHostKey(_ session: OpaquePointer) throws -> SSHHostKey {
         var length = 0
         var type: Int32 = 0
@@ -1854,11 +2606,27 @@ actor SessionDriver {
     }
 
     private func openSessionChannel(
-        session: OpaquePointer,
         deadline: ContinuousClock.Instant
     ) async throws -> OpaquePointer {
+        do {
+            try await claimChannelOpenSlot(deadline: deadline, cancellable: true)
+        } catch {
+            throw ChannelOpenAdmissionError(underlying: normalize(error))
+        }
+        defer { releaseChannelOpenSlot() }
+        let owner = allocateTransportSendOwner()
         while true {
             try checkProgress(deadline: deadline)
+            do {
+                try await waitForTransportSendAdmission(
+                    owner: owner,
+                    deadline: deadline,
+                    cancellable: true)
+            } catch {
+                if transportSendOwner == owner { invalidateResources() }
+                throw error
+            }
+            let session = try requireSession()
             if let channel = libssh2_channel_open_ex(
                 session,
                 "session",
@@ -1868,21 +2636,44 @@ actor SessionDriver {
                 nil,
                 0)
             {
+                notePacketProducingResult(0, owner: owner, session: session)
                 return channel
             }
             let error = libssh2_session_last_errno(session)
+            notePacketProducingResult(error, owner: owner, session: session)
             guard error == LIBSSH2_ERROR_EAGAIN else { throw SSHError.channelFailed }
-            try await waitForSession(session, deadline: deadline)
+            do {
+                try await waitForSession(session, deadline: deadline)
+            } catch {
+                if transportSendOwner == owner { invalidateResources() }
+                throw error
+            }
         }
     }
 
     private func openStreamLocalChannel(
         socketPath: String,
-        session: OpaquePointer,
         deadline: ContinuousClock.Instant
     ) async throws -> OpaquePointer {
+        do {
+            try await claimChannelOpenSlot(deadline: deadline, cancellable: true)
+        } catch {
+            throw ChannelOpenAdmissionError(underlying: normalize(error))
+        }
+        defer { releaseChannelOpenSlot() }
+        let owner = allocateTransportSendOwner()
         while true {
             try checkProgress(deadline: deadline)
+            do {
+                try await waitForTransportSendAdmission(
+                    owner: owner,
+                    deadline: deadline,
+                    cancellable: true)
+            } catch {
+                if transportSendOwner == owner { invalidateResources() }
+                throw error
+            }
+            let session = try requireSession()
             let channel = socketPath.withCString { socketPathPointer in
                 libssh2_channel_direct_streamlocal_ex(
                     session,
@@ -1890,11 +2681,20 @@ actor SessionDriver {
                     "127.0.0.1",
                     0)
             }
-            if let channel { return channel }
+            if let channel {
+                notePacketProducingResult(0, owner: owner, session: session)
+                return channel
+            }
 
             let error = libssh2_session_last_errno(session)
+            notePacketProducingResult(error, owner: owner, session: session)
             if error == LIBSSH2_ERROR_EAGAIN {
-                try await waitForSession(session, deadline: deadline)
+                do {
+                    try await waitForSession(session, deadline: deadline)
+                } catch {
+                    if transportSendOwner == owner { invalidateResources() }
+                    throw error
+                }
             } else {
                 throw Self.mappedStreamLocalOpenError(error)
             }
@@ -1919,12 +2719,14 @@ actor SessionDriver {
     }
 
     private func startExec(
-        channel: OpaquePointer,
+        identity: ChannelIdentity,
         command: String,
-        session: OpaquePointer,
         deadline: ContinuousClock.Instant
     ) async throws {
-        let result = try await repeatUntilComplete(deadline: deadline) {
+        let result = try await repeatUntilCompleteYielding(
+            deadline: deadline,
+            identity: identity
+        ) { channel in
             command.withCString { commandPointer in
                 libssh2_channel_process_startup(
                     channel,
@@ -1938,19 +2740,23 @@ actor SessionDriver {
     }
 
     private func configurePTY(
-        channel: OpaquePointer,
+        identity: ChannelIdentity,
         terminal: String,
         columns: Int,
         rows: Int,
         deadline: ContinuousClock.Instant
     ) async throws {
+        let mergeChannel = try resolveChannel(identity)
         let mergeResult = libssh2_channel_handle_extended_data2(
-            channel,
+            mergeChannel,
             LIBSSH2_CHANNEL_EXTENDED_DATA_MERGE)
         guard mergeResult == 0 else { throw SSHError.channelFailed }
 
         let result = try await repeatUntilComplete(deadline: deadline) {
-            terminal.withCString { terminalPointer in
+            guard let channel = try? resolveChannel(identity) else {
+                return LIBSSH2_ERROR_CHANNEL_CLOSED
+            }
+            return terminal.withCString { terminalPointer in
                 libssh2_channel_request_pty_ex(
                     channel,
                     terminalPointer,
@@ -1967,9 +2773,8 @@ actor SessionDriver {
     }
 
     private func exchange(
-        channel: OpaquePointer,
+        identity: ChannelIdentity,
         input: Data,
-        session: OpaquePointer,
         deadline: ContinuousClock.Instant
     ) async throws -> SSHExecResult {
         var inputOffset = 0
@@ -1977,73 +2782,152 @@ actor SessionDriver {
         var stdout = Data()
         var stderr = Data()
         var buffer = [UInt8](repeating: 0, count: 16 * 1024)
+        let writeOwner = allocateTransportSendOwner()
+        let eofOwner = allocateTransportSendOwner()
+        let stdoutOwner = allocateTransportSendOwner()
+        let stderrOwner = allocateTransportSendOwner()
+
+        func drainOwnedSends() async {
+            await finishOwnedSendIfNeeded(owner: writeOwner) {
+                writeChannelOnce(identity: identity, data: input, offset: inputOffset)
+            }
+            await finishOwnedSendIfNeeded(owner: eofOwner) {
+                guard let channel = try? resolveChannel(identity) else { return nil }
+                return libssh2_channel_send_eof(channel)
+            }
+            await finishOwnedSendIfNeeded(owner: stdoutOwner) {
+                guard let channel = try? resolveChannel(identity) else { return nil }
+                var scratch = [UInt8](repeating: 0, count: 16 * 1024)
+                return readOnce(channel: channel, stream: 0, buffer: &scratch)
+            }
+            await finishOwnedSendIfNeeded(owner: stderrOwner) {
+                guard let channel = try? resolveChannel(identity) else { return nil }
+                var scratch = [UInt8](repeating: 0, count: 16 * 1024)
+                return readOnce(
+                    channel: channel,
+                    stream: Int32(SSH_EXTENDED_DATA_STDERR),
+                    buffer: &scratch)
+            }
+        }
 
         while true {
-            try checkProgress(deadline: deadline)
-            var madeProgress = false
+            do {
+                try checkProgress(deadline: deadline)
+                var madeProgress = false
+                var skipReads = false
 
-            if inputOffset < input.count {
-                let written = input.withUnsafeBytes { bytes -> Int in
-                    guard let baseAddress = bytes.baseAddress else { return 0 }
-                    let pointer = baseAddress.advanced(by: inputOffset)
-                        .assumingMemoryBound(to: CChar.self)
-                    return libssh2_channel_write_ex(
-                        channel,
-                        0,
-                        pointer,
-                        input.count - inputOffset)
+                if inputOffset < input.count {
+                    try await waitForTransportSendAdmission(
+                        owner: writeOwner,
+                        deadline: deadline,
+                        cancellable: true)
+                    let channel = try resolveChannel(identity)
+                    let session = try requireSession()
+                    let written = writeChannel(channel, data: input, offset: inputOffset)
+                    notePacketProducingWrite(written, owner: writeOwner, session: session)
+                    if written > 0 {
+                        inputOffset += written
+                        madeProgress = true
+                    } else if written != Int(LIBSSH2_ERROR_EAGAIN) {
+                        throw SSHError.channelFailed
+                    } else if transportSendOwner == writeOwner {
+                        skipReads = true
+                    }
+                } else if !sentEOF {
+                    try await waitForTransportSendAdmission(
+                        owner: eofOwner,
+                        deadline: deadline,
+                        cancellable: true)
+                    let channel = try resolveChannel(identity)
+                    let session = try requireSession()
+                    let result = libssh2_channel_send_eof(channel)
+                    notePacketProducingResult(result, owner: eofOwner, session: session)
+                    if result == 0 {
+                        sentEOF = true
+                        madeProgress = true
+                    } else if result != LIBSSH2_ERROR_EAGAIN {
+                        throw SSHError.channelFailed
+                    } else if transportSendOwner == eofOwner {
+                        skipReads = true
+                    }
                 }
-                if written > 0 {
-                    inputOffset += written
-                    madeProgress = true
-                } else if written != Int(LIBSSH2_ERROR_EAGAIN) {
-                    throw SSHError.channelFailed
-                }
-            } else if !sentEOF {
-                let result = libssh2_channel_send_eof(channel)
-                if result == 0 {
-                    sentEOF = true
-                    madeProgress = true
-                } else if result != LIBSSH2_ERROR_EAGAIN {
-                    throw SSHError.channelFailed
-                }
-            }
 
-            let stdoutRead = try readAvailable(channel: channel, stream: 0, buffer: &buffer)
-            if stdoutRead.count > 0 {
-                stdout.append(stdoutRead)
-                madeProgress = true
-            }
-            let stderrRead = try readAvailable(
-                channel: channel,
-                stream: Int32(SSH_EXTENDED_DATA_STDERR),
-                buffer: &buffer)
-            if stderrRead.count > 0 {
-                stderr.append(stderrRead)
-                madeProgress = true
-            }
+                if !skipReads {
+                    try await waitForTransportSendAdmission(
+                        owner: stdoutOwner,
+                        deadline: deadline,
+                        cancellable: true)
+                    let stdoutChannel = try resolveChannel(identity)
+                    let session = try requireSession()
+                    let stdoutRead = try readAvailableNoting(
+                        channel: stdoutChannel,
+                        stream: 0,
+                        buffer: &buffer,
+                        owner: stdoutOwner,
+                        session: session)
+                    if stdoutRead.count > 0 {
+                        stdout.append(stdoutRead)
+                        madeProgress = true
+                    }
+                    if transportSendOwner != stdoutOwner {
+                        try await waitForTransportSendAdmission(
+                            owner: stderrOwner,
+                            deadline: deadline,
+                            cancellable: true)
+                        let stderrChannel = try resolveChannel(identity)
+                        let stderrSession = try requireSession()
+                        let stderrRead = try readAvailableNoting(
+                            channel: stderrChannel,
+                            stream: Int32(SSH_EXTENDED_DATA_STDERR),
+                            buffer: &buffer,
+                            owner: stderrOwner,
+                            session: stderrSession)
+                        if stderrRead.count > 0 {
+                            stderr.append(stderrRead)
+                            madeProgress = true
+                        }
+                    }
+                }
 
-            if libssh2_channel_eof(channel) == 1 {
-                let exitStatus = try await exitStatusAfterChannelClose(
-                    channel: channel,
-                    deadline: deadline)
-                return SSHExecResult(
-                    stdout: stdout,
-                    stderr: stderr,
-                    exitStatus: exitStatus,
-                    reachedEOF: true)
-            }
-            if !madeProgress {
-                try await waitForSession(session, deadline: deadline)
+                let eofChannel = try resolveChannel(identity)
+                if libssh2_channel_eof(eofChannel) == 1 {
+                    let exitStatus = try await exitStatusAfterChannelClose(
+                        identity: identity,
+                        deadline: deadline)
+                    return SSHExecResult(
+                        stdout: stdout,
+                        stderr: stderr,
+                        exitStatus: exitStatus,
+                        reachedEOF: true)
+                }
+
+                let plan = sessionWaitPlan(try requireSession())
+                if madeProgress {
+                    releaseOperation()
+                    await Task.yield()
+                    await acquireOperation()
+                } else {
+                    releaseOperation()
+                    do {
+                        try await awaitSessionProgress(plan, until: deadline)
+                    } catch {
+                        await acquireOperation()
+                        await drainOwnedSends()
+                        throw error
+                    }
+                    await acquireOperation()
+                }
+            } catch {
+                await drainOwnedSends()
+                throw error
             }
         }
     }
 
     private func exchangeResponseLine(
-        channel: OpaquePointer,
+        identity: ChannelIdentity,
         request: Data,
         maximumResponseBytes: Int,
-        session: OpaquePointer,
         deadline: ContinuousClock.Instant,
         beforeRequestWrite: (@Sendable () async throws -> Void)? = nil,
         onRequestWritten: (@Sendable () async -> Void)? = nil
@@ -2052,56 +2936,105 @@ actor SessionDriver {
         var response = Data()
         var buffer = [UInt8](repeating: 0, count: 16 * 1024)
         var didAnnounceWrite = false
+        let writeOwner = allocateTransportSendOwner()
+        let readOwner = allocateTransportSendOwner()
 
         try await beforeRequestWrite?()
 
+        func drainOwnedSends() async {
+            await finishOwnedSendIfNeeded(owner: writeOwner) {
+                writeChannelOnce(identity: identity, data: request, offset: requestOffset)
+            }
+            await finishOwnedSendIfNeeded(owner: readOwner) {
+                guard let channel = try? resolveChannel(identity) else { return nil }
+                var scratch = [UInt8](repeating: 0, count: 16 * 1024)
+                return readOnce(channel: channel, stream: 0, buffer: &scratch)
+            }
+        }
+
         while true {
-            try checkProgress(deadline: deadline)
-            var madeProgress = false
+            do {
+                try checkProgress(deadline: deadline)
+                var madeProgress = false
+                var skipRead = false
 
-            if requestOffset < request.count {
-                let written = request.withUnsafeBytes { bytes -> Int in
-                    guard let baseAddress = bytes.baseAddress else { return 0 }
-                    return libssh2_channel_write_ex(
-                        channel,
-                        0,
-                        baseAddress.advanced(by: requestOffset)
-                            .assumingMemoryBound(to: CChar.self),
-                        request.count - requestOffset)
-                }
-                if written > 0 {
-                    requestOffset += written
-                    madeProgress = true
-                } else if written != Int(LIBSSH2_ERROR_EAGAIN) {
-                    throw SSHError.channelFailed
-                }
-            }
-            if requestOffset == request.count, !didAnnounceWrite {
-                didAnnounceWrite = true
-                await onRequestWritten?()
-            }
-
-            let received = try readAvailable(channel: channel, stream: 0, buffer: &buffer)
-            if !received.isEmpty {
-                response.append(received)
-                madeProgress = true
-                if let newline = response.firstIndex(of: 0x0A) {
-                    let lineLength = response.distance(from: response.startIndex, to: newline) + 1
-                    guard lineLength <= maximumResponseBytes else {
-                        throw SSHError.responseTooLarge(limit: maximumResponseBytes)
+                if requestOffset < request.count {
+                    try await waitForTransportSendAdmission(
+                        owner: writeOwner,
+                        deadline: deadline,
+                        cancellable: true)
+                    let channel = try resolveChannel(identity)
+                    let session = try requireSession()
+                    let written = writeChannel(channel, data: request, offset: requestOffset)
+                    notePacketProducingWrite(written, owner: writeOwner, session: session)
+                    if written > 0 {
+                        requestOffset += written
+                        madeProgress = true
+                    } else if written != Int(LIBSSH2_ERROR_EAGAIN) {
+                        throw SSHError.channelFailed
+                    } else if transportSendOwner == writeOwner {
+                        skipRead = true
                     }
-                    return Data(response.prefix(lineLength))
                 }
-                guard response.count <= maximumResponseBytes else {
-                    throw SSHError.responseTooLarge(limit: maximumResponseBytes)
+                if requestOffset == request.count, !didAnnounceWrite {
+                    didAnnounceWrite = true
+                    await onRequestWritten?()
                 }
-            }
 
-            if libssh2_channel_eof(channel) == 1 {
-                throw SSHError.unexpectedEOF
-            }
-            if !madeProgress {
-                try await waitForSession(session, deadline: deadline)
+                if !skipRead {
+                    try await waitForTransportSendAdmission(
+                        owner: readOwner,
+                        deadline: deadline,
+                        cancellable: true)
+                    let channel = try resolveChannel(identity)
+                    let session = try requireSession()
+                    let received = try readAvailableNoting(
+                        channel: channel,
+                        stream: 0,
+                        buffer: &buffer,
+                        owner: readOwner,
+                        session: session)
+                    if !received.isEmpty {
+                        response.append(received)
+                        madeProgress = true
+                        if let newline = response.firstIndex(of: 0x0A) {
+                            let lineLength = response.distance(
+                                from: response.startIndex,
+                                to: newline) + 1
+                            guard lineLength <= maximumResponseBytes else {
+                                throw SSHError.responseTooLarge(limit: maximumResponseBytes)
+                            }
+                            return Data(response.prefix(lineLength))
+                        }
+                        guard response.count <= maximumResponseBytes else {
+                            throw SSHError.responseTooLarge(limit: maximumResponseBytes)
+                        }
+                    }
+                }
+
+                if libssh2_channel_eof(try resolveChannel(identity)) == 1 {
+                    throw SSHError.unexpectedEOF
+                }
+
+                let plan = sessionWaitPlan(try requireSession())
+                if madeProgress {
+                    releaseOperation()
+                    await Task.yield()
+                    await acquireOperation()
+                } else {
+                    releaseOperation()
+                    do {
+                        try await awaitSessionProgress(plan, until: deadline)
+                    } catch {
+                        await acquireOperation()
+                        await drainOwnedSends()
+                        throw error
+                    }
+                    await acquireOperation()
+                }
+            } catch {
+                await drainOwnedSends()
+                throw error
             }
         }
     }
@@ -2111,7 +3044,43 @@ actor SessionDriver {
         stream: Int32,
         buffer: inout [UInt8]
     ) throws -> Data {
-        let count = buffer.withUnsafeMutableBytes { bytes -> Int in
+        let count = rawChannelRead(channel: channel, stream: stream, buffer: &buffer)
+        if count > 0 { return Data(buffer.prefix(count)) }
+        if count == 0 || count == Int(LIBSSH2_ERROR_EAGAIN) { return Data() }
+        throw SSHError.channelFailed
+    }
+
+    private func readAvailableNoting(
+        channel: OpaquePointer,
+        stream: Int32,
+        buffer: inout [UInt8],
+        owner: UInt64,
+        session: OpaquePointer
+    ) throws -> Data {
+        let count = rawChannelRead(channel: channel, stream: stream, buffer: &buffer)
+        notePacketProducingWrite(count, owner: owner, session: session)
+        if count > 0 { return Data(buffer.prefix(count)) }
+        if count == 0 || count == Int(LIBSSH2_ERROR_EAGAIN) { return Data() }
+        throw SSHError.channelFailed
+    }
+
+    private func readOnce(
+        channel: OpaquePointer,
+        stream: Int32,
+        buffer: inout [UInt8]
+    ) -> Int32 {
+        let count = rawChannelRead(channel: channel, stream: stream, buffer: &buffer)
+        if count == Int(LIBSSH2_ERROR_EAGAIN) { return LIBSSH2_ERROR_EAGAIN }
+        if count >= 0 { return 0 }
+        return Int32(clamping: count)
+    }
+
+    private func rawChannelRead(
+        channel: OpaquePointer,
+        stream: Int32,
+        buffer: inout [UInt8]
+    ) -> Int {
+        buffer.withUnsafeMutableBytes { bytes -> Int in
             guard let baseAddress = bytes.baseAddress else { return 0 }
             return libssh2_channel_read_ex(
                 channel,
@@ -2119,31 +3088,74 @@ actor SessionDriver {
                 baseAddress.assumingMemoryBound(to: CChar.self),
                 bytes.count)
         }
-        if count > 0 { return Data(buffer.prefix(count)) }
-        if count == 0 || count == Int(LIBSSH2_ERROR_EAGAIN) { return Data() }
-        throw SSHError.channelFailed
     }
 
     /// Close the remote channel, wait for the peer to acknowledge close, then
     /// read exit status. Remote EOF can precede the exit-status request, so
     /// status is only reliable after wait_closed.
     private func exitStatusAfterChannelClose(
-        channel: OpaquePointer,
+        identity: ChannelIdentity,
         deadline: ContinuousClock.Instant
     ) async throws -> Int32 {
-        let closeResult = try await repeatUntilComplete(deadline: deadline) {
-            libssh2_channel_close(channel)
+        let closeResult = try await repeatUntilCompleteYielding(
+            deadline: deadline,
+            identity: identity
+        ) {
+            libssh2_channel_close($0)
         }
         guard closeResult == 0 || closeResult == LIBSSH2_ERROR_CHANNEL_CLOSED else {
             throw SSHError.channelFailed
         }
-        let waitResult = try await repeatUntilComplete(deadline: deadline) {
-            libssh2_channel_wait_closed(channel)
+        let waitResult = try await repeatUntilCompleteYielding(
+            deadline: deadline,
+            identity: identity
+        ) {
+            libssh2_channel_wait_closed($0)
         }
         guard waitResult == 0 || waitResult == LIBSSH2_ERROR_CHANNEL_CLOSED else {
             throw SSHError.channelFailed
         }
-        return Int32(libssh2_channel_get_exit_status(channel))
+        return Int32(libssh2_channel_get_exit_status(try resolveChannel(identity)))
+    }
+
+    private func cleanChannel(
+        identity: ChannelIdentity,
+        deadline: ContinuousClock.Instant,
+        cancellable: Bool
+    ) async throws {
+        let eofResult = try await repeatUntilCompleteYielding(
+            deadline: deadline,
+            cancellable: cancellable,
+            identity: identity
+        ) {
+            libssh2_channel_send_eof($0)
+        }
+        guard eofResult == 0
+            || eofResult == LIBSSH2_ERROR_CHANNEL_EOF_SENT
+            || eofResult == LIBSSH2_ERROR_CHANNEL_CLOSED
+        else {
+            throw SSHError.channelFailed
+        }
+
+        let closeResult = try await repeatUntilCompleteYielding(
+            deadline: deadline,
+            cancellable: cancellable,
+            identity: identity
+        ) {
+            libssh2_channel_close($0)
+        }
+        guard closeResult == 0 || closeResult == LIBSSH2_ERROR_CHANNEL_CLOSED else {
+            throw SSHError.channelFailed
+        }
+
+        let freeResult = try await repeatUntilCompleteYielding(
+            deadline: deadline,
+            cancellable: cancellable,
+            identity: identity
+        ) {
+            libssh2_channel_free($0)
+        }
+        guard freeResult == 0 else { throw SSHError.channelFailed }
     }
 
     private func cleanChannel(
@@ -2184,25 +3196,326 @@ actor SessionDriver {
         guard freeResult == 0 else { throw SSHError.channelFailed }
     }
 
+    private func beginSFTPUse(id: UInt64) throws {
+        guard valid, sftpClients[id] != nil else {
+            throw SSHError.connectionInvalidated
+        }
+        sftpUses[id, default: 0] += 1
+    }
+
+    private func endSFTPUse(id: UInt64) {
+        guard let count = sftpUses[id] else { return }
+        if count <= 1 {
+            sftpUses.removeValue(forKey: id)
+            wakeSFTPIdleWaiters()
+        } else {
+            sftpUses[id] = count - 1
+        }
+    }
+
+    private func wakeSFTPIdleWaiters() {
+        let ids = Array(sftpIdleWaiters.keys)
+        for id in ids { resumeSFTPIdleWaiter(id: id, .success(())) }
+    }
+
+    private func waitUntilSFTPIdle(
+        id: UInt64,
+        deadline: ContinuousClock.Instant,
+        cancellable: Bool
+    ) async throws {
+        while (sftpUses[id] ?? 0) > 0 {
+            if cancellable {
+                try checkProgress(deadline: deadline)
+            } else if ContinuousClock.now >= deadline {
+                throw SSHError.timedOut
+            }
+            nextSFTPIdleWaiterID &+= 1
+            let waiterID = nextSFTPIdleWaiterID
+            do {
+                try await waitForSFTPIdleSignal(
+                    id: waiterID,
+                    deadline: deadline,
+                    cancellable: cancellable)
+            } catch {
+                await acquireOperation()
+                throw error
+            }
+            await acquireOperation()
+            if cancellable {
+                try checkProgress(deadline: deadline)
+            } else if ContinuousClock.now >= deadline {
+                throw SSHError.timedOut
+            }
+            guard valid else { throw SSHError.connectionInvalidated }
+        }
+    }
+
+    private func waitForSFTPIdleSignal(
+        id: UInt64,
+        deadline: ContinuousClock.Instant,
+        cancellable: Bool
+    ) async throws {
+        if cancellable {
+            try await withTaskCancellationHandler {
+                try await parkSFTPIdleWaiterUntilDeadline(id: id, deadline: deadline)
+            } onCancel: {
+                Task { await self.resumeSFTPIdleWaiter(id: id, .failure(SSHError.cancelled)) }
+            }
+        } else {
+            try await parkSFTPIdleWaiterUntilDeadline(id: id, deadline: deadline)
+        }
+    }
+
+    private func parkSFTPIdleWaiterUntilDeadline(
+        id: UInt64,
+        deadline: ContinuousClock.Instant
+    ) async throws {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, any Error>) in
+            sftpIdleWaiters[id] = continuation
+            releaseOperation()
+            Task {
+                try? await Task.sleep(until: deadline, clock: .continuous)
+                await self.resumeSFTPIdleWaiter(id: id, .failure(SSHError.timedOut))
+            }
+        }
+    }
+
+    private func resumeSFTPIdleWaiter(
+        id: UInt64,
+        _ result: Result<Void, any Error>
+    ) {
+        guard let continuation = sftpIdleWaiters.removeValue(forKey: id) else { return }
+        continuation.resume(with: result)
+    }
+
+    private func withSFTPUse<T: Sendable>(
+        id: UInt64,
+        deadline: ContinuousClock.Instant,
+        _ body: () async throws -> T
+    ) async throws -> T {
+        await acquireOperation()
+        do {
+            try await waitUntilSFTPIdle(
+                id: id,
+                deadline: deadline,
+                cancellable: true)
+            try beginSFTPUse(id)
+        } catch {
+            releaseOperation()
+            throw error
+        }
+        releaseOperation()
+        do {
+            let result = try await body()
+            await acquireOperation()
+            endSFTPUse(id)
+            releaseOperation()
+            return result
+        } catch {
+            await acquireOperation()
+            endSFTPUse(id)
+            releaseOperation()
+            throw error
+        }
+    }
+
+    private func holdOwnedLoopTopForTestingIfNeeded(owner: UInt64) async throws {
+#if DEBUG
+        guard transportSendOwner == owner, let hold = nextOwnedLoopTopHoldForTesting else {
+            return
+        }
+        nextOwnedLoopTopHoldForTesting = nil
+        try await hold()
+#else
+        _ = owner
+#endif
+    }
+
+    private func checkProgressFinishingOwnedSend(
+        owner: UInt64,
+        deadline: ContinuousClock.Instant,
+        cancellable: Bool,
+        drive: () -> Int32?
+    ) async throws {
+        do {
+            try await holdOwnedLoopTopForTestingIfNeeded(owner: owner)
+        } catch {
+            await finishOwnedSendIfNeeded(owner: owner, drive: drive)
+            throw normalize(error)
+        }
+        let cancelled = cancellable && Task.isCancelled
+        let timedOut = ContinuousClock.now >= deadline
+        guard cancelled || timedOut else { return }
+        await finishOwnedSendIfNeeded(owner: owner, drive: drive)
+        if cancelled { throw SSHError.cancelled }
+        throw SSHError.timedOut
+    }
+
+    @discardableResult
+    private func repeatUntilCompleteHolding(
+        deadline: ContinuousClock.Instant,
+        cancellable: Bool = true,
+        _ operation: () -> Int32
+    ) async throws -> Int32 {
+        let owner = allocateTransportSendOwner()
+        while true {
+            try await checkProgressFinishingOwnedSend(
+                owner: owner,
+                deadline: deadline,
+                cancellable: cancellable,
+                drive: operation)
+            let session = try requireSession()
+            let result = operation()
+            notePacketProducingResult(result, owner: owner, session: session)
+            if result != LIBSSH2_ERROR_EAGAIN { return result }
+            do {
+                try await waitForSession(
+                    session,
+                    deadline: deadline,
+                    cancellable: cancellable)
+            } catch {
+                await finishOwnedSendIfNeeded(owner: owner, drive: operation)
+                throw error
+            }
+        }
+    }
+
+    @discardableResult
+    private func repeatUntilCompleteHoldingSFTP(
+        id: UInt64,
+        deadline: ContinuousClock.Instant,
+        cancellable: Bool = true,
+        _ operation: (OpaquePointer) -> Int32
+    ) async throws -> Int32 {
+        try await waitUntilSFTPIdle(
+            id: id,
+            deadline: deadline,
+            cancellable: cancellable)
+        try beginSFTPUse(id)
+        defer { endSFTPUse(id) }
+        let owner = allocateTransportSendOwner()
+        func drive() -> Int32? {
+            guard let sftp = sftpClients[id]?.handle else { return nil }
+            return operation(sftp)
+        }
+        do {
+            try await waitForTransportSendAdmission(
+                owner: owner,
+                deadline: deadline,
+                cancellable: cancellable)
+        } catch {
+            await finishOwnedSendIfNeeded(owner: owner, drive: drive)
+            throw error
+        }
+        while true {
+            try await checkProgressFinishingOwnedSend(
+                owner: owner,
+                deadline: deadline,
+                cancellable: cancellable,
+                drive: drive)
+            guard let sftp = sftpClients[id]?.handle else {
+                throw SSHError.connectionInvalidated
+            }
+            let session = try requireSession()
+            let result = operation(sftp)
+            notePacketProducingResult(result, owner: owner, session: session)
+            if result != LIBSSH2_ERROR_EAGAIN { return result }
+            do {
+                try await waitForSession(
+                    session,
+                    deadline: deadline,
+                    cancellable: cancellable)
+            } catch {
+                await finishOwnedSendIfNeeded(owner: owner, drive: drive)
+                throw error
+            }
+        }
+    }
+
     @discardableResult
     private func repeatUntilComplete(
         deadline: ContinuousClock.Instant,
         cancellable: Bool = true,
         _ operation: () -> Int32
     ) async throws -> Int32 {
-        guard let session else { throw SSHError.connectionInvalidated }
+        let owner = allocateTransportSendOwner()
         while true {
-            if cancellable {
-                try checkProgress(deadline: deadline)
-            } else if ContinuousClock.now >= deadline {
-                throw SSHError.timedOut
-            }
-            let result = operation()
-            if result != LIBSSH2_ERROR_EAGAIN { return result }
-            try await waitForSession(
-                session,
+            try await checkProgressFinishingOwnedSend(
+                owner: owner,
                 deadline: deadline,
-                cancellable: cancellable)
+                cancellable: cancellable,
+                drive: operation)
+            do {
+                try await waitForTransportSendAdmission(
+                    owner: owner,
+                    deadline: deadline,
+                    cancellable: cancellable)
+            } catch {
+                await finishOwnedSendIfNeeded(owner: owner, drive: operation)
+                throw error
+            }
+            let session = try requireSession()
+            let result = operation()
+            notePacketProducingResult(result, owner: owner, session: session)
+            if result != LIBSSH2_ERROR_EAGAIN { return result }
+            do {
+                try await waitForSession(
+                    session,
+                    deadline: deadline,
+                    cancellable: cancellable)
+            } catch {
+                await finishOwnedSendIfNeeded(owner: owner, drive: operation)
+                throw error
+            }
+        }
+    }
+
+    @discardableResult
+    private func repeatUntilCompleteYielding(
+        deadline: ContinuousClock.Instant,
+        cancellable: Bool = true,
+        identity: ChannelIdentity,
+        _ operation: (OpaquePointer) -> Int32
+    ) async throws -> Int32 {
+        let owner = allocateTransportSendOwner()
+        func drive() -> Int32? {
+            guard let channel = try? resolveChannel(identity) else { return nil }
+            return operation(channel)
+        }
+        while true {
+            try await checkProgressFinishingOwnedSend(
+                owner: owner,
+                deadline: deadline,
+                cancellable: cancellable,
+                drive: drive)
+            do {
+                try await waitForTransportSendAdmission(
+                    owner: owner,
+                    deadline: deadline,
+                    cancellable: cancellable)
+            } catch {
+                await finishOwnedSendIfNeeded(owner: owner, drive: drive)
+                throw error
+            }
+            let channel = try resolveChannel(identity)
+            let session = try requireSession()
+            let result = operation(channel)
+            notePacketProducingResult(result, owner: owner, session: session)
+            if result != LIBSSH2_ERROR_EAGAIN { return result }
+            let plan = sessionWaitPlan(session)
+            releaseOperation()
+            do {
+                try await awaitSessionProgress(
+                    plan,
+                    until: deadline,
+                    cancellable: cancellable)
+            } catch {
+                await acquireOperation()
+                await finishOwnedSendIfNeeded(owner: owner, drive: drive)
+                throw error
+            }
+            await acquireOperation()
         }
     }
 
@@ -2212,22 +3525,29 @@ actor SessionDriver {
         cancellable: Bool,
         _ operation: () -> Int32
     ) async throws -> Int32 {
-        guard let session else { throw SSHError.connectionInvalidated }
+        let owner = allocateTransportSendOwner()
         while true {
-            if cancellable {
-                try checkProgress(deadline: deadline)
-            } else if ContinuousClock.now >= deadline {
-                throw SSHError.timedOut
-            }
+            try await checkProgressFinishingOwnedSend(
+                owner: owner,
+                deadline: deadline,
+                cancellable: cancellable,
+                drive: operation)
+            let session = try requireSession()
             let result = operation()
 #if DEBUG
             try await runCompensationPhaseHookForTestingIfNeeded(phase)
 #endif
+            notePacketProducingResult(result, owner: owner, session: session)
             if result != LIBSSH2_ERROR_EAGAIN { return result }
-            try await waitForSession(
-                session,
-                deadline: deadline,
-                cancellable: cancellable)
+            do {
+                try await waitForSession(
+                    session,
+                    deadline: deadline,
+                    cancellable: cancellable)
+            } catch {
+                await finishOwnedSendIfNeeded(owner: owner, drive: operation)
+                throw error
+            }
         }
     }
 
@@ -2332,6 +3652,13 @@ actor SessionDriver {
         guard valid, self.session == session else { throw SSHError.connectionInvalidated }
     }
 
+    private func checkSFTPResult(_ result: Int32, sftpID: UInt64) throws {
+        guard valid, let session, let sftp = sftpClients[sftpID]?.handle else {
+            throw SSHError.connectionInvalidated
+        }
+        try checkSFTPResult(result, sftp: sftp, session: session)
+    }
+
     private func mappedSFTPError(sftp: OpaquePointer, code: Int32) -> SSHError {
         if Self.isConnectionLoss(code) { return .connectionInvalidated }
         return .sftpFailure(status: UInt64(libssh2_sftp_last_error(sftp)))
@@ -2360,6 +3687,7 @@ actor SessionDriver {
     }
 
     private func normalize(_ error: any Error) -> SSHError {
+        if let error = error as? ChannelOpenAdmissionError { return error.underlying }
         if let error = error as? SSHError { return error }
         return .connectionFailed
     }
@@ -2396,7 +3724,14 @@ actor SessionDriver {
         streamLocalChannels.removeAll()
         ptyChannels.removeAll()
         sftpClients.removeAll()
+        sftpUses.removeAll()
+        oneShotChannels.removeAll()
+        channelOpenInProgress = false
+        resumeAllChannelOpenWaiters()
+        wakeSFTPIdleWaiters()
+        activity.releaseAllWaiters()
         InvalidatedSessionTeardown.reclaim(&session)
+        transportSendOwner = nil
         closeDescriptor()
     }
 
@@ -2410,11 +3745,13 @@ actor SessionDriver {
     private func acquireOperation() async {
         if !operationInProgress {
             operationInProgress = true
+            sampleTransportSendOwnerIfNeeded()
             return
         }
         await withCheckedContinuation { continuation in
             operationWaiters.append(continuation)
         }
+        sampleTransportSendOwnerIfNeeded()
     }
 
     private func releaseOperation() {
@@ -2503,6 +3840,16 @@ struct SessionDriverResourceState: Sendable, Equatable {
     let hasSession: Bool
     let descriptorIsOpen: Bool
     let isValid: Bool
+}
+
+struct TransportSendOwnerSample: Sendable, Equatable {
+    let hasOwner: Bool
+    let isValid: Bool
+    let outboundPending: Bool
+
+    var isForbiddenClearWindow: Bool {
+        !hasOwner && isValid && outboundPending
+    }
 }
 #endif
 

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -2496,12 +2496,6 @@ actor SessionDriver {
                 throw error
             }
             await acquireOperation()
-#if DEBUG
-            if let error = nextResumedChannelOpenWaiterErrorForTesting {
-                nextResumedChannelOpenWaiterErrorForTesting = nil
-                throw error
-            }
-#endif
             if cancellable {
                 try checkProgress(deadline: deadline)
             } else if ContinuousClock.now >= deadline {
@@ -2530,7 +2524,7 @@ actor SessionDriver {
             do {
                 try await hold()
             } catch {
-                invalidateResources()
+                abandonOwnedSend(owner: owner, drive: drive)
                 return
             }
         }
@@ -2539,7 +2533,7 @@ actor SessionDriver {
         do {
             while transportSendOwner == owner {
                 if ContinuousClock.now >= deadline {
-                    invalidateResources()
+                    abandonOwnedSend(owner: owner, drive: drive)
                     return
                 }
                 guard valid else { return }
@@ -2552,6 +2546,10 @@ actor SessionDriver {
                     result,
                     owner: owner,
                     session: session)
+                if disposition == .invalidate {
+                    abandonOwnedSend(owner: owner, drive: drive)
+                    return
+                }
                 applyTransportSendOwnerDisposition(disposition)
                 if result != LIBSSH2_ERROR_EAGAIN { return }
                 try await waitForSession(
@@ -2560,8 +2558,23 @@ actor SessionDriver {
                     cancellable: false)
             }
         } catch {
-            invalidateResources()
+            abandonOwnedSend(owner: owner, drive: drive)
         }
+    }
+
+    /// Completes the one pending packet through its exact owning call while
+    /// native I/O is redirected locally, then synchronously frees the session.
+    private func abandonOwnedSend(
+        owner: UInt64,
+        drive: () -> Int32?
+    ) {
+        guard transportSendOwner == owner, let session else {
+            invalidateResources()
+            return
+        }
+        heeler_libssh2_prepare_session_abandonment(session)
+        _ = drive()
+        invalidateResources()
     }
 
     private func claimChannelOpenSlot(
@@ -2586,6 +2599,12 @@ actor SessionDriver {
                 throw error
             }
             await acquireOperation()
+#if DEBUG
+            if let error = nextResumedChannelOpenWaiterErrorForTesting {
+                nextResumedChannelOpenWaiterErrorForTesting = nil
+                throw error
+            }
+#endif
             if cancellable {
                 try checkProgress(deadline: deadline)
             } else if ContinuousClock.now >= deadline {
@@ -2597,12 +2616,17 @@ actor SessionDriver {
 #if DEBUG
         if let hold = nextChannelOpenSlotHoldForTesting {
             nextChannelOpenSlotHoldForTesting = nil
+            // Keep the native-open slot claimed while allowing later callers
+            // to reach and observe its waiter queue.
+            releaseOperation()
             do {
                 try await hold()
             } catch {
+                await acquireOperation()
                 releaseChannelOpenSlot()
                 throw error
             }
+            await acquireOperation()
         }
 #endif
     }

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -4,6 +4,12 @@ import Darwin
 import Foundation
 
 actor SessionDriver {
+    enum TransportSendOwnerDisposition: Equatable {
+        case unchanged
+        case clear
+        case invalidate
+    }
+
     static let hostKeyAlgorithms = [
         "ssh-ed25519",
         "ecdsa-sha2-nistp384",
@@ -49,11 +55,18 @@ actor SessionDriver {
     private var valid = true
     private var forwarding = false
     private var nextStreamLocalChannelID: UInt64 = 0
-    private var streamLocalChannels: [UInt64: OpaquePointer] = [:]
+    private struct StreamLocalChannelState {
+        let channel: OpaquePointer
+        var acceptsIO = true
+        var teardownInProgress = false
+    }
+    private var streamLocalChannels: [UInt64: StreamLocalChannelState] = [:]
     private struct PTYChannelState {
         let channel: OpaquePointer
         var reachedEOF = false
         var closed = false
+        var acceptsIO = true
+        var teardownInProgress = false
     }
     private var nextPTYChannelID: UInt64 = 0
     private var ptyChannels: [UInt64: PTYChannelState] = [:]
@@ -95,10 +108,14 @@ actor SessionDriver {
     /// releases the operation mutex to wait for a foreign send owner.
     private var channelOpenInProgress = false
     private var nextChannelOpenWaiterID: UInt64 = 0
-    private var channelOpenWaiters: [UInt64: CheckedContinuation<Void, any Error>] = [:]
+    private struct DriverWaiter {
+        let continuation: CheckedContinuation<Void, any Error>
+        let deadlineTask: Task<Void, Never>
+    }
+    private var channelOpenWaiters: [UInt64: DriverWaiter] = [:]
     private var sftpUses: [UInt64: Int] = [:]
     private var nextSFTPIdleWaiterID: UInt64 = 0
-    private var sftpIdleWaiters: [UInt64: CheckedContinuation<Void, any Error>] = [:]
+    private var sftpIdleWaiters: [UInt64: DriverWaiter] = [:]
 
 #if DEBUG
     private var nextSFTPWriteDelayForTesting: Duration?
@@ -115,6 +132,8 @@ actor SessionDriver {
     private var nextOwnedLoopTopHoldForTesting: (@Sendable () async throws -> Void)?
     private var nextOwnedDrainHoldForTesting: (@Sendable () async throws -> Void)?
     private var nextChannelOpenSlotHoldForTesting: (@Sendable () async throws -> Void)?
+    private var nextChannelTeardownHoldForTesting: (@Sendable () async -> Void)?
+    private var nextResumedChannelOpenWaiterErrorForTesting: SSHError?
     private var eachSessionWaitHoldForTesting: (@Sendable () async -> Void)?
     private var ownerSamplesForTesting: [TransportSendOwnerSample]?
     private var shouldFailNextSFTPInitBeforeEAGAINForTesting = false
@@ -608,33 +627,55 @@ actor SessionDriver {
         let deadline = ContinuousClock.now.advanced(by: timeout)
         try checkProgress(deadline: deadline)
         guard valid, session != nil else { throw SSHError.connectionInvalidated }
-        guard let state = ptyChannels[id], state.reachedEOF else {
+        guard var state = ptyChannels[id], state.reachedEOF else {
             throw SSHError.channelFailed
         }
+        guard !state.teardownInProgress else { throw SSHError.channelFailed }
+        state.acceptsIO = false
+        state.teardownInProgress = true
+        ptyChannels[id] = state
+#if DEBUG
+        await holdChannelTeardownForTestingIfNeeded()
+#endif
 
-        let exitStatus = try await exitStatusAfterChannelClose(
-            identity: .pty(id),
-            deadline: deadline)
-        ptyChannels[id]?.closed = true
-        return exitStatus
+        do {
+            let exitStatus = try await exitStatusAfterChannelClose(
+                identity: .pty(id),
+                deadline: deadline,
+                allowClosing: true)
+            ptyChannels[id]?.closed = true
+            ptyChannels[id]?.teardownInProgress = false
+            return exitStatus
+        } catch {
+            ptyChannels[id]?.teardownInProgress = false
+            throw error
+        }
     }
 
     func closePTY(id: UInt64, timeout: Duration) async throws {
         await acquireOperation()
         defer { releaseOperation() }
 
-        guard ptyChannels[id] != nil else { return }
+        guard var state = ptyChannels[id] else { return }
         guard valid, session != nil else {
             ptyChannels.removeValue(forKey: id)
             return
         }
+        guard !state.teardownInProgress else { return }
+        state.acceptsIO = false
+        state.teardownInProgress = true
+        ptyChannels[id] = state
+#if DEBUG
+        await holdChannelTeardownForTestingIfNeeded()
+#endif
         do {
             let deadline = ContinuousClock.now.advanced(by: timeout)
             if ptyChannels[id]?.closed == true {
                 let freeResult = try await repeatUntilCompleteYielding(
                     deadline: deadline,
                     cancellable: false,
-                    identity: .pty(id)
+                    identity: .pty(id),
+                    allowClosing: true
                 ) {
                     libssh2_channel_free($0)
                 }
@@ -643,7 +684,8 @@ actor SessionDriver {
                 try await cleanChannel(
                     identity: .pty(id),
                     deadline: deadline,
-                    cancellable: false)
+                    cancellable: false,
+                    allowClosing: true)
             }
             ptyChannels.removeValue(forKey: id)
         } catch {
@@ -705,7 +747,12 @@ actor SessionDriver {
             removeOneShot(id)
             return response
         } catch {
-            let normalized = (error as? SSHError).map(normalize)
+            let normalized: SSHError?
+            if error is ChannelOpenAdmissionError {
+                normalized = normalize(error)
+            } else {
+                normalized = (error as? SSHError).map(normalize)
+            }
             if let id = oneShotID {
                 do {
                     try await cleanChannel(
@@ -757,7 +804,7 @@ actor SessionDriver {
             guard let channel else { throw SSHError.streamLocalOpenFailed }
             nextStreamLocalChannelID &+= 1
             let id = nextStreamLocalChannelID
-            streamLocalChannels[id] = channel
+            streamLocalChannels[id] = StreamLocalChannelState(channel: channel)
             return SSHStreamLocalChannel(id: id, driver: self)
         } catch {
             let normalized = normalize(error)
@@ -908,16 +955,24 @@ actor SessionDriver {
         await acquireOperation()
         defer { releaseOperation() }
 
-        guard streamLocalChannels[id] != nil else { return }
+        guard var state = streamLocalChannels[id] else { return }
         guard valid, session != nil else {
             streamLocalChannels.removeValue(forKey: id)
             return
         }
+        guard !state.teardownInProgress else { return }
+        state.acceptsIO = false
+        state.teardownInProgress = true
+        streamLocalChannels[id] = state
+#if DEBUG
+        await holdChannelTeardownForTestingIfNeeded()
+#endif
         do {
             try await cleanChannel(
                 identity: .streamLocal(id),
                 deadline: ContinuousClock.now.advanced(by: timeout),
-                cancellable: false)
+                cancellable: false,
+                allowClosing: true)
             streamLocalChannels.removeValue(forKey: id)
         } catch {
             streamLocalChannels.removeValue(forKey: id)
@@ -1151,6 +1206,9 @@ actor SessionDriver {
             }
 
             let error = libssh2_session_last_errno(session)
+            let openFailure = error == LIBSSH2_ERROR_EAGAIN
+                ? nil
+                : classifyDirectTCPIPOpenFailure(session)
             notePacketProducingResult(error, owner: owner, session: session)
             if error == LIBSSH2_ERROR_EAGAIN {
                 try await waitForSession(session, deadline: deadline)
@@ -1791,6 +1849,16 @@ actor SessionDriver {
         nextChannelOpenSlotHoldForTesting = hold
     }
 
+    func holdNextChannelTeardownForTesting(
+        _ hold: @escaping @Sendable () async -> Void
+    ) {
+        nextChannelTeardownHoldForTesting = hold
+    }
+
+    func failNextResumedChannelOpenWaiterForTesting(_ error: SSHError) {
+        nextResumedChannelOpenWaiterErrorForTesting = error
+    }
+
     func holdEachSessionWaitForTesting(
         _ hold: @escaping @Sendable () async -> Void
     ) {
@@ -2014,7 +2082,7 @@ actor SessionDriver {
                     throw error
                 }
             } else {
-                throw classifyDirectTCPIPOpenFailure(session)
+                throw openFailure ?? SSHError.channelFailed
             }
         }
     }
@@ -2267,9 +2335,30 @@ actor SessionDriver {
             if sessionReportsOutbound(session), transportSendOwner == nil {
                 transportSendOwner = owner
             }
-        } else if transportSendOwner == owner {
-            transportSendOwner = nil
+        } else {
+            switch Self.transportSendOwnerDisposition(
+                result: result,
+                isCurrentOwner: transportSendOwner == owner,
+                hasOutbound: sessionReportsOutbound(session))
+            {
+            case .unchanged:
+                break
+            case .clear:
+                transportSendOwner = nil
+            case .invalidate:
+                invalidateResources()
+            }
         }
+    }
+
+    static func transportSendOwnerDisposition(
+        result: Int32,
+        isCurrentOwner: Bool,
+        hasOutbound: Bool
+    ) -> TransportSendOwnerDisposition {
+        guard isCurrentOwner else { return .unchanged }
+        if result < 0, hasOutbound { return .invalidate }
+        return .clear
     }
 
     private func notePacketProducingWrite(
@@ -2308,6 +2397,12 @@ actor SessionDriver {
                 throw error
             }
             await acquireOperation()
+#if DEBUG
+            if let error = nextResumedChannelOpenWaiterErrorForTesting {
+                nextResumedChannelOpenWaiterErrorForTesting = nil
+                throw error
+            }
+#endif
             if cancellable {
                 try checkProgress(deadline: deadline)
             } else if ContinuousClock.now >= deadline {
@@ -2416,37 +2511,57 @@ actor SessionDriver {
     ) async throws {
         if cancellable {
             try await withTaskCancellationHandler {
-                try await parkChannelOpenWaiterUntilDeadline(id: id, deadline: deadline)
+                try await parkChannelOpenWaiterUntilDeadline(
+                    id: id,
+                    deadline: deadline,
+                    cancellable: true)
             } onCancel: {
                 Task { await self.resumeChannelOpenWaiter(id: id, .failure(SSHError.cancelled)) }
             }
         } else {
-            try await parkChannelOpenWaiterUntilDeadline(id: id, deadline: deadline)
+            try await parkChannelOpenWaiterUntilDeadline(
+                id: id,
+                deadline: deadline,
+                cancellable: false)
         }
     }
 
     private func parkChannelOpenWaiterUntilDeadline(
         id: UInt64,
-        deadline: ContinuousClock.Instant
+        deadline: ContinuousClock.Instant,
+        cancellable: Bool
     ) async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-            channelOpenWaiters[id] = continuation
-            releaseOperation()
-            Task {
-                try? await Task.sleep(until: deadline, clock: .continuous)
+            guard !cancellable || !Task.isCancelled else {
+                releaseOperation()
+                continuation.resume(throwing: SSHError.cancelled)
+                return
+            }
+            let deadlineTask = Task {
+                do {
+                    try await Task.sleep(until: deadline, clock: .continuous)
+                } catch {
+                    return
+                }
                 await self.resumeChannelOpenWaiter(id: id, .failure(SSHError.timedOut))
             }
+            channelOpenWaiters[id] = DriverWaiter(
+                continuation: continuation,
+                deadlineTask: deadlineTask)
+            releaseOperation()
         }
     }
 
     private func resumeChannelOpenWaiter(id: UInt64, _ result: Result<Void, any Error>) {
-        guard let continuation = channelOpenWaiters.removeValue(forKey: id) else { return }
-        continuation.resume(with: result)
+        guard let waiter = channelOpenWaiters.removeValue(forKey: id) else { return }
+        waiter.deadlineTask.cancel()
+        waiter.continuation.resume(with: result)
     }
 
     private func releaseChannelOpenSlot() {
         channelOpenInProgress = false
-        if let id = channelOpenWaiters.keys.sorted().first {
+        let ids = Array(channelOpenWaiters.keys)
+        for id in ids {
             resumeChannelOpenWaiter(id: id, .success(()))
         }
     }
@@ -2474,7 +2589,10 @@ actor SessionDriver {
         oneShotChannels.removeValue(forKey: id)
     }
 
-    private func resolveChannel(_ identity: ChannelIdentity) throws -> OpaquePointer {
+    private func resolveChannel(
+        _ identity: ChannelIdentity,
+        allowClosing: Bool = false
+    ) throws -> OpaquePointer {
         let session = try requireSession()
         switch identity {
         case .oneShot(let id):
@@ -2483,13 +2601,15 @@ actor SessionDriver {
             }
             return entry.channel
         case .pty(let id):
-            guard let state = ptyChannels[id] else { throw SSHError.channelFailed }
+            guard let state = ptyChannels[id], allowClosing || state.acceptsIO else {
+                throw SSHError.channelFailed
+            }
             return state.channel
         case .streamLocal(let id):
-            guard let channel = streamLocalChannels[id] else {
-                throw SSHError.connectionInvalidated
+            guard let state = streamLocalChannels[id], allowClosing || state.acceptsIO else {
+                throw SSHError.channelFailed
             }
-            return channel
+            return state.channel
         }
     }
 
@@ -3095,11 +3215,13 @@ actor SessionDriver {
     /// status is only reliable after wait_closed.
     private func exitStatusAfterChannelClose(
         identity: ChannelIdentity,
-        deadline: ContinuousClock.Instant
+        deadline: ContinuousClock.Instant,
+        allowClosing: Bool = false
     ) async throws -> Int32 {
         let closeResult = try await repeatUntilCompleteYielding(
             deadline: deadline,
-            identity: identity
+            identity: identity,
+            allowClosing: allowClosing
         ) {
             libssh2_channel_close($0)
         }
@@ -3108,25 +3230,29 @@ actor SessionDriver {
         }
         let waitResult = try await repeatUntilCompleteYielding(
             deadline: deadline,
-            identity: identity
+            identity: identity,
+            allowClosing: allowClosing
         ) {
             libssh2_channel_wait_closed($0)
         }
         guard waitResult == 0 || waitResult == LIBSSH2_ERROR_CHANNEL_CLOSED else {
             throw SSHError.channelFailed
         }
-        return Int32(libssh2_channel_get_exit_status(try resolveChannel(identity)))
+        return Int32(libssh2_channel_get_exit_status(
+            try resolveChannel(identity, allowClosing: allowClosing)))
     }
 
     private func cleanChannel(
         identity: ChannelIdentity,
         deadline: ContinuousClock.Instant,
-        cancellable: Bool
+        cancellable: Bool,
+        allowClosing: Bool = false
     ) async throws {
         let eofResult = try await repeatUntilCompleteYielding(
             deadline: deadline,
             cancellable: cancellable,
-            identity: identity
+            identity: identity,
+            allowClosing: allowClosing
         ) {
             libssh2_channel_send_eof($0)
         }
@@ -3140,7 +3266,8 @@ actor SessionDriver {
         let closeResult = try await repeatUntilCompleteYielding(
             deadline: deadline,
             cancellable: cancellable,
-            identity: identity
+            identity: identity,
+            allowClosing: allowClosing
         ) {
             libssh2_channel_close($0)
         }
@@ -3151,7 +3278,8 @@ actor SessionDriver {
         let freeResult = try await repeatUntilCompleteYielding(
             deadline: deadline,
             cancellable: cancellable,
-            identity: identity
+            identity: identity,
+            allowClosing: allowClosing
         ) {
             libssh2_channel_free($0)
         }
@@ -3196,14 +3324,14 @@ actor SessionDriver {
         guard freeResult == 0 else { throw SSHError.channelFailed }
     }
 
-    private func beginSFTPUse(id: UInt64) throws {
+    private func beginSFTPUse(_ id: UInt64) throws {
         guard valid, sftpClients[id] != nil else {
             throw SSHError.connectionInvalidated
         }
         sftpUses[id, default: 0] += 1
     }
 
-    private func endSFTPUse(id: UInt64) {
+    private func endSFTPUse(_ id: UInt64) {
         guard let count = sftpUses[id] else { return }
         if count <= 1 {
             sftpUses.removeValue(forKey: id)
@@ -3257,27 +3385,45 @@ actor SessionDriver {
     ) async throws {
         if cancellable {
             try await withTaskCancellationHandler {
-                try await parkSFTPIdleWaiterUntilDeadline(id: id, deadline: deadline)
+                try await parkSFTPIdleWaiterUntilDeadline(
+                    id: id,
+                    deadline: deadline,
+                    cancellable: true)
             } onCancel: {
                 Task { await self.resumeSFTPIdleWaiter(id: id, .failure(SSHError.cancelled)) }
             }
         } else {
-            try await parkSFTPIdleWaiterUntilDeadline(id: id, deadline: deadline)
+            try await parkSFTPIdleWaiterUntilDeadline(
+                id: id,
+                deadline: deadline,
+                cancellable: false)
         }
     }
 
     private func parkSFTPIdleWaiterUntilDeadline(
         id: UInt64,
-        deadline: ContinuousClock.Instant
+        deadline: ContinuousClock.Instant,
+        cancellable: Bool
     ) async throws {
         try await withCheckedThrowingContinuation {
             (continuation: CheckedContinuation<Void, any Error>) in
-            sftpIdleWaiters[id] = continuation
-            releaseOperation()
-            Task {
-                try? await Task.sleep(until: deadline, clock: .continuous)
+            guard !cancellable || !Task.isCancelled else {
+                releaseOperation()
+                continuation.resume(throwing: SSHError.cancelled)
+                return
+            }
+            let deadlineTask = Task {
+                do {
+                    try await Task.sleep(until: deadline, clock: .continuous)
+                } catch {
+                    return
+                }
                 await self.resumeSFTPIdleWaiter(id: id, .failure(SSHError.timedOut))
             }
+            sftpIdleWaiters[id] = DriverWaiter(
+                continuation: continuation,
+                deadlineTask: deadlineTask)
+            releaseOperation()
         }
     }
 
@@ -3285,8 +3431,9 @@ actor SessionDriver {
         id: UInt64,
         _ result: Result<Void, any Error>
     ) {
-        guard let continuation = sftpIdleWaiters.removeValue(forKey: id) else { return }
-        continuation.resume(with: result)
+        guard let waiter = sftpIdleWaiters.removeValue(forKey: id) else { return }
+        waiter.deadlineTask.cancel()
+        waiter.continuation.resume(with: result)
     }
 
     private func withSFTPUse<T: Sendable>(
@@ -3476,11 +3623,14 @@ actor SessionDriver {
         deadline: ContinuousClock.Instant,
         cancellable: Bool = true,
         identity: ChannelIdentity,
+        allowClosing: Bool = false,
         _ operation: (OpaquePointer) -> Int32
     ) async throws -> Int32 {
         let owner = allocateTransportSendOwner()
         func drive() -> Int32? {
-            guard let channel = try? resolveChannel(identity) else { return nil }
+            guard let channel = try? resolveChannel(identity, allowClosing: allowClosing) else {
+                return nil
+            }
             return operation(channel)
         }
         while true {
@@ -3498,7 +3648,7 @@ actor SessionDriver {
                 await finishOwnedSendIfNeeded(owner: owner, drive: drive)
                 throw error
             }
-            let channel = try resolveChannel(identity)
+            let channel = try resolveChannel(identity, allowClosing: allowClosing)
             let session = try requireSession()
             let result = operation(channel)
             notePacketProducingResult(result, owner: owner, session: session)
@@ -3552,6 +3702,14 @@ actor SessionDriver {
     }
 
 #if DEBUG
+    private func holdChannelTeardownForTestingIfNeeded() async {
+        guard let hold = nextChannelTeardownHoldForTesting else { return }
+        nextChannelTeardownHoldForTesting = nil
+        releaseOperation()
+        await hold()
+        await acquireOperation()
+    }
+
     private func holdExecChannelAllocationForTestingIfNeeded() async throws {
         guard let hold = nextExecChannelAllocatedHoldForTesting else { return }
         nextExecChannelAllocatedHoldForTesting = nil

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -3122,7 +3122,7 @@ actor SessionDriver {
         let stdoutOwner = allocateTransportSendOwner()
         let stderrOwner = allocateTransportSendOwner()
 
-        func drainOwnedSends() async {
+        func drainOwnedSends(inputOffset: Int) async {
             await finishOwnedSendIfNeeded(owner: writeOwner) {
                 writeChannelOnce(identity: identity, data: input, offset: inputOffset)
             }
@@ -3254,14 +3254,15 @@ actor SessionDriver {
                     do {
                         try await awaitSessionProgress(plan, until: deadline)
                     } catch {
+                        let drainInputOffset = inputOffset
                         await acquireOperation()
-                        await drainOwnedSends()
+                        await drainOwnedSends(inputOffset: drainInputOffset)
                         throw error
                     }
                     await acquireOperation()
                 }
             } catch {
-                await drainOwnedSends()
+                await drainOwnedSends(inputOffset: inputOffset)
                 throw error
             }
         }
@@ -3284,7 +3285,7 @@ actor SessionDriver {
 
         try await beforeRequestWrite?()
 
-        func drainOwnedSends() async {
+        func drainOwnedSends(requestOffset: Int) async {
             await finishOwnedSendIfNeeded(owner: writeOwner) {
                 writeChannelOnce(identity: identity, data: request, offset: requestOffset)
             }
@@ -3373,14 +3374,15 @@ actor SessionDriver {
                     do {
                         try await awaitSessionProgress(plan, until: deadline)
                     } catch {
+                        let drainRequestOffset = requestOffset
                         await acquireOperation()
-                        await drainOwnedSends()
+                        await drainOwnedSends(requestOffset: drainRequestOffset)
                         throw error
                     }
                     await acquireOperation()
                 }
             } catch {
-                await drainOwnedSends()
+                await drainOwnedSends(requestOffset: requestOffset)
                 throw error
             }
         }

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -4,6 +4,12 @@ import Darwin
 import Foundation
 
 actor SessionDriver {
+    enum BridgeWriteResult: Equatable {
+        case blocked
+        case peerClosed
+        case wrote(Int)
+    }
+
     enum TransportSendOwnerDisposition: Equatable {
         case unchanged
         case clear
@@ -2309,18 +2315,27 @@ actor SessionDriver {
             }
 
             if !toInner.isEmpty {
-                let written = toInner.withUnsafeBytes { bytes in
-                    Darwin.write(bridgeDescriptor, bytes.baseAddress, bytes.count)
-                }
-                if written > 0 {
+                switch try Self.writeBridge(toInner, descriptor: bridgeDescriptor) {
+                case .wrote(let written):
                     toInner.removeFirst(written)
                     madeProgress = true
-                } else if written < 0, errno != EAGAIN, errno != EWOULDBLOCK {
-                    throw SSHError.connectionFailed
+                case .blocked:
+                    break
+                case .peerClosed:
+                    // The nested session closes its socket before the pump has
+                    // necessarily delivered the last bytes already read from
+                    // the outer channel. No consumer remains for this
+                    // direction, and that full-descriptor close also ends the
+                    // opposite one.
+                    toInner.removeAll(keepingCapacity: true)
+                    innerEOF = true
+                    madeProgress = true
                 }
             }
 
             if outerEOF, toInner.isEmpty {
+                // `toInner` only grows while `outerEOF` is false, so no later
+                // bridge write can misread this local shutdown as peer close.
                 _ = Darwin.shutdown(bridgeDescriptor, SHUT_WR)
             }
             if innerEOF, toOuter.isEmpty { return }
@@ -2353,6 +2368,20 @@ actor SessionDriver {
                 }
             }
         }
+    }
+
+    static func writeBridge(_ data: Data, descriptor: Int32) throws -> BridgeWriteResult {
+        let (written, writeErrno) = data.withUnsafeBytes { bytes -> (Int, Int32) in
+            guard let baseAddress = bytes.baseAddress else { return (0, 0) }
+            let result = Darwin.write(descriptor, baseAddress, bytes.count)
+            return (result, result < 0 ? errno : 0)
+        }
+        if written > 0 { return .wrote(written) }
+        if written == 0 || writeErrno == EAGAIN || writeErrno == EWOULDBLOCK {
+            return .blocked
+        }
+        if writeErrno == EPIPE { return .peerClosed }
+        throw SSHError.connectionFailed
     }
 
     /// Everything a blocked operation needs to wait on the session, captured

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/DirectTCPIPBridgeTests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/DirectTCPIPBridgeTests.swift
@@ -1,0 +1,25 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import HeelerSSH
+
+@Test("a bridge write to a closed peer reports peerClosed")
+func bridgeWriteToClosedPeerReportsPeerClosed() throws {
+    let transport = try DirectTCPIPByteTransport()
+    var innerDescriptor = try transport.takeDescriptor()
+    let pumpDescriptor = try transport.takePumpDescriptor()
+    defer {
+        if innerDescriptor >= 0 { Darwin.close(innerDescriptor) }
+        Darwin.close(pumpDescriptor)
+    }
+
+    Darwin.close(innerDescriptor)
+    innerDescriptor = -1
+
+    let result = try SessionDriver.writeBridge(
+        Data("pending outer bytes".utf8),
+        descriptor: pumpDescriptor)
+
+    #expect(result == .peerClosed)
+}

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/InvalidatedSessionTeardownTests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/InvalidatedSessionTeardownTests.swift
@@ -19,7 +19,7 @@ func invalidationAttemptsSessionReclamationOnlyOnce() {
 }
 
 @Test("invalidation retains ownership until native reclamation succeeds")
-func invalidationRetainsOwnershipUntilNativeReclamationSucceeds() {
+func invalidationRetainsOwnershipUntilNativeReclamationSucceeds() throws {
     var session: OpaquePointer? = OpaquePointer(bitPattern: 1)
     var results = [Int32(LIBSSH2_ERROR_EAGAIN), 0]
 
@@ -35,4 +35,11 @@ func invalidationRetainsOwnershipUntilNativeReclamationSucceeds() {
     #expect(secondResult == 0)
     #expect(session == nil)
     #expect(results.isEmpty)
+
+    try #require(NativeLibrary.initializationResult == 0)
+    let createdSession = try #require(libssh2_session_init_ex(nil, nil, nil, nil))
+    var nativeSession: OpaquePointer? = createdSession
+    let nativeResult = InvalidatedSessionTeardown.reclaim(&nativeSession)
+    #expect(nativeResult == 0)
+    #expect(nativeSession == nil)
 }

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionActivityTests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionActivityTests.swift
@@ -1,0 +1,17 @@
+import Testing
+
+@testable import HeelerSSH
+
+@Test("an invalidation generation rejects a watch armed before it")
+func invalidationGenerationRejectsAWatchArmedBeforeIt() {
+    let activity = SessionActivity()
+    let watch = activity.watch()
+    activity.releaseAllWaiters()
+
+    let waiter = DispatchWaiter()
+    #expect(watch.register(waiter) == false)
+
+    let fresh = activity.watch()
+    #expect(fresh.register(waiter))
+    fresh.unregister(waiter)
+}

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionActivityTests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionActivityTests.swift
@@ -33,4 +33,9 @@ func transportSendOwnerErrorWithOutboundPendingInvalidates() {
             result: -37,
             isCurrentOwner: false,
             hasOutbound: true) == .unchanged)
+    #expect(
+        SessionDriver.transportSendOwnerDisposition(
+            result: 0,
+            isCurrentOwner: true,
+            hasOutbound: true) == .clear)
 }

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionActivityTests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionActivityTests.swift
@@ -15,3 +15,22 @@ func invalidationGenerationRejectsAWatchArmedBeforeIt() {
     #expect(fresh.register(waiter))
     fresh.unregister(waiter)
 }
+
+@Test("a transport-send owner error with outbound pending invalidates")
+func transportSendOwnerErrorWithOutboundPendingInvalidates() {
+    #expect(
+        SessionDriver.transportSendOwnerDisposition(
+            result: -37,
+            isCurrentOwner: true,
+            hasOutbound: true) == .invalidate)
+    #expect(
+        SessionDriver.transportSendOwnerDisposition(
+            result: -37,
+            isCurrentOwner: true,
+            hasOutbound: false) == .clear)
+    #expect(
+        SessionDriver.transportSendOwnerDisposition(
+            result: -37,
+            isCurrentOwner: false,
+            hasOutbound: true) == .unchanged)
+}

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
@@ -979,9 +979,9 @@ struct SessionDriverE2ETests {
             #expect(result.stdout == Data("opened".utf8))
             #expect(result.exitStatus == 0)
             #expect(await connection.oneShotRegistryCountForTesting() == 0)
-            #expect(
-                await connection.transportSendOwnerSamplesForTesting()
-                    .allSatisfy { !$0.isForbiddenClearWindow })
+            let ownerSamples = await connection.transportSendOwnerSamplesForTesting()
+            #expect(!ownerSamples.isEmpty)
+            #expect(ownerSamples.allSatisfy { !$0.isForbiddenClearWindow })
             let ping = try await connection.execute("printf ping", timeout: .seconds(5))
             #expect(ping.stdout == Data("ping".utf8))
             #expect(await connection.isConnected)
@@ -1132,6 +1132,59 @@ struct SessionDriverE2ETests {
         #expect(state.hasSession == false)
     }
 
+    @Test("yielded channel teardown rejects same-id I/O")
+    func yieldedChannelTeardownRejectsSameIDIO() async throws {
+        let environment = try #require(SessionDriverTestEnvironment.current)
+        let socketPath = try #require(SessionDriverTestEnvironment.streamLocalSocketPath)
+        let connection = try await environment.connect()
+
+        let pty = try await connection.openPTY(
+            command: "cat",
+            columns: 80,
+            rows: 24,
+            timeout: .seconds(5))
+        let ptyTeardown = SessionWaitHold()
+        await connection.holdNextChannelTeardownForTesting {
+            await ptyTeardown.waitUntilReleased()
+        }
+        let closePTY = Task { try await pty.close(timeout: .seconds(5)) }
+        try await waitUntilTrue("PTY teardown should yield after closing starts") {
+            await ptyTeardown.hasEntered
+        }
+        await #expect(throws: SSHError.channelFailed) {
+            try await pty.write(Data("x".utf8), timeout: .seconds(1))
+        }
+        await #expect(throws: SSHError.channelFailed) {
+            _ = try await pty.read(timeout: .seconds(1))
+        }
+        await #expect(throws: SSHError.channelFailed) {
+            try await pty.resize(columns: 81, rows: 24, timeout: .seconds(1))
+        }
+        await ptyTeardown.release()
+        try await closePTY.value
+
+        let stream = try await connection.openStreamLocal(
+            socketPath: socketPath,
+            timeout: .seconds(5))
+        let streamTeardown = SessionWaitHold()
+        await connection.holdNextChannelTeardownForTesting {
+            await streamTeardown.waitUntilReleased()
+        }
+        let closeStream = Task { try await stream.close(timeout: .seconds(5)) }
+        try await waitUntilTrue("stream-local teardown should yield after closing starts") {
+            await streamTeardown.hasEntered
+        }
+        await #expect(throws: SSHError.channelFailed) {
+            try await stream.write(Data("x".utf8), timeout: .seconds(1))
+        }
+        await #expect(throws: SSHError.channelFailed) {
+            _ = try await stream.read(timeout: .seconds(1))
+        }
+        await streamTeardown.release()
+        try await closeStream.value
+        try await connection.close(timeout: .seconds(2))
+    }
+
     @Test("repeated invalidation reclaims every file descriptor")
     func repeatedInvalidationReclaimsEveryFileDescriptor() async throws {
         let environment = try #require(SessionDriverTestEnvironment.current)
@@ -1150,8 +1203,10 @@ struct SessionDriverE2ETests {
             "descriptors grew from \(baseline) to \(final) across \(rounds) sessions")
     }
 
-    @Test("Attach throughput with concurrent RPCs is printed")
-    func attachThroughputWithConcurrentRPCsIsPrinted() async throws {
+    /// Measurement only. The red regression guard for scheduling progress is
+    /// `one-shot RPCs yield so a live PTY can progress`.
+    @Test("measurement: Attach throughput with concurrent RPCs")
+    func measureAttachThroughputWithConcurrentRPCs() async throws {
         let environment = try #require(SessionDriverTestEnvironment.current)
         let connection = try await environment.connect()
         let pty = try await connection.openPTY(
@@ -1328,10 +1383,6 @@ struct SessionDriverE2ETests {
             try await waitUntilTrue("the first open should claim the slot") {
                 await slot.hasEntered
             }
-            try await waitUntilTrue("the first open should release the mutex") {
-                await connection.operationWaiterCountForTesting == 0
-            }
-
             let timedOut = Task {
                 try await connection.execute("printf timed-out-open", timeout: .milliseconds(200))
             }
@@ -1351,10 +1402,56 @@ struct SessionDriverE2ETests {
             await #expect(throws: SSHError.cancelled) { _ = try await cancelled.value }
             #expect(await connection.isConnected)
 
+            let registrationGate = SessionWaitHold()
+            let cancelledBeforeRegistration = Task {
+                await registrationGate.waitUntilReleased()
+                return try await connection.execute(
+                    "printf cancelled-before-registration",
+                    timeout: .seconds(15))
+            }
+            cancelledBeforeRegistration.cancel()
+            await registrationGate.release()
+            await #expect(throws: SSHError.cancelled) {
+                _ = try await cancelledBeforeRegistration.value
+            }
+            #expect(await connection.channelOpenWaiterCountForTesting() == 0)
+
+            await connection.failNextResumedChannelOpenWaiterForTesting(.cancelled)
+            let resumedHead = Task {
+                try await connection.execute("printf resumed-head", timeout: .seconds(15))
+            }
+            let resumedFollower = Task {
+                try await connection.execute("printf resumed-follower", timeout: .seconds(15))
+            }
+            try await waitUntilTrue("both channel-open waiters should park") {
+                await connection.channelOpenWaiterCountForTesting() == 2
+            }
+
             await park.release()
             try await write.value
             let firstResult = try await first.value
             #expect(firstResult.stdout == Data("first-open".utf8))
+            let resumedHeadResult: Result<SSHExecResult, any Error>
+            do {
+                resumedHeadResult = .success(try await resumedHead.value)
+            } catch {
+                resumedHeadResult = .failure(error)
+            }
+            let resumedFollowerResult: Result<SSHExecResult, any Error>
+            do {
+                resumedFollowerResult = .success(try await resumedFollower.value)
+            } catch {
+                resumedFollowerResult = .failure(error)
+            }
+            let resumedResults = [resumedHeadResult, resumedFollowerResult]
+            #expect(resumedResults.filter {
+                if case .success = $0 { return true }
+                return false
+            }.count == 1)
+            #expect(resumedResults.filter { result in
+                guard case .failure(let error) = result else { return false }
+                return error as? SSHError == .cancelled
+            }.count == 1)
             let ping = try await connection.execute("printf after-open-wait", timeout: .seconds(5))
             #expect(ping.stdout == Data("after-open-wait".utf8))
             try await pty.close(timeout: .seconds(5))
@@ -1467,9 +1564,9 @@ struct SessionDriverE2ETests {
                 try? await pty.close(timeout: .seconds(2))
                 throw error
             }
-            #expect(
-                await connection.transportSendOwnerSamplesForTesting()
-                    .allSatisfy { !$0.isForbiddenClearWindow })
+            let ownerSamples = await connection.transportSendOwnerSamplesForTesting()
+            #expect(!ownerSamples.isEmpty)
+            #expect(ownerSamples.allSatisfy { !$0.isForbiddenClearWindow })
             #expect(await connection.oneShotRegistryCountForTesting() == 0)
             let state = await connection.resourceStateForTesting()
             switch expected {

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
@@ -1132,8 +1132,8 @@ struct SessionDriverE2ETests {
         #expect(state.hasSession == false)
     }
 
-    @Test("yielded channel teardown rejects same-id I/O")
-    func yieldedChannelTeardownRejectsSameIDIO() async throws {
+    @Test("yielded channel teardown rejects same-id I/O and preserves close")
+    func yieldedChannelTeardownRejectsSameIDIOAndPreservesClose() async throws {
         let environment = try #require(SessionDriverTestEnvironment.current)
         let socketPath = try #require(SessionDriverTestEnvironment.streamLocalSocketPath)
         let connection = try await environment.connect()
@@ -1162,6 +1162,58 @@ struct SessionDriverE2ETests {
         }
         await ptyTeardown.release()
         try await closePTY.value
+
+        let exitingPTY = try await connection.openPTY(
+            command: "sh -c 'exit 7'",
+            columns: 80,
+            rows: 24,
+            timeout: .seconds(5))
+        while try await exitingPTY.read(timeout: .seconds(5)) != nil {}
+        let exitStatusTeardown = SessionWaitHold()
+        await connection.holdNextChannelTeardownForTesting {
+            await exitStatusTeardown.waitUntilReleased()
+        }
+        let exitStatus = Task {
+            try await exitingPTY.exitStatus(timeout: .seconds(5))
+        }
+        try await waitUntilTrue("exit status should suspend during teardown") {
+            await exitStatusTeardown.hasEntered
+        }
+        let closeExitingPTY = Task {
+            try await exitingPTY.close(timeout: .seconds(5))
+        }
+        try await waitUntilTrue("close should wait for exit-status teardown") {
+            await connection.ptyTeardownWaiterCountForTesting() == 1
+        }
+        #expect(await connection.ptyChannelCountForTesting() == 1)
+        await exitStatusTeardown.release()
+        #expect(try await exitStatus.value == 7)
+        try await closeExitingPTY.value
+        #expect(await connection.ptyChannelCountForTesting() == 0)
+
+        let retryablePTY = try await connection.openPTY(
+            command: "sh -c 'exit 0'",
+            columns: 80,
+            rows: 24,
+            timeout: .seconds(5))
+        while try await retryablePTY.read(timeout: .seconds(5)) != nil {}
+        let failedExitStatusTeardown = SessionWaitHold()
+        await connection.holdNextChannelTeardownForTesting {
+            await failedExitStatusTeardown.waitUntilReleased()
+        }
+        let failedExitStatus = Task {
+            try await retryablePTY.exitStatus(timeout: .milliseconds(50))
+        }
+        try await waitUntilTrue("the failing exit status should suspend") {
+            await failedExitStatusTeardown.hasEntered
+        }
+        try await Task.sleep(for: .milliseconds(75))
+        await failedExitStatusTeardown.release()
+        await #expect(throws: SSHError.timedOut) {
+            _ = try await failedExitStatus.value
+        }
+        #expect(await retryablePTY.acceptsIOForTesting())
+        try await retryablePTY.close(timeout: .seconds(5))
 
         let stream = try await connection.openStreamLocal(
             socketPath: socketPath,
@@ -1402,15 +1454,20 @@ struct SessionDriverE2ETests {
             await #expect(throws: SSHError.cancelled) { _ = try await cancelled.value }
             #expect(await connection.isConnected)
 
-            let registrationGate = SessionWaitHold()
+            let registrationGuard = SessionWaitHold()
+            await connection.holdNextChannelOpenWaiterRegistrationForTesting {
+                await registrationGuard.waitUntilReleased()
+            }
             let cancelledBeforeRegistration = Task {
-                await registrationGate.waitUntilReleased()
-                return try await connection.execute(
+                try await connection.execute(
                     "printf cancelled-before-registration",
                     timeout: .seconds(15))
             }
+            try await waitUntilTrue("the waiter should reach its registration guard") {
+                await registrationGuard.hasEntered
+            }
             cancelledBeforeRegistration.cancel()
-            await registrationGate.release()
+            await registrationGuard.release()
             await #expect(throws: SSHError.cancelled) {
                 _ = try await cancelledBeforeRegistration.value
             }

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
@@ -1061,18 +1061,30 @@ struct SessionDriverE2ETests {
             let rpc = Task {
                 try await site.run(on: connection, socketPath: socketPath)
             }
-            try await waitUntilTrue("\(site.rawValue) should wait after establishment") {
-                await hold.hasEntered
+            do {
+                try await requireEventually(
+                    "\(site.rawValue) should wait after establishment"
+                ) {
+                    await hold.hasEntered
+                }
+                let marker = "yield-\(site.rawValue)"
+                try await pty.write(Data("\(marker)\n".utf8), timeout: .seconds(5))
+                try await readPTY(
+                    pty,
+                    untilContaining: marker,
+                    timeout: .seconds(5),
+                    comment: "\(site.rawValue) held the session while a live PTY was waiting")
+                await hold.release()
+                try await site.finish(rpc)
+                #expect(await connection.oneShotRegistryCountForTesting() == 0)
+            } catch {
+                rpc.cancel()
+                await hold.release()
+                _ = try? await rpc.value
+                try? await pty.close(timeout: .seconds(2))
+                try? await connection.close(timeout: .seconds(2))
+                throw error
             }
-            let marker = "yield-\(site.rawValue)"
-            try await pty.write(Data("\(marker)\n".utf8), timeout: .seconds(5))
-            let output = try #require(try await pty.read(timeout: .seconds(5)))
-            #expect(
-                String(decoding: output, as: UTF8.self).contains(marker),
-                "\(site.rawValue) held the session while a live PTY was waiting")
-            await hold.release()
-            try await site.finish(rpc)
-            #expect(await connection.oneShotRegistryCountForTesting() == 0)
         }
 
         try await pty.close(timeout: .seconds(5))
@@ -1282,10 +1294,6 @@ struct SessionDriverE2ETests {
         }
 
         let quiet = try await pump()
-        let parked = CountingHold()
-        await connection.holdEachSessionWaitForTesting {
-            await parked.arriveAndWait()
-        }
         let busy: Double
         do {
             busy = try await withThrowingTaskGroup(of: Void.self) { group in
@@ -1297,19 +1305,21 @@ struct SessionDriverE2ETests {
                         #expect(!result.stdout.isEmpty)
                     }
                 }
-                try await waitUntilTrue("all eight RPCs should park during the pump") {
-                    await parked.arrivedCount == 8
+                try await requireEventually("all eight RPCs should be in flight") {
+                    await connection.oneShotRegistryCountForTesting() == 8
                 }
                 let measured = try await pump()
-                await connection.clearEachSessionWaitForTesting()
-                await parked.releaseAll()
                 try await group.waitForAll()
                 return measured
             }
+        } catch {
+            try? await pty.close(timeout: .seconds(2))
+            try? await connection.close(timeout: .seconds(2))
+            throw error
         }
         print(
             "[issue-130] Attach throughput: \(Int(quiet)) B/s quiet, "
-                + "\(Int(busy)) B/s with 8 parked RPCs")
+                + "\(Int(busy)) B/s with 8 in-flight RPCs")
         try await pty.close(timeout: .seconds(5))
         try await connection.close(timeout: .seconds(2))
     }
@@ -1534,6 +1544,44 @@ struct SessionDriverE2ETests {
         #expect(await condition(), comment)
     }
 
+    private func requireEventually(
+        _ comment: Comment,
+        timeout: Duration = SessionDriverE2ETests.phaseGateObservationBudget,
+        condition: () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        try #require(await condition(), comment)
+    }
+
+    private func readPTY(
+        _ pty: SSHPTYChannel,
+        untilContaining marker: String,
+        timeout: Duration,
+        comment: Comment
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        var output = Data()
+        var decoded = ""
+        while ContinuousClock.now < deadline {
+            let remaining = ContinuousClock.now.duration(to: deadline)
+            do {
+                guard let fragment = try await pty.read(timeout: remaining) else { break }
+                output.append(fragment)
+                decoded = String(decoding: output, as: UTF8.self)
+                if decoded.contains(marker) { return }
+            } catch SSHError.timedOut {
+                break
+            }
+        }
+        try #require(
+            decoded.contains(marker),
+            "\(comment); output \(String(reflecting: decoded)) did not contain \(marker)")
+    }
+
     private func connectThroughProxy(
         environment: SessionDriverTestEnvironment,
         proxy: WeakNetworkProxyFixture
@@ -1641,7 +1689,8 @@ struct SessionDriverE2ETests {
                 #expect(await connection.isConnected == false)
                 #expect(state.isValid == false)
                 #expect(state.descriptorIsOpen == false)
-                #expect(state.hasSession == false)
+                // Failed native reclamation retains pointer ownership for a
+                // later retry; this state snapshot never dereferences it.
                 await #expect(throws: SSHError.connectionInvalidated) {
                     _ = try await connection.execute("printf poisoned", timeout: .seconds(1))
                 }
@@ -1649,6 +1698,15 @@ struct SessionDriverE2ETests {
             }
             try? await pty.close(timeout: .seconds(2))
             try await connection.close(timeout: .seconds(2))
+            if expected == .invalidated {
+                // Closing an already-invalid connection retries the retained
+                // native reclamation without making the session reusable.
+                let reclaimedState = await connection.resourceStateForTesting()
+                #expect(reclaimedState == SessionDriverResourceState(
+                    hasSession: false,
+                    descriptorIsOpen: false,
+                    isValid: false))
+            }
         }
     }
 
@@ -2341,25 +2399,6 @@ private actor SessionWaitHold {
     }
 
     func release() {
-        isReleased = true
-        let resumed = waiters
-        waiters.removeAll()
-        for waiter in resumed { waiter.resume() }
-    }
-}
-
-private actor CountingHold {
-    private(set) var arrivedCount = 0
-    private var isReleased = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
-
-    func arriveAndWait() async {
-        arrivedCount += 1
-        guard !isReleased else { return }
-        await withCheckedContinuation { waiters.append($0) }
-    }
-
-    func releaseAll() {
         isReleased = true
         let resumed = waiters
         waiters.removeAll()

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
@@ -1334,6 +1334,7 @@ struct SessionDriverE2ETests {
                 proxy: proxy)
             try await connection.shrinkSendBufferForTesting(bytes: 2_048)
             let home = try await remoteHome(of: connection)
+            let missingPath = "\(home)/.heeler-missing-\(UUID().uuidString)"
             let sftp = try await connection.openSFTP(timeout: .seconds(15))
             let pty = try await connection.openPTY(
                 command: "cat",
@@ -1346,29 +1347,48 @@ struct SessionDriverE2ETests {
             }
             let write = Task {
                 try await pty.write(
-                    Data(repeating: 0x61, count: 512 * 1_024),
+                    Data(repeating: 0x61, count: 32 * 1_024),
                     timeout: .seconds(15))
             }
-            try await waitUntilTrue("the PTY write should own the send") {
-                await park.hasEntered
+            var leaseTasks: [Task<Data?, any Error>] = []
+            do {
+                try await requireEventually("the PTY write should own the send") {
+                    await park.hasEntered
+                }
+                let read = Task {
+                    try await sftp.readFileIfPresent(
+                        at: missingPath,
+                        timeout: .seconds(15))
+                }
+                leaseTasks.append(read)
+                try await requireEventually("the SFTP call should hold a handle lease") {
+                    await connection.sftpUseCountForTesting() == 1
+                }
+                let secondRead = Task {
+                    try await sftp.readFileIfPresent(
+                        at: missingPath,
+                        timeout: .seconds(15))
+                }
+                leaseTasks.append(secondRead)
+                try await requireEventually("a second SFTP call should wait for the lease") {
+                    await connection.sftpIdleWaiterCountForTesting() == 1
+                }
+                #expect(await connection.sftpUseCountForTesting() == 1)
+                await park.release()
+                try await write.value
+                #expect(try await read.value == nil)
+                #expect(try await secondRead.value == nil)
+            } catch {
+                write.cancel()
+                for task in leaseTasks { task.cancel() }
+                await park.release()
+                _ = try? await write.value
+                for task in leaseTasks { _ = try? await task.value }
+                try? await sftp.close(timeout: .seconds(2))
+                try? await pty.close(timeout: .seconds(2))
+                try? await connection.close(timeout: .seconds(2))
+                throw error
             }
-            let stat = Task {
-                _ = try await sftp.attributes(at: home, timeout: .seconds(15))
-            }
-            try await waitUntilTrue("the SFTP call should hold a handle lease") {
-                await connection.sftpUseCountForTesting() == 1
-            }
-            let secondStat = Task {
-                _ = try await sftp.attributes(at: home, timeout: .seconds(15))
-            }
-            try await waitUntilTrue("a second SFTP call should wait for the lease") {
-                await connection.sftpIdleWaiterCountForTesting() == 1
-            }
-            #expect(await connection.sftpUseCountForTesting() == 1)
-            await park.release()
-            try await write.value
-            _ = try await stat.value
-            _ = try await secondStat.value
 
             let closePark = SessionWaitHold()
             await connection.holdNextOutboundWriteParkForTesting {
@@ -1376,28 +1396,48 @@ struct SessionDriverE2ETests {
             }
             let closeWrite = Task {
                 try await pty.write(
-                    Data(repeating: 0x62, count: 512 * 1_024),
+                    Data(repeating: 0x62, count: 32 * 1_024),
                     timeout: .seconds(15))
             }
-            try await waitUntilTrue("the second PTY write should own the send") {
-                await closePark.hasEntered
+            var closeRead: Task<Data?, any Error>?
+            var closing: Task<Void, any Error>?
+            do {
+                try await requireEventually("the second PTY write should own the send") {
+                    await closePark.hasEntered
+                }
+                let read = Task {
+                    try await sftp.readFileIfPresent(
+                        at: missingPath,
+                        timeout: .seconds(15))
+                }
+                closeRead = read
+                try await requireEventually("the SFTP call should hold the close lease") {
+                    await connection.sftpUseCountForTesting() == 1
+                }
+                let close = Task {
+                    try await sftp.close(timeout: .seconds(15))
+                }
+                closing = close
+                try await requireEventually("closeSFTP should wait for the lease") {
+                    await connection.sftpIdleWaiterCountForTesting() == 1
+                }
+                await closePark.release()
+                try await closeWrite.value
+                #expect(try await read.value == nil)
+                try await close.value
+            } catch {
+                closeWrite.cancel()
+                closeRead?.cancel()
+                closing?.cancel()
+                await closePark.release()
+                _ = try? await closeWrite.value
+                if let closeRead { _ = try? await closeRead.value }
+                if let closing { _ = try? await closing.value }
+                try? await sftp.close(timeout: .seconds(2))
+                try? await pty.close(timeout: .seconds(2))
+                try? await connection.close(timeout: .seconds(2))
+                throw error
             }
-            let closeStat = Task {
-                _ = try await sftp.attributes(at: home, timeout: .seconds(15))
-            }
-            try await waitUntilTrue("the SFTP call should hold the close lease") {
-                await connection.sftpUseCountForTesting() == 1
-            }
-            let closing = Task {
-                try await sftp.close(timeout: .seconds(15))
-            }
-            try await waitUntilTrue("closeSFTP should wait for the lease") {
-                await connection.sftpIdleWaiterCountForTesting() == 1
-            }
-            await closePark.release()
-            try await closeWrite.value
-            _ = try await closeStat.value
-            try await closing.value
             #expect(await connection.sftpUseCountForTesting() == 0)
             #expect(await connection.isConnected)
             let ping = try await connection.execute("printf sftp-lease", timeout: .seconds(5))
@@ -1427,102 +1467,124 @@ struct SessionDriverE2ETests {
             }
             let write = Task {
                 try await pty.write(
-                    Data(repeating: 0x61, count: 512 * 1_024),
+                    Data(repeating: 0x61, count: 32 * 1_024),
                     timeout: .seconds(15))
             }
-            try await waitUntilTrue("the PTY write should own the send") {
-                await park.hasEntered
-            }
-
             let slot = SessionWaitHold()
-            await slot.release()
+            let registrationGuard = SessionWaitHold()
             await connection.holdNextChannelOpenSlotForTesting {
                 await slot.waitUntilReleased()
             }
             let first = Task {
                 try await connection.execute("printf first-open", timeout: .seconds(15))
             }
-            try await waitUntilTrue("the first open should claim the slot") {
-                await slot.hasEntered
-            }
-            let timedOut = Task {
-                try await connection.execute("printf timed-out-open", timeout: .milliseconds(200))
-            }
-            try await waitUntilTrue("the timed-out open should park on the slot") {
-                await connection.channelOpenWaiterCountForTesting() == 1
-            }
-            await #expect(throws: SSHError.timedOut) { _ = try await timedOut.value }
-            #expect(await connection.isConnected)
-
-            let cancelled = Task {
-                try await connection.execute("printf cancelled-open", timeout: .seconds(15))
-            }
-            try await waitUntilTrue("the cancelled open should park on the slot") {
-                await connection.channelOpenWaiterCountForTesting() == 1
-            }
-            cancelled.cancel()
-            await #expect(throws: SSHError.cancelled) { _ = try await cancelled.value }
-            #expect(await connection.isConnected)
-
-            let registrationGuard = SessionWaitHold()
-            await connection.holdNextChannelOpenWaiterRegistrationForTesting {
-                await registrationGuard.waitUntilReleased()
-            }
-            let cancelledBeforeRegistration = Task {
-                try await connection.execute(
-                    "printf cancelled-before-registration",
-                    timeout: .seconds(15))
-            }
-            try await waitUntilTrue("the waiter should reach its registration guard") {
-                await registrationGuard.hasEntered
-            }
-            cancelledBeforeRegistration.cancel()
-            await registrationGuard.release()
-            await #expect(throws: SSHError.cancelled) {
-                _ = try await cancelledBeforeRegistration.value
-            }
-            #expect(await connection.channelOpenWaiterCountForTesting() == 0)
-
-            await connection.failNextResumedChannelOpenWaiterForTesting(.cancelled)
-            let resumedHead = Task {
-                try await connection.execute("printf resumed-head", timeout: .seconds(15))
-            }
-            let resumedFollower = Task {
-                try await connection.execute("printf resumed-follower", timeout: .seconds(15))
-            }
-            try await waitUntilTrue("both channel-open waiters should park") {
-                await connection.channelOpenWaiterCountForTesting() == 2
-            }
-
-            await park.release()
-            try await write.value
-            let firstResult = try await first.value
-            #expect(firstResult.stdout == Data("first-open".utf8))
-            let resumedHeadResult: Result<SSHExecResult, any Error>
+            var openTasks = [first]
             do {
-                resumedHeadResult = .success(try await resumedHead.value)
+                try await requireEventually("the PTY write should own the send") {
+                    await park.hasEntered
+                }
+                try await requireEventually("the first open should claim the slot") {
+                    await slot.hasEntered
+                }
+                let timedOut = Task {
+                    try await connection.execute(
+                        "printf timed-out-open",
+                        timeout: .milliseconds(200))
+                }
+                openTasks.append(timedOut)
+                try await requireEventually("the timed-out open should park on the slot") {
+                    await connection.channelOpenWaiterCountForTesting() == 1
+                }
+                await #expect(throws: SSHError.timedOut) { _ = try await timedOut.value }
+                #expect(await connection.isConnected)
+
+                let cancelled = Task {
+                    try await connection.execute("printf cancelled-open", timeout: .seconds(15))
+                }
+                openTasks.append(cancelled)
+                try await requireEventually("the cancelled open should park on the slot") {
+                    await connection.channelOpenWaiterCountForTesting() == 1
+                }
+                cancelled.cancel()
+                await #expect(throws: SSHError.cancelled) { _ = try await cancelled.value }
+                #expect(await connection.isConnected)
+
+                await connection.holdNextChannelOpenWaiterRegistrationForTesting {
+                    await registrationGuard.waitUntilReleased()
+                }
+                let cancelledBeforeRegistration = Task {
+                    try await connection.execute(
+                        "printf cancelled-before-registration",
+                        timeout: .seconds(15))
+                }
+                openTasks.append(cancelledBeforeRegistration)
+                try await requireEventually("the waiter should reach its registration guard") {
+                    await registrationGuard.hasEntered
+                }
+                cancelledBeforeRegistration.cancel()
+                await registrationGuard.release()
+                await #expect(throws: SSHError.cancelled) {
+                    _ = try await cancelledBeforeRegistration.value
+                }
+                #expect(await connection.channelOpenWaiterCountForTesting() == 0)
+
+                await connection.failNextResumedChannelOpenWaiterForTesting(.cancelled)
+                let resumedHead = Task {
+                    try await connection.execute("printf resumed-head", timeout: .seconds(15))
+                }
+                openTasks.append(resumedHead)
+                let resumedFollower = Task {
+                    try await connection.execute("printf resumed-follower", timeout: .seconds(15))
+                }
+                openTasks.append(resumedFollower)
+                try await requireEventually("both channel-open waiters should park") {
+                    await connection.channelOpenWaiterCountForTesting() == 2
+                }
+
+                await slot.release()
+                await park.release()
+                try await write.value
+                let firstResult = try await first.value
+                #expect(firstResult.stdout == Data("first-open".utf8))
+                let resumedHeadResult: Result<SSHExecResult, any Error>
+                do {
+                    resumedHeadResult = .success(try await resumedHead.value)
+                } catch {
+                    resumedHeadResult = .failure(error)
+                }
+                let resumedFollowerResult: Result<SSHExecResult, any Error>
+                do {
+                    resumedFollowerResult = .success(try await resumedFollower.value)
+                } catch {
+                    resumedFollowerResult = .failure(error)
+                }
+                let resumedResults = [resumedHeadResult, resumedFollowerResult]
+                #expect(resumedResults.filter {
+                    if case .success = $0 { return true }
+                    return false
+                }.count == 1)
+                #expect(resumedResults.filter { result in
+                    guard case .failure(let error) = result else { return false }
+                    return error as? SSHError == .cancelled
+                }.count == 1)
+                let ping = try await connection.execute(
+                    "printf after-open-wait",
+                    timeout: .seconds(5))
+                #expect(ping.stdout == Data("after-open-wait".utf8))
+                try await pty.close(timeout: .seconds(5))
+                try await connection.close(timeout: .seconds(2))
             } catch {
-                resumedHeadResult = .failure(error)
+                write.cancel()
+                for task in openTasks { task.cancel() }
+                await registrationGuard.release()
+                await slot.release()
+                await park.release()
+                _ = try? await write.value
+                for task in openTasks { _ = try? await task.value }
+                try? await pty.close(timeout: .seconds(2))
+                try? await connection.close(timeout: .seconds(2))
+                throw error
             }
-            let resumedFollowerResult: Result<SSHExecResult, any Error>
-            do {
-                resumedFollowerResult = .success(try await resumedFollower.value)
-            } catch {
-                resumedFollowerResult = .failure(error)
-            }
-            let resumedResults = [resumedHeadResult, resumedFollowerResult]
-            #expect(resumedResults.filter {
-                if case .success = $0 { return true }
-                return false
-            }.count == 1)
-            #expect(resumedResults.filter { result in
-                guard case .failure(let error) = result else { return false }
-                return error as? SSHError == .cancelled
-            }.count == 1)
-            let ping = try await connection.execute("printf after-open-wait", timeout: .seconds(5))
-            #expect(ping.stdout == Data("after-open-wait".utf8))
-            try await pty.close(timeout: .seconds(5))
-            try await connection.close(timeout: .seconds(2))
         }
     }
 
@@ -1689,8 +1751,7 @@ struct SessionDriverE2ETests {
                 #expect(await connection.isConnected == false)
                 #expect(state.isValid == false)
                 #expect(state.descriptorIsOpen == false)
-                // Failed native reclamation retains pointer ownership for a
-                // later retry; this state snapshot never dereferences it.
+                #expect(state.hasSession == false)
                 await #expect(throws: SSHError.connectionInvalidated) {
                     _ = try await connection.execute("printf poisoned", timeout: .seconds(1))
                 }
@@ -1699,8 +1760,8 @@ struct SessionDriverE2ETests {
             try? await pty.close(timeout: .seconds(2))
             try await connection.close(timeout: .seconds(2))
             if expected == .invalidated {
-                // Closing an already-invalid connection retries the retained
-                // native reclamation without making the session reusable.
+                // Explicit close stays idempotent after synchronous native
+                // reclamation and cannot make the connection reusable.
                 let reclaimedState = await connection.resourceStateForTesting()
                 #expect(reclaimedState == SessionDriverResourceState(
                     hasSession: false,

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
@@ -943,6 +943,425 @@ struct SessionDriverE2ETests {
         try await connection.close(timeout: .seconds(2))
     }
 
+    @Test("outbound backpressure does not livelock a channel open")
+    func outboundBackpressureDoesNotLivelockAChannelOpen() async throws {
+        let environment = try #require(SessionDriverTestEnvironment.current)
+        let proxy = try #require(WeakNetworkProxyFixture.current)
+        try await withDegradedLink(proxy) {
+            let connection = try await connectThroughProxy(
+                environment: environment,
+                proxy: proxy)
+            await connection.startSamplingTransportSendOwnerForTesting()
+            try await connection.shrinkSendBufferForTesting(bytes: 2_048)
+            let pty = try await connection.openPTY(
+                command: "cat",
+                columns: 80,
+                rows: 24,
+                timeout: .seconds(15))
+            let hold = SessionWaitHold()
+            await connection.holdNextOutboundWriteParkForTesting {
+                await hold.waitUntilReleased()
+            }
+            let write = Task {
+                try await pty.write(
+                    Data(repeating: 0x61, count: 32 * 1_024),
+                    timeout: .seconds(10))
+            }
+            try await waitUntilTrue("the write should park on an outbound send") {
+                await hold.hasEntered
+            }
+            let opened = Task {
+                try await connection.execute("printf opened", timeout: .seconds(10))
+            }
+            await hold.release()
+            try await write.value
+            let result = try await opened.value
+            #expect(result.stdout == Data("opened".utf8))
+            #expect(result.exitStatus == 0)
+            #expect(await connection.oneShotRegistryCountForTesting() == 0)
+            #expect(
+                await connection.transportSendOwnerSamplesForTesting()
+                    .allSatisfy { !$0.isForbiddenClearWindow })
+            let ping = try await connection.execute("printf ping", timeout: .seconds(5))
+            #expect(ping.stdout == Data("ping".utf8))
+            #expect(await connection.isConnected)
+            try await pty.close(timeout: .seconds(5))
+            try await connection.close(timeout: .seconds(2))
+        }
+    }
+
+    @Test("cancelling a transport-send owner drains")
+    func cancellingATransportSendOwnerDrains() async throws {
+        try await exerciseOwnedWriteInterruption(
+            expected: .drained,
+            expectedError: .cancelled
+        ) { write, gates in
+            try await waitForOwnedLoopTop(gates)
+            write.cancel()
+            await gates.loopTop.release()
+        }
+    }
+
+    @Test("cancelling a transport-send owner invalidates")
+    func cancellingATransportSendOwnerInvalidates() async throws {
+        try await exerciseOwnedWriteInterruption(
+            expected: .invalidated,
+            expectedError: .cancelled,
+            drainThrows: true
+        ) { write, gates in
+            try await waitForOwnedLoopTop(gates)
+            write.cancel()
+            await gates.loopTop.release()
+        }
+    }
+
+    @Test("timing out a transport-send owner at loop-top drains")
+    func timingOutATransportSendOwnerAtLoopTopDrains() async throws {
+        try await exerciseOwnedWriteInterruption(
+            expected: .drained,
+            expectedError: .timedOut,
+            loopTopThrows: .timedOut
+        ) { _, gates in
+            try await waitForOwnedLoopTop(gates)
+            await gates.loopTop.release()
+        }
+    }
+
+    @Test("timing out a transport-send owner at loop-top invalidates")
+    func timingOutATransportSendOwnerAtLoopTopInvalidates() async throws {
+        try await exerciseOwnedWriteInterruption(
+            expected: .invalidated,
+            expectedError: .timedOut,
+            loopTopThrows: .timedOut,
+            drainThrows: true
+        ) { _, gates in
+            try await waitForOwnedLoopTop(gates)
+            await gates.loopTop.release()
+        }
+    }
+
+    @Test("one-shot RPCs yield so a live PTY can progress")
+    func oneShotRPCsYieldSoALivePTYCanProgress() async throws {
+        let environment = try #require(SessionDriverTestEnvironment.current)
+        let socketPath = try #require(SessionDriverTestEnvironment.streamLocalSocketPath)
+        let connection = try await environment.connect()
+        let pty = try await connection.openPTY(
+            command: "cat",
+            columns: 80,
+            rows: 24,
+            timeout: .seconds(5))
+
+        for site in OneShotYieldSite.allCases {
+            let hold = SessionWaitHold()
+            await connection.holdNextOneShotEstablishedForTesting {
+                await connection.holdNextSessionWaitForTesting {
+                    await hold.waitUntilReleased()
+                }
+            }
+            let rpc = Task {
+                try await site.run(on: connection, socketPath: socketPath)
+            }
+            try await waitUntilTrue("\(site.rawValue) should wait after establishment") {
+                await hold.hasEntered
+            }
+            let marker = "yield-\(site.rawValue)"
+            try await pty.write(Data("\(marker)\n".utf8), timeout: .seconds(5))
+            let output = try #require(try await pty.read(timeout: .seconds(5)))
+            #expect(
+                String(decoding: output, as: UTF8.self).contains(marker),
+                "\(site.rawValue) held the session while a live PTY was waiting")
+            await hold.release()
+            try await site.finish(rpc)
+            #expect(await connection.oneShotRegistryCountForTesting() == 0)
+        }
+
+        try await pty.close(timeout: .seconds(5))
+        #expect(await connection.isConnected)
+        try await connection.close(timeout: .seconds(2))
+    }
+
+    @Test("cancelling a yielded one-shot distinguishes cleanup outcomes")
+    func cancellingAYieldedOneShotDistinguishesCleanupOutcomes() async throws {
+        for expected in TransportSendOwnerOutcome.allCases {
+            try await exerciseYieldedOneShotInterruption(
+                expected: expected,
+                expectedError: .cancelled
+            ) { rpc, hold in
+                rpc.cancel()
+                await hold.release()
+            }
+        }
+    }
+
+    @Test("timing out a yielded one-shot distinguishes cleanup outcomes")
+    func timingOutAYieldedOneShotDistinguishesCleanupOutcomes() async throws {
+        for expected in TransportSendOwnerOutcome.allCases {
+            try await exerciseYieldedOneShotInterruption(
+                expected: expected,
+                expectedError: .timedOut,
+                waitThrows: .timedOut
+            ) { _, hold in
+                await hold.release()
+            }
+        }
+    }
+
+    @Test("invalidation during a yielding wait does not touch a stale native pointer")
+    func invalidationDuringAYieldingWaitDoesNotTouchAStaleNativePointer() async throws {
+        let environment = try #require(SessionDriverTestEnvironment.current)
+        let connection = try await environment.connect()
+        let hold = SessionWaitHold()
+        await connection.holdNextOneShotEstablishedForTesting {
+            await connection.holdNextSessionWaitForTesting {
+                await hold.waitUntilReleased()
+            }
+        }
+        let rpc = Task {
+            try await connection.execute("sleep 20", timeout: .seconds(15))
+        }
+        try await waitUntilTrue("the one-shot should wait after establishment") {
+            await hold.hasEntered
+        }
+        try await connection.close(timeout: .seconds(2))
+        await hold.release()
+        await #expect(throws: SSHError.self) { _ = try await rpc.value }
+        #expect(await connection.oneShotRegistryCountForTesting() == 0)
+        let state = await connection.resourceStateForTesting()
+        #expect(state.isValid == false)
+        #expect(state.descriptorIsOpen == false)
+        #expect(state.hasSession == false)
+    }
+
+    @Test("repeated invalidation reclaims every file descriptor")
+    func repeatedInvalidationReclaimsEveryFileDescriptor() async throws {
+        let environment = try #require(SessionDriverTestEnvironment.current)
+        try await invalidateOneYieldingSession(environment: environment)
+        let baseline = openFileDescriptorCount()
+        let rounds = 5
+        for _ in 0..<rounds {
+            try await invalidateOneYieldingSession(environment: environment)
+        }
+        let final = openFileDescriptorCount()
+        print(
+            "[issue-130] descriptors: baseline \(baseline), "
+                + "after \(rounds) invalidated sessions \(final)")
+        #expect(
+            final <= baseline + 2,
+            "descriptors grew from \(baseline) to \(final) across \(rounds) sessions")
+    }
+
+    @Test("Attach throughput with concurrent RPCs is printed")
+    func attachThroughputWithConcurrentRPCsIsPrinted() async throws {
+        let environment = try #require(SessionDriverTestEnvironment.current)
+        let connection = try await environment.connect()
+        let pty = try await connection.openPTY(
+            command: "cat",
+            columns: 80,
+            rows: 24,
+            timeout: .seconds(5))
+        let payload = Data("probe-bytes-0123456789\n".utf8)
+        let rounds = 20
+
+        func pump() async throws -> Double {
+            let started = ContinuousClock.now
+            var bytes = 0
+            for _ in 0..<rounds {
+                try await pty.write(payload, timeout: .seconds(5))
+                let output = try #require(try await pty.read(timeout: .seconds(5)))
+                bytes += payload.count + output.count
+            }
+            let seconds = durationSeconds(started.duration(to: .now))
+            return seconds > 0 ? Double(bytes) / seconds : 0
+        }
+
+        let quiet = try await pump()
+        let parked = CountingHold()
+        await connection.holdEachSessionWaitForTesting {
+            await parked.arriveAndWait()
+        }
+        let busy: Double
+        do {
+            busy = try await withThrowingTaskGroup(of: Void.self) { group in
+                for index in 0..<8 {
+                    group.addTask {
+                        let result = try await connection.execute(
+                            "sleep 2; printf rpc\(index)",
+                            timeout: .seconds(15))
+                        #expect(!result.stdout.isEmpty)
+                    }
+                }
+                try await waitUntilTrue("all eight RPCs should park during the pump") {
+                    await parked.arrivedCount == 8
+                }
+                let measured = try await pump()
+                await connection.clearEachSessionWaitForTesting()
+                await parked.releaseAll()
+                try await group.waitForAll()
+                return measured
+            }
+        }
+        print(
+            "[issue-130] Attach throughput: \(Int(quiet)) B/s quiet, "
+                + "\(Int(busy)) B/s with 8 parked RPCs")
+        try await pty.close(timeout: .seconds(5))
+        try await connection.close(timeout: .seconds(2))
+    }
+
+    @Test("SFTP operations and close wait out an in-flight handle use")
+    func sftpOperationsAndCloseWaitOutAnInFlightHandleUse() async throws {
+        let environment = try #require(SessionDriverTestEnvironment.current)
+        let proxy = try #require(WeakNetworkProxyFixture.current)
+        try await withDegradedLink(proxy) {
+            let connection = try await connectThroughProxy(
+                environment: environment,
+                proxy: proxy)
+            try await connection.shrinkSendBufferForTesting(bytes: 2_048)
+            let home = try await remoteHome(of: connection)
+            let sftp = try await connection.openSFTP(timeout: .seconds(15))
+            let pty = try await connection.openPTY(
+                command: "cat",
+                columns: 80,
+                rows: 24,
+                timeout: .seconds(15))
+            let park = SessionWaitHold()
+            await connection.holdNextOutboundWriteParkForTesting {
+                await park.waitUntilReleased()
+            }
+            let write = Task {
+                try await pty.write(
+                    Data(repeating: 0x61, count: 512 * 1_024),
+                    timeout: .seconds(15))
+            }
+            try await waitUntilTrue("the PTY write should own the send") {
+                await park.hasEntered
+            }
+            let stat = Task {
+                _ = try await sftp.attributes(at: home, timeout: .seconds(15))
+            }
+            try await waitUntilTrue("the SFTP call should hold a handle lease") {
+                await connection.sftpUseCountForTesting() == 1
+            }
+            let secondStat = Task {
+                _ = try await sftp.attributes(at: home, timeout: .seconds(15))
+            }
+            try await waitUntilTrue("a second SFTP call should wait for the lease") {
+                await connection.sftpIdleWaiterCountForTesting() == 1
+            }
+            #expect(await connection.sftpUseCountForTesting() == 1)
+            await park.release()
+            try await write.value
+            _ = try await stat.value
+            _ = try await secondStat.value
+
+            let closePark = SessionWaitHold()
+            await connection.holdNextOutboundWriteParkForTesting {
+                await closePark.waitUntilReleased()
+            }
+            let closeWrite = Task {
+                try await pty.write(
+                    Data(repeating: 0x62, count: 512 * 1_024),
+                    timeout: .seconds(15))
+            }
+            try await waitUntilTrue("the second PTY write should own the send") {
+                await closePark.hasEntered
+            }
+            let closeStat = Task {
+                _ = try await sftp.attributes(at: home, timeout: .seconds(15))
+            }
+            try await waitUntilTrue("the SFTP call should hold the close lease") {
+                await connection.sftpUseCountForTesting() == 1
+            }
+            let closing = Task {
+                try await sftp.close(timeout: .seconds(15))
+            }
+            try await waitUntilTrue("closeSFTP should wait for the lease") {
+                await connection.sftpIdleWaiterCountForTesting() == 1
+            }
+            await closePark.release()
+            try await closeWrite.value
+            _ = try await closeStat.value
+            try await closing.value
+            #expect(await connection.sftpUseCountForTesting() == 0)
+            #expect(await connection.isConnected)
+            let ping = try await connection.execute("printf sftp-lease", timeout: .seconds(5))
+            #expect(ping.stdout == Data("sftp-lease".utf8))
+            try await pty.close(timeout: .seconds(5))
+            try await connection.close(timeout: .seconds(2))
+        }
+    }
+
+    @Test("a serialized channel-open wait honors deadline and cancellation")
+    func serializedChannelOpenWaitHonorsDeadlineAndCancellation() async throws {
+        let environment = try #require(SessionDriverTestEnvironment.current)
+        let proxy = try #require(WeakNetworkProxyFixture.current)
+        try await withDegradedLink(proxy) {
+            let connection = try await connectThroughProxy(
+                environment: environment,
+                proxy: proxy)
+            try await connection.shrinkSendBufferForTesting(bytes: 2_048)
+            let pty = try await connection.openPTY(
+                command: "cat",
+                columns: 80,
+                rows: 24,
+                timeout: .seconds(15))
+            let park = SessionWaitHold()
+            await connection.holdNextOutboundWriteParkForTesting {
+                await park.waitUntilReleased()
+            }
+            let write = Task {
+                try await pty.write(
+                    Data(repeating: 0x61, count: 512 * 1_024),
+                    timeout: .seconds(15))
+            }
+            try await waitUntilTrue("the PTY write should own the send") {
+                await park.hasEntered
+            }
+
+            let slot = SessionWaitHold()
+            await slot.release()
+            await connection.holdNextChannelOpenSlotForTesting {
+                await slot.waitUntilReleased()
+            }
+            let first = Task {
+                try await connection.execute("printf first-open", timeout: .seconds(15))
+            }
+            try await waitUntilTrue("the first open should claim the slot") {
+                await slot.hasEntered
+            }
+            try await waitUntilTrue("the first open should release the mutex") {
+                await connection.operationWaiterCountForTesting == 0
+            }
+
+            let timedOut = Task {
+                try await connection.execute("printf timed-out-open", timeout: .milliseconds(200))
+            }
+            try await waitUntilTrue("the timed-out open should park on the slot") {
+                await connection.channelOpenWaiterCountForTesting() == 1
+            }
+            await #expect(throws: SSHError.timedOut) { _ = try await timedOut.value }
+            #expect(await connection.isConnected)
+
+            let cancelled = Task {
+                try await connection.execute("printf cancelled-open", timeout: .seconds(15))
+            }
+            try await waitUntilTrue("the cancelled open should park on the slot") {
+                await connection.channelOpenWaiterCountForTesting() == 1
+            }
+            cancelled.cancel()
+            await #expect(throws: SSHError.cancelled) { _ = try await cancelled.value }
+            #expect(await connection.isConnected)
+
+            await park.release()
+            try await write.value
+            let firstResult = try await first.value
+            #expect(firstResult.stdout == Data("first-open".utf8))
+            let ping = try await connection.execute("printf after-open-wait", timeout: .seconds(5))
+            #expect(ping.stdout == Data("after-open-wait".utf8))
+            try await pty.close(timeout: .seconds(5))
+            try await connection.close(timeout: .seconds(2))
+        }
+    }
+
     /// How long phase-gate probes may wait to observe a held path under CI load.
     /// This is a test-observation guard only; product operation timeouts
     /// (100ms / 200ms / 2s) are independent and must not be widened to match.
@@ -959,6 +1378,239 @@ struct SessionDriverE2ETests {
             try await Task.sleep(for: .milliseconds(5))
         }
         #expect(await condition(), comment)
+    }
+
+    private func connectThroughProxy(
+        environment: SessionDriverTestEnvironment,
+        proxy: WeakNetworkProxyFixture
+    ) async throws -> SSHConnection {
+        let endpoint = SSHEndpoint(host: environment.endpoint.host, port: proxy.port)
+        let connection = try await SSHConnection.connect(
+            to: endpoint,
+            timeout: .seconds(15))
+        try await environment.authenticate(connection)
+        return connection
+    }
+
+    private struct OwnedWriteGates: Sendable {
+        let park: SessionWaitHold
+        let wait: SessionWaitHold
+        let loopTop: SessionWaitHold
+    }
+
+    private func waitForOwnedLoopTop(_ gates: OwnedWriteGates) async throws {
+        try await waitUntilTrue("the write should own the send") {
+            await gates.park.hasEntered
+        }
+        await gates.park.release()
+        try await waitUntilTrue("the write should reach its session wait") {
+            await gates.wait.hasEntered
+        }
+        await gates.wait.release()
+        try await waitUntilTrue("the write should reach an owned loop-top") {
+            await gates.loopTop.hasEntered
+        }
+    }
+
+    private func exerciseOwnedWriteInterruption(
+        expected: TransportSendOwnerOutcome,
+        expectedError: SSHError,
+        loopTopThrows: SSHError? = nil,
+        drainThrows: Bool = false,
+        interrupt: (Task<Void, any Error>, OwnedWriteGates) async throws -> Void
+    ) async throws {
+        let environment = try #require(SessionDriverTestEnvironment.current)
+        let proxy = try #require(WeakNetworkProxyFixture.current)
+        try await withDegradedLink(proxy) {
+            let connection = try await connectThroughProxy(
+                environment: environment,
+                proxy: proxy)
+            await connection.startSamplingTransportSendOwnerForTesting()
+            try await connection.shrinkSendBufferForTesting(bytes: 2_048)
+            let pty = try await connection.openPTY(
+                command: "cat",
+                columns: 80,
+                rows: 24,
+                timeout: .seconds(15))
+            let gates = OwnedWriteGates(
+                park: SessionWaitHold(),
+                wait: SessionWaitHold(),
+                loopTop: SessionWaitHold())
+            await connection.holdNextOutboundWriteParkForTesting {
+                await gates.park.waitUntilReleased()
+            }
+            await connection.holdNextSessionWaitForTesting {
+                await gates.wait.waitUntilReleased()
+            }
+            await connection.holdNextOwnedLoopTopForTesting {
+                await gates.loopTop.waitUntilReleased()
+                if let loopTopThrows { throw loopTopThrows }
+            }
+            if drainThrows {
+                await connection.holdNextOwnedDrainForTesting {
+                    throw expectedError
+                }
+            }
+            let write = Task {
+                try await pty.write(
+                    Data(repeating: 0x61, count: 512 * 1_024),
+                    timeout: .seconds(15))
+            }
+            do {
+                try await interrupt(write, gates)
+                await #expect(throws: expectedError) { try await write.value }
+            } catch {
+                write.cancel()
+                await gates.park.release()
+                await gates.wait.release()
+                await gates.loopTop.release()
+                try? await pty.close(timeout: .seconds(2))
+                throw error
+            }
+            #expect(
+                await connection.transportSendOwnerSamplesForTesting()
+                    .allSatisfy { !$0.isForbiddenClearWindow })
+            #expect(await connection.oneShotRegistryCountForTesting() == 0)
+            let state = await connection.resourceStateForTesting()
+            switch expected {
+            case .drained:
+                #expect(await connection.isConnected)
+                #expect(state.isValid)
+                #expect(state.descriptorIsOpen)
+                #expect(state.hasSession)
+                let descriptors = openFileDescriptorCount()
+                let echo = try await connection.execute("printf drained", timeout: .seconds(5))
+                #expect(echo.stdout == Data("drained".utf8))
+                #expect(openFileDescriptorCount() <= descriptors + 2)
+                print("[issue-130] owner interruption outcome: drained")
+            case .invalidated:
+                #expect(await connection.isConnected == false)
+                #expect(state.isValid == false)
+                #expect(state.descriptorIsOpen == false)
+                #expect(state.hasSession == false)
+                await #expect(throws: SSHError.connectionInvalidated) {
+                    _ = try await connection.execute("printf poisoned", timeout: .seconds(1))
+                }
+                print("[issue-130] owner interruption outcome: invalidated")
+            }
+            try? await pty.close(timeout: .seconds(2))
+            try await connection.close(timeout: .seconds(2))
+        }
+    }
+
+    private func exerciseYieldedOneShotInterruption(
+        expected: TransportSendOwnerOutcome,
+        expectedError: SSHError,
+        waitThrows: SSHError? = nil,
+        interrupt: (Task<SSHExecResult, any Error>, SessionWaitHold) async -> Void
+    ) async throws {
+        let environment = try #require(SessionDriverTestEnvironment.current)
+        let connection = try await environment.connect()
+        let hold = SessionWaitHold()
+        await connection.holdNextOneShotEstablishedForTesting {
+            await connection.holdNextSessionWaitForTesting {
+                await hold.waitUntilReleased()
+                if let waitThrows { throw waitThrows }
+            }
+        }
+        if expected == .invalidated {
+            await connection.holdNextExecCleanupForTesting {
+                throw SSHError.channelFailed
+            }
+        }
+        let rpc = Task {
+            try await connection.execute("sleep 20", timeout: .seconds(15))
+        }
+        try await waitUntilTrue("the one-shot should yield after establishment") {
+            await hold.hasEntered
+        }
+        await interrupt(rpc, hold)
+        await #expect(throws: expectedError) { _ = try await rpc.value }
+        #expect(await connection.oneShotRegistryCountForTesting() == 0)
+        let state = await connection.resourceStateForTesting()
+        switch expected {
+        case .drained:
+            #expect(await connection.isConnected)
+            #expect(state.isValid)
+            #expect(state.descriptorIsOpen)
+            #expect(state.hasSession)
+            let echo = try await connection.execute("printf reclaimed", timeout: .seconds(5))
+            #expect(echo.stdout == Data("reclaimed".utf8))
+        case .invalidated:
+            #expect(await connection.isConnected == false)
+            #expect(state.isValid == false)
+            #expect(state.descriptorIsOpen == false)
+            #expect(state.hasSession == false)
+            await #expect(throws: SSHError.connectionInvalidated) {
+                _ = try await connection.execute("printf poisoned", timeout: .seconds(1))
+            }
+        }
+        try? await connection.close(timeout: .seconds(2))
+    }
+
+    private func invalidateOneYieldingSession(
+        environment: SessionDriverTestEnvironment
+    ) async throws {
+        let connection = try await environment.connect()
+        let hold = SessionWaitHold()
+        await connection.holdNextOneShotEstablishedForTesting {
+            await connection.holdNextSessionWaitForTesting {
+                await hold.waitUntilReleased()
+            }
+        }
+        let rpc = Task {
+            try await connection.execute("sleep 20", timeout: .seconds(15))
+        }
+        try await waitUntilTrue("the one-shot should wait after establishment") {
+            await hold.hasEntered
+        }
+        try? await connection.close(timeout: .seconds(2))
+        await hold.release()
+        _ = try? await rpc.value
+    }
+
+    private func durationSeconds(_ duration: Duration) -> Double {
+        let components = duration.components
+        return Double(components.seconds) + Double(components.attoseconds) / 1e18
+    }
+}
+
+private enum TransportSendOwnerOutcome: String, CaseIterable, Equatable {
+    case drained
+    case invalidated
+}
+
+private enum OneShotYieldSite: String, CaseIterable {
+    case execute
+    case executeResponseLine
+    case exchangeStreamLocal
+
+    func run(on connection: SSHConnection, socketPath: String) async throws {
+        switch self {
+        case .execute:
+            _ = try await connection.execute("sleep 8", timeout: .seconds(15))
+        case .executeResponseLine:
+            let response = try await connection.executeResponseLine(
+                "IFS= read -r line; sleep 8; printf 'accepted:%s\\n' \"$line\"",
+                input: Data("device-key-line\n".utf8),
+                maximumResponseBytes: 64,
+                timeout: .seconds(15))
+            #expect(response == Data("accepted:device-key-line\n".utf8))
+        case .exchangeStreamLocal:
+            let token = UUID().uuidString
+            let request = Data(
+                #"{"id":"delay","method":"pane.read","params":{"pane_id":"fixture:delay:\#(token)"}}\#n"#
+                    .utf8)
+            let response = try await connection.exchangeStreamLocal(
+                socketPath: socketPath,
+                request: request,
+                timeout: .seconds(15))
+            #expect(!response.isEmpty)
+        }
+    }
+
+    func finish(_ rpc: Task<Void, any Error>) async throws {
+        try await rpc.value
     }
 }
 
@@ -1535,6 +2187,25 @@ private actor SessionWaitHold {
     }
 
     func release() {
+        isReleased = true
+        let resumed = waiters
+        waiters.removeAll()
+        for waiter in resumed { waiter.resume() }
+    }
+}
+
+private actor CountingHold {
+    private(set) var arrivedCount = 0
+    private var isReleased = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func arriveAndWait() async {
+        arrivedCount += 1
+        guard !isReleased else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func releaseAll() {
         isReleased = true
         let resumed = waiters
         waiters.removeAll()

--- a/Tests/HeelerTests/AppForegroundRecoveryTests.swift
+++ b/Tests/HeelerTests/AppForegroundRecoveryTests.swift
@@ -713,6 +713,7 @@ struct AppForegroundRecoveryTests {
         try await waitUntil("the Host should come up connected") {
             store.hostStatuses[host.id] == .connected
         }
+        try await waitUntilPaneResubscribeSettles(on: stopped)
 
         await stopped.failEventStream(failure)
         try await waitUntil("the stopped herdr should fail the Host") {
@@ -793,6 +794,7 @@ struct AppForegroundRecoveryTests {
         try await waitUntil("the Host should come up connected") {
             projection.status == .connected
         }
+        try await waitUntilPaneResubscribeSettles(on: stopped)
 
         await stopped.failEventStream(failure)
         try await waitUntil("the stopped herdr should fail the Host") {
@@ -879,6 +881,7 @@ struct AppForegroundRecoveryTests {
         try await waitUntil("the Host should come up connected") {
             store.hostStatuses[host.id] == .connected
         }
+        try await waitUntilPaneResubscribeSettles(on: first)
         await first.failEventStream(failure)
         try await waitUntil("the Host should fail") {
             store.hostStatuses[host.id] == .failed(failure)
@@ -940,6 +943,7 @@ struct AppForegroundRecoveryTests {
         try await waitUntil("the Host should come up connected") {
             store.hostStatuses[host.id] == .connected
         }
+        try await waitUntilPaneResubscribeSettles(on: first)
         await first.failEventStream(failure)
         try await waitUntil("the Host should fail") {
             store.hostStatuses[host.id] == .failed(failure)

--- a/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
@@ -250,17 +250,13 @@ struct HeelerSSHTransportBehaviorE2ETests {
     @Test("direct Host RPC does not stall Attach")
     func directRPCDoesNotStallAttach() async throws {
         let environment = try #require(HeelerSSHTransportBehaviorEnvironment.current)
-        try await exerciseRPCDoesNotStallAttach(
-            settings: environment.directSettings(),
-            observerSettings: environment.directSettings())
+        try await exerciseRPCDoesNotStallAttach(settings: environment.directSettings())
     }
 
     @Test("Jump Host RPC does not stall Attach")
     func jumpRPCDoesNotStallAttach() async throws {
         let environment = try #require(HeelerSSHTransportBehaviorEnvironment.current)
-        try await exerciseRPCDoesNotStallAttach(
-            settings: environment.jumpSettings(),
-            observerSettings: environment.jumpSettings())
+        try await exerciseRPCDoesNotStallAttach(settings: environment.jumpSettings())
     }
 
     @Test("direct Host clean Attach exit frees the reserved channel")
@@ -1310,8 +1306,7 @@ struct HeelerSSHTransportBehaviorE2ETests {
     }
 
     private func exerciseRPCDoesNotStallAttach(
-        settings: SSHTransportSettings,
-        observerSettings: SSHTransportSettings
+        settings: SSHTransportSettings
     ) async throws {
         let transport = try await HeelerSSHTransport.connect(settings: settings)
         defer { Task { try? await transport.close() } }
@@ -1326,7 +1321,7 @@ struct HeelerSSHTransportBehaviorE2ETests {
         try await expectAttachOutput(&iterator, accumulated: &output, contains: "24 80")
         #expect(output.hasPrefix("TTY-OK"))
 
-        var observerSettings = observerSettings
+        var observerSettings = settings
         observerSettings.requestTimeout = .seconds(25)
         let observer = try await HeelerSSHTransport.connect(settings: observerSettings)
         defer { Task { try? await observer.close() } }
@@ -1340,6 +1335,7 @@ struct HeelerSSHTransportBehaviorE2ETests {
             await delayedCompletion.markCompleted()
             return result
         }
+        defer { delayed.cancel() }
         let observation = try await observer.readPane(
             PaneReadParams(paneID: "fixture:await-delay:\(delayToken)", source: .recent))
         try #require(observation.text == "observed")
@@ -1354,11 +1350,10 @@ struct HeelerSSHTransportBehaviorE2ETests {
         let echoElapsed = echoStarted.duration(to: .now)
         #expect(await delayedCompletion.completed == false)
         #expect(echoElapsed < .seconds(2), "Attach echoed in \(echoElapsed)")
-        #expect(delayedStarted.duration(to: .now) < .seconds(4.5))
 
         let delayedResult = try await delayed.value
         #expect(await delayedCompletion.completed)
-        #expect(!delayedResult.text.isEmpty)
+        #expect(delayedResult.text == "delayed")
         #expect(delayedStarted.duration(to: .now) >= .seconds(4.5))
         #expect(try await transport.ping().protocolVersion == 17)
         await session.end()

--- a/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
@@ -247,6 +247,22 @@ struct HeelerSSHTransportBehaviorE2ETests {
             socketPath: environment.socketPath)
     }
 
+    @Test("direct Host RPC does not stall Attach")
+    func directRPCDoesNotStallAttach() async throws {
+        let environment = try #require(HeelerSSHTransportBehaviorEnvironment.current)
+        try await exerciseRPCDoesNotStallAttach(
+            settings: environment.directSettings(),
+            observerSettings: environment.directSettings())
+    }
+
+    @Test("Jump Host RPC does not stall Attach")
+    func jumpRPCDoesNotStallAttach() async throws {
+        let environment = try #require(HeelerSSHTransportBehaviorEnvironment.current)
+        try await exerciseRPCDoesNotStallAttach(
+            settings: environment.jumpSettings(),
+            observerSettings: environment.jumpSettings())
+    }
+
     @Test("direct Host clean Attach exit frees the reserved channel")
     func directCleanAttachExit() async throws {
         let environment = try #require(HeelerSSHTransportBehaviorEnvironment.current)
@@ -1293,6 +1309,62 @@ struct HeelerSSHTransportBehaviorE2ETests {
         #expect(try await transport.ping().protocolVersion == 17)
     }
 
+    private func exerciseRPCDoesNotStallAttach(
+        settings: SSHTransportSettings,
+        observerSettings: SSHTransportSettings
+    ) async throws {
+        let transport = try await HeelerSSHTransport.connect(settings: settings)
+        defer { Task { try? await transport.close() } }
+        let session = try await transport.attachTerminal(
+            TerminalAttachRequest(
+                target: "fixture:pane",
+                takeover: true,
+                cols: 80,
+                rows: 24))
+        var iterator = session.output.makeAsyncIterator()
+        var output = ""
+        try await expectAttachOutput(&iterator, accumulated: &output, contains: "24 80")
+        #expect(output.hasPrefix("TTY-OK"))
+
+        var observerSettings = observerSettings
+        observerSettings.requestTimeout = .seconds(25)
+        let observer = try await HeelerSSHTransport.connect(settings: observerSettings)
+        defer { Task { try? await observer.close() } }
+
+        let delayToken = UUID().uuidString
+        let delayedStarted = ContinuousClock.now
+        let delayedCompletion = RPCCompletionFlag()
+        let delayed = Task {
+            let result = try await transport.readPane(
+                PaneReadParams(paneID: "fixture:delay:\(delayToken)", source: .recent))
+            await delayedCompletion.markCompleted()
+            return result
+        }
+        let observation = try await observer.readPane(
+            PaneReadParams(paneID: "fixture:await-delay:\(delayToken)", source: .recent))
+        try #require(observation.text == "observed")
+
+        let echoStarted = ContinuousClock.now
+        let marker = "rpc-hol-\(UUID().uuidString.prefix(8))"
+        session.send(Data("\(marker)\n".utf8))
+        try await expectAttachOutput(
+            &iterator,
+            accumulated: &output,
+            contains: "GOT:\(marker)")
+        let echoElapsed = echoStarted.duration(to: .now)
+        #expect(await delayedCompletion.completed == false)
+        #expect(echoElapsed < .seconds(2), "Attach echoed in \(echoElapsed)")
+        #expect(delayedStarted.duration(to: .now) < .seconds(4.5))
+
+        let delayedResult = try await delayed.value
+        #expect(await delayedCompletion.completed)
+        #expect(!delayedResult.text.isEmpty)
+        #expect(delayedStarted.duration(to: .now) >= .seconds(4.5))
+        #expect(try await transport.ping().protocolVersion == 17)
+        await session.end()
+        #expect(await transport.isConnected)
+    }
+
     private func exerciseAttach(
         settings: SSHTransportSettings,
         socketPath: String
@@ -1659,5 +1731,13 @@ struct HeelerSSHTransportBehaviorEnvironment: Sendable {
         let jumpPort: UInt16
         let targetHost: String
         let targetPort: UInt16
+    }
+}
+
+private actor RPCCompletionFlag {
+    private(set) var completed = false
+
+    func markCompleted() {
+        completed = true
     }
 }

--- a/docs/adr/0011-libssh2-direct-streamlocal-transport.md
+++ b/docs/adr/0011-libssh2-direct-streamlocal-transport.md
@@ -186,11 +186,13 @@ ownership too eagerly costs concurrency, while recording it too late strands
 the owner behind a caller that can never make progress and can only end at its
 own deadline.
 
-Ownership ends in exactly two ways, and a caller giving up is neither of them.
-The exact owning call returning a non-`EAGAIN` result with no outbound state
-remaining is one; completed
-whole-session invalidation, which reclaims the session and its pending packet
-together, is the other. Cancellation or a deadline observed while that call is
+Ownership ends only from the exact owning call or whole-session invalidation,
+and a caller giving up is neither. A successful non-`EAGAIN` result clears the
+owner regardless of a possibly stale outbound direction bit. A negative
+non-`EAGAIN` result clears only when no outbound block remains; otherwise the
+caller captures any native error status first and then invalidates the session.
+Completed whole-session invalidation reclaims the session and its pending
+packet together. Cancellation or a deadline observed while that call is
 parked clears nothing by itself, because the native packet outlives the task
 that produced it and the next producer or cleanup call to enter meets the same
 refusal and rebuilds the livelock. An operation cancelled or timed out while it
@@ -232,11 +234,14 @@ replaces the caller's own. Channel admission is unchanged too: a lease is held
 for a channel's whole lifetime, and yielding the operation mutex mid-turn
 neither releases one nor creates capacity for another.
 
-Close is an explicit resource transition. Before a PTY or direct-streamlocal
-teardown yields, its registry entry stops accepting user reads, writes, and
-resizes. The cleanup operation alone may re-resolve the entry while closing,
-so close/free cannot race same-id I/O even though unrelated resources can keep
-using the session.
+Close is an explicit resource transition. Before PTY exit-status, PTY close,
+or direct-streamlocal teardown yields, its registry entry stops accepting user
+reads, writes, and resizes. The cleanup operation alone may re-resolve the
+entry while closing, so close/free cannot race same-id I/O even though
+unrelated resources can keep using the session. PTY close waits for an
+in-flight exit-status handshake instead of treating it as an already-complete
+close; exit-status failure restores ordinary I/O eligibility so the caller can
+retry or close explicitly.
 
 The native dependencies will be built without the OpenSSL legacy provider and
 will not enable obsolete SSH-DSS, SHA-1 SSH-RSA, CBC, group1, or equivalent

--- a/docs/adr/0011-libssh2-direct-streamlocal-transport.md
+++ b/docs/adr/0011-libssh2-direct-streamlocal-transport.md
@@ -139,6 +139,98 @@ Host driver uses the outer direct-tcpip channel as its transport and coordinates
 progress with the outer driver; blocking libssh2 calls and a global cross-Host
 lock are prohibited.
 
+Amendment (#130): the promise that channel state machines may make concurrent
+progress is bounded by libssh2 in three places — channel open, the outbound
+transport packet, and any one SFTP handle. The first is channel open. In the
+pinned 1.11.1 the continuation state for an unfinished open lives on the
+session, not on any channel — `open_state`, `open_channel`, `open_packet`,
+`open_data` and
+`open_packet_requirev_state` for the generic open, `direct_state` and
+`direct_message` for direct-streamlocal, all fields of `LIBSSH2_SESSION` in
+`src/libssh2_priv.h`. A second open entered while the first is at `EAGAIN`
+skips its own setup, resumes the first state machine, and returns the first
+call's channel to the second caller. Every open therefore stays serialized
+under the driver's operation mutex and finishes before another one begins.
+Waiting for that serialized slot is admission, not an open attempt: cancelling
+or timing out there leaves the session reusable because no native continuation
+belongs to the waiter. Once its own open call begins, an interrupted open still
+invalidates the session under the original cancellation rule above.
+
+Post-open continuation is usually channel-owned — process startup, reads,
+writes, close, wait-closed and free each keep their state on `LIBSSH2_CHANNEL`
+— so an established channel may make progress in bounded turns instead of
+holding the session for a whole round trip. A turn re-acquires the operation
+mutex, confirms the driver is still valid and still owns the same session,
+re-resolves its channel from a driver-owned registry by stable id, does one
+bounded piece of libssh2 work, and releases before it waits or yields. No
+native pointer survives a release across a turn boundary: invalidation clears
+the registries before it frees the session, and freeing a session destroys
+every channel on it, so a resumed turn that finds no entry has nothing left to
+dereference. The rule belongs to the shared retry primitive rather than to the
+three round-trip methods alone, because a resize holds the session across its
+own waits for exactly the same reason an ordinary RPC does, and a resize that
+cannot reach the Host promptly is the failure this decision exists to prevent.
+
+"Usually" is load-bearing: every packet producer also shares one session-owned
+outbound transport continuation. A send that could not flush its whole packet
+records that packet on the session and requires the next attempt to arrive with
+the same data pointer and the same length; a different producer is handed
+`EAGAIN` and cannot advance it. So when a packet-producing call returns `EAGAIN`
+while the session reports an outbound block, the driver records that logical
+operation as the transport-send owner, and until the same logical call returns
+a non-`EAGAIN` result no other libssh2 call may enter that session unless it is
+proved incapable of producing a packet. Channel open is not exempt and cannot
+cut ahead of the owner. The rule reads only the public block-direction report,
+never private packet layout, and is conservative by construction: recording
+ownership too eagerly costs concurrency, while recording it too late strands
+the owner behind a caller that can never make progress and can only end at its
+own deadline.
+
+Ownership ends in exactly two ways, and a caller giving up is neither of them.
+The exact owning call returning a non-`EAGAIN` result is one; completed
+whole-session invalidation, which reclaims the session and its pending packet
+together, is the other. Cancellation or a deadline observed while that call is
+parked clears nothing by itself, because the native packet outlives the task
+that produced it and the next producer or cleanup call to enter meets the same
+refusal and rebuilds the livelock. An operation cancelled or timed out while it
+owns the send must therefore first drive the exact owning call non-cancellably
+to a non-`EAGAIN` result inside its own reclamation budget and only then run
+channel-scoped cleanup; a budget that expires invalidates the whole session,
+exactly as a channel that cannot be reclaimed already does. There is no
+admissible state in which the owner is clear while the session is still valid
+and its packet still pending.
+
+Yielding is a per-resource privilege rather than a session-wide one: only an
+operation whose complete native continuation is proven safe for its own
+resource may take bounded turns. SFTP does not qualify and stays outside this
+decision. One `LIBSSH2_SFTP` holds a single continuation slot per operation
+kind and one partial-packet parser shared across all of them, so a second call
+of the same kind resumes the first call's state instead of starting its own,
+and a handle id re-resolves to exactly that shared state rather than isolating
+it. Every call on one SFTP handle therefore remains mutually exclusive for its
+whole logical operation, waits included, and `libssh2_sftp_init` stays fully
+serialized because its continuation is session-owned. Letting SFTP yield needs
+its own decision and a per-handle logical-operation lease to go with it.
+
+Three costs are accepted with it. Waking is session-wide: an operation that
+takes bytes off the socket releases every wait armed before it, so raising the
+number of channels that can be parked at once raises the number of wakeups each
+inbound packet causes, and the turn body has to stay small enough that the
+extra wakeups cost less than the stall they remove. Concurrency is suspended
+for as long as a transport-send owner exists, which is precisely when the link
+is congested — the case where the stall this decision removes hurts most. And
+an open the server is slow to confirm still holds the session for that one
+round trip; only a separate single-flight open owner could relax that, and it
+needs its own evidence that open itself costs user-visible time.
+
+Error precedence is unchanged. A turn checks cancellation and the deadline
+before it checks session validity, and the error that entered the catch is the
+error the caller sees; whole-session invalidation remains a side effect of
+cleanup that could not reclaim its channel, never a reported outcome that
+replaces the caller's own. Channel admission is unchanged too: a lease is held
+for a channel's whole lifetime, and yielding the operation mutex mid-turn
+neither releases one nor creates capacity for another.
+
 The native dependencies will be built without the OpenSSL legacy provider and
 will not enable obsolete SSH-DSS, SHA-1 SSH-RSA, CBC, group1, or equivalent
 legacy algorithms for compatibility. The supported algorithm set must be at

--- a/docs/adr/0011-libssh2-direct-streamlocal-transport.md
+++ b/docs/adr/0011-libssh2-direct-streamlocal-transport.md
@@ -187,7 +187,8 @@ the owner behind a caller that can never make progress and can only end at its
 own deadline.
 
 Ownership ends in exactly two ways, and a caller giving up is neither of them.
-The exact owning call returning a non-`EAGAIN` result is one; completed
+The exact owning call returning a non-`EAGAIN` result with no outbound state
+remaining is one; completed
 whole-session invalidation, which reclaims the session and its pending packet
 together, is the other. Cancellation or a deadline observed while that call is
 parked clears nothing by itself, because the native packet outlives the task
@@ -230,6 +231,12 @@ cleanup that could not reclaim its channel, never a reported outcome that
 replaces the caller's own. Channel admission is unchanged too: a lease is held
 for a channel's whole lifetime, and yielding the operation mutex mid-turn
 neither releases one nor creates capacity for another.
+
+Close is an explicit resource transition. Before a PTY or direct-streamlocal
+teardown yields, its registry entry stops accepting user reads, writes, and
+resizes. The cleanup operation alone may re-resolve the entry while closing,
+so close/free cannot race same-id I/O even though unrelated resources can keep
+using the session.
 
 The native dependencies will be built without the OpenSSL legacy provider and
 will not enable obsolete SSH-DSS, SHA-1 SSH-RSA, CBC, group1, or equivalent

--- a/scripts/fixtures/fake-herdr-streamlocal.py
+++ b/scripts/fixtures/fake-herdr-streamlocal.py
@@ -79,6 +79,7 @@ class Server:
         self.hang_condition = threading.Condition()
         self.hang_requests = _OneShotBarrier(self.hang_condition)
         self.pane_hangs = _OneShotBarrier(self.hang_condition)
+        self.pane_delays = _OneShotBarrier(self.hang_condition)
         self.script_lock = threading.Lock()
         self.recorded_requests: dict[str, list[str]] = {}
         self.agent_start_attempts: dict[str, int] = {}
@@ -140,12 +141,37 @@ class Server:
                 self.pane_hangs.record(pane_hang_token)
                 time.sleep(30)
                 return
+            pane_delay_token = self._fixture_token(pane_id, "fixture:delay:")
+            pane_await_delay_token = self._fixture_token(
+                pane_id,
+                "fixture:await-delay:",
+            )
             pane_observer_token = self._fixture_token(
                 pane_id,
                 "fixture:await-hang:",
             )
             record_query = self._fixture_token(pane_id, RECORD_QUERY_PREFIX)
-            if method == "pane.read" and record_query is not None:
+            if method == "pane.read" and pane_delay_token is not None:
+                self.pane_delays.record(pane_delay_token)
+                time.sleep(5)
+                response = {
+                    "id": envelope.get("id"),
+                    "result": self._pane_read_result(pane_id, "delayed"),
+                }
+                payload = json.dumps(response, separators=(",", ":")).encode() + b"\n"
+                chunk_size = 7
+            elif method == "pane.read" and pane_await_delay_token is not None:
+                observed = self.pane_delays.wait(pane_await_delay_token)
+                response = {
+                    "id": envelope.get("id"),
+                    "result": self._pane_read_result(
+                        pane_id,
+                        "observed" if observed else "not observed",
+                    ),
+                }
+                payload = json.dumps(response, separators=(",", ":")).encode() + b"\n"
+                chunk_size = 7
+            elif method == "pane.read" and record_query is not None:
                 response = {
                     "id": envelope.get("id"),
                     "result": self._pane_read_result(

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -1742,7 +1742,7 @@ clear_simulator_environment
 
 if grep -q 'Suite "Session driver resource e2e" skipped' "$package_e2e_log" \
     || grep -q 'skipped:' "$package_e2e_log" \
-    || ! grep -q 'Test run with 26 tests in 2 suites passed' "$package_e2e_log" \
+    || ! grep -q 'Test run with 42 tests in 2 suites passed' "$package_e2e_log" \
     || ! grep -q 'Test "remote transport loss reclaims every owned native resource" passed' \
         "$package_e2e_log" \
     || ! grep -q 'Test "an abruptly severed weak link reclaims every owned native resource" passed' \
@@ -1775,8 +1775,56 @@ if grep -q 'Suite "Session driver resource e2e" skipped' "$package_e2e_log" \
         "$package_e2e_log" \
     || ! grep -q \
         'Test "direct TCP/IP pump backpressures a fast raw writer without losing bytes" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "outbound backpressure does not livelock a channel open" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "cancelling a transport-send owner drains" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "cancelling a transport-send owner invalidates" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "timing out a transport-send owner at loop-top drains" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "timing out a transport-send owner at loop-top invalidates" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "one-shot RPCs yield so a live PTY can progress" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "cancelling a yielded one-shot distinguishes cleanup outcomes" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "timing out a yielded one-shot distinguishes cleanup outcomes" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "invalidation during a yielding wait does not touch a stale native pointer" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "yielded channel teardown rejects same-id I/O" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "repeated invalidation reclaims every file descriptor" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "measurement: Attach throughput with concurrent RPCs" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "SFTP operations and close wait out an in-flight handle use" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "a serialized channel-open wait honors deadline and cancellation" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "an invalidation generation rejects a watch armed before it" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "a transport-send owner error with outbound pending invalidates" passed' \
         "$package_e2e_log"; then
-    echo "The mandatory HeelerSSH package suites did not execute all twenty-six tests" >&2
+    echo "The mandatory HeelerSSH package suites did not execute all forty-two tests" >&2
     exit 1
 fi
 pinned_lane_logs+=("$package_e2e_log")

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -1742,7 +1742,7 @@ clear_simulator_environment
 
 if grep -q 'Suite "Session driver resource e2e" skipped' "$package_e2e_log" \
     || grep -q 'skipped:' "$package_e2e_log" \
-    || ! grep -q 'Test run with 42 tests in 2 suites passed' "$package_e2e_log" \
+    || ! grep -q 'Test run with 43 tests in 2 suites passed' "$package_e2e_log" \
     || ! grep -q 'Test "remote transport loss reclaims every owned native resource" passed' \
         "$package_e2e_log" \
     || ! grep -q 'Test "an abruptly severed weak link reclaims every owned native resource" passed' \
@@ -1823,8 +1823,11 @@ if grep -q 'Suite "Session driver resource e2e" skipped' "$package_e2e_log" \
         "$package_e2e_log" \
     || ! grep -q \
         'Test "a transport-send owner error with outbound pending invalidates" passed' \
+        "$package_e2e_log" \
+    || ! grep -q \
+        'Test "a bridge write to a closed peer reports peerClosed" passed' \
         "$package_e2e_log"; then
-    echo "The mandatory HeelerSSH package suites did not execute all forty-two tests" >&2
+    echo "The mandatory HeelerSSH package suites did not execute all forty-three tests" >&2
     exit 1
 fi
 pinned_lane_logs+=("$package_e2e_log")

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -1804,7 +1804,7 @@ if grep -q 'Suite "Session driver resource e2e" skipped' "$package_e2e_log" \
         'Test "invalidation during a yielding wait does not touch a stale native pointer" passed' \
         "$package_e2e_log" \
     || ! grep -q \
-        'Test "yielded channel teardown rejects same-id I/O" passed' \
+        'Test "yielded channel teardown rejects same-id I/O and preserves close" passed' \
         "$package_e2e_log" \
     || ! grep -q \
         'Test "repeated invalidation reclaims every file descriptor" passed' \

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -1616,7 +1616,7 @@ fi
 run_suite HeelerSSHPTYE2ETests 3 1
 run_suite HeelerSSHDirectStreamLocalE2ETests 11 1
 run_suite HeelerSSHJumpHostGateE2ETests 9 1
-run_suite HeelerSSHTransportBehaviorE2ETests 48 1
+run_suite HeelerSSHTransportBehaviorE2ETests 50 1
 run_suite ImageStagingE2ETests 8 1
 run_suite WeakNetworkE2ETests 8 1
 run_suite PairingCeremonyE2ETests 11 1
@@ -1644,6 +1644,11 @@ assert_behavior "PTY" HeelerSSHPTYE2ETests \
     '"PTY exec preserves raw IO, merged output, geometry, and exit status"'
 assert_behavior "resize" HeelerSSHTransportBehaviorE2ETests \
     '"direct Host Attach preserves PTY IO, resize, end, and reuse"'
+assert_behavior "RPC does not stall Attach" HeelerSSHTransportBehaviorE2ETests \
+    '"direct Host RPC does not stall Attach"'
+assert_behavior "RPC does not stall Attach on a Jump Host" \
+    HeelerSSHTransportBehaviorE2ETests \
+    '"Jump Host RPC does not stall Attach"'
 # These writes can return healthy response envelopes even when a serializer
 # silently drops a field. Keep every distinct wire contract named (#165).
 assert_behavior "agent rename params" HeelerSSHTransportBehaviorE2ETests \


### PR DESCRIPTION
## Summary

- yield the libssh2 session between non-blocking RPC turns so Attach and Events can keep making progress
- preserve session/channel ownership across cancellation, invalidation, and teardown
- treat a nested Jump Host socket closing during normal teardown as peer closure instead of a transport failure
- add deterministic scheduler, real-SSH, resource-reclamation, and bridge-close regression coverage

Closes #130

## Verification

- `scripts/run-heelerssh-package-tests.sh` passed: 43 tests in 2 suites
- disposable real-SSH direct-streamlocal, PTY, Jump Host, Events, Attach, and RPC/Attach concurrency lanes passed
- real double-hop Jump Host stress passed 100/100 iterations (2,000 sequential RPCs, 1,200 concurrent RPCs, 100 complete closes)
- Opus 5 final review: ACCEPT, no blocking findings
- the complete `scripts/run-ci-ios-tests.sh` run reached and passed every real-SSH lane, then failed in the unrelated `AppForegroundRecoveryTests.aFailedHostsRestartHoldsTheForegroundActivation` full-app lane; that exact test passed 20/20 in isolation

## Local environment caveat

The password-auth fixture was skipped locally because this machine does not provide passwordless `sudo`; CI remains responsible for that lane.