### PR TITLE
Show Host connection telemetry in Agent Detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ Entries reference the issue that motivated them.
 - Agent detail shows the Host's latest connection latency next to Agent
   status, rounded exactly as the Hosts sheet rounds it. It measures the Host's
   API connection over SSH, not the Agent's response time, and disappears
-  whenever the current connection has no measurement of its own. (#236)
+  whenever the current connection has no measurement of its own. The status
+  row it joins now follows the terminal theme's luminance instead of the
+  system appearance, so both labels stay legible on a dark theme under a
+  light system and vice versa. (#236)
 
 - Agent detail's More menu gains Open Terminal: it creates a new herdr tab in
   the Agent's launch directory and opens its shell as a fully interactive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Entries reference the issue that motivated them.
 
 ### Added
 
+- Agent detail shows the Host's latest connection latency next to Agent
+  status, rounded exactly as the Hosts sheet rounds it. It measures the Host's
+  API connection over SSH, not the Agent's response time, and disappears
+  whenever the current connection has no measurement of its own. (#236)
+
 - Agent detail's More menu gains Open Terminal: it creates a new herdr tab in
   the Agent's launch directory and opens its shell as a fully interactive
   Shell Terminal. Back detaches and leaves the remote tab alive for desktop

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		24075F825EA192C037A09507 /* SnippetsManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB430B706185A38891A5DAC2 /* SnippetsManagementView.swift */; };
 		247E069905D31490FEF889CE /* ComposerStagingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D23517AF3A39615725A0ADC /* ComposerStagingStore.swift */; };
 		24B38E6323258B77CF7E17B8 /* NotificationPreferencesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C87F6E13D72316E56DC0C571 /* NotificationPreferencesStore.swift */; };
+		25AE0EAE56CE592F547BE1F2 /* HostLatencyFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = E088B83BDB55BAFA2D41450F /* HostLatencyFormatting.swift */; };
 		268E43B24D46A51173DB8349 /* HostFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EF900D8EF7982B54965402 /* HostFormView.swift */; };
 		28155122AFE694FA3D41F172 /* ImageStagingE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A8ED9AD5019F303932B0F9C /* ImageStagingE2ETests.swift */; };
 		289D5FF53D330E3C7CA81707 /* TerminalScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847A1406F4AAEBF2F1EDFA1F /* TerminalScreenView.swift */; };
@@ -108,6 +109,7 @@
 		5789049E3BA965EB057C4577 /* FilePreparerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C833B5BA50276247A54258B /* FilePreparerTests.swift */; };
 		58D1F69AF9167C13A9E0EAB9 /* NotificationEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61A04DBA56C56925B594FF1 /* NotificationEnvelope.swift */; };
 		58EE685D5F9C4B21D4B4DC0E /* FakeLiveActivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856A8398D8F0FB87F252D193 /* FakeLiveActivityController.swift */; };
+		59BBACE18DAE1754D2B75441 /* HostTelemetryPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CAC72199BF308E484F37439 /* HostTelemetryPresentation.swift */; };
 		5B0522DF97BC46599DDE4E93 /* TransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A41E40939438986DE30402 /* TransportConnector.swift */; };
 		5B137E763FFACD1AFE5C7E30 /* AgentNotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7EC7BEC9AACD2DAF634B2C /* AgentNotificationRouter.swift */; };
 		5C68C3082AD5958A28843055 /* TerminalTitleGlyphs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651D511E8A282C4CB0214098 /* TerminalTitleGlyphs.swift */; };
@@ -160,6 +162,7 @@
 		804C5B2318FD3F57703BA226 /* AgentStatusPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B853441AF972F5F05ADA67 /* AgentStatusPaletteTests.swift */; };
 		80E28FB88E27A5A8FA516BAA /* IBMPlexMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 48F025CF6E2C3068BF911290 /* IBMPlexMono-Regular.ttf */; };
 		81E0207D8AA28513FEA755B0 /* SkillsPaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9156B9BB51E7A5AD1792D9 /* SkillsPaneStore.swift */; };
+		81F92E9FF8783F2B473DAE5A /* HostTelemetryPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2FDB99BA76C2379B0590B3B /* HostTelemetryPresentationTests.swift */; };
 		82600FB64A99ADAD1C60D451 /* PairingCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D419158B027AF5F38B73AD8B /* PairingCodeTests.swift */; };
 		836C6CE781A0FE57FBA87727 /* JSONValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F261A0911D08819AFC013F1E /* JSONValueTests.swift */; };
 		83AAFC996DF32402681F38AB /* HostDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A63EFEB7D00E59949CF331 /* HostDraft.swift */; };
@@ -467,6 +470,7 @@
 		696C6905D9D6EEFF77A64E2E /* FakeTransportConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeTransportConnector.swift; sourceTree = "<group>"; };
 		69EBBC2C99AA84420FDF600A /* AgentActivityEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentActivityEnvelope.swift; sourceTree = "<group>"; };
 		6A9156B9BB51E7A5AD1792D9 /* SkillsPaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsPaneStore.swift; sourceTree = "<group>"; };
+		6CAC72199BF308E484F37439 /* HostTelemetryPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostTelemetryPresentation.swift; sourceTree = "<group>"; };
 		6D83F0739372AE699009E238 /* ConsoleAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleAgent.swift; sourceTree = "<group>"; };
 		6FF0DA87C092E176838C1EF7 /* IBMPlexMono-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "IBMPlexMono-Bold.ttf"; sourceTree = "<group>"; };
 		702DF66CBA3DE023470DBA1F /* PairingCeremonyE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCeremonyE2ETests.swift; sourceTree = "<group>"; };
@@ -534,6 +538,7 @@
 		A14FB8560976CE777FB5A105 /* ConsoleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleStore.swift; sourceTree = "<group>"; };
 		A1E30B96F852EFC3C322C9EB /* TerminalInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalInputController.swift; sourceTree = "<group>"; };
 		A2CED0240EA91B680CF3A758 /* TerminalZoomSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalZoomSettings.swift; sourceTree = "<group>"; };
+		A2FDB99BA76C2379B0590B3B /* HostTelemetryPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostTelemetryPresentationTests.swift; sourceTree = "<group>"; };
 		A30FA0CFA49274EB428AD3E0 /* HerdrWireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWireTests.swift; sourceTree = "<group>"; };
 		A4B83DAB243F0D4C697FA3B8 /* LiveActivityControlling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityControlling.swift; sourceTree = "<group>"; };
 		A579E1DA3F59AFBC3ECAD69C /* SSHChannelAdmissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHChannelAdmissionTests.swift; sourceTree = "<group>"; };
@@ -603,6 +608,7 @@
 		DD7EC7BEC9AACD2DAF634B2C /* AgentNotificationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationRouter.swift; sourceTree = "<group>"; };
 		DD8509C4FD5C50A0D7AFEC1A /* TerminalAgentSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAgentSwitcher.swift; sourceTree = "<group>"; };
 		DEABDC4E573B0F9EA67F64F1 /* HostListViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostListViewTests.swift; sourceTree = "<group>"; };
+		E088B83BDB55BAFA2D41450F /* HostLatencyFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostLatencyFormatting.swift; sourceTree = "<group>"; };
 		E0B72AE2059C59D8A59C9B2A /* AppActivityCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivityCoordinator.swift; sourceTree = "<group>"; };
 		E4F4EF125BAB77F0DE121AAB /* DeviceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKey.swift; sourceTree = "<group>"; };
 		E70C49925D454207F859F897 /* HeelerSSHHostKeyPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHHostKeyPolicyTests.swift; sourceTree = "<group>"; };
@@ -724,6 +730,7 @@
 				67D6865847B4D827038D1AF0 /* HostOnboardingPresentationTests.swift */,
 				4D961656A6D8B4F3964740BD /* HostOnboardingStoreTests.swift */,
 				0443F1688BCEC3474F278889 /* HostStoreTests.swift */,
