### PR TITLE
feat: allow New Agent to create a workspace from a directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
         # privileged part (the real-password sshd) a hard requirement here
         # rather than something merge CI may quietly run without.
         env:
+          HEELER_CI_LANE: app
           HEELER_CI_MANDATORY: "1"
         run: scripts/run-ci-ios-tests.sh
 
@@ -146,6 +147,34 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ios-ci-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/heeler-ci-diagnostics-*
+          if-no-files-found: ignore
+          retention-days: 7
+
+  heelerssh-package-e2e:
+    name: HeelerSSH package E2E (iOS Simulator)
+    runs-on: macos-26
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Show Xcode and simulator versions
+        run: |
+          xcodebuild -version
+          xcrun simctl list runtimes
+
+      - name: Run package E2E
+        timeout-minutes: 12
+        env:
+          HEELER_CI_LANE: package
+          HEELER_CI_MANDATORY: "1"
+        run: scripts/run-ci-ios-tests.sh
+
+      - name: Upload package timeout diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: heelerssh-package-ci-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/heeler-ci-diagnostics-*
           if-no-files-found: ignore
           retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Entries reference the issue that motivated them.
 
 ### Added
 
+- New Agent can start in a new Workspace at a remote directory, with an
+  optional label, even when the Host reports none. (#230)
+
 - Linked worktrees are now marked on Console cards. Agent detail shows their
   repository, branch, and checkout path, and can remove the checkout and its
   workspace after an identity-bound confirmation while keeping the local

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,6 +66,12 @@ _Avoid_: agent state, activity
 herdr's unit of terminal real estate that an Agent lives in. Used as an address (`pane_id`), never as a layout concept in this app.
 _Avoid_: window, tile
 
+**Workspace**:
+herdr's unit that groups tabs and panes around one working directory. New
+Agent can start in an existing Workspace, a new Worktree of one, or a new
+Workspace opened at a remote directory. The id is an opaque string.
+_Avoid_: project, folder, window
+
 **Worktree**:
 A fresh git checkout of a workspace's repository, created by herdr as its own
 workspace so a new Agent starts on a clean copy of the code. The branch

--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -350,6 +350,16 @@ final class ConsoleStore {
         try await projection(for: hostID).startAgentInNewWorktree(request, worktree: worktree)
     }
 
+    @discardableResult
+    func startAgentInNewWorkspace(
+        _ request: AgentLaunchRequest,
+        workspace: NewWorkspaceSpec,
+        on hostID: Host.ID
+    ) async throws -> Agent {
+        try await projection(for: hostID).startAgentInNewWorkspace(
+            request, workspace: workspace)
+    }
+
     /// Suspends until `id` is reported by its Host's sync machinery, or the
     /// timeout elapses. The new-agent flow (#12) opens the started Agent's
     /// terminal, and the row it navigates to exists only once the post-start

--- a/Sources/Heeler/Console/HostConsoleProjection.swift
+++ b/Sources/Heeler/Console/HostConsoleProjection.swift
@@ -234,6 +234,17 @@ final class HostConsoleProjection {
         return agent
     }
 
+    @discardableResult
+    func startAgentInNewWorkspace(
+        _ request: AgentLaunchRequest, workspace: NewWorkspaceSpec
+    ) async throws -> Agent {
+        let agent = try await session.withTransport { transport in
+            try await transport.startAgentInNewWorkspace(request, workspace: workspace)
+        }
+        scheduleResync()
+        return agent
+    }
+
     func availableAgentKinds() async throws -> [SupportedAgentKind] {
         try await session.withTransport { transport in
             try await transport.availableAgentKinds()

--- a/Sources/Heeler/Console/StartAgentStore.swift
+++ b/Sources/Heeler/Console/StartAgentStore.swift
@@ -2,11 +2,12 @@ import Foundation
 import Observation
 
 /// The new-agent flow's form logic (#12, User Story 8): pick a Host, pick a
-/// workspace (or the Host's current one), detect and select an installed
-/// Agent, parse its native arguments, and dispatch it via the Transport launch
-/// flow. The started pane surfaces in the Console through the store's normal
-/// snapshot/delta machinery; on success the store reports the started Agent's
-/// Console identity so the owning screen can open it right away.
+/// launch target (an existing Workspace, or a new one at a remote directory),
+/// detect and select an installed Agent, parse its native arguments, and
+/// dispatch it via the Transport launch flow. The started pane surfaces in
+/// the Console through the store's normal snapshot/delta machinery; on
+/// success the store reports the started Agent's Console identity so the
+/// owning screen can open it right away.
 ///
 /// Kept off the SSH types (standing repo rule): it talks to injected closures
 /// over the `ConsoleStore`, so it is testable against a scripted transport.
@@ -40,6 +41,22 @@ final class StartAgentStore {
         let hostID: Host.ID
         let workspaceID: String
         let cwd: String
+    }
+
+    /// Where a Console-originated launch should create the Agent (#230).
+    /// Origin launches skip this choice: they inherit the origin Workspace.
+    enum LaunchTarget: Equatable, Hashable {
+        case existingWorkspace
+        case newWorkspace
+    }
+
+    /// The Transport variant `submit()` dispatches. Invalid combinations
+    /// (a Worktree of a Workspace that does not exist yet) cannot be
+    /// represented.
+    enum LaunchDestination: Equatable, Sendable {
+        case existingWorkspace
+        case newWorktree(WorktreeSpec)
+        case newWorkspace(NewWorkspaceSpec)
     }
 
     enum ArgumentError: Error, Equatable {
@@ -79,6 +96,9 @@ final class StartAgentStore {
                 availableAgentKinds = []
                 selectedAgentKind = nil
                 agentDiscoveryState = .idle
+                launchTarget = .existingWorkspace
+                newWorkspaceDirectory = ""
+                newWorkspaceLabel = ""
                 startsInNewWorktree = false
                 worktreeBranch = ""
                 worktreeBase = ""
@@ -86,12 +106,13 @@ final class StartAgentStore {
         }
     }
 
-    /// The workspace the agent starts in: what the user picked, else the one
-    /// they last started an agent in on this Host, else the Host's first.
+    /// The existing Workspace the agent starts in: what the user picked, else
+    /// the one they last started an agent in on this Host, else the Host's
+    /// first.
     ///
-    /// Nil while the Host reports no workspaces at all. The form cannot submit
-    /// until a concrete workspace is available, so the launch target is always
-    /// visible to the user.
+    /// Nil while the Host reports no Workspaces at all. Existing-Workspace
+    /// and origin launches cannot submit until a concrete Workspace is
+    /// available; New Workspace does not use this pick.
     var selectedWorkspaceID: String? {
         get {
             // The origin agent is living proof its workspace exists, so it
@@ -129,6 +150,24 @@ final class StartAgentStore {
     /// parsing still normalizes any smart characters supplied by paste or a
     /// third-party keyboard without mutating the live editing buffer.
     var arguments: String = ""
+    /// Existing Workspace vs New Workspace on the Console-originated form.
+    /// Switching target drops an incompatible Worktree request so it cannot
+    /// ride along with a launch that has no source Workspace.
+    var launchTarget: LaunchTarget = .existingWorkspace {
+        didSet {
+            if launchTarget != oldValue {
+                startsInNewWorktree = false
+                worktreeBranch = ""
+                worktreeBase = ""
+            }
+        }
+    }
+    /// Remote directory for a New Workspace launch. Required once that
+    /// target is selected; trimmed at submit.
+    var newWorkspaceDirectory: String = ""
+    /// Optional label for a New Workspace launch. Empty or whitespace
+    /// becomes nil so herdr applies its default.
+    var newWorkspaceLabel: String = ""
     /// Whether the launch targets a fresh git worktree of the selected
     /// workspace's repository instead of the workspace itself (#97).
     var startsInNewWorktree = false
@@ -152,9 +191,9 @@ final class StartAgentStore {
     /// skipping them merely bumps the suffix.
     private let existingAgentNames: (Host.ID) -> Set<String>
     private let discoverAgentKinds: (Host.ID) async throws -> [SupportedAgentKind]
-    /// A non-nil `WorktreeSpec` routes the launch through the fresh-worktree
-    /// choreography; nil starts in the workspace itself.
-    private let start: (AgentLaunchRequest, WorktreeSpec?, Host.ID) async throws -> Agent
+    /// Dispatches the assembled request through the matching Transport
+    /// launch variant.
+    private let start: (AgentLaunchRequest, LaunchDestination, Host.ID) async throws -> Agent
     /// Suspends (bounded) until the started Agent is visible in the Console.
     /// The row the owner navigates to exists only after the post-start resync
     /// lands; waiting here keeps the opened detail from flashing its
@@ -171,7 +210,7 @@ final class StartAgentStore {
         workspaces: @escaping (Host.ID) -> [ConsoleWorkspace],
         existingAgentNames: @escaping (Host.ID) -> Set<String>,
         discoverAgentKinds: @escaping (Host.ID) async throws -> [SupportedAgentKind],
-        start: @escaping (AgentLaunchRequest, WorktreeSpec?, Host.ID) async throws -> Agent,
+        start: @escaping (AgentLaunchRequest, LaunchDestination, Host.ID) async throws -> Agent,
         awaitAgentVisible: @escaping (ConsoleAgent.ID) async -> Void,
         origin: LaunchOrigin? = nil,
         recents: RecentWorkspaceStore = RecentWorkspaceStore()
@@ -192,8 +231,14 @@ final class StartAgentStore {
     /// defined by landing in the origin agent's directory, and a worktree
     /// launch lands in a brand-new checkout instead — the two cannot both
     /// hold, so the origin flow drops the option rather than silently
-    /// ignoring the requested directory.
-    var offersWorktree: Bool { origin == nil }
+    /// ignoring the requested directory. New Workspace likewise has no
+    /// source Workspace to branch from.
+    var offersWorktree: Bool { origin == nil && launchTarget == .existingWorkspace }
+
+    /// Whether the form offers Existing vs New Workspace. Origin launches
+    /// inherit the origin agent's Workspace and directory, so the choice
+    /// would contradict that inheritance.
+    var offersNewWorkspace: Bool { origin == nil }
 
     /// The workspaces the selected Host knows; empty when no Host is picked.
     var workspaces: [ConsoleWorkspace] {
@@ -237,13 +282,25 @@ final class StartAgentStore {
 
     /// Whether the form is complete enough to dispatch.
     var canSubmit: Bool {
-        selectedHostID != nil && selectedWorkspaceID != nil
+        selectedHostID != nil && hasLaunchTarget
             && nameErrorMessage == nil
             && selectedAgentKind != nil
             && parsedArguments.isSuccess
             && worktreeBranchErrorMessage == nil
             && agentDiscoveryState == .loaded
             && state != .starting
+    }
+
+    /// Existing Workspace and origin launches need a reported Workspace;
+    /// New Workspace needs a non-empty trimmed directory instead.
+    private var hasLaunchTarget: Bool {
+        if origin != nil { return selectedWorkspaceID != nil }
+        switch launchTarget {
+        case .existingWorkspace:
+            return selectedWorkspaceID != nil
+        case .newWorkspace:
+            return Self.nonEmptyTrimmed(newWorkspaceDirectory) != nil
+        }
     }
 
     /// Whether the sheet may be dismissed without abandoning an in-flight
@@ -284,8 +341,8 @@ final class StartAgentStore {
         guard
             !isStarting,
             let hostID = selectedHostID,
-            let workspaceID = selectedWorkspaceID,
             let kind = selectedAgentKind,
+            let destination = launchDestination,
             case .success(let arguments) = parsedArguments,
             worktreeBranchErrorMessage == nil,
             nameErrorMessage == nil
@@ -298,21 +355,26 @@ final class StartAgentStore {
         isStarting = true
         state = .starting
         defer { isStarting = false }
+        let workspaceID: String?
+        switch destination {
+        case .newWorkspace:
+            workspaceID = nil
+        case .existingWorkspace, .newWorktree:
+            workspaceID = selectedWorkspaceID
+        }
         let request = AgentLaunchRequest(
             kind: kind.rawValue,
             name: agentName,
             arguments: arguments,
             workspaceID: workspaceID,
             cwd: origin?.cwd)
-        let worktree: WorktreeSpec? =
-            offersWorktree && startsInNewWorktree
-            ? WorktreeSpec(
-                branch: Self.nonEmptyTrimmed(worktreeBranch),
-                base: Self.nonEmptyTrimmed(worktreeBase))
-            : nil
         do {
-            let agent = try await start(request, worktree, hostID)
-            recents.remember(workspaceID, for: hostID)
+            let agent = try await start(request, destination, hostID)
+            if case .newWorkspace = destination {
+                recents.remember(agent.workspaceID, for: hostID)
+            } else if let workspaceID {
+                recents.remember(workspaceID, for: hostID)
+            }
             let startedID = ConsoleAgent.ID(hostID: hostID, paneID: agent.paneID)
             // The wait is bounded; on timeout the owner still navigates and
             // the row catches up with the next resync.
@@ -320,6 +382,35 @@ final class StartAgentStore {
             state = .started(startedID)
         } catch {
             state = .failed(Self.message(for: error))
+        }
+    }
+
+    /// Assembles the Transport variant from the current form. Nil when the
+    /// chosen target is incomplete, so `submit()` is a no-op rather than
+    /// inventing a Workspace id.
+    private var launchDestination: LaunchDestination? {
+        if origin != nil {
+            guard selectedWorkspaceID != nil else { return nil }
+            return .existingWorkspace
+        }
+        switch launchTarget {
+        case .existingWorkspace:
+            guard selectedWorkspaceID != nil else { return nil }
+            if offersWorktree && startsInNewWorktree {
+                return .newWorktree(
+                    WorktreeSpec(
+                        branch: Self.nonEmptyTrimmed(worktreeBranch),
+                        base: Self.nonEmptyTrimmed(worktreeBase)))
+            }
+            return .existingWorkspace
+        case .newWorkspace:
+            guard let directory = Self.nonEmptyTrimmed(newWorkspaceDirectory) else {
+                return nil
+            }
+            return .newWorkspace(
+                NewWorkspaceSpec(
+                    directory: directory,
+                    label: Self.nonEmptyTrimmed(newWorkspaceLabel)))
         }
     }
 

--- a/Sources/Heeler/Console/StartAgentView.swift
+++ b/Sources/Heeler/Console/StartAgentView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
-/// The new-agent sheet (#12, User Story 8): pick a Host and workspace, type a
+/// The new-agent sheet (#12, User Story 8): pick a Host and a launch target
+/// (an existing Workspace or a new one at a remote directory), type an
 /// installed Agent and its native arguments, and dispatch it through the
 /// Transport launch flow. On success the sheet dismisses and hands the
 /// started Agent's identity to `onStarted`; the owner opens it, so a fresh
@@ -27,12 +28,16 @@ struct StartAgentView: View {
                             .compactMap { $0.agent.name })
                 },
                 discoverAgentKinds: { try await console.availableAgentKinds(on: $0) },
-                start: { params, worktree, hostID in
-                    if let worktree {
+                start: { params, destination, hostID in
+                    switch destination {
+                    case .existingWorkspace:
+                        try await console.startAgent(params, on: hostID)
+                    case .newWorktree(let worktree):
                         try await console.startAgentInNewWorktree(
                             params, worktree: worktree, on: hostID)
-                    } else {
-                        try await console.startAgent(params, on: hostID)
+                    case .newWorkspace(let workspace):
+                        try await console.startAgentInNewWorkspace(
+                            params, workspace: workspace, on: hostID)
                     }
                 },
                 awaitAgentVisible: { await console.waitForAgent($0) },
@@ -66,21 +71,58 @@ struct StartAgentView: View {
                     }
 
                     Section {
-                        Picker("Workspace", selection: $store.selectedWorkspaceID) {
-                            if store.workspaces.isEmpty {
-                                Text("None reported").tag(String?.none)
-                            }
-                            ForEach(store.workspaces) { workspace in
-                                Text(workspace.label).tag(String?.some(workspace.id))
+                        if store.offersNewWorkspace {
+                            Picker("Launch", selection: $store.launchTarget) {
+                                Text("Existing Workspace").tag(
+                                    StartAgentStore.LaunchTarget.existingWorkspace)
+                                Text("New Workspace").tag(
+                                    StartAgentStore.LaunchTarget.newWorkspace)
                             }
                         }
-                        .disabled(store.selectedHostID == nil || store.workspaces.isEmpty)
+                        if store.launchTarget != .newWorkspace {
+                            Picker("Workspace", selection: $store.selectedWorkspaceID) {
+                                if store.workspaces.isEmpty {
+                                    Text("None reported").tag(String?.none)
+                                }
+                                ForEach(store.workspaces) { workspace in
+                                    Text(workspace.label).tag(String?.some(workspace.id))
+                                }
+                            }
+                            .disabled(store.selectedHostID == nil || store.workspaces.isEmpty)
+                        }
                     } header: {
                         Text("Workspace")
                     } footer: {
-                        Text(
-                            "Where the agent runs. Defaults to the one you last started an agent in."
-                        )
+                        if store.launchTarget == .newWorkspace {
+                            Text("The Host does not need to report an existing Workspace.")
+                        } else {
+                            Text(
+                                "Where the agent runs. Defaults to the one you last started an agent in."
+                            )
+                        }
+                    }
+
+                    if store.launchTarget == .newWorkspace {
+                        Section {
+                            TextField("e.g. /home/you/src/app", text: $store.newWorkspaceDirectory)
+                                .font(.callout.monospaced())
+                                .autocorrectionDisabled()
+                                .textInputAutocapitalization(.never)
+                        } header: {
+                            Text("Directory")
+                        } footer: {
+                            Text("Remote path herdr opens as the new Workspace.")
+                        }
+
+                        Section {
+                            TextField("Optional", text: $store.newWorkspaceLabel)
+                                .autocorrectionDisabled()
+                                .textInputAutocapitalization(.never)
+                        } header: {
+                            Text("Workspace Label")
+                        } footer: {
+                            Text("Empty uses herdr's default label.")
+                        }
                     }
                 }
 

--- a/Sources/Heeler/Demo/DemoScreenshotMode.swift
+++ b/Sources/Heeler/Demo/DemoScreenshotMode.swift
@@ -419,6 +419,12 @@
             try await startAgent(request)
         }
 
+        func startAgentInNewWorkspace(
+            _ request: AgentLaunchRequest, workspace: NewWorkspaceSpec
+        ) async throws -> Agent {
+            try await startAgent(request)
+        }
+
         func closePane(_ params: PaneTarget) async throws {}
         func renameAgent(_ params: AgentRenameParams) async throws {}
         func renameWorkspace(_ params: WorkspaceRenameParams) async throws {}

--- a/Sources/Heeler/Transport/Generated/HerdrAPITypes.swift
+++ b/Sources/Heeler/Transport/Generated/HerdrAPITypes.swift
@@ -851,6 +851,45 @@ struct TabInfo: Codable, Equatable, Sendable {
     }
 }
 
+/// herdr schema `$defs/WorkspaceCreateParams`.
+struct WorkspaceCreateParams: Codable, Equatable, Sendable {
+    let cwd: String?
+    let env: [String: String]?
+    let focus: Bool?
+    let label: String?
+
+    init(
+        cwd: String? = nil,
+        env: [String: String]? = nil,
+        focus: Bool? = nil,
+        label: String? = nil
+    ) {
+        self.cwd = cwd
+        self.env = env
+        self.focus = focus
+        self.label = label
+    }
+}
+
+/// The `"type":"workspace_created"` result payload of herdr's success_response schema.
+struct WorkspaceCreatedResponse: Codable, Equatable, Sendable {
+    let rootPane: PaneInfo
+    let tab: TabInfo
+    let workspace: WorkspaceInfo
+
+    init(rootPane: PaneInfo, tab: TabInfo, workspace: WorkspaceInfo) {
+        self.rootPane = rootPane
+        self.tab = tab
+        self.workspace = workspace
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case rootPane = "root_pane"
+        case tab
+        case workspace
+    }
+}
+
 /// herdr schema `$defs/WorkspaceInfo`.
 struct WorkspaceInfo: Codable, Equatable, Sendable {
     let activeTabID: String
@@ -923,6 +962,19 @@ struct WorkspaceRenameParams: Codable, Equatable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case label
+        case workspaceID = "workspace_id"
+    }
+}
+
+/// herdr schema `$defs/WorkspaceTarget`.
+struct WorkspaceTarget: Codable, Equatable, Sendable {
+    let workspaceID: String
+
+    init(workspaceID: String) {
+        self.workspaceID = workspaceID
+    }
+
+    private enum CodingKeys: String, CodingKey {
         case workspaceID = "workspace_id"
     }
 }

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -664,6 +664,28 @@ actor HeelerSSHTransport: Transport {
         }
     }
 
+    func startAgentInNewWorkspace(
+        _ launch: AgentLaunchRequest,
+        workspace: NewWorkspaceSpec
+    ) async throws -> Agent {
+        let created = try await request(
+            method: "workspace.create",
+            params: WorkspaceCreateParams(
+                cwd: workspace.directory,
+                focus: false,
+                label: workspace.label),
+            decoding: WorkspaceCreatedResponse.self)
+        do {
+            let response = try await startAgentAwaitingShell(
+                launch,
+                paneID: created.rootPane.paneID)
+            return Agent(response.agent)
+        } catch let error as HerdrAPIError {
+            try? await closeCreatedWorkspace(workspaceID: created.workspace.workspaceID)
+            throw error
+        }
+    }
+
     func listWorktrees(forWorkspaceID workspaceID: String) async throws -> WorktreeListResponse {
         try await request(
             method: "worktree.list",
@@ -691,6 +713,13 @@ actor HeelerSSHTransport: Transport {
             method: "worktree.remove",
             params: WorktreeRemoveParams(workspaceID: workspaceID),
             decoding: WorktreeRemovedResponse.self)
+    }
+
+    private func closeCreatedWorkspace(workspaceID: String) async throws {
+        _ = try await request(
+            method: "workspace.close",
+            params: WorkspaceTarget(workspaceID: workspaceID),
+            decoding: OkResponse.self)
     }
 
     private func startAgentAwaitingShell(

--- a/Sources/Heeler/Transport/Transport.swift
+++ b/Sources/Heeler/Transport/Transport.swift
@@ -66,6 +66,18 @@ protocol Transport: Sendable {
         _ request: AgentLaunchRequest, worktree: WorktreeSpec
     ) async throws -> Agent
 
+    /// Starts a new Agent in a freshly created Workspace (#230):
+    /// `workspace.create` opens the remote directory as its own Workspace
+    /// (no existing Workspace required) and returns a root pane already
+    /// running a shell, so this variant skips `tab.create` and starts the
+    /// agent in that pane directly (the `agent_pane_busy` readiness retry
+    /// still applies). `request.workspaceID` is unused; the started agent
+    /// lives in the returned Workspace and surfaces through the normal
+    /// snapshot/delta machinery.
+    func startAgentInNewWorkspace(
+        _ request: AgentLaunchRequest, workspace: NewWorkspaceSpec
+    ) async throws -> Agent
+
     /// Closes a Pane (`pane.close`): the Agent detail screen's destructive
     /// close action (#13, User Story 9 — a Done agent must not be destroyed
     /// by a stray swipe, so the UI gates this behind an explicit
@@ -384,6 +396,19 @@ struct WorktreeSpec: Sendable, Equatable {
     init(branch: String? = nil, base: String? = nil) {
         self.branch = branch
         self.base = base
+    }
+}
+
+/// App-domain refinements for the new-Workspace launch variant (#230).
+/// `directory` is the remote path `workspace.create` opens; `label` is
+/// optional and omitted on the wire when nil so herdr applies its default.
+struct NewWorkspaceSpec: Sendable, Equatable {
+    let directory: String
+    let label: String?
+
+    init(directory: String, label: String? = nil) {
+        self.directory = directory
+        self.label = label
     }
 }
 

--- a/Tests/HeelerTests/ConsoleStoreTests.swift
+++ b/Tests/HeelerTests/ConsoleStoreTests.swift
@@ -968,6 +968,40 @@ struct ConsoleStoreTests {
         store.setHosts([])
     }
 
+    @Test func startAgentInNewWorkspaceForwardsTheSpecAndResnapshots() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(snapshot: .fixture(agents: []))
+        let store = makeStore(transports: [host.id: transport])
+
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the Host should connect") {
+            store.hostStatuses[host.id] == .connected
+        }
+        let snapshotsBefore = await transport.snapshotFetchCount
+
+        await transport.setSnapshot(
+            .fixture(agents: [.fixture(paneID: "nw1:pnew", status: .working, workspaceID: "nw1")]))
+        let started = try await store.startAgentInNewWorkspace(
+            AgentLaunchRequest(kind: "claude", name: "reviewer"),
+            workspace: NewWorkspaceSpec(directory: "/src/app", label: "App"),
+            on: host.id)
+
+        #expect(started.workspaceID == "nw1")
+        let starts = await transport.workspaceStarts
+        #expect(starts.map { $0.request.kind } == ["claude"])
+        #expect(starts.map { $0.request.workspaceID } == [nil])
+        #expect(
+            starts.map { $0.workspace }
+                == [NewWorkspaceSpec(directory: "/src/app", label: "App")])
+        try await waitUntil("the resync should surface the new pane") {
+            store.agents.map(\.agent.paneID) == ["nw1:pnew"]
+        }
+        #expect(await transport.snapshotFetchCount > snapshotsBefore)
+
+        store.setHosts([])
+    }
+
     @Test func waitForAgentReturnsOnceTheResyncSurfacesThePane() async throws {
         // The new-agent flow opens the started pane's terminal; the wait
         // bridges the gap between the start RPC and the resync that makes

--- a/Tests/HeelerTests/GeneratedWireTypesTests.swift
+++ b/Tests/HeelerTests/GeneratedWireTypesTests.swift
@@ -153,6 +153,20 @@ import Testing
         #expect(response.workspace.label == "Proj")
     }
 
+    @Test func workspaceCreatedResponseRoundTripsProtocolTwentyShape() throws {
+        // `workspace.create` success payload (protocol 20): workspace, tab,
+        // and root pane. Synthetic per the schema; no live capture in this
+        // checkout.
+        let json = #"{"type":"workspace_created","workspace":{"workspace_id":"wN","number":4,"label":"app","focused":false,"pane_count":1,"tab_count":1,"active_tab_id":"wN:t1","agent_status":"unknown"},"tab":{"tab_id":"wN:t1","workspace_id":"wN","number":1,"label":"1","focused":false,"pane_count":1,"agent_status":"unknown"},"root_pane":{"pane_id":"wN:p1","terminal_id":"term_ws","workspace_id":"wN","tab_id":"wN:t1","focused":false,"agent_status":"unknown","revision":0}}"#
+
+        let response = try roundTrip(WorkspaceCreatedResponse.self, json)
+
+        #expect(response.workspace.workspaceID == "wN")
+        #expect(response.workspace.label == "app")
+        #expect(response.tab.tabID == "wN:t1")
+        #expect(response.rootPane.paneID == "wN:p1")
+    }
+
     @Test func worktreeCreatedResponseRoundTripsLiveCapture() throws {
         // `worktree.create` live capture (herdr 0.7.5, sanitized, #97): the
         // new workspace arrives with its tab and root pane, plus the
@@ -316,6 +330,31 @@ import Testing
         ) as? [String: Any]
         #expect(fields?.keys.sorted() == ["label", "workspace_id"])
         #expect(fields?["workspace_id"] as? String == "w9")
+    }
+
+    @Test func workspaceCreateParamsEncodeDirectoryFocusAndOptionalLabel() throws {
+        let unlabeled = try JSONSerialization.jsonObject(
+            with: JSONEncoder().encode(
+                WorkspaceCreateParams(cwd: "/home/you/src/app", focus: false))
+        ) as? [String: Any]
+        #expect(unlabeled?.keys.sorted() == ["cwd", "focus"])
+        #expect(unlabeled?["cwd"] as? String == "/home/you/src/app")
+        #expect(unlabeled?["focus"] as? Bool == false)
+
+        let labeled = try JSONSerialization.jsonObject(
+            with: JSONEncoder().encode(
+                WorkspaceCreateParams(cwd: "/home/you/src/app", focus: false, label: "app"))
+        ) as? [String: Any]
+        #expect(labeled?.keys.sorted() == ["cwd", "focus", "label"])
+        #expect(labeled?["label"] as? String == "app")
+    }
+
+    @Test func workspaceTargetEncodesSnakeCase() throws {
+        let fields = try JSONSerialization.jsonObject(
+            with: JSONEncoder().encode(WorkspaceTarget(workspaceID: "wN"))
+        ) as? [String: Any]
+        #expect(fields?.keys.sorted() == ["workspace_id"])
+        #expect(fields?["workspace_id"] as? String == "wN")
     }
 
     @Test func paneTargetTravelsThroughTheRequestEnvelope() throws {

--- a/Tests/HeelerTests/HeelerSSHDirectStreamLocalE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHDirectStreamLocalE2ETests.swift
@@ -12,25 +12,6 @@ import Testing
         "requires the disposable stream-local fixture"),
     .serialized)
 struct HeelerSSHDirectStreamLocalE2ETests {
-    @Test("Transport ping validates protocol 17 and opens a fresh channel")
-    func transportPingUsesFreshChannels() async throws {
-        let environment = try #require(DirectStreamLocalTestEnvironment.current)
-        let connection = try await environment.deviceKeyConnection(to: environment.endpoint)
-        let before = try await environment.connectionCount(using: connection)
-        let transport: any Transport = HeelerSSHTransport(
-            connection: connection,
-            socketPath: environment.socketPath)
-
-        let first = try await transport.ping()
-        let second = try await transport.ping()
-        let after = try await environment.connectionCount(using: connection)
-
-        #expect(first == ServerInfo(version: "fake", protocolVersion: 17))
-        #expect(second == first)
-        #expect(after == before + 2)
-        try await transport.close()
-    }
-
     @Test("partial request writes and response reads complete one line")
     func partialReadsAndWritesComplete() async throws {
         let environment = try #require(DirectStreamLocalTestEnvironment.current)

--- a/Tests/HeelerTests/HeelerSSHDirectStreamLocalE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHDirectStreamLocalE2ETests.swift
@@ -77,21 +77,6 @@ struct HeelerSSHDirectStreamLocalE2ETests {
         }
     }
 
-    @Test("timeout closes only its channel and preserves connection reuse")
-    func timeoutPreservesConnectionReuse() async throws {
-        let environment = try #require(DirectStreamLocalTestEnvironment.current)
-        let connection = try await environment.deviceKeyConnection(to: environment.endpoint)
-        try await withClosingDirectConnection(connection) { connection in
-            await #expect(throws: SSHError.timedOut) {
-                _ = try await connection.exchangeStreamLocal(
-                    socketPath: environment.socketPath,
-                    request: requestLine(method: "hang"),
-                    timeout: .milliseconds(150))
-            }
-            try await expectPing(connection, socketPath: environment.socketPath)
-        }
-    }
-
     @Test("cancellation closes only its channel and preserves connection reuse")
     func cancellationPreservesConnectionReuse() async throws {
         let environment = try #require(DirectStreamLocalTestEnvironment.current)

--- a/Tests/HeelerTests/HeelerSSHJumpHostGateE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHJumpHostGateE2ETests.swift
@@ -265,32 +265,6 @@ struct HeelerSSHJumpHostGateE2ETests {
         try await deadlineTarget.close(timeout: .seconds(3))
     }
 
-    @Test("stream-local timeout and cancellation preserve only cleanly closed sessions")
-    func exchangeCancellationAndTimeoutRemainClean() async throws {
-        let environment = try #require(HeelerSSHJumpHostTestEnvironment.current)
-        let (_, target) = try await environment.connectAuthenticatedTarget()
-
-        await #expect(throws: SSHError.timedOut) {
-            _ = try await target.exchangeStreamLocal(
-                socketPath: environment.socketPath,
-                request: requestLine(id: "hang-timeout", method: "hang"),
-                timeout: .milliseconds(150))
-        }
-        try await expectPing(target, environment: environment, id: "after-timeout")
-
-        let exchange = Task {
-            try await target.exchangeStreamLocal(
-                socketPath: environment.socketPath,
-                request: requestLine(id: "hang-cancel", method: "hang"),
-                timeout: .seconds(30))
-        }
-        try await Task.sleep(for: .milliseconds(100))
-        exchange.cancel()
-        await #expect(throws: SSHError.cancelled) { _ = try await exchange.value }
-        try await expectPing(target, environment: environment, id: "after-cancel")
-        try await target.close(timeout: .seconds(3))
-    }
-
     @Test("sequential and concurrent nested exchanges make bounded progress")
     func nestedStressMakesProgress() async throws {
         let environment = try #require(HeelerSSHJumpHostTestEnvironment.current)

--- a/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
+++ b/Tests/HeelerTests/HeelerSSHTransportBehaviorE2ETests.swift
@@ -709,6 +709,84 @@ struct HeelerSSHTransportBehaviorE2ETests {
         #expect(recorded[2] == #"worktree.remove {"workspace_id":"workspace:\#(token)"}"#)
     }
 
+    /// New Workspace (#230) creates the Workspace first, then starts in its
+    /// root pane. `tab.create` would open a second tab inside a Workspace
+    /// that already has one.
+    @Test("a new-workspace agent start creates the workspace then starts in its root pane")
+    func newWorkspaceAgentStartCreatesThenStartsWithoutATab() async throws {
+        let environment = try #require(HeelerSSHTransportBehaviorEnvironment.current)
+        let transport = try await HeelerSSHTransport.connect(
+            settings: environment.directSettings())
+        defer { Task { try? await transport.close() } }
+
+        let token = Self.scriptToken("ok")
+        let agent = try await transport.startAgentInNewWorkspace(
+            AgentLaunchRequest(kind: "codex", name: "fixture"),
+            workspace: NewWorkspaceSpec(directory: "/fixture/\(token)", label: "App"))
+
+        #expect(agent.paneID == "pane:\(token)")
+        #expect(agent.workspaceID == "workspace:\(token)")
+        let recorded = try await Self.recordedRequests(from: transport, token: token)
+        try #require(recorded.count == 2)
+        #expect(
+            recorded[0]
+                == #"workspace.create {"cwd":"/fixture/\#(token)","focus":false,"label":"App"}"#)
+        #expect(recorded[1].hasPrefix("agent.start "))
+        #expect(!recorded.contains { $0.hasPrefix("tab.create ") })
+    }
+
+    /// The new-Workspace half of the same compensation: a refused launch
+    /// would otherwise leave an empty Workspace behind.
+    @Test("a refused new-workspace agent start closes the workspace it created")
+    func refusedNewWorkspaceAgentStartClosesTheWorkspace() async throws {
+        let environment = try #require(HeelerSSHTransportBehaviorEnvironment.current)
+        let transport = try await HeelerSSHTransport.connect(
+            settings: environment.directSettings())
+        defer { Task { try? await transport.close() } }
+
+        let token = Self.scriptToken("startfails")
+        await #expect(throws: Self.refusedStart) {
+            _ = try await transport.startAgentInNewWorkspace(
+                AgentLaunchRequest(kind: "codex", name: "fixture"),
+                workspace: NewWorkspaceSpec(directory: "/fixture/\(token)"))
+        }
+
+        let recorded = try await Self.recordedRequests(from: transport, token: token)
+        try #require(recorded.count == 3)
+        #expect(
+            recorded[0]
+                == #"workspace.create {"cwd":"/fixture/\#(token)","focus":false}"#)
+        #expect(recorded[1].hasPrefix("agent.start "))
+        #expect(recorded[2] == #"workspace.close {"workspace_id":"workspace:\#(token)"}"#)
+        #expect(!recorded.contains { $0.hasPrefix("tab.create ") })
+    }
+
+    /// Closing the channel without a herdr error envelope is ambiguous: the
+    /// Agent may already exist on the Host. Compensating `workspace.close`
+    /// would destroy a possibly successful result.
+    @Test("an ambiguous new-workspace agent start does not close the workspace")
+    func ambiguousNewWorkspaceAgentStartPreservesTheWorkspace() async throws {
+        let environment = try #require(HeelerSSHTransportBehaviorEnvironment.current)
+        var settings = environment.directSettings()
+        settings.requestTimeout = .seconds(1)
+        let transport = try await HeelerSSHTransport.connect(settings: settings)
+        defer { Task { try? await transport.close() } }
+
+        let token = Self.scriptToken("startdrop")
+        await #expect(throws: TransportError.self) {
+            _ = try await transport.startAgentInNewWorkspace(
+                AgentLaunchRequest(kind: "codex", name: "fixture"),
+                workspace: NewWorkspaceSpec(directory: "/fixture/\(token)"))
+        }
+
+        let recorded = try await Self.recordedRequests(from: transport, token: token)
+        try #require(recorded.count == 2)
+        #expect(recorded[0].hasPrefix("workspace.create "))
+        #expect(recorded[1].hasPrefix("agent.start "))
+        #expect(!recorded.contains { $0.hasPrefix("workspace.close ") })
+        #expect(!recorded.contains { $0.hasPrefix("tab.create ") })
+    }
+
     @Test("confirmed worktree removal crosses the real wire dispatch seam")
     func confirmedWorktreeRemovalCrossesTheRealWireDispatchSeam() async throws {
         let environment = try #require(HeelerSSHTransportBehaviorEnvironment.current)
@@ -1119,6 +1197,11 @@ struct HeelerSSHTransportBehaviorE2ETests {
                     workspaceID: "workspace-1"),
                 worktree: WorktreeSpec(branch: "task/fixture", base: "main"))
                 .workspaceID == "workspace-worktree")
+        #expect(
+            try await transport.startAgentInNewWorkspace(
+                AgentLaunchRequest(kind: "codex", name: "fixture-workspace"),
+                workspace: NewWorkspaceSpec(directory: "/tmp/project", label: "Fixture"))
+                .workspaceID == "workspace-new")
         await #expect(
             throws: HerdrAPIError(
                 code: "500",

--- a/Tests/HeelerTests/StartAgentStoreTests.swift
+++ b/Tests/HeelerTests/StartAgentStoreTests.swift
@@ -5,9 +5,9 @@ import UIKit
 
 @testable import Heeler
 
-/// New-agent form logic (#12) against scripted discovery and start closures:
-/// argument parsing, Host/workspace/Agent selection, param assembly, and outcome
-/// mapping — no SSH, no ConsoleStore.
+/// New-agent form logic (#12, #97, #230) against scripted discovery and start
+/// closures: argument parsing, Host/workspace/Agent selection, param assembly,
+/// and outcome mapping — no SSH, no ConsoleStore.
 @MainActor
 @Suite("Start agent store")
 struct StartAgentStoreTests {
@@ -15,19 +15,27 @@ struct StartAgentStoreTests {
     @MainActor
     private final class StartRecorder {
         var params: [AgentLaunchRequest] = []
+        var destinations: [StartAgentStore.LaunchDestination] = []
         /// One entry per start, aligned with `params`; nil is a plain
         /// workspace launch, non-nil the fresh-worktree variant (#97).
-        var worktrees: [WorktreeSpec?] = []
+        var worktrees: [WorktreeSpec?] {
+            destinations.map {
+                if case .newWorktree(let spec) = $0 { return spec }
+                return nil
+            }
+        }
         var hostIDs: [Host.ID] = []
         var error: (any Error)?
         var agent = Agent(.fixture(paneID: "w1:pnew", status: .working))
         var gate: ScriptedTransportCallGate?
 
         func record(
-            _ params: AgentLaunchRequest, _ worktree: WorktreeSpec?, _ hostID: Host.ID
+            _ params: AgentLaunchRequest,
+            _ destination: StartAgentStore.LaunchDestination,
+            _ hostID: Host.ID
         ) async throws -> Agent {
             self.params.append(params)
-            worktrees.append(worktree)
+            destinations.append(destination)
             hostIDs.append(hostID)
             await gate?.waitUntilOpen()
             if let error { throw error }
@@ -60,8 +68,8 @@ struct StartAgentStoreTests {
             hosts: hosts, workspaces: workspaces,
             existingAgentNames: existingAgentNames,
             discoverAgentKinds: agentKinds,
-            start: { params, worktree, hostID in
-                try await recorder.record(params, worktree, hostID)
+            start: { params, destination, hostID in
+                try await recorder.record(params, destination, hostID)
             },
             awaitAgentVisible: awaitAgentVisible,
             origin: origin,
@@ -362,10 +370,125 @@ struct StartAgentStoreTests {
         store.name = "reviewer"
         await store.discoverAgents()
 
+        #expect(store.launchTarget == .existingWorkspace)
         #expect(store.canSubmit == false)
         await store.submit()
         #expect(store.state == .editing)
         #expect(recorder.params.isEmpty)
+    }
+
+    @Test func newWorkspaceCanSubmitWithZeroReportedWorkspaces() async {
+        let host = Host.fixture()
+        let recorder = StartRecorder()
+        let store = makeStore(hosts: [host], recorder: recorder)
+        await store.discoverAgents()
+
+        #expect(store.canSubmit == false)
+        store.launchTarget = .newWorkspace
+        #expect(store.canSubmit == false)
+        store.newWorkspaceDirectory = "   "
+        #expect(store.canSubmit == false)
+        store.newWorkspaceDirectory = "  /home/you/src/app  "
+        #expect(store.canSubmit == true)
+
+        await store.submit()
+
+        #expect(store.state == started(on: host))
+        #expect(recorder.params.first?.workspaceID == nil)
+        #expect(recorder.params.first?.cwd == nil)
+        #expect(
+            recorder.destinations
+                == [.newWorkspace(NewWorkspaceSpec(directory: "/home/you/src/app"))])
+    }
+
+    @Test func newWorkspaceTrimsDirectoryAndDropsAnEmptyLabel() async {
+        let host = Host.fixture()
+        let recorder = StartRecorder()
+        let store = makeStore(
+            hosts: [host],
+            workspaces: { _ in [ConsoleWorkspace(id: "w1", label: "Proj")] },
+            recorder: recorder)
+        await store.discoverAgents()
+        store.launchTarget = .newWorkspace
+        store.newWorkspaceDirectory = "\n /tmp/project \t"
+        store.newWorkspaceLabel = "   "
+
+        await store.submit()
+
+        #expect(store.state == started(on: host))
+        #expect(recorder.params.first?.workspaceID == nil)
+        #expect(
+            recorder.destinations
+                == [.newWorkspace(NewWorkspaceSpec(directory: "/tmp/project", label: nil))])
+    }
+
+    @Test func newWorkspaceSubmitRemembersTheReturnedWorkspaceAndWaits() async throws {
+        let host = Host.fixture()
+        let recents = makeRecents()
+        let recorder = StartRecorder()
+        recorder.agent = Agent(
+            .fixture(paneID: "nw1:pnew", status: .working, workspaceID: "nw1"))
+        let visibilityGate = ScriptedTransportCallGate()
+        final class SeenBox { var ids: [ConsoleAgent.ID] = [] }
+        let seen = SeenBox()
+        let store = makeStore(
+            hosts: [host],
+            awaitAgentVisible: { id in
+                seen.ids.append(id)
+                await visibilityGate.waitUntilOpen()
+            },
+            recents: recents,
+            recorder: recorder)
+        await store.discoverAgents()
+        store.launchTarget = .newWorkspace
+        store.newWorkspaceDirectory = "/src/app"
+        store.newWorkspaceLabel = "  App  "
+
+        let submit = Task { await store.submit() }
+        try await waitUntil("the visibility wait should begin") {
+            await visibilityGate.entryCount == 1
+        }
+        #expect(store.state == .starting)
+
+        await visibilityGate.open()
+        await submit.value
+
+        #expect(store.state == started(on: host, paneID: "nw1:pnew"))
+        #expect(seen.ids == [ConsoleAgent.ID(hostID: host.id, paneID: "nw1:pnew")])
+        #expect(
+            recorder.destinations
+                == [.newWorkspace(NewWorkspaceSpec(directory: "/src/app", label: "App"))])
+
+        let next = makeStore(
+            hosts: [host],
+            workspaces: { _ in
+                [ConsoleWorkspace(id: "w1", label: "Old"),
+                    ConsoleWorkspace(id: "nw1", label: "App")]
+            },
+            recents: recents,
+            recorder: StartRecorder())
+        #expect(next.selectedWorkspaceID == "nw1")
+    }
+
+    @Test func newWorkspaceServerRejectionUsesExistingErrorPresentation() async {
+        let host = Host.fixture()
+        let recents = makeRecents()
+        let recorder = StartRecorder()
+        recorder.error = HerdrAPIError(code: "cwd_not_found", message: "no such directory")
+        let store = makeStore(hosts: [host], recents: recents, recorder: recorder)
+        await store.discoverAgents()
+        store.launchTarget = .newWorkspace
+        store.newWorkspaceDirectory = "/missing"
+
+        await store.submit()
+
+        #expect(store.state == .failed("herdr rejected the command: no such directory"))
+        let next = makeStore(
+            hosts: [host],
+            workspaces: { _ in [ConsoleWorkspace(id: "w1", label: "Proj")] },
+            recents: recents,
+            recorder: StartRecorder())
+        #expect(next.selectedWorkspaceID == "w1")
     }
 
     @Test func switchingHostClearsStaleWorkspaceAndAgentPicks() async {
@@ -529,6 +652,7 @@ struct StartAgentStoreTests {
             recorder.params.first?.arguments
                 == ["--yolo", "--continue", "--label", "code review"])
         #expect(recorder.params.first?.workspaceID == "w1")
+        #expect(recorder.destinations == [.existingWorkspace])
         #expect(recorder.worktrees == [nil])
     }
 
@@ -600,6 +724,31 @@ struct StartAgentStoreTests {
         #expect(recorder.params.first?.cwd == "/Users/dev/proj")
     }
 
+    /// New Workspace would open a different directory and drop the origin
+    /// Workspace. The origin flow hides the choice, and forcing the fields
+    /// cannot smuggle it onto the request.
+    @Test func originLaunchNeverExposesOrTakesNewWorkspace() async {
+        let host = Host.fixture()
+        let recorder = StartRecorder()
+        let store = makeStore(
+            hosts: [host],
+            workspaces: { _ in [ConsoleWorkspace(id: "w1", label: "Proj")] },
+            origin: StartAgentStore.LaunchOrigin(
+                hostID: host.id, workspaceID: "w1", cwd: "/Users/dev/proj"),
+            recorder: recorder)
+        #expect(!store.offersNewWorkspace)
+        store.launchTarget = .newWorkspace
+        store.newWorkspaceDirectory = "/tmp/elsewhere"
+        await store.discoverAgents()
+
+        await store.submit()
+
+        #expect(store.state == started(on: host))
+        #expect(recorder.destinations == [.existingWorkspace])
+        #expect(recorder.params.first?.workspaceID == "w1")
+        #expect(recorder.params.first?.cwd == "/Users/dev/proj")
+    }
+
     /// The origin agent proves its workspace exists, so it outranks both the
     /// remembered pick and the snapshot the Host happens to report.
     @Test func originWorkspaceOutranksTheRememberedAndReportedOnes() async {
@@ -657,6 +806,9 @@ struct StartAgentStoreTests {
 
         #expect(store.state == started(on: host))
         #expect(recorder.params.first?.workspaceID == "w1")
+        #expect(
+            recorder.destinations
+                == [.newWorktree(WorktreeSpec(branch: "task/fix-97", base: "origin/main"))])
         #expect(recorder.worktrees == [WorktreeSpec(branch: "task/fix-97", base: "origin/main")])
     }
 
@@ -716,6 +868,52 @@ struct StartAgentStoreTests {
         #expect(store.startsInNewWorktree == false)
         #expect(store.worktreeBranch.isEmpty)
         #expect(store.worktreeBase.isEmpty)
+    }
+
+    @Test func switchingToNewWorkspaceDropsAnActiveWorktreeRequest() async {
+        let host = Host.fixture()
+        let recorder = StartRecorder()
+        let store = makeStore(
+            hosts: [host],
+            workspaces: { _ in [ConsoleWorkspace(id: "w1", label: "Proj")] },
+            recorder: recorder)
+        await store.discoverAgents()
+        store.startsInNewWorktree = true
+        store.worktreeBranch = "task/fix"
+        store.worktreeBase = "origin/main"
+        #expect(store.offersWorktree)
+
+        store.launchTarget = .newWorkspace
+
+        #expect(!store.offersWorktree)
+        #expect(store.startsInNewWorktree == false)
+        #expect(store.worktreeBranch.isEmpty)
+        #expect(store.worktreeBase.isEmpty)
+        store.newWorkspaceDirectory = "/src/app"
+        await store.submit()
+
+        #expect(
+            recorder.destinations
+                == [.newWorkspace(NewWorkspaceSpec(directory: "/src/app"))])
+        #expect(recorder.worktrees == [nil])
+        #expect(recorder.params.first?.workspaceID == nil)
+    }
+
+    @Test func switchingHostResetsNewWorkspaceFields() {
+        let hostA = Host.fixture(address: "a.example")
+        let hostB = Host.fixture(address: "b.example")
+        let store = makeStore(hosts: [hostA, hostB], recorder: StartRecorder())
+        store.selectedHostID = hostA.id
+        store.launchTarget = .newWorkspace
+        store.newWorkspaceDirectory = "/src/app"
+        store.newWorkspaceLabel = "App"
+
+        store.selectedHostID = hostB.id
+
+        #expect(store.launchTarget == .existingWorkspace)
+        #expect(store.newWorkspaceDirectory.isEmpty)
+        #expect(store.newWorkspaceLabel.isEmpty)
+        #expect(store.offersWorktree)
     }
 
     @Test func worktreeFailuresGetFirstClassCopy() async {

--- a/Tests/HeelerTests/Support/FakeTransportConnector.swift
+++ b/Tests/HeelerTests/Support/FakeTransportConnector.swift
@@ -65,6 +65,12 @@ final actor FakeTransport: Transport {
         throw TransportError.channelFailed(detail: "FakeTransport does not script agent starts")
     }
 
+    func startAgentInNewWorkspace(
+        _ request: AgentLaunchRequest, workspace: NewWorkspaceSpec
+    ) async throws -> Agent {
+        throw TransportError.channelFailed(detail: "FakeTransport does not script agent starts")
+    }
+
     func closePane(_ params: PaneTarget) async throws {
         throw TransportError.channelFailed(detail: "FakeTransport does not script closes")
     }

--- a/Tests/HeelerTests/Support/ScriptedTransport.swift
+++ b/Tests/HeelerTests/Support/ScriptedTransport.swift
@@ -18,6 +18,10 @@ final actor ScriptedTransport: Transport {
     /// Every worktree launch received, in order; the new-worktree flow (#97)
     /// asserts on the request/spec pairs it forwarded.
     private(set) var worktreeStarts: [(request: AgentLaunchRequest, worktree: WorktreeSpec)] = []
+    /// Every new-Workspace launch received, in order; the new-Workspace flow
+    /// (#230) asserts on the request/spec pairs it forwarded.
+    private(set) var workspaceStarts: [(request: AgentLaunchRequest, workspace: NewWorkspaceSpec)] =
+        []
     private(set) var agentDiscoveryCount = 0
     private var availableKinds = SupportedAgentKind.allCases
     private var agentDiscoveryFailure: TransportError?
@@ -404,6 +408,18 @@ final actor ScriptedTransport: Transport {
         return Agent(
             .fixture(
                 paneID: "wt1:pnew", status: .working, workspaceID: "wt1",
+                kind: request.kind, title: request.name))
+    }
+
+    func startAgentInNewWorkspace(
+        _ request: AgentLaunchRequest, workspace: NewWorkspaceSpec
+    ) async throws -> Agent {
+        workspaceStarts.append((request, workspace))
+        if let startFailure { throw startFailure }
+        if let startedAgent { return Agent(startedAgent) }
+        return Agent(
+            .fixture(
+                paneID: "nw1:pnew", status: .working, workspaceID: "nw1",
                 kind: request.kind, title: request.name))
     }
 

--- a/scripts/fixtures/fake-herdr-streamlocal.py
+++ b/scripts/fixtures/fake-herdr-streamlocal.py
@@ -12,10 +12,10 @@ from typing import Optional
 
 # One scripted run, spelled `fixture:<behavior>:<unique>`. Tests plant it in a
 # request parameter the Transport carries to herdr — `tab.create`'s cwd,
-# `worktree.create`'s branch — and the fixture derives every id it answers with
-# from it, so each later request in the same launch carries the token onward.
-# That both steers the scripted failures and keeps one test's recorded requests
-# from being confused with another's.
+# `worktree.create`'s branch, `workspace.create`'s cwd — and the fixture
+# derives every id it answers with from it, so each later request in the same
+# launch carries the token onward. That both steers the scripted failures and
+# keeps one test's recorded requests from being confused with another's.
 SCRIPT_TOKEN_PATTERN = re.compile(r"fixture:[a-z0-9]+:[0-9a-f-]+")
 
 # `pane.read` on this pane id answers with the requests recorded under the
@@ -208,6 +208,11 @@ class Server:
                 token = self._scripted_run_token(params)
                 if token is not None:
                     self._record(token, method, params)
+                    if (
+                        method == "agent.start"
+                        and token.split(":")[1] == "startdrop"
+                    ):
+                        return
                 error = self._scripted_error(method, token)
                 if error is not None:
                     response = {"id": envelope.get("id"), "error": error}
@@ -264,7 +269,9 @@ class Server:
         `busyN` refuses the first N starts the way herdr 0.7.5 refuses a pane
         whose shell has not reached its prompt, then lets the launch through;
         `busyforever` never lets it through; `startfails` refuses once with a
-        code no retry policy may swallow; `ok` scripts no failure at all.
+        code no retry policy may swallow; `startdrop` is handled in `_serve`
+        by closing the channel with no reply (an ambiguous transport failure);
+        `ok` scripts no failure at all.
 
         A word outside that set is refused rather than treated as `ok`: a
         mistyped behaviour would otherwise leave a test green while proving
@@ -274,6 +281,8 @@ class Server:
             return None
         behavior = token.split(":")[1]
         if behavior == "ok":
+            return None
+        if behavior == "startdrop":
             return None
         if behavior == "startfails":
             return dict(NON_RETRYABLE_START_FAILURE)
@@ -466,10 +475,25 @@ class Server:
                     "open_workspace_id": "workspace-worktree",
                 },
             }
+        if method == "workspace.create":
+            return {
+                "type": "workspace_created",
+                "workspace": self._workspace("workspace-new"),
+                "tab": self._tab("tab-workspace", "workspace-new"),
+                "root_pane": self._pane(
+                    "pane-workspace", "tab-workspace", "workspace-new"
+                ),
+            }
+        if method == "workspace.close":
+            return {"type": "ok"}
         if method == "agent.start":
             pane_id = params.get("pane_id", "pane-new") if isinstance(params, dict) else "pane-new"
             workspace_id = (
-                "workspace-worktree" if pane_id == "pane-worktree" else "workspace-1"
+                "workspace-worktree"
+                if pane_id == "pane-worktree"
+                else "workspace-new"
+                if pane_id == "pane-workspace"
+                else "workspace-1"
             )
             return {
                 "type": "agent_started",
@@ -485,9 +509,10 @@ class Server:
     def _scripted_result(self, method: str, token: str) -> Optional[object]:
         """Ids derived from `token`, so a scripted launch stays self-identifying.
 
-        `tab.create` and `worktree.create` hand the Transport a pane the token
-        names; the `agent.start`, `pane.close` and `worktree.remove` that follow
-        therefore carry it back without the test having to inject anything else.
+        `tab.create`, `worktree.create` and `workspace.create` hand the
+        Transport a pane the token names; the `agent.start`, `pane.close`,
+        `worktree.remove` and `workspace.close` that follow therefore carry
+        it back without the test having to inject anything else.
         """
         pane_id = "pane:" + token
         tab_id = "tab:" + token
@@ -514,6 +539,13 @@ class Server:
                     "label": "fixture",
                     "open_workspace_id": workspace_id,
                 },
+            }
+        if method == "workspace.create":
+            return {
+                "type": "workspace_created",
+                "workspace": self._workspace(workspace_id),
+                "tab": self._tab(tab_id, workspace_id),
+                "root_pane": self._pane(pane_id, tab_id, workspace_id),
             }
         if method == "agent.start":
             return {
@@ -559,7 +591,12 @@ class Server:
         tab_id: Optional[str] = None,
     ) -> object:
         if tab_id is None:
-            tab_id = "tab-worktree" if workspace_id == "workspace-worktree" else "tab-new"
+            if workspace_id == "workspace-worktree":
+                tab_id = "tab-worktree"
+            elif workspace_id == "workspace-new":
+                tab_id = "tab-workspace"
+            else:
+                tab_id = "tab-new"
         return {
             "terminal_id": "terminal-1",
             "agent": "codex",

--- a/scripts/generate-wire-types.py
+++ b/scripts/generate-wire-types.py
@@ -61,7 +61,9 @@ METHODS = [
     "pane.read",
     "pane.close",
     "session.snapshot",
+    "workspace.create",
     "workspace.rename",
+    "workspace.close",
     "worktree.create",
     "worktree.list",
     "worktree.remove",
@@ -92,7 +94,8 @@ RESULT_TAGS = [
     "session_snapshot",  # session.snapshot
     "subscription_started",  # events.subscribe ack
     "tab_created",  # tab.create
-    "ok",  # pane.close
+    "ok",  # pane.close, workspace.close
+    "workspace_created",  # workspace.create
     "workspace_info",  # workspace.rename
     "worktree_created",  # worktree.create
     "worktree_list",  # worktree.list

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -23,6 +23,15 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 
+ci_lane="${HEELER_CI_LANE:-app}"
+case "$ci_lane" in
+    app | package) ;;
+    *)
+        echo "HEELER_CI_LANE must be app or package, got: $ci_lane" >&2
+        exit 2
+        ;;
+esac
+
 # The gate must leave the worktree byte-identical: this workflow treats a clean
 # worktree as a verification precondition, so a stray `__pycache__` beside the
 # Python fixtures is a standing false signal. `.gitignore` covers it too; this
@@ -1100,7 +1109,7 @@ pairing_mismatched_pid=$started_sshd_pid
 # Real password authentication is the one behaviour macOS cannot exercise
 # unprivileged: only root can verify an account password, and an unprivileged
 # sshd can only authenticate the account it already runs as.
-if sudo -n true >/dev/null 2>&1; then
+if [[ "$ci_lane" == "app" ]] && sudo -n true >/dev/null 2>&1; then
     password_username="heelerssh${RANDOM}"
     password_secret="$(uuidgen)-$(uuidgen)"
     password_home="$fixture_dir/password-home"
@@ -1165,10 +1174,10 @@ if sudo -n true >/dev/null 2>&1; then
         password_log_printed=1
         exit 1
     fi
-elif [[ "$mandatory_matrix" == "1" ]]; then
+elif [[ "$ci_lane" == "app" && "$mandatory_matrix" == "1" ]]; then
     echo "Merge CI requires passwordless sudo for the real-password fixture" >&2
     exit 1
-else
+elif [[ "$ci_lane" == "app" ]]; then
     echo "==> No passwordless sudo: skipping the real-password sshd fixture." >&2
     echo "==> Twelve of the thirteen mandatory behaviours still run." >&2
 fi
@@ -1309,28 +1318,31 @@ jump_fixture_configuration=$(printf \
     "$device_key_seed" \
     "$streamlocal_socket")
 jump_fixture_configuration_base64=$(printf '%s' "$jump_fixture_configuration" | base64)
-if ! pairing_node_path="$(command -v node)"; then
-    echo "Node is required for the mandatory Pairing ceremony suite" >&2
-    exit 1
+pairing_fixture_configuration_base64=""
+if [[ "$ci_lane" == "app" ]]; then
+    if ! pairing_node_path="$(command -v node)"; then
+        echo "Node is required for the mandatory Pairing ceremony suite" >&2
+        exit 1
+    fi
+    pairing_accept_script="$PWD/plugin/src/pair-accept.js"
+    if [[ ! -f "$pairing_accept_script" ]]; then
+        echo "Pairing accept entrypoint not found at $pairing_accept_script" >&2
+        exit 1
+    fi
+    pairing_fixture_configuration=$(printf \
+        '{"host":"127.0.0.1","port":%s,"mismatchedHostAddress":"::1","username":"%s","deviceKeySeed":"%s","nodePath":"%s","acceptScriptPath":"%s","homePath":"%s","authorizedKeysPath":"%s","localStateRoot":"%s","remoteStateRoot":"%s"}' \
+        "$pairing_port" \
+        "$pairing_username" \
+        "$device_key_seed" \
+        "$pairing_node_path" \
+        "$pairing_accept_script" \
+        "$pairing_home" \
+        "$pairing_authorized_keys" \
+        "$pairing_state_root" \
+        "$pairing_state_root")
+    pairing_fixture_configuration_base64=$(printf \
+        '%s' "$pairing_fixture_configuration" | base64)
 fi
-pairing_accept_script="$PWD/plugin/src/pair-accept.js"
-if [[ ! -f "$pairing_accept_script" ]]; then
-    echo "Pairing accept entrypoint not found at $pairing_accept_script" >&2
-    exit 1
-fi
-pairing_fixture_configuration=$(printf \
-    '{"host":"127.0.0.1","port":%s,"mismatchedHostAddress":"::1","username":"%s","deviceKeySeed":"%s","nodePath":"%s","acceptScriptPath":"%s","homePath":"%s","authorizedKeysPath":"%s","localStateRoot":"%s","remoteStateRoot":"%s"}' \
-    "$pairing_port" \
-    "$pairing_username" \
-    "$device_key_seed" \
-    "$pairing_node_path" \
-    "$pairing_accept_script" \
-    "$pairing_home" \
-    "$pairing_authorized_keys" \
-    "$pairing_state_root" \
-    "$pairing_state_root")
-pairing_fixture_configuration_base64=$(printf \
-    '%s' "$pairing_fixture_configuration" | base64)
 # A disjoint port block is necessary for two runs to coexist but not
 # sufficient: the fixture reaches the tests through `simctl launchctl setenv`,
 # which is per-device state. Two runs sharing one device overwrite each other's
@@ -1440,36 +1452,48 @@ pinned_lane_logs=()
 # HEELER_SSH_E2E_REQUIRED set a fixture-backed suite must fail rather than skip,
 # so a skip here means a condition that can still hide missing coverage.
 run_suite() {
-    local suite=$1
+    local lane=$1
     local expected_tests=$2
     local expected_suites=$3
     local expected_skips=${4:-0}
-    local log="$fixture_dir/$suite.log"
+    shift 4
+    local log="$fixture_dir/$lane.log"
     local noun="suite"
     local skips
+    local suite
+    local -a selectors=()
+
+    if [[ "$#" -eq 0 ]]; then
+        echo "$lane has no test selectors" >&2
+        exit 1
+    fi
+    for suite in "$@"; do
+        selectors+=("-only-testing:HeelerTests/$suite")
+    done
 
     if [[ "$expected_suites" != "1" ]]; then
         noun="suites"
     fi
-    run_xcodebuild "$suite" "$xcodebuild_test_timeout_seconds" \
+    run_xcodebuild "$lane" "$xcodebuild_test_timeout_seconds" \
         test-without-building \
         -project Heeler.xcodeproj \
         -scheme Heeler \
         -derivedDataPath "$app_derived_data_path" \
         -destination "$simulator_destination" \
         -collect-test-diagnostics never \
-        "-only-testing:HeelerTests/$suite" \
+        -parallel-testing-enabled NO \
+        "${selectors[@]}" \
         2>&1 | tee "$log"
 
     skips=$(grep -cE '(Test|Suite) .* skipped' "$log" || true)
     if [[ "$skips" != "$expected_skips" ]]; then
-        echo "$suite skipped $skips tests; exactly $expected_skips may skip" >&2
+        echo "$lane skipped $skips tests; exactly $expected_skips may skip" >&2
         exit 1
     fi
     if ! grep -q \
         "Test run with $expected_tests tests in $expected_suites $noun passed" \
         "$log"; then
-        echo "$suite did not execute all $expected_tests tests" >&2
+        echo "$lane did not execute all $expected_tests tests" >&2
         exit 1
     fi
     pinned_lane_logs+=("$log")
@@ -1564,6 +1588,7 @@ assert_full_lane_coverage() {
         "$skips skipped and all of them proven elsewhere." >&2
 }
 
+if [[ "$ci_lane" == "app" ]]; then
 # The direct-streamlocal suite asserts that a stale socket is still stale.
 # HeelerSSHTransportBehaviorE2ETests relinks that socket, so it must run after.
 # Swift Testing counts a skipped test in the run total, so only the permitted
@@ -1605,7 +1630,8 @@ push_simulator_environment \
 if [[ "$password_fixture_available" == "1" ]]; then
     start_password_sshd || exit 1
 fi
-run_suite HeelerSSHSessionE2ETests 13 1 "$session_skip_count"
+run_suite HeelerSSHSessionE2ETests 13 1 "$session_skip_count" \
+    HeelerSSHSessionE2ETests
 if [[ "$password_fixture_available" == "1" ]]; then
     if stop_privileged_sshd "$password_pid" "$password_pid_file"; then
         password_pid=""
@@ -1613,13 +1639,27 @@ if [[ "$password_fixture_available" == "1" ]]; then
         exit 1
     fi
 fi
-run_suite HeelerSSHPTYE2ETests 3 1
-run_suite HeelerSSHDirectStreamLocalE2ETests 9 1
-run_suite HeelerSSHJumpHostGateE2ETests 8 1
-run_suite HeelerSSHTransportBehaviorE2ETests 53 1
-run_suite ImageStagingE2ETests 8 1
-run_suite WeakNetworkE2ETests 8 1
-run_suite PairingCeremonyE2ETests 11 1
+run_suite HeelerSSHDirectStreamLocalE2ETests 9 1 0 \
+    HeelerSSHDirectStreamLocalE2ETests
+run_suite SharedFixtureE2ETests 91 6 0 \
+    HeelerSSHPTYE2ETests \
+    HeelerSSHJumpHostGateE2ETests \
+    HeelerSSHTransportBehaviorE2ETests \
+    ImageStagingE2ETests \
+    WeakNetworkE2ETests \
+    PairingCeremonyE2ETests
+
+# Named behaviour assertions still identify their owning suite. Point those
+# logical names at the one serialized lane log rather than duplicating it.
+for suite in \
+    HeelerSSHPTYE2ETests \
+    HeelerSSHJumpHostGateE2ETests \
+    HeelerSSHTransportBehaviorE2ETests \
+    ImageStagingE2ETests \
+    WeakNetworkE2ETests \
+    PairingCeremonyE2ETests; do
+    ln -s "SharedFixtureE2ETests.log" "$fixture_dir/$suite.log"
+done
 
 if [[ "$password_fixture_available" == "1" ]]; then
     assert_behavior "real Password" HeelerSSHSessionE2ETests \
@@ -1727,6 +1767,15 @@ assert_behavior "weak-network descriptor reclamation" WeakNetworkE2ETests \
 assert_behavior "disconnect is reported" WeakNetworkE2ETests \
     '"a severed link makes the transport report itself disconnected"'
 
+else
+    xcrun simctl bootstatus "$simulator_udid" -b
+fi
+
+if [[ "$ci_lane" == "app" ]]; then
+    clear_simulator_environment
+fi
+
+if [[ "$ci_lane" == "package" ]]; then
 push_simulator_environment \
     HEELER_SSH_E2E_REQUIRED \
     HEELER_SSH_E2E_HOST \
@@ -1838,7 +1887,8 @@ if grep -q 'Suite "Session driver resource e2e" skipped' "$package_e2e_log" \
     echo "The mandatory HeelerSSH package suites did not execute all forty-three tests" >&2
     exit 1
 fi
-pinned_lane_logs+=("$package_e2e_log")
+exit 0
+fi
 
 # The full lane runs with no fixture configured, so every fixture-backed suite
 # must skip — hence the clear above. The gate is still in force, though, and

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -1616,7 +1616,7 @@ fi
 run_suite HeelerSSHPTYE2ETests 3 1
 run_suite HeelerSSHDirectStreamLocalE2ETests 11 1
 run_suite HeelerSSHJumpHostGateE2ETests 9 1
-run_suite HeelerSSHTransportBehaviorE2ETests 50 1
+run_suite HeelerSSHTransportBehaviorE2ETests 53 1
 run_suite ImageStagingE2ETests 8 1
 run_suite WeakNetworkE2ETests 8 1
 run_suite PairingCeremonyE2ETests 11 1
@@ -1673,13 +1673,25 @@ assert_behavior "session API rejection mapping" HeelerSSHTransportBehaviorE2ETes
 # between a refactor and silently dropping a documented server behaviour (#128).
 assert_behavior "agent_pane_busy retry" HeelerSSHTransportBehaviorE2ETests \
     '"agent start waits out a fresh pane'"'"'s booting shell"'
-# Both compensations, named separately: they clean up different Host state and
-# a count alone cannot tell which of the two a change removed.
+# Each compensation cleans up different Host state; a count alone cannot tell
+# which of them a change removed. New Workspace (#230) also names the
+# create-then-start shape and the ambiguous-failure preserve rule, because
+# those are the two ways that path can silently drift without changing the
+# suite total.
 assert_behavior "failed launch closes its pane" HeelerSSHTransportBehaviorE2ETests \
     '"a refused agent start closes the pane it created"'
 assert_behavior "failed launch removes its worktree" \
     HeelerSSHTransportBehaviorE2ETests \
     '"a refused worktree agent start removes the worktree it created"'
+assert_behavior "new-workspace launch skips tab.create" \
+    HeelerSSHTransportBehaviorE2ETests \
+    '"a new-workspace agent start creates the workspace then starts in its root pane"'
+assert_behavior "failed launch closes its workspace" \
+    HeelerSSHTransportBehaviorE2ETests \
+    '"a refused new-workspace agent start closes the workspace it created"'
+assert_behavior "ambiguous launch preserves its workspace" \
+    HeelerSSHTransportBehaviorE2ETests \
+    '"an ambiguous new-workspace agent start does not close the workspace"'
 assert_behavior "SFTP" ImageStagingE2ETests \
     'directStagingStreamsPrivateFileAndAtomicallyRenamesThePart()'
 assert_behavior "forwarding denial" HeelerSSHDirectStreamLocalE2ETests \

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -1615,7 +1615,7 @@ if [[ "$password_fixture_available" == "1" ]]; then
 fi
 run_suite HeelerSSHPTYE2ETests 3 1
 run_suite HeelerSSHDirectStreamLocalE2ETests 10 1
-run_suite HeelerSSHJumpHostGateE2ETests 9 1
+run_suite HeelerSSHJumpHostGateE2ETests 8 1
 run_suite HeelerSSHTransportBehaviorE2ETests 53 1
 run_suite ImageStagingE2ETests 8 1
 run_suite WeakNetworkE2ETests 8 1

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -1614,7 +1614,7 @@ if [[ "$password_fixture_available" == "1" ]]; then
     fi
 fi
 run_suite HeelerSSHPTYE2ETests 3 1
-run_suite HeelerSSHDirectStreamLocalE2ETests 11 1
+run_suite HeelerSSHDirectStreamLocalE2ETests 10 1
 run_suite HeelerSSHJumpHostGateE2ETests 9 1
 run_suite HeelerSSHTransportBehaviorE2ETests 53 1
 run_suite ImageStagingE2ETests 8 1
@@ -1703,8 +1703,6 @@ assert_behavior "forwarding denial surviving a failed wake" \
     '"a failed wake does not narrow a forwarding denial"'
 assert_behavior "cancellation" HeelerSSHDirectStreamLocalE2ETests \
     '"cancellation closes only its channel and preserves connection reuse"'
-assert_behavior "timeout" HeelerSSHDirectStreamLocalE2ETests \
-    '"timeout closes only its channel and preserves connection reuse"'
 assert_behavior "teardown" HeelerSSHSessionE2ETests \
     '"clean channel close leaves the connection reusable"'
 

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -1614,7 +1614,7 @@ if [[ "$password_fixture_available" == "1" ]]; then
     fi
 fi
 run_suite HeelerSSHPTYE2ETests 3 1
-run_suite HeelerSSHDirectStreamLocalE2ETests 10 1
+run_suite HeelerSSHDirectStreamLocalE2ETests 9 1
 run_suite HeelerSSHJumpHostGateE2ETests 8 1
 run_suite HeelerSSHTransportBehaviorE2ETests 53 1
 run_suite ImageStagingE2ETests 8 1
@@ -1636,8 +1636,6 @@ assert_behavior "two-hop trust" HeelerSSHJumpHostGateE2ETests \
 # down in order. Folded into the trust assertion it was invisible to rename.
 assert_behavior "Jump Host product path" HeelerSSHJumpHostGateE2ETests \
     '"protocol 17 ping traverses independent SSH hops"'
-assert_behavior "RPC" HeelerSSHDirectStreamLocalE2ETests \
-    '"Transport ping validates protocol 17 and opens a fresh channel"'
 assert_behavior "Events" HeelerSSHTransportBehaviorE2ETests \
     '"direct Host Events preserve framing, concurrency, and slot reuse"'
 assert_behavior "PTY" HeelerSSHPTYE2ETests \

--- a/scripts/test-run-ci-ios-tests-guards.sh
+++ b/scripts/test-run-ci-ios-tests-guards.sh
@@ -98,6 +98,26 @@ extract_shipped_function clear_simulator_environment
 extract_shipped_function stop_privileged_sshd
 extract_shipped_function release_resource_lock
 
+# The optimized gate has exactly three app fixture invocations. The package
+# suite runs in its own workflow job, so putting it back into the app lane or
+# silently expanding the fixture invocations must make this harness fail.
+app_fixture_lane_count=$(grep -c '^run_suite ' "$gate_script")
+[[ "$app_fixture_lane_count" == 3 ]] \
+    || die "gate has $app_fixture_lane_count app fixture lanes, expected 3"
+grep -qF 'if [[ "$ci_lane" == "package" ]]; then' "$gate_script" \
+    || die "gate has no isolated package lane"
+grep -qF 'HEELER_CI_LANE: package' "$repo_root/.github/workflows/ci.yml" \
+    || die "workflow has no package-only job"
+grep -qF 'HEELER_CI_LANE: app' "$repo_root/.github/workflows/ci.yml" \
+    || die "workflow does not pin the app-only job"
+awk '
+    /if \[\[ "\$ci_lane" == "app" \]\]; then/ { in_app_lane = 1; next }
+    in_app_lane && /clear_simulator_environment/ { cleared = 1 }
+    in_app_lane && /^fi$/ { in_app_lane = 0 }
+    END { exit cleared ? 0 : 1 }
+' "$gate_script" \
+    || die "app lane does not clear fixture environment before the full test lane"
+
 # cleanup reads these ownership slots even when a case never claimed a
 # resource. The real gate initializes them before installing its trap; the
 # extracted function needs the same empty starting state. Only the extracted
@@ -197,6 +217,14 @@ new_case() {
     rm -rf "$dir"
     mkdir -p "$dir"
     cp "$work/lanes/"*.log "$dir/"
+    cat \
+        "$dir/HeelerSSHPTYE2ETests.log" \
+        "$dir/HeelerSSHJumpHostGateE2ETests.log" \
+        "$dir/HeelerSSHTransportBehaviorE2ETests.log" \
+        "$dir/ImageStagingE2ETests.log" \
+        "$dir/WeakNetworkE2ETests.log" \
+        "$dir/PairingCeremonyE2ETests.log" \
+        > "$dir/SharedFixtureE2ETests.log"
     printf '%s' "$dir"
 }
 
@@ -230,11 +258,11 @@ run_case() {
         fixture_dir="$case_dir"
         # shellcheck disable=SC2034
         password_fixture_available="$case_password_fixture"
-        pinned_lane_logs=()
-        for lane in "${lane_names[@]}"; do
-            [[ "$lane" == full-lane ]] && continue
-            pinned_lane_logs+=("$case_dir/$lane.log")
-        done
+        pinned_lane_logs=(
+            "$case_dir/HeelerSSHSessionE2ETests.log"
+            "$case_dir/HeelerSSHDirectStreamLocalE2ETests.log"
+            "$case_dir/SharedFixtureE2ETests.log"
+        )
         # The guards signal failure with `exit`, which would take this capture
         # subshell down with them and leave no status to read. Nesting one more
         # subshell keeps the status observable, so a red case is recorded as the
@@ -382,7 +410,7 @@ run_case pass '' "added tests do not require editing the gate" "$case_dir" \
 echo
 echo "== a full-lane skip loses the lane that proved it =="
 case_dir=$(new_case unproven-skip)
-/usr/bin/python3 - "$case_dir/HeelerSSHPTYE2ETests.log" <<'PY'
+/usr/bin/python3 - "$case_dir/SharedFixtureE2ETests.log" <<'PY'
 import sys
 
 path = sys.argv[1]
@@ -464,7 +492,7 @@ run_case pass '' "with it absent, exactly those two are exempt" "$case_dir" \
     assert_full_lane_coverage "$case_dir/full-lane.log" "$gate_executed_floor"
 
 case_dir=$(new_case exemption-cannot-widen)
-/usr/bin/python3 - "$case_dir/HeelerSSHTransportBehaviorE2ETests.log" <<'PY'
+/usr/bin/python3 - "$case_dir/SharedFixtureE2ETests.log" <<'PY'
 import sys
 
 path = sys.argv[1]
@@ -551,16 +579,16 @@ run_suite_case() {
 # nothing to reason from. This is the case that dies if the append is removed.
 run_suite_case pass "PINNED_LAST=$work/cases" \
     "a passing lane is recorded as evidence" HeelerSSHPTYE2ETests \
-    HeelerSSHPTYE2ETests 3 1
+    HeelerSSHPTYE2ETests 3 1 0 HeelerSSHPTYE2ETests
 
 # And run_suite's own guards, which were equally untested: a lane whose executed
 # count moved, and a lane that skipped where no skip was budgeted.
 run_suite_case fail "did not execute all 4 tests" \
     "a lane with the wrong executed count is refused" HeelerSSHPTYE2ETests \
-    HeelerSSHPTYE2ETests 4 1
+    HeelerSSHPTYE2ETests 4 1 0 HeelerSSHPTYE2ETests
 run_suite_case fail "skipped 2 tests; exactly 0 may skip" \
     "an unbudgeted skip is refused" HeelerSSHSessionE2ETests \
-    HeelerSSHSessionE2ETests 14 1
+    HeelerSSHSessionE2ETests 14 1 0 HeelerSSHSessionE2ETests
 
 echo
 echo "== privileged sshd stop is bounded before preserving evidence =="


### PR DESCRIPTION
## Summary

- add Existing Workspace and New Workspace launch targets to the global New Agent flow
- create a herdr Workspace from a required remote directory and optional label, then start the Agent in its returned root pane without an extra `tab.create`
- clean up a newly created Workspace after a definitive launch rejection while preserving it after an ambiguous transport failure
- generate and test the `workspace.create` wire surface and pin its real-SSH behavior in the merge gate

## Validation

- `make test` on stacked successor `68ae300`: 1196 app tests passed; HeelerSSH package tests passed with fixture-gated tests skipped as designed
- `scripts/run-ci-ios-tests.sh` on stacked successor `68ae300`: exit 0; disposable-sshd lanes, HeelerSSH package E2E, and the full app lane passed
- generated project and wire-type drift checks passed through the repository test entry points

Closes #230