+				A2FDB99BA76C2379B0590B3B /* HostTelemetryPresentationTests.swift */,
 				C4889F56EFEFCC5004A55B4C /* ImagePreparerTests.swift */,
 				7A8ED9AD5019F303932B0F9C /* ImageStagingE2ETests.swift */,
 				64B0C3E8DD054078EF85AB5A /* ImageStagingTests.swift */,
@@ -863,6 +870,7 @@
 				0DBBD602AA4969937A9306C3 /* HostCredentialsProvider.swift */,
 				F3A63EFEB7D00E59949CF331 /* HostDraft.swift */,
 				33EF900D8EF7982B54965402 /* HostFormView.swift */,
+				E088B83BDB55BAFA2D41450F /* HostLatencyFormatting.swift */,
 				79662827F6A91D8EFBF112F7 /* HostListView.swift */,
 				1E9D993852C5C7BFE8515A46 /* HostOnboardingStore.swift */,
 				7FC1C5701C464ADBBAE0525D /* HostOnboardingView.swift */,
@@ -922,6 +930,7 @@
 				C74A32020C9520EB5629B071 /* ConsoleView.swift */,
 				2D6996CA1550E32EE6AC3669 /* GitBranchName.swift */,
 				88E1434C9C39A6419A3A0D79 /* HostConsoleProjection.swift */,
+				6CAC72199BF308E484F37439 /* HostTelemetryPresentation.swift */,
 				B2437B1D6B97638031514C0F /* PinnedAgentsStore.swift */,
 				C7BD377C8BB7AA8205DD8AFC /* RecentWorkspaceStore.swift */,
 				C82C6169E59B0000AA3FF5CC /* RenameSheetView.swift */,
@@ -1445,11 +1454,13 @@
 				268E43B24D46A51173DB8349 /* HostFormView.swift in Sources */,
 				88C55182255106627222F533 /* HostKeyFingerprint.swift in Sources */,
 				B7EFF1362120B2CD74A0F910 /* HostKeyPolicy.swift in Sources */,
+				25AE0EAE56CE592F547BE1F2 /* HostLatencyFormatting.swift in Sources */,
 				A2DE15E21439EDC3B04F5DFA /* HostListView.swift in Sources */,
 				F0A8E77693C3508A42EBF75F /* HostLiveActivityCoordinator.swift in Sources */,
 				B71854386F1CF79B863F15FE /* HostOnboardingStore.swift in Sources */,
 				D868123FC703E505D48AFD85 /* HostOnboardingView.swift in Sources */,
 				F1942670E29F7B340860DC8D /* HostStore.swift in Sources */,
+				59BBACE18DAE1754D2B75441 /* HostTelemetryPresentation.swift in Sources */,
 				EA83373CB743395BF9FF0689 /* ImagePreparer.swift in Sources */,
 				D8742E32B3BA3A76771BC2B7 /* JSONValue.swift in Sources */,
 				A20CC86A7DC41BD651647882 /* KnownHostsStore.swift in Sources */,
@@ -1609,6 +1620,7 @@
 				388498BDF8F2848EA515819B /* HostOnboardingPresentationTests.swift in Sources */,
 				D6620368048468EFA09B4142 /* HostOnboardingStoreTests.swift in Sources */,
 				519B9551A9C12FB14C8349FD /* HostStoreTests.swift in Sources */,
+				81F92E9FF8783F2B473DAE5A /* HostTelemetryPresentationTests.swift in Sources */,
 				1EDDD0227C94C6B7C2586A68 /* ImagePreparerTests.swift in Sources */,
 				28155122AFE694FA3D41F172 /* ImageStagingE2ETests.swift in Sources */,
 				A04812B36F6E9AF3F683AB50 /* ImageStagingTests.swift in Sources */,

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 		F96B2A54E2C6FF38CF5407BA /* DemoScreenshotModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFE51A74497E9691DBD8D7D /* DemoScreenshotModeTests.swift */; };
 		FA19EF5420E1D4FFFEF78155 /* TerminalStatusDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DAC3DCDEF81B14A2019DDBE /* TerminalStatusDialog.swift */; };
 		FB3A2B881CE2C93601F1A90F /* SkillFrontmatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB3A0C20671F436B322D0F3 /* SkillFrontmatter.swift */; };
+		FBC2F27922BF5A627A27C339 /* EventsSessionLatencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F565A5BE8CC4ABA3FA10D57 /* EventsSessionLatencyTests.swift */; };
 		FC3565466275E3A63ED59687 /* PairingCeremony.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CA687285B470E3968D1DB6 /* PairingCeremony.swift */; };
 		FCC374190EE36E254109D6AD /* HerdrHostPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB90BB1A82BAAD178E1258F3 /* HerdrHostPathTests.swift */; };
 		FCCE1492C64201FF221B64A3 /* AgentActivityEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69EBBC2C99AA84420FDF600A /* AgentActivityEnvelope.swift */; };
@@ -401,6 +402,7 @@
 		29723E2E7A65ABAF27698733 /* AgentActivityContentBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentActivityContentBuilder.swift; sourceTree = "<group>"; };
 		297D9D4C1F200A21A2A0AA64 /* NotificationRegistrationFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRegistrationFileTests.swift; sourceTree = "<group>"; };
 		2D6996CA1550E32EE6AC3669 /* GitBranchName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitBranchName.swift; sourceTree = "<group>"; };
+		2F565A5BE8CC4ABA3FA10D57 /* EventsSessionLatencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionLatencyTests.swift; sourceTree = "<group>"; };
 		31B3368D352EFC805C2534F9 /* RealSSHFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealSSHFixture.swift; sourceTree = "<group>"; };
 		31F09325DE68693680E5A3BB /* HerdrSocketLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrSocketLocationTests.swift; sourceTree = "<group>"; };
 		321E267EE49BFE4A60F3B7CB /* FilePreparer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreparer.swift; sourceTree = "<group>"; };
@@ -709,6 +711,7 @@
 				016BA41A48C6D6CCCEB10A47 /* DeviceKeyTests.swift */,
 				FE302F516B139F4BADCEC6CB /* EventsSessionBufferingTests.swift */,
 				823B2239BDC425FCE456B625 /* EventsSessionKeepaliveTests.swift */,
+				2F565A5BE8CC4ABA3FA10D57 /* EventsSessionLatencyTests.swift */,
 				39AD641EA732307D72698216 /* EventsSessionSubscriptionsTests.swift */,
 				0C833B5BA50276247A54258B /* FilePreparerTests.swift */,
 				D5C058D102046A707547A0FD /* GeneratedWireTypesTests.swift */,
@@ -1595,6 +1598,7 @@
 				C30EE891E4215D9F2D3B7821 /* DeviceKeyTests.swift in Sources */,
 				4934C8086D2B27A7F07391E5 /* EventsSessionBufferingTests.swift in Sources */,
 				DA9ABDB7E506248091ACF17E /* EventsSessionKeepaliveTests.swift in Sources */,
+				FBC2F27922BF5A627A27C339 /* EventsSessionLatencyTests.swift in Sources */,
 				FEC497C4A95E5F4D945EF3BA /* EventsSessionSubscriptionsTests.swift in Sources */,
 				58EE685D5F9C4B21D4B4DC0E /* FakeLiveActivityController.swift in Sources */,
 				E7CE4737CFB94163D9EEC8F2 /* FakePairingConnector.swift in Sources */,

--- a/Sources/Heeler/Console/AgentComposerView.swift
+++ b/Sources/Heeler/Console/AgentComposerView.swift
@@ -78,6 +78,9 @@ struct AgentComposerLinkPresentation: Equatable {
 struct AgentComposerView: View {
     let store: AgentComposerStore
     let status: AgentStatus
+    /// Read-only projection of the Host's own connection telemetry; nil
+    /// whenever there is nothing proven to show.
+    let hostTelemetry: HostTelemetryPresentation?
     let switcher: TerminalAgentSwitcher
     let keyboardHandoff: TerminalKeyboardHandoff
     let keyboardHeight: CGFloat
@@ -93,8 +96,14 @@ struct AgentComposerView: View {
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 6) {
-                statusLabel
-                    .padding(.horizontal, 16)
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    statusLabel
+                    Spacer(minLength: 8)
+                    if let hostTelemetry {
+                        hostTelemetryLabel(hostTelemetry)
+                    }
+                }
+                .padding(.horizontal, 16)
 
                 VStack(spacing: 0) {
                     VStack(alignment: .leading, spacing: 8) {
@@ -377,6 +386,21 @@ struct AgentComposerView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Agent status")
         .accessibilityValue(status.rawValue.capitalized)
+    }
+
+    /// Deliberately quieter than Agent Status: it never changes color with the
+    /// value and never animates, so a number that moves on its own cadence
+    /// cannot pull attention away from the Agent the user came here for.
+    private func hostTelemetryLabel(
+        _ telemetry: HostTelemetryPresentation
+    ) -> some View {
+        Text(telemetry.title)
+            .font(.caption2)
+            .monospacedDigit()
+            .foregroundStyle(.tertiary)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(telemetry.accessibilityLabel)
+            .accessibilityValue(telemetry.accessibilityValue)
     }
 }
 

--- a/Sources/Heeler/Console/AgentComposerView.swift
+++ b/Sources/Heeler/Console/AgentComposerView.swift
@@ -404,7 +404,11 @@ struct AgentComposerView: View {
         Text(telemetry.title)
             .font(.caption2)
             .monospacedDigit()
-            .foregroundStyle(.tertiary)
+            // One step brighter on dark themes: tertiary gray recedes into a
+            // near-black surface faster than it does into a light one.
+            .foregroundStyle(
+                chromeColorScheme == .dark
+                    ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tertiary))
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(telemetry.accessibilityLabel)
             .accessibilityValue(telemetry.accessibilityValue)

--- a/Sources/Heeler/Console/AgentComposerView.swift
+++ b/Sources/Heeler/Console/AgentComposerView.swift
@@ -81,6 +81,12 @@ struct AgentComposerView: View {
     /// Read-only projection of the Host's own connection telemetry; nil
     /// whenever there is nothing proven to show.
     let hostTelemetry: HostTelemetryPresentation?
+    /// The terminal theme's luminance, not the system appearance. The status
+    /// row sits directly on the themed terminal surface, so hierarchical
+    /// styles and the status inks must resolve against that background — a
+    /// dark theme under a light system otherwise renders light-mode grays
+    /// into near-black and the row disappears.
+    let chromeColorScheme: ColorScheme
     let switcher: TerminalAgentSwitcher
     let keyboardHandoff: TerminalKeyboardHandoff
     let keyboardHeight: CGFloat
@@ -104,6 +110,7 @@ struct AgentComposerView: View {
                     }
                 }
                 .padding(.horizontal, 16)
+                .environment(\.colorScheme, chromeColorScheme)
 
                 VStack(spacing: 0) {
                     VStack(alignment: .leading, spacing: 8) {

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -372,6 +372,15 @@ struct AgentTerminalView: View {
         }
     }
 
+    /// Read inside the view body so it follows `ConsoleStore`'s observation:
+    /// a fresh keepalive measurement re-renders this row and nothing else.
+    /// No request of its own — the Host's connection measured this already.
+    private var hostTelemetry: HostTelemetryPresentation? {
+        HostTelemetryPresentation(
+            status: console.hostStatuses[agent.hostID],
+            latency: console.hostLatencies[agent.hostID])
+    }
+
     private var composerKeyboardLayout: AgentComposerKeyboardLayout {
         AgentComposerKeyboardLayout(
             currentHeight: keyboardInset.height,
@@ -443,6 +452,7 @@ struct AgentTerminalView: View {
             AgentComposerView(
                 store: composer,
                 status: agent.agent.status,
+                hostTelemetry: hostTelemetry,
                 switcher: agentSwitcher,
                 keyboardHandoff: keyboardHandoff,
                 keyboardHeight: composerKeyboardLayout.availableToolsHeight,

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -453,6 +453,8 @@ struct AgentTerminalView: View {
                 store: composer,
                 status: agent.agent.status,
                 hostTelemetry: hostTelemetry,
+                chromeColorScheme: terminal.themes.selection(for: colorScheme)
+                    .chromeColorScheme(for: colorScheme),
                 switcher: agentSwitcher,
                 keyboardHandoff: keyboardHandoff,
                 keyboardHeight: composerKeyboardLayout.availableToolsHeight,

--- a/Sources/Heeler/Console/HostConsoleProjection.swift
+++ b/Sources/Heeler/Console/HostConsoleProjection.swift
@@ -17,7 +17,7 @@ final class HostConsoleProjection {
     /// See Standing Failure in `CONTEXT.md`.
     private(set) var standingFailure: TransportError?
     /// The last herdr `ping` round trip measured on the Host's *current*
-    /// connection. Cleared the moment the session leaves `.connected`, so a
+    /// connection, mirrored from `EventsSession.currentLatency` so a
     /// measurement never outlives the connection that proved it.
     private(set) var latency: Duration?
     private(set) var syncError: String?
@@ -96,11 +96,16 @@ final class HostConsoleProjection {
                 self.handle(update)
             }
         }
+        // The stream is only the wake-up: `latencyUpdates` and `updates` are
+        // consumed by two tasks whose order against each other is undefined,
+        // so the sample it carries could be one this Host's connection no
+        // longer stands behind. `session.currentLatency` is the value ordered
+        // against the status updates the other task folds.
         latencyTask = Task { [weak self] in
             guard let self else { return }
-            for await latency in session.latencyUpdates {
+            for await _ in session.latencyUpdates {
                 guard !Task.isCancelled else { return }
-                self.latency = latency
+                self.latency = session.currentLatency
                 self.publish()
             }
         }
@@ -164,6 +169,10 @@ final class HostConsoleProjection {
     /// Makes the new activation visible on this projection before the
     /// session hops into teardown, so an in-flight resync cannot observe
     /// `.connected` after `currentTransport` is already gone.
+    ///
+    /// The latency is dropped outright rather than re-read from the session:
+    /// this decision is what ends the old connection, and the session has not
+    /// yet been asked to publish the status that clears its own copy.
     private func beginNewActivation() {
         status = .connecting
         latency = nil
@@ -450,6 +459,14 @@ final class HostConsoleProjection {
         switch update {
         case .status(let status):
             self.status = status
+            // A latency belongs to the connection that measured it, and the
+            // session clears this before publishing any status that ends one.
+            // Reading it here rather than tracking the latency stream's
+            // payload is what makes the pairing exact: a status that ends a
+            // connection can only ever be folded against nil, and the sample
+            // a new connection proved before announcing itself is already
+            // here when its `.connected` lands.
+            latency = session.currentLatency
             switch status {
             case .failed(let failure):
                 standingFailure = failure
@@ -474,11 +491,6 @@ final class HostConsoleProjection {
                 }
                 scheduleResync()
             } else {
-                // A latency belongs to the connection that measured it. Any
-                // other status means the Host is unproven, so every surface
-                // reading this projection stops showing a number rather than
-                // holding the last one across the gap.
-                latency = nil
                 invalidateSnapshot()
                 publish()
             }

--- a/Sources/Heeler/Console/HostConsoleProjection.swift
+++ b/Sources/Heeler/Console/HostConsoleProjection.swift
@@ -16,6 +16,9 @@ final class HostConsoleProjection {
     /// next activation begins and discarded when that activation resolves.
     /// See Standing Failure in `CONTEXT.md`.
     private(set) var standingFailure: TransportError?
+    /// The last herdr `ping` round trip measured on the Host's *current*
+    /// connection. Cleared the moment the session leaves `.connected`, so a
+    /// measurement never outlives the connection that proved it.
     private(set) var latency: Duration?
     private(set) var syncError: String?
     private(set) var transportGeneration: UInt64 = 0
@@ -163,6 +166,7 @@ final class HostConsoleProjection {
     /// `.connected` after `currentTransport` is already gone.
     private func beginNewActivation() {
         status = .connecting
+        latency = nil
         invalidateSnapshot()
         publish()
     }
@@ -470,6 +474,11 @@ final class HostConsoleProjection {
                 }
                 scheduleResync()
             } else {
+                // A latency belongs to the connection that measured it. Any
+                // other status means the Host is unproven, so every surface
+                // reading this projection stops showing a number rather than
+                // holding the last one across the gap.
+                latency = nil
                 invalidateSnapshot()
                 publish()
             }

--- a/Sources/Heeler/Console/HostTelemetryPresentation.swift
+++ b/Sources/Heeler/Console/HostTelemetryPresentation.swift
@@ -19,7 +19,10 @@ struct HostTelemetryPresentation: Equatable {
 
     init?(status: EventsSessionStatus?, latency: Duration?) {
         guard status == .connected, let latency else { return nil }
-        title = "Host · \(HostLatencyFormatting.formatted(latency))"
+        // Bare number: the accessibility label carries what it measures, and
+        // visually the trailing corner plus the Hosts sheet's identical figure
+        // are the context. A "Host" prefix read as noise in practice.
+        title = HostLatencyFormatting.formatted(latency)
         accessibilityValue = "\(HostLatencyFormatting.spoken(latency)) over SSH"
     }
 }

--- a/Sources/Heeler/Console/HostTelemetryPresentation.swift
+++ b/Sources/Heeler/Console/HostTelemetryPresentation.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Agent detail's Host telemetry label: the latest herdr `ping` round trip
+/// measured over this Host's live SSH connection — SSH plus the forwarded
+/// socket plus the herdr API. It is Host reachability, never the Agent's own
+/// response time.
+///
+/// Only a connected Host with a measurement on its current connection renders
+/// anything; every other combination fails initialization and the label simply
+/// disappears. The Hosts sheet chip and the Host recovery surfaces already
+/// narrate connection trouble, and a second, quieter voice repeating it here
+/// would only compete with them. Nothing is preferable to a stale number, and
+/// a placeholder zero would be a measurement the app never took.
+struct HostTelemetryPresentation: Equatable {
+    let title: String
+    let accessibilityValue: String
+
+    var accessibilityLabel: String { "Host API connection latency" }
+
+    init?(status: EventsSessionStatus?, latency: Duration?) {
+        guard status == .connected, let latency else { return nil }
+        title = "Host · \(HostLatencyFormatting.formatted(latency))"
+        accessibilityValue = "\(HostLatencyFormatting.spoken(latency)) over SSH"
+    }
+}

--- a/Sources/Heeler/Hosts/HostLatencyFormatting.swift
+++ b/Sources/Heeler/Hosts/HostLatencyFormatting.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// The one rounding rule for a Host's measured `ping` round trip. The Hosts
+/// sheet chip and Agent detail's telemetry label both render through it, so
+/// the same measurement can never read as two different numbers depending on
+/// which surface the user is looking at.
+enum HostLatencyFormatting {
+    /// Integer milliseconds, or `<1 ms` below the first one — an integer
+    /// there would round to a zero the measurement does not support.
+    static func formatted(_ latency: Duration) -> String {
+        guard let milliseconds = roundedMilliseconds(latency) else { return "<1 ms" }
+        return "\(milliseconds) ms"
+    }
+
+    /// The same value spelled for VoiceOver, which reads `ms` as letters.
+    static func spoken(_ latency: Duration) -> String {
+        guard let milliseconds = roundedMilliseconds(latency) else {
+            return "Less than 1 millisecond"
+        }
+        return "\(milliseconds) millisecond\(milliseconds == 1 ? "" : "s")"
+    }
+
+    /// Nil below one millisecond. A negative measurement — a clock that moved
+    /// under the sample — clamps to zero rather than rendering backwards.
+    private static func roundedMilliseconds(_ latency: Duration) -> Int? {
+        let components = latency.components
+        let milliseconds = max(
+            0,
+            Double(components.seconds) * 1_000
+                + Double(components.attoseconds) / 1_000_000_000_000_000)
+        guard milliseconds >= 1 else { return nil }
+        return Int(milliseconds.rounded())
+    }
+}

--- a/Sources/Heeler/Hosts/HostListView.swift
+++ b/Sources/Heeler/Hosts/HostListView.swift
@@ -311,7 +311,7 @@ struct HostConnectionPresentation: Equatable {
         switch status {
         case .connected:
             if let latency {
-                let formattedLatency = Self.formatted(latency)
+                let formattedLatency = HostLatencyFormatting.formatted(latency)
                 title = formattedLatency
                 accessibilityLabel = "Connected, latency \(formattedLatency)"
             } else {
@@ -346,16 +346,6 @@ struct HostConnectionPresentation: Equatable {
             accessibilityLabel = "Connecting"
             tone = .pending
         }
-    }
-
-    private static func formatted(_ latency: Duration) -> String {
-        let components = latency.components
-        let milliseconds = max(
-            0,
-            Double(components.seconds) * 1_000
-                + Double(components.attoseconds) / 1_000_000_000_000_000)
-        guard milliseconds >= 1 else { return "<1 ms" }
-        return "\(Int(milliseconds.rounded())) ms"
     }
 }
 

--- a/Sources/Heeler/Transport/EventsSession.swift
+++ b/Sources/Heeler/Transport/EventsSession.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Synchronization
 
 /// Bounded backoff for transient events-channel failures (#18): capped
 /// exponential delay, unlimited attempts. Action-required failures stop and
@@ -121,9 +122,26 @@ actor EventsSession {
     private let updatesContinuation: AsyncStream<EventsSessionUpdate>.Continuation
     /// Successful herdr ping round trips on the Host's live SSH connection.
     /// This is separate from `updates`: latency is latest-value telemetry, not
-    /// part of the ordered status/event convergence stream.
+    /// part of the ordered status/event convergence stream. It is a *signal* —
+    /// "a new measurement exists" — and carries the sample for callers that
+    /// only want the number. A consumer that also folds `updates` must read
+    /// `currentLatency` instead of this payload; see that property.
     nonisolated let latencyUpdates: AsyncStream<Duration>
     private let latencyContinuation: AsyncStream<Duration>.Continuation
+    /// The round trip the Host's *current* connection last proved, or nil
+    /// while no live connection has proved one.
+    ///
+    /// `updates` and `latencyUpdates` are separate streams with separate
+    /// consumers, so their consumption order establishes nothing: a delayed
+    /// sample from a dead connection could otherwise land after the status
+    /// that ended it. This value is instead written strictly before the update
+    /// that makes the same fact observable — set before the `.connected` that
+    /// follows a fresh ping, cleared before any non-connected status leaves
+    /// `yieldUpdate` — so folding an update and reading this in the same turn
+    /// yields a measurement that belongs to that update's own connection, at
+    /// whatever moment either stream is actually consumed.
+    nonisolated var currentLatency: Duration? { latencyBox.withLock { $0 } }
+    private nonisolated let latencyBox = Mutex<Duration?>(nil)
     /// How many updates the bounded buffer has shed so far. Every shed
     /// update is covered by a marker (see `yieldUpdate`), so this is
     /// observability for diagnostics and tests, not a consumer signal.
@@ -247,7 +265,7 @@ actor EventsSession {
         else { return }
         do {
             let latency = try await measureLatency(on: transport)
-            latencyContinuation.yield(latency)
+            publishLatency(latency)
             noteConnectionActivity()
         } catch is CancellationError {
         } catch TransportError.cancelled {
@@ -375,6 +393,12 @@ actor EventsSession {
     /// is later shed itself lands right back here and is re-armed (see
     /// `HerdrEvent.eventsDropped`).
     private func yieldUpdate(_ update: EventsSessionUpdate) {
+        // Ordered before the yield, so no consumer can observe a status that
+        // ends a connection while `currentLatency` still holds that
+        // connection's measurement.
+        if case .status(let status) = update, status != .connected {
+            latencyBox.withLock { $0 = nil }
+        }
         guard case .dropped = updatesContinuation.yield(update) else { return }
         droppedUpdateCount += 1
         if case .dropped = updatesContinuation.yield(.event(.eventsDropped)) {
@@ -546,7 +570,7 @@ actor EventsSession {
             guard activationIsCurrent(generation) else {
                 throw TransportError.cancelled
             }
-            latencyContinuation.yield(latency)
+            publishLatency(latency)
         } catch {
             try? await transport.close()
             throw error
@@ -624,7 +648,7 @@ actor EventsSession {
                 guard self.connectionIsIdle(within: keepalive.interval) else { continue }
                 do {
                     let latency = try await self.measureLatency(on: transport)
-                    self.latencyContinuation.yield(latency)
+                    self.publishLatency(latency)
                     self.noteConnectionActivity()
                 } catch is CancellationError {
                     break
@@ -645,6 +669,14 @@ actor EventsSession {
 
     private func noteConnectionActivity() {
         lastConnectionActivity = .now
+    }
+
+    /// The single gate every measurement leaves through: the connection-scoped
+    /// value first, then the signal. A consumer woken by the signal reads the
+    /// value it was woken for or a newer one, never an older one.
+    private func publishLatency(_ latency: Duration) {
+        latencyBox.withLock { $0 = latency }
+        latencyContinuation.yield(latency)
     }
 
     /// Measures only the herdr `ping` request on an established Transport.

--- a/Sources/Heeler/Transport/EventsSession.swift
+++ b/Sources/Heeler/Transport/EventsSession.swift
@@ -265,7 +265,7 @@ actor EventsSession {
         else { return }
         do {
             let latency = try await measureLatency(on: transport)
-            publishLatency(latency)
+            guard publishLatency(latency, measuredOn: stream) else { return }
             noteConnectionActivity()
         } catch is CancellationError {
         } catch TransportError.cancelled {
@@ -648,7 +648,10 @@ actor EventsSession {
                 guard self.connectionIsIdle(within: keepalive.interval) else { continue }
                 do {
                     let latency = try await self.measureLatency(on: transport)
-                    self.publishLatency(latency)
+                    // A ping answered after this channel was replaced also
+                    // means this loop is keeping a connection alive that the
+                    // session no longer has.
+                    guard self.publishLatency(latency, measuredOn: stream) else { break }
                     self.noteConnectionActivity()
                 } catch is CancellationError {
                     break
@@ -669,6 +672,29 @@ actor EventsSession {
 
     private func noteConnectionActivity() {
         lastConnectionActivity = .now
+    }
+
+    /// Publishes a measurement taken on `stream`, unless that channel is no
+    /// longer the session's live one — and reports which it was.
+    ///
+    /// Cancellation is a request, not a guarantee: `windDown` cancels the
+    /// keepalive task without awaiting it, and a Transport is free to answer a
+    /// ping that was already in flight when its connection was torn down. Such
+    /// an answer describes a connection this session no longer has, so
+    /// publishing it would resurrect the value the non-connected status
+    /// cleared on the way out — and, once a replacement has connected,
+    /// overwrite that connection's own proof with the dead one's.
+    ///
+    /// The connect path has no channel to name yet and does not need one: it
+    /// publishes with no suspension point between its activation check and the
+    /// write, and any teardown after that clears the value through the status
+    /// it publishes.
+    private func publishLatency(
+        _ latency: Duration, measuredOn stream: HerdrEventStream
+    ) -> Bool {
+        guard phase == .active, liveStream === stream else { return false }
+        publishLatency(latency)
+        return true
     }
 
     /// The single gate every measurement leaves through: the connection-scoped

--- a/Tests/HeelerTests/ConsoleStoreTests.swift
+++ b/Tests/HeelerTests/ConsoleStoreTests.swift
@@ -1254,6 +1254,36 @@ struct ConsoleStoreTests {
         #expect(store.hostLatencies.isEmpty)
     }
 
+    /// A latency belongs to the connection that measured it (#236). Leaving
+    /// `.connected` drops it immediately, so neither the Hosts sheet nor Agent
+    /// detail can present a number the current connection never proved.
+    @Test func leavingConnectedDropsTheHostLatencyImmediately() async throws {
+        let host = Host.fixture()
+        let transport = ScriptedTransport(snapshot: .fixture())
+        let store = makeStore(transports: [host.id: transport])
+
+        store.setHosts([host])
+        await store.resume()
+        try await waitUntil("the Host should publish its ping latency") {
+            store.hostLatencies[host.id] != nil
+        }
+
+        await store.suspend()
+        try await waitUntil("the Host should report suspended") {
+            store.hostStatuses[host.id] == .suspended
+        }
+        // Absent, not zero and not the previous measurement: the Host is
+        // still in the catalog, only its proof is gone.
+        #expect(store.hostLatencies[host.id] == nil)
+
+        await store.resume()
+        try await waitUntil("the reconnected Host should measure again") {
+            store.hostLatencies[host.id] != nil
+        }
+
+        store.setHosts([])
+    }
+
     @Test func resumedHostStaysLoadingUntilItsReplacementSnapshotLands() async throws {
         let host = Host.fixture()
         let transport = ScriptedTransport(

--- a/Tests/HeelerTests/ConsoleStoreTests.swift
+++ b/Tests/HeelerTests/ConsoleStoreTests.swift
@@ -1254,19 +1254,25 @@ struct ConsoleStoreTests {
         #expect(store.hostLatencies.isEmpty)
     }
 
-    /// A latency belongs to the connection that measured it (#236). Leaving
-    /// `.connected` drops it immediately, so neither the Hosts sheet nor Agent
-    /// detail can present a number the current connection never proved.
-    @Test func leavingConnectedDropsTheHostLatencyImmediately() async throws {
+    /// A latency belongs to the connection that measured it (#236), and the
+    /// projection folds both from one ordered source — so every assertion here
+    /// is made the instant the status is observable, with nothing waited for
+    /// in between. Neither the Hosts sheet nor Agent detail can present a
+    /// number the current connection never proved, and neither is left blank
+    /// while it has one.
+    @Test func hostLatencyIsPairedWithTheConnectionThatMeasuredIt() async throws {
         let host = Host.fixture()
         let transport = ScriptedTransport(snapshot: .fixture())
         let store = makeStore(transports: [host.id: transport])
 
         store.setHosts([host])
         await store.resume()
-        try await waitUntil("the Host should publish its ping latency") {
-            store.hostLatencies[host.id] != nil
+        try await waitUntil("the Host should report connected") {
+            store.hostStatuses[host.id] == .connected
         }
+        // Not waited for: the connect ping answered before `.connected` was
+        // published, so the number is already here.
+        #expect(store.hostLatencies[host.id] != nil)
 
         await store.suspend()
         try await waitUntil("the Host should report suspended") {
@@ -1276,10 +1282,21 @@ struct ConsoleStoreTests {
         // still in the catalog, only its proof is gone.
         #expect(store.hostLatencies[host.id] == nil)
 
+        // Hold the replacement connection's ping open. Any latency published
+        // in this window could only be the suspended connection's.
+        let gate = ScriptedTransportCallGate()
+        await transport.gateNextPing(using: gate)
         await store.resume()
-        try await waitUntil("the reconnected Host should measure again") {
-            store.hostLatencies[host.id] != nil
+        try await waitUntil("the replacement connection should be pinging") {
+            await gate.entryCount == 1
         }
+        #expect(store.hostLatencies[host.id] == nil)
+
+        await gate.open()
+        try await waitUntil("the reconnected Host should report connected") {
+            store.hostStatuses[host.id] == .connected
+        }
+        #expect(store.hostLatencies[host.id] != nil)
 
         store.setHosts([])
     }

--- a/Tests/HeelerTests/EventsSessionLatencyTests.swift
+++ b/Tests/HeelerTests/EventsSessionLatencyTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+/// `EventsSession.currentLatency` (#236): the measurement a consumer folds
+/// against a status update.
+///
+/// `updates` and `latencyUpdates` are separate streams with separate
+/// consumers, so nothing about the order one is drained in tells you anything
+/// about the other. These tests pin the producer-side ordering that makes the
+/// pairing exact regardless: the value is in place before the `.connected`
+/// that announces a proven connection, and gone before the status that ends
+/// one — even while the sample itself is still queued for its own consumer.
+/// A session that stops answering simply never publishes again, so the suite
+/// is bounded rather than left waiting for a status that will not arrive.
+@Suite("EventsSession latency pairing", .timeLimit(.minutes(1)))
+struct EventsSessionLatencyTests {
+    private let subscriptions: [EventSubscription] = [.global(.paneAgentDetected)]
+
+    private func makeSession(
+        transport: ScriptedTransport
+    ) -> EventsSession {
+        EventsSession(
+            subscriptions: subscriptions,
+            connect: { transport },
+            reconnectPolicy: ReconnectPolicy(
+                initialDelay: .milliseconds(10), multiplier: 2, maxDelay: .milliseconds(50)),
+            keepalive: nil)
+    }
+
+    private func waitUntil(
+        _ comment: Comment, timeout: Duration = .seconds(5),
+        condition: () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if await condition() { break }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await condition(), comment)
+    }
+
+    /// The connect ping is held open, so "unproven" is a fact here rather
+    /// than a race: nothing can have answered yet.
+    @Test func theConnectionIsUnprovenUntilItsPingAnswers() async throws {
+        let transport = ScriptedTransport()
+        let gate = ScriptedTransportCallGate()
+        await transport.gateNextPing(using: gate)
+        let session = makeSession(transport: transport)
+        var updates = session.updates.makeAsyncIterator()
+
+        await session.resume()
+        #expect(await updates.next() == .status(.connecting))
+        try await waitUntil("the connect ping should be in flight") {
+            await gate.entryCount == 1
+        }
+        #expect(session.currentLatency == nil)
+
+        await gate.open()
+        #expect(await updates.next() == .status(.connected))
+        // Folding `.connected` and reading the value in the same turn must
+        // never find the connection unproven: the sample is published before
+        // the status that announces it.
+        #expect(session.currentLatency != nil)
+
+        await session.end()
+    }
+
+    /// The exact shape of the race this property exists for: a consumer that
+    /// has not drained `latencyUpdates` yet still finds nothing to present
+    /// once the connection that measured the queued sample is gone.
+    @Test func aQueuedSampleNeverOutlivesTheConnectionThatMeasuredIt() async throws {
+        let transport = ScriptedTransport()
+        let session = makeSession(transport: transport)
+        var updates = session.updates.makeAsyncIterator()
+        // Deliberately not drained until the very end.
+        var samples = session.latencyUpdates.makeAsyncIterator()
+
+        await session.resume()
+        #expect(await updates.next() == .status(.connecting))
+        #expect(await updates.next() == .status(.connected))
+        let proven = session.currentLatency
+        #expect(proven != nil)
+
+        await session.suspend()
+        #expect(await updates.next() == .status(.suspended))
+        #expect(session.currentLatency == nil)
+
+        // The dead connection's sample is still sitting in its stream, and
+        // arrives whenever that consumer gets around to it — long after the
+        // status that ended the connection was published.
+        #expect(await samples.next() == proven)
+        #expect(session.currentLatency == nil)
+
+        await session.end()
+    }
+
+    /// A reconnect stays unproven until its own ping answers: the previous
+    /// connection's number is never inherited.
+    @Test func aReconnectIsUnprovenUntilItsOwnPingAnswers() async throws {
+        let transport = ScriptedTransport()
+        let session = makeSession(transport: transport)
+        var updates = session.updates.makeAsyncIterator()
+
+        await session.resume()
+        #expect(await updates.next() == .status(.connecting))
+        #expect(await updates.next() == .status(.connected))
+        #expect(session.currentLatency != nil)
+
+        await session.suspend()
+        #expect(await updates.next() == .status(.suspended))
+
+        let gate = ScriptedTransportCallGate()
+        await transport.gateNextPing(using: gate)
+        await session.resume()
+        #expect(await updates.next() == .status(.connecting))
+        try await waitUntil("the replacement connection should be pinging") {
+            await gate.entryCount == 1
+        }
+        // Held here on purpose: any value at this point could only be the
+        // suspended connection's.
+        #expect(session.currentLatency == nil)
+
+        await gate.open()
+        #expect(await updates.next() == .status(.connected))
+        #expect(session.currentLatency != nil)
+
+        await session.end()
+    }
+
+    /// Terminal teardown is a status like any other: `.ended` clears the
+    /// value before it is published.
+    @Test func endingTheSessionClearsTheValue() async throws {
+        let transport = ScriptedTransport()
+        let session = makeSession(transport: transport)
+        var updates = session.updates.makeAsyncIterator()
+
+        await session.resume()
+        #expect(await updates.next() == .status(.connecting))
+        #expect(await updates.next() == .status(.connected))
+        #expect(session.currentLatency != nil)
+
+        await session.end()
+        #expect(await updates.next() == .status(.ended))
+        #expect(session.currentLatency == nil)
+    }
+}

--- a/Tests/HeelerTests/EventsSessionLatencyTests.swift
+++ b/Tests/HeelerTests/EventsSessionLatencyTests.swift
@@ -18,12 +18,16 @@ import Testing
 struct EventsSessionLatencyTests {
     private let subscriptions: [EventSubscription] = [.global(.paneAgentDetected)]
 
+    private func makeSession(transport: ScriptedTransport) -> EventsSession {
+        makeSession(connect: { transport })
+    }
+
     private func makeSession(
-        transport: ScriptedTransport
+        connect: @escaping @Sendable () async throws -> any Transport
     ) -> EventsSession {
         EventsSession(
             subscriptions: subscriptions,
-            connect: { transport },
+            connect: connect,
             reconnectPolicy: ReconnectPolicy(
                 initialDelay: .milliseconds(10), multiplier: 2, maxDelay: .milliseconds(50)),
             keepalive: nil)
@@ -125,6 +129,58 @@ struct EventsSessionLatencyTests {
         await gate.open()
         #expect(await updates.next() == .status(.connected))
         #expect(session.currentLatency != nil)
+
+        await session.end()
+    }
+
+    /// A ping is only cancellable by request: `windDown` cancels the keepalive
+    /// task without awaiting it, and a Transport may answer a request that was
+    /// already in flight when its connection was torn down —
+    /// `ScriptedTransport.ping()` returns successfully whether or not its task
+    /// was cancelled, exactly as a real one is free to. Such an answer
+    /// describes a connection the session no longer has, so it must neither
+    /// resurrect its own value nor overwrite the replacement connection's.
+    @Test func aPingThatOutlivesItsConnectionCannotPublish() async throws {
+        let first = ScriptedTransport()
+        let second = ScriptedTransport()
+        let connector = SequencedTransportConnector([first, second])
+        let session = makeSession(connect: { try await connector.connect() })
+        var updates = session.updates.makeAsyncIterator()
+
+        await session.resume()
+        #expect(await updates.next() == .status(.connecting))
+        #expect(await updates.next() == .status(.connected))
+        #expect(session.currentLatency != nil)
+
+        // A revalidate ping goes out on the live connection and is held there.
+        let parked = ScriptedTransportCallGate()
+        await first.gateNextPing(using: parked)
+        let revalidation = Task { await session.revalidate() }
+        try await waitUntil("the revalidate ping should be in flight") {
+            await parked.entryCount == 1
+        }
+
+        // The connection it was taken on goes away, and a different one
+        // replaces it and proves itself.
+        await session.suspend()
+        #expect(await updates.next() == .status(.suspended))
+        #expect(session.currentLatency == nil)
+
+        await session.resume()
+        #expect(await updates.next() == .status(.connecting))
+        #expect(await updates.next() == .status(.connected))
+        let fresh = session.currentLatency
+        #expect(fresh != nil)
+        #expect(
+            await connector.connectCount == 2,
+            "the replacement connection must be a fresh dial with its own ping")
+
+        // The parked ping answers at last, on a channel this session no longer
+        // has.
+        await parked.open()
+        await revalidation.value
+        #expect(await first.pingCount == 2, "the held ping did answer")
+        #expect(session.currentLatency == fresh)
 
         await session.end()
     }

--- a/Tests/HeelerTests/HostTelemetryPresentationTests.swift
+++ b/Tests/HeelerTests/HostTelemetryPresentationTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+/// Agent detail's Host telemetry label (#236): what it shows, what it
+/// refuses to show, and that it can never disagree with the Hosts sheet.
+@Suite("Host telemetry presentation")
+struct HostTelemetryPresentationTests {
+    @Test func connectedHostShowsTheRoundedRoundTrip() throws {
+        let presentation = try #require(
+            HostTelemetryPresentation(
+                status: .connected,
+                latency: .milliseconds(25) + .microseconds(600)))
+
+        #expect(presentation.title == "Host · 26 ms")
+        #expect(presentation.accessibilityLabel == "Host API connection latency")
+        #expect(presentation.accessibilityValue == "26 milliseconds over SSH")
+    }
+
+    @Test func subMillisecondLatencyNeverRoundsToZero() throws {
+        let presentation = try #require(
+            HostTelemetryPresentation(status: .connected, latency: .microseconds(400)))
+
+        #expect(presentation.title == "Host · <1 ms")
+        #expect(presentation.accessibilityValue == "Less than 1 millisecond over SSH")
+    }
+
+    @Test func oneMillisecondIsTheFirstSpokenSingular() throws {
+        let presentation = try #require(
+            HostTelemetryPresentation(status: .connected, latency: .milliseconds(1)))
+
+        #expect(presentation.title == "Host · 1 ms")
+        #expect(presentation.accessibilityValue == "1 millisecond over SSH")
+    }
+
+    /// The floor is the value, not the rounding: 1.4 ms is a measured
+    /// millisecond and reads as one, while 0.999 ms stays below the floor.
+    @Test func roundingCrossesTheFloorOnValueNotOnDisplay() throws {
+        #expect(
+            HostTelemetryPresentation(
+                status: .connected, latency: .microseconds(1_400)
+            )?.title == "Host · 1 ms")
+        #expect(
+            HostTelemetryPresentation(
+                status: .connected, latency: .microseconds(999)
+            )?.title == "Host · <1 ms")
+        #expect(
+            HostTelemetryPresentation(
+                status: .connected, latency: .microseconds(1_500)
+            )?.title == "Host · 2 ms")
+    }
+
+    @Test func connectedWithoutAMeasurementRendersNothing() {
+        #expect(HostTelemetryPresentation(status: .connected, latency: nil) == nil)
+    }
+
+    @Test func everyUnprovenStatusRendersNothingEvenWithALatency() {
+        let latency = Duration.milliseconds(42)
+        let unproven: [EventsSessionStatus?] = [
+            .connecting,
+            .reconnecting(attempt: 1, delay: .seconds(1), failure: .timedOut),
+            .failed(.authenticationFailed),
+            .suspended,
+            .ended,
+            nil,
+        ]
+
+        for status in unproven {
+            #expect(
+                HostTelemetryPresentation(status: status, latency: latency) == nil,
+                "\(String(describing: status)) must not show a latency")
+        }
+    }
+
+    /// The Hosts sheet chip and this label read the same measurement, so a
+    /// user comparing the two surfaces must never see two numbers.
+    @Test func theNumberMatchesTheHostsSheetChip() throws {
+        let latencies: [Duration] = [
+            .microseconds(1),
+            .microseconds(400),
+            .microseconds(999),
+            .milliseconds(1),
+            .microseconds(1_500),
+            .milliseconds(34),
+            .milliseconds(25) + .microseconds(600),
+            .seconds(1) + .milliseconds(250),
+        ]
+
+        for latency in latencies {
+            let chip = HostConnectionPresentation(status: .connected, latency: latency)
+            let label = try #require(
+                HostTelemetryPresentation(status: .connected, latency: latency))
+            #expect(label.title == "Host · \(chip.title)")
+        }
+    }
+
+    /// A clock that moved under the sample must not render backwards.
+    @Test func negativeMeasurementsClampRatherThanRenderBackwards() throws {
+        let presentation = try #require(
+            HostTelemetryPresentation(status: .connected, latency: .milliseconds(-5)))
+
+        #expect(presentation.title == "Host · <1 ms")
+        #expect(
+            HostConnectionPresentation(
+                status: .connected, latency: .milliseconds(-5)
+            ).title == "<1 ms")
+    }
+}

--- a/Tests/HeelerTests/HostTelemetryPresentationTests.swift
+++ b/Tests/HeelerTests/HostTelemetryPresentationTests.swift
@@ -13,7 +13,7 @@ struct HostTelemetryPresentationTests {
                 status: .connected,
                 latency: .milliseconds(25) + .microseconds(600)))
 
-        #expect(presentation.title == "Host · 26 ms")
+        #expect(presentation.title == "26 ms")
         #expect(presentation.accessibilityLabel == "Host API connection latency")
         #expect(presentation.accessibilityValue == "26 milliseconds over SSH")
     }
@@ -22,7 +22,7 @@ struct HostTelemetryPresentationTests {
         let presentation = try #require(
             HostTelemetryPresentation(status: .connected, latency: .microseconds(400)))
 
-        #expect(presentation.title == "Host · <1 ms")
+        #expect(presentation.title == "<1 ms")
         #expect(presentation.accessibilityValue == "Less than 1 millisecond over SSH")
     }
 
@@ -30,7 +30,7 @@ struct HostTelemetryPresentationTests {
         let presentation = try #require(
             HostTelemetryPresentation(status: .connected, latency: .milliseconds(1)))
 
-        #expect(presentation.title == "Host · 1 ms")
+        #expect(presentation.title == "1 ms")
         #expect(presentation.accessibilityValue == "1 millisecond over SSH")
     }
 
@@ -40,15 +40,15 @@ struct HostTelemetryPresentationTests {
         #expect(
             HostTelemetryPresentation(
                 status: .connected, latency: .microseconds(1_400)
-            )?.title == "Host · 1 ms")
+            )?.title == "1 ms")
         #expect(
             HostTelemetryPresentation(
                 status: .connected, latency: .microseconds(999)
-            )?.title == "Host · <1 ms")
+            )?.title == "<1 ms")
         #expect(
             HostTelemetryPresentation(
                 status: .connected, latency: .microseconds(1_500)
-            )?.title == "Host · 2 ms")
+            )?.title == "2 ms")
     }
 
     @Test func connectedWithoutAMeasurementRendersNothing() {
@@ -91,7 +91,7 @@ struct HostTelemetryPresentationTests {
             let chip = HostConnectionPresentation(status: .connected, latency: latency)
             let label = try #require(
                 HostTelemetryPresentation(status: .connected, latency: latency))
-            #expect(label.title == "Host · \(chip.title)")
+            #expect(label.title == chip.title)
         }
     }
 
@@ -100,7 +100,7 @@ struct HostTelemetryPresentationTests {
         let presentation = try #require(
             HostTelemetryPresentation(status: .connected, latency: .milliseconds(-5)))
 
-        #expect(presentation.title == "Host · <1 ms")
+        #expect(presentation.title == "<1 ms")
         #expect(
             HostConnectionPresentation(
                 status: .connected, latency: .milliseconds(-5)


### PR DESCRIPTION
## Summary
- Surfaces the Host’s latest herdr API round-trip latency next to Agent status in Agent Detail, reusing the existing Host-scoped `EventsSession` / `hostLatencies` stream (refs #236).
- Hides stale measurements when the connection has no proof of its own, and keeps the status row legible by resolving colors from terminal-theme luminance rather than system appearance.
- Adds focused tests for latency pairing, presentation (connected / missing / stale / sub-ms), and formatting consistency with the Hosts sheet.

## Test plan
- [x] Open a connected Agent Detail and confirm latency matches the Hosts sheet (same rounding, Host/API wording, not Agent response time).
- [x] Confirm multiple Agents on one Host share one measurement and do not trigger extra pings.
- [x] Disconnect / reconnect / suspend / fail the Host and confirm old latency never shows as current; missing values degrade without a zero placeholder.
- [x] Check dark terminal theme under light system appearance (and vice versa) that status + latency stay readable.
- [x] Run `EventsSessionLatencyTests`, `HostTelemetryPresentationTests`, and related `ConsoleStoreTests`.