### PR TITLE
Suggest and pick Skills from Composer

### DIFF
--- a/.testloop/reports/2026-08-25-composer-skills.md
+++ b/.testloop/reports/2026-08-25-composer-skills.md
@@ -1,0 +1,40 @@
+# testloop — 2026-08-25 — composer-skills (issue #234)
+
+**Verdict:** pass · **Rounds:** 3 (1 environment-blocked, 1 test, 1 re-verify)
+
+## Covered
+
+- Both new Skills entry points on a live claude agent: the More-menu picker
+  (sheet, Global grouping, case-insensitive search, insert-without-send,
+  Done leaves the draft alone) and inline suggestions (trigger on `/`,
+  filter while typing, token replacement to the full invocation plus
+  trailing space, ✕ dismissal, auto-close after insertion).
+- The Codex `$` path end to end: `$apple` suggests and inserts
+  `$apple-design `; a `/` token on a codex agent correctly triggers nothing
+  (prefixes ride the agent's skill catalog, not the Composer).
+- Two disposable live agents (claude + codex) were provisioned on the local
+  herdr for the run and closed afterwards; no live session was touched.
+
+## Found & fixed
+
+- The inline suggestion panel reserved its full 176pt cap even for a single
+  match, leaving a large empty area. Fixed by sizing the panel's scroll
+  view to the measured list height, capped at 176pt
+  (`Sources/Heeler/Console/AgentComposerView.swift`,
+  AgentComposerSkillSuggestions). Re-verified in the Simulator.
+
+## Still open
+
+- The GUI pass did not exercise: unmatched-query/mid-token non-triggering
+  (unit-tested), the codex More-menu picker (kind-independent code path),
+  the tools-keyboard Skills tab sharing (structural), or VoiceOver.
+- The Codex computer-use tester could not drive this screen reliably: its
+  screen-coordinate taps landed on the agent-switcher strip below the
+  Composer, and one stray long-press trapped its own session's detail view
+  in a terminal Select Text overlay. The driver finished the plan with
+  device-level HID automation instead. Future rounds on Agent detail
+  should steer the tester toward idb-style point coordinates or expect
+  driver takeover.
+- Environment repair made durable: the `local-ui-test-17pro` Host now
+  targets 127.0.0.1:22 with the app's device key enrolled on the Mac;
+  preflight is fully green (herdr 0.8.2 / protocol 20).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Entries reference the issue that motivated them.
 
 ### Added
 
+- The Composer now suggests the selected Agent's discovered Skills inline
+  while an invocation prefix is typed, and its More menu gains a searchable
+  Skill picker. Both entry points share the tools keyboard's Skills
+  catalogue and insert the full command into the draft without sending it —
+  Codex Skills with `$`, each Skill by its own prefix. (#234)
+
 - Agent detail's More menu gains Open Terminal: it creates a new herdr tab in
   the Agent's launch directory and opens its shell as a fully interactive
   Shell Terminal. Back detaches and leaves the remote tab alive for desktop

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		58EE685D5F9C4B21D4B4DC0E /* FakeLiveActivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856A8398D8F0FB87F252D193 /* FakeLiveActivityController.swift */; };
 		5B0522DF97BC46599DDE4E93 /* TransportConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A41E40939438986DE30402 /* TransportConnector.swift */; };
 		5B137E763FFACD1AFE5C7E30 /* AgentNotificationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7EC7BEC9AACD2DAF634B2C /* AgentNotificationRouter.swift */; };
+		5B9625AD120C35F4EE02CC69 /* SkillSuggestionTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC5FC371E96C4EF1E3F1039 /* SkillSuggestionTriggerTests.swift */; };
 		5C68C3082AD5958A28843055 /* TerminalTitleGlyphs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651D511E8A282C4CB0214098 /* TerminalTitleGlyphs.swift */; };
 		5C79B0EEF08521BF5907D3F2 /* NotificationKeyMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91F0473741A92D7EFA40CBA /* NotificationKeyMirror.swift */; };
 		5DBC04E1863A4740B3C84F3B /* DemoScreenshotMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0A5D6A13F3F940E50EDCFD /* DemoScreenshotMode.swift */; };
@@ -228,6 +229,7 @@
 		BA5D3FE58111F8918A50DE2A /* SSHChannelAdmissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A579E1DA3F59AFBC3ECAD69C /* SSHChannelAdmissionTests.swift */; };
 		BB26A50348D73A7852417D5B /* HerdrWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CFA2284DB622A6EB63D2F85 /* HerdrWire.swift */; };
 		BC3CE4B2C61D43EB4BA6B66E /* ConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74A32020C9520EB5629B071 /* ConsoleView.swift */; };
+		BDE691882C96CE51F4BABB05 /* SkillSuggestionTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F8AC685DA90F638BF187DA /* SkillSuggestionTrigger.swift */; };
 		BE4118A67B3A605412FFF79E /* AgentStatusPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A430D16838A39772ED0AA73 /* AgentStatusPalette.swift */; };
 		BFE02F9C58F080B95770E878 /* WakeCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C2343D5ED9436077682CD1 /* WakeCommandTests.swift */; };
 		BFFC881E19AD745075F7155E /* HeelerSSHNativeRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75E8F9733C77314E6D222AC /* HeelerSSHNativeRuntimeTests.swift */; };
@@ -237,6 +239,7 @@
 		C1F06F7588D4713392223CC5 /* RecentWorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BD377C8BB7AA8205DD8AFC /* RecentWorkspaceStore.swift */; };
 		C30EE891E4215D9F2D3B7821 /* DeviceKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016BA41A48C6D6CCCEB10A47 /* DeviceKeyTests.swift */; };
 		C345ECAFFFA3CBDC2C4B2BB7 /* NotificationRegistrationFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297D9D4C1F200A21A2A0AA64 /* NotificationRegistrationFileTests.swift */; };
+		C3A7347C5A4C2219832A9F46 /* SkillsPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444F11A4450A3CA904B26658 /* SkillsPickerView.swift */; };
 		C3CAE683F15A2DB5866FE702 /* HeelerSSHJumpHostGateE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F5C337F9BC29D46E48E35E /* HeelerSSHJumpHostGateE2ETests.swift */; };
 		C626797B247A8ED6513D2EBB /* HeelerSSHSessionE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1AEA55D1F06B12005DEEE5F /* HeelerSSHSessionE2ETests.swift */; };
 		C6E6E92365F39EDDD50CDE49 /* WeakNetworkE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB8C5EA497D1094E86F69C4 /* WeakNetworkE2ETests.swift */; };
@@ -389,6 +392,7 @@
 		1D46328CE795C513FE11AD04 /* ClosePaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosePaneStore.swift; sourceTree = "<group>"; };
 		1E9D993852C5C7BFE8515A46 /* HostOnboardingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostOnboardingStore.swift; sourceTree = "<group>"; };
 		1F0763484EE05424146492C1 /* PairingCeremonyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCeremonyTests.swift; sourceTree = "<group>"; };
+		20F8AC685DA90F638BF187DA /* SkillSuggestionTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillSuggestionTrigger.swift; sourceTree = "<group>"; };
 		21B19CA0EB3B37BB6C50BA4B /* HeelerWidgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HeelerWidgets.entitlements; sourceTree = "<group>"; };
 		233075006FC2C8907BBFF40F /* GitBranchNameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitBranchNameTests.swift; sourceTree = "<group>"; };
 		239FD696B72E804AE3D85D72 /* ComposerStagingStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerStagingStoreTests.swift; sourceTree = "<group>"; };
@@ -418,6 +422,7 @@
 		4273AC6F39EB1E015820E614 /* TerminalAppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAppearanceSettingsView.swift; sourceTree = "<group>"; };
 		427512344847A84699F819A0 /* TerminalFontSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalFontSettingsTests.swift; sourceTree = "<group>"; };
 		442A5127B47FF6FF8840B0B9 /* WorktreeDetailStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeDetailStoreTests.swift; sourceTree = "<group>"; };
+		444F11A4450A3CA904B26658 /* SkillsPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsPickerView.swift; sourceTree = "<group>"; };
 		4582B5EA42CFA9C8878E6207 /* HeelerSSH */ = {isa = PBXFileReference; lastKnownFileType = folder; name = HeelerSSH; path = Packages/HeelerSSH; sourceTree = SOURCE_ROOT; };
 		45DB60007029322902FD1AFF /* PairingScanStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScanStore.swift; sourceTree = "<group>"; };
 		4692E780178FDFA1CF9537B1 /* AgentName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentName.swift; sourceTree = "<group>"; };
@@ -580,6 +585,7 @@
 		CBC80D00F652CB84103C246F /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		CC2E07D2395573D9EF9DE8B9 /* StartAgentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentView.swift; sourceTree = "<group>"; };
 		CC67B000BBBD99D10CB7A30E /* SnippetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetTests.swift; sourceTree = "<group>"; };
+		CDC5FC371E96C4EF1E3F1039 /* SkillSuggestionTriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillSuggestionTriggerTests.swift; sourceTree = "<group>"; };
 		CE868FFAE7FC91684AF77452 /* TerminalThemePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemePreview.swift; sourceTree = "<group>"; };
 		CFB39D40748D247CC747A83D /* AppActivityCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivityCoordinatorTests.swift; sourceTree = "<group>"; };
 		D026719294E631141C3A59F9 /* PairingScanStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScanStoreTests.swift; sourceTree = "<group>"; };
@@ -756,6 +762,7 @@
 				A5C6340A9A91119C998F64C3 /* SkillFrontmatterTests.swift */,
 				176C059114F4646026196943 /* SkillProbeTests.swift */,
 				9578B0F124B9B77740E8E38F /* SkillsPaneStoreTests.swift */,
+				CDC5FC371E96C4EF1E3F1039 /* SkillSuggestionTriggerTests.swift */,
 				962BDE6D5BFCD443EC3B5FF4 /* SnippetStoreTests.swift */,
 				CC67B000BBBD99D10CB7A30E /* SnippetTests.swift */,
 				9F979754410821940D0C4DEC /* SolvingOrbRendererTests.swift */,
@@ -852,6 +859,8 @@
 				80D43A25D50EDEF5D1E64BEF /* SkillProbe.swift */,
 				C2EF92E96C6A4905CD809C5C /* SkillsKeyboardPane.swift */,
 				6A9156B9BB51E7A5AD1792D9 /* SkillsPaneStore.swift */,
+				444F11A4450A3CA904B26658 /* SkillsPickerView.swift */,
+				20F8AC685DA90F638BF187DA /* SkillSuggestionTrigger.swift */,
 			);
 			path = Skills;
 			sourceTree = "<group>";
@@ -1493,8 +1502,10 @@
 				AEE3EAD6534D2D9774BBDB1E /* SkillContentSheet.swift in Sources */,
 				FB3A2B881CE2C93601F1A90F /* SkillFrontmatter.swift in Sources */,
 				23C1FFEFABBB955BBCDA6D64 /* SkillProbe.swift in Sources */,
+				BDE691882C96CE51F4BABB05 /* SkillSuggestionTrigger.swift in Sources */,
 				299786029A482075003F78B9 /* SkillsKeyboardPane.swift in Sources */,
 				81E0207D8AA28513FEA755B0 /* SkillsPaneStore.swift in Sources */,
+				C3A7347C5A4C2219832A9F46 /* SkillsPickerView.swift in Sources */,
 				7CF1965195B7578472B615B9 /* Snippet.swift in Sources */,
 				637B8BBB6F06AD8290874101 /* SnippetStore.swift in Sources */,
 				A4693B8221D4D110809D1175 /* SnippetsKeyboardPane.swift in Sources */,
@@ -1649,6 +1660,7 @@
 				48D308D66F7A9070C81E273E /* SkeletonTests.swift in Sources */,
 				4E1315630C0CE5EE5187799B /* SkillFrontmatterTests.swift in Sources */,
 				2D7DC2A884FB9BA311D265A6 /* SkillProbeTests.swift in Sources */,
+				5B9625AD120C35F4EE02CC69 /* SkillSuggestionTriggerTests.swift in Sources */,
 				E6D3DCE16CD5B192FD1B9E07 /* SkillsPaneStoreTests.swift in Sources */,
 				3C887B853B2B6DFAADEAD38E /* SnippetStoreTests.swift in Sources */,
 				9650868D94494A36E70CF651 /* SnippetTests.swift in Sources */,

--- a/Sources/Heeler/Console/AgentComposerStore.swift
+++ b/Sources/Heeler/Console/AgentComposerStore.swift
@@ -93,6 +93,16 @@ final class AgentComposerStore: ComposerDraftOperations {
         draft.append(text)
     }
 
+    /// Completes an inline Skill suggestion: swaps the typed trigger token at
+    /// the end of the draft for the full invocation. A draft that no longer
+    /// ends with the token — edited under a stale suggestion — is left alone
+    /// rather than mangled.
+    func replaceTrailingToken(_ token: String, with text: String) {
+        guard !token.isEmpty, draft.hasSuffix(token) else { return }
+        draft.removeLast(token.count)
+        draft.append(text)
+    }
+
     /// Starts consuming Console's existing per-Agent status fan-out. This
     /// does not open a Transport event stream or perform an RPC.
     func open() {

--- a/Sources/Heeler/Console/AgentComposerView.swift
+++ b/Sources/Heeler/Console/AgentComposerView.swift
@@ -439,6 +439,12 @@ private struct AgentComposerSkillSuggestions: View {
     let trigger: SkillSuggestionTrigger
     let onSelect: (AgentSkill) -> Void
     let onDismiss: () -> Void
+    /// The suggestion list's measured content height. The scroll view is
+    /// sized to it so one match does not reserve the full cap of empty
+    /// space; the cap only bounds long lists.
+    @State private var listHeight: CGFloat = Self.maximumListHeight
+
+    private static let maximumListHeight: CGFloat = 176
 
     var body: some View {
         switch skills.phase {
@@ -464,13 +470,18 @@ private struct AgentComposerSkillSuggestions: View {
                 VStack(alignment: .leading, spacing: 0) {
                     header { EmptyView() }
                     ScrollView {
-                        LazyVStack(alignment: .leading, spacing: 0) {
+                        VStack(alignment: .leading, spacing: 0) {
                             ForEach(matches) { skill in
                                 row(for: skill)
                             }
                         }
+                        .onGeometryChange(for: CGFloat.self) { proxy in
+                            proxy.size.height
+                        } action: { height in
+                            listHeight = height
+                        }
                     }
-                    .frame(maxHeight: 176)
+                    .frame(height: min(listHeight, Self.maximumListHeight))
                     .scrollBounceBehavior(.basedOnSize)
                     Divider()
                 }

--- a/Sources/Heeler/Console/AgentComposerView.swift
+++ b/Sources/Heeler/Console/AgentComposerView.swift
@@ -51,6 +51,10 @@ struct AgentComposerActions {
     let isOpeningTerminal: Bool
     let startAgent: () -> Void
     let manageSnippets: () -> Void
+    /// Opens the explicit Skill picker. Nil for agent kinds without a skills
+    /// source catalog, which hides the More-menu entry entirely rather than
+    /// offering a dead button.
+    let showSkills: (() -> Void)?
     let showWorktreeDetails: (() -> Void)?
     let renameAgent: () -> Void
     let renameWorkspace: () -> Void
@@ -82,9 +86,16 @@ struct AgentComposerView: View {
     let keyboardHandoff: TerminalKeyboardHandoff
     let keyboardHeight: CGFloat
     let actions: AgentComposerActions
+    /// The screen's one Skills store, shared with the tools keyboard and the
+    /// explicit picker. Nil for kinds without a skills source catalog, which
+    /// disables inline suggestions.
+    let skills: SkillsPaneStore?
     @Binding var keyboardPresentation: AgentComposerKeyboardPresentation
     let prepareKeyboardPresentation: (AgentComposerKeyboardPresentation) -> Void
     @State private var isInputFocused = false
+    /// An explicit dismissal hides suggestions for the current trigger token;
+    /// removing the token arms them again.
+    @State private var isSuggestionsDismissed = false
 
     private var isToolsKeyboardPresented: Bool {
         keyboardPresentation == .tools
@@ -98,6 +109,18 @@ struct AgentComposerView: View {
 
                 VStack(spacing: 0) {
                     VStack(alignment: .leading, spacing: 8) {
+                        if let skills, let trigger = suggestionTrigger,
+                            isInputFocused, !isSuggestionsDismissed
+                        {
+                            AgentComposerSkillSuggestions(
+                                skills: skills,
+                                trigger: trigger,
+                                onSelect: { skill in
+                                    store.replaceTrailingToken(
+                                        trigger.token, with: skill.insertionText)
+                                },
+                                onDismiss: { isSuggestionsDismissed = true })
+                        }
                         ZStack(alignment: .topLeading) {
                             AgentComposerTextEditor(
                                 text: Binding(
@@ -168,6 +191,13 @@ struct AgentComposerView: View {
                                     )
                                     Button("New Agent", systemImage: "plus") {
                                         actions.startAgent()
+                                    }
+                                    // Skills before Snippets: the Keys
+                                    // keyboard's tab order.
+                                    if let showSkills = actions.showSkills {
+                                        Button("Skills", systemImage: "sparkles") {
+                                            showSkills()
+                                        }
                                     }
                                     Button("Snippets", systemImage: "quote.bubble") {
                                         actions.manageSnippets()
@@ -274,6 +304,25 @@ struct AgentComposerView: View {
                 setKeyboardPresentation(.hidden)
             }
         }
+        .onChange(of: store.draft) { _, _ in
+            guard let skills else { return }
+            if suggestionTrigger == nil {
+                isSuggestionsDismissed = false
+            } else if !isSuggestionsDismissed {
+                // Typing the prefix is the pane-selection moment: load once,
+                // then reuse (the ConsoleStore caches underneath).
+                Task { await skills.loadIfNeeded() }
+            }
+        }
+    }
+
+    /// The invocation token at the end of the draft, when this agent has
+    /// skill sources at all. Prefixes ride the skills and their catalog, not
+    /// the Composer.
+    private var suggestionTrigger: SkillSuggestionTrigger? {
+        guard let skills else { return nil }
+        return SkillSuggestionTrigger.detect(
+            draft: store.draft, prefixes: skills.triggerPrefixes)
     }
 
     private var isKeyboardPresented: Bool {
@@ -377,6 +426,106 @@ struct AgentComposerView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Agent status")
         .accessibilityValue(status.rawValue.capitalized)
+    }
+}
+
+/// The inline suggestion menu above the Composer's text area: the Skills the
+/// typed trigger token matches, or the load in progress behind them. Selecting
+/// a row swaps the token for the full invocation in the draft — nothing is
+/// sent. Renders nothing when a loaded catalogue has no match, so prose that
+/// happens to contain a prefix is not nagged.
+private struct AgentComposerSkillSuggestions: View {
+    let skills: SkillsPaneStore
+    let trigger: SkillSuggestionTrigger
+    let onSelect: (AgentSkill) -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        switch skills.phase {
+        case .idle, .loading:
+            header {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        case .failed(let message):
+            VStack(alignment: .leading, spacing: 4) {
+                header {
+                    Button("Retry") { Task { await skills.refresh() } }
+                        .font(.caption)
+                }
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+        case .loaded:
+            let matches = trigger.matches(in: skills.skills)
+            if !matches.isEmpty {
+                VStack(alignment: .leading, spacing: 0) {
+                    header { EmptyView() }
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 0) {
+                            ForEach(matches) { skill in
+                                row(for: skill)
+                            }
+                        }
+                    }
+                    .frame(maxHeight: 176)
+                    .scrollBounceBehavior(.basedOnSize)
+                    Divider()
+                }
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel("Skill Suggestions")
+            }
+        }
+    }
+
+    private func header(@ViewBuilder trailing: () -> some View) -> some View {
+        HStack(spacing: 8) {
+            Text("Skills")
+                .font(.caption.weight(.semibold))
+                .textCase(.uppercase)
+                .foregroundStyle(.secondary)
+            trailing()
+            Spacer(minLength: 0)
+            Button {
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 28, height: 28)
+                    .contentShape(.rect)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss Skill Suggestions")
+        }
+    }
+
+    private func row(for skill: AgentSkill) -> some View {
+        Button {
+            onSelect(skill)
+        } label: {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(skill.command)
+                    .font(.subheadline.weight(.medium))
+                    .fontDesign(.monospaced)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                if let description = skill.description {
+                    Text(description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 7)
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(skill.name)
+        .accessibilityHint("Inserts \(skill.command) without sending it")
     }
 }
 

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -46,6 +46,7 @@ struct AgentTerminalView: View {
     @State private var isConfirmingClose = false
     @State private var isStartingAgent = false
     @State private var isManagingSnippets = false
+    @State private var isShowingSkillsPicker = false
     @State private var isRenamingAgent = false
     /// The skill whose full document is on screen; set from the Skills
     /// pane's long-press menu.
@@ -120,12 +121,13 @@ struct AgentTerminalView: View {
     private static func makeSkillsStore(
         for agent: ConsoleAgent, console: ConsoleStore
     ) -> SkillsPaneStore? {
-        guard
-            let kind = SupportedAgentKind(rawValue: agent.agent.kind),
-            SkillSourceCatalog.supports(kind)
-        else { return nil }
+        guard let kind = SupportedAgentKind(rawValue: agent.agent.kind) else { return nil }
+        let sources = SkillSourceCatalog.sources(for: kind)
+        guard !sources.isEmpty else { return nil }
         let projectRoot = agent.skillsProjectRoot
-        return SkillsPaneStore { [console] forceRefresh in
+        return SkillsPaneStore(
+            commandPrefixes: sources.map(\.commandPrefix)
+        ) { [console] forceRefresh in
             try await console.fetchSkills(
                 kind: kind,
                 projectRoot: projectRoot,
@@ -206,6 +208,19 @@ struct AgentTerminalView: View {
         // back; see `allowsKeyboardActivation` in HeelerTerminalView.
         .sheet(isPresented: $isManagingSnippets) {
             SnippetsManagementView(store: terminal.snippets)
+        }
+        // Same keyboard choreography as the Snippets sheet above. The picker
+        // shares the tools keyboard's SkillsPaneStore, so both surfaces load
+        // and fail together.
+        .sheet(isPresented: $isShowingSkillsPicker) {
+            if let skills {
+                SkillsPickerView(
+                    store: skills,
+                    onInsert: { composer.insertIntoDraft($0.insertionText) },
+                    readSkill: { [console, agent] skill in
+                        try await console.readSkillFile(path: skill.path, on: agent.hostID)
+                    })
+            }
         }
         // Same keyboard choreography as the Snippets sheet above.
         .sheet(item: $viewingSkill) { skill in
@@ -390,6 +405,7 @@ struct AgentTerminalView: View {
             isOpeningTerminal: isOpeningTerminal,
             startAgent: { isStartingAgent = true },
             manageSnippets: { isManagingSnippets = true },
+            showSkills: skills != nil ? { isShowingSkillsPicker = true } : nil,
             showWorktreeDetails: agent.isLinkedWorktree
                 ? {
                     if let checkout = agent.repositoryCheckout {
@@ -447,6 +463,7 @@ struct AgentTerminalView: View {
                 keyboardHandoff: keyboardHandoff,
                 keyboardHeight: composerKeyboardLayout.availableToolsHeight,
                 actions: composerActions,
+                skills: skills,
                 keyboardPresentation: $composerKeyboardPresentation,
                 prepareKeyboardPresentation: prepareComposerKeyboardPresentation)
         }

--- a/Sources/Heeler/Skills/SkillSuggestionTrigger.swift
+++ b/Sources/Heeler/Skills/SkillSuggestionTrigger.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// An invocation token detected at the end of the Composer draft: `/rev`,
+/// `$pdf`, `/skill:web`. Detection is suffix-based on purpose — the draft
+/// store has no cursor, and command invocations are typed at the end of the
+/// draft — so editing earlier text never opens suggestions.
+struct SkillSuggestionTrigger: Equatable {
+    /// The whole typed token, prefix included.
+    let token: String
+    /// The invocation prefix the token was recognized by.
+    let prefix: String
+
+    /// What the user typed after the prefix; the filter text.
+    var query: String { String(token.dropFirst(prefix.count)) }
+
+    /// The token at the end of the draft when it starts with one of the
+    /// given prefixes, longest prefix winning so `/skill:` beats `/`. A
+    /// token starts at the draft's beginning or after whitespace — `path/to`
+    /// never triggers.
+    static func detect(draft: String, prefixes: [String]) -> SkillSuggestionTrigger? {
+        let token: Substring =
+            if let boundary = draft.lastIndex(where: \.isWhitespace) {
+                draft[draft.index(after: boundary)...]
+            } else {
+                draft[...]
+            }
+        guard !token.isEmpty else { return nil }
+        let byLengthDescending = prefixes.sorted { $0.count > $1.count }
+        guard let prefix = byLengthDescending.first(where: { token.hasPrefix($0) })
+        else { return nil }
+        return SkillSuggestionTrigger(token: String(token), prefix: prefix)
+    }
+
+    /// The skills worth suggesting for this token: those whose full command
+    /// continues it (so `/sk` already offers `/skill:web`), and — once a
+    /// query exists — same-prefix skills whose name or description contains
+    /// it. Skills on another prefix never match a foreign token.
+    func matches(in skills: [AgentSkill]) -> [AgentSkill] {
+        skills.filter { skill in
+            if skill.command.lowercased().hasPrefix(token.lowercased()) {
+                return true
+            }
+            guard skill.commandPrefix == prefix, !query.isEmpty else { return false }
+            return skill.name.localizedStandardContains(query)
+                || (skill.description?.localizedStandardContains(query) ?? false)
+        }
+    }
+}

--- a/Sources/Heeler/Skills/SkillsPaneStore.swift
+++ b/Sources/Heeler/Skills/SkillsPaneStore.swift
@@ -20,17 +20,49 @@ final class SkillsPaneStore {
     private(set) var phase: Phase = .idle
     private(set) var skills: [AgentSkill] = []
 
+    /// The invocation prefixes this agent's skill sources use, known before
+    /// anything is fetched so typing one can open suggestions immediately.
+    private let commandPrefixes: [String]
     private let fetch: (_ forceRefresh: Bool) async throws -> [AgentSkill]
     /// Flipped synchronously before the first await so a re-selected pane
     /// racing a manual refresh cannot dispatch a second probe.
     private var isFetching = false
 
-    init(fetch: @escaping (_ forceRefresh: Bool) async throws -> [AgentSkill]) {
+    init(
+        commandPrefixes: [String] = ["/"],
+        fetch: @escaping (_ forceRefresh: Bool) async throws -> [AgentSkill]
+    ) {
+        self.commandPrefixes = commandPrefixes
         self.fetch = fetch
     }
 
     var projectSkills: [AgentSkill] { skills.filter { $0.scope == .project } }
     var globalSkills: [AgentSkill] { skills.filter { $0.scope == .global } }
+
+    /// The prefixes that open inline suggestions: the catalog's plus any a
+    /// loaded skill actually carries, longest first so `/skill:` is matched
+    /// before `/`.
+    var triggerPrefixes: [String] {
+        var prefixes = Set(commandPrefixes)
+        for skill in skills {
+            prefixes.insert(skill.commandPrefix)
+        }
+        return prefixes.sorted { lhs, rhs in
+            lhs.count != rhs.count ? lhs.count > rhs.count : lhs < rhs
+        }
+    }
+
+    /// Case- and diacritic-insensitive match over the command and the
+    /// description — the Snippets rule, plus the prefix so "$" finds Codex
+    /// skills.
+    func matching(_ query: String) -> [AgentSkill] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return skills }
+        return skills.filter { skill in
+            skill.command.localizedStandardContains(trimmed)
+                || (skill.description?.localizedStandardContains(trimmed) ?? false)
+        }
+    }
 
     /// The pane's appearance hook: loads once, then reuses what is loaded
     /// (the ConsoleStore caches per connection underneath).

--- a/Sources/Heeler/Skills/SkillsPickerView.swift
+++ b/Sources/Heeler/Skills/SkillsPickerView.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+
+/// The explicit Skill picker, presented as a sheet from the Composer's More
+/// menu. It reads the same `SkillsPaneStore` as the tools keyboard's Skills
+/// pane — one catalogue, one load, one set of failure states — and adds the
+/// search field the keyboard pane cannot host. Tapping a Skill inserts its
+/// invocation into the draft without sending it, then closes the picker.
+struct SkillsPickerView: View {
+    let store: SkillsPaneStore
+    let onInsert: (AgentSkill) -> Void
+    /// Fetches the skill's full document for View Content. The picker owns
+    /// that sheet itself: the screen's own skill sheet cannot present while
+    /// this one is up.
+    let readSkill: (AgentSkill) async throws -> String
+
+    @State private var query = ""
+    @State private var viewingSkill: AgentSkill?
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Skills")
+                .navigationBarTitleDisplayMode(.inline)
+                .searchable(text: $query, prompt: "Search Skills")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+        }
+        .task { await store.loadIfNeeded() }
+        .sheet(item: $viewingSkill) { skill in
+            SkillContentSheet(skill: skill) { try await readSkill(skill) }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if store.skills.isEmpty {
+            emptyContent
+        } else {
+            resultsList
+        }
+    }
+
+    /// Before the first list arrives: a spinner, the failure with a retry,
+    /// or the honest "nothing installed" answer.
+    @ViewBuilder
+    private var emptyContent: some View {
+        switch store.phase {
+        case .idle, .loading:
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .failed(let message):
+            ContentUnavailableView {
+                Label("Skills Unavailable", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(message)
+            } actions: {
+                Button("Retry") { Task { await store.refresh() } }
+                    .buttonStyle(.borderedProminent)
+            }
+        case .loaded:
+            ContentUnavailableView {
+                Label("No Skills", systemImage: "sparkles")
+            } description: {
+                Text("No skills found for this agent.")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var resultsList: some View {
+        let results = store.matching(query)
+        if results.isEmpty {
+            ContentUnavailableView.search(text: query)
+        } else {
+            List {
+                section(titled: "Project", skills: results.filter { $0.scope == .project })
+                section(titled: "Global", skills: results.filter { $0.scope == .global })
+            }
+            .refreshable { await store.refresh() }
+        }
+    }
+
+    @ViewBuilder
+    private func section(titled title: String, skills: [AgentSkill]) -> some View {
+        if !skills.isEmpty {
+            Section(title) {
+                ForEach(skills) { skill in
+                    row(for: skill)
+                }
+            }
+        }
+    }
+
+    private func row(for skill: AgentSkill) -> some View {
+        Button {
+            onInsert(skill)
+            dismiss()
+        } label: {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(skill.command)
+                    .font(.body.weight(.medium))
+                    .fontDesign(.monospaced)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                if let description = skill.description {
+                    Text(description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(skill.name)
+        .accessibilityHint("Inserts \(skill.command) without sending it")
+        .contextMenu {
+            Button("View Content", systemImage: "doc.text") {
+                viewingSkill = skill
+            }
+            Button("Insert", systemImage: "text.insert") {
+                onInsert(skill)
+                dismiss()
+            }
+        } preview: {
+            SkillDetailPreview(skill: skill)
+        }
+    }
+}

--- a/Tests/HeelerTests/AgentComposerStoreTests.swift
+++ b/Tests/HeelerTests/AgentComposerStoreTests.swift
@@ -477,6 +477,39 @@ struct AgentComposerStoreTests {
         #expect(writes == [Data("n".utf8)])
     }
 
+    @Test func replaceTrailingTokenSwapsTheTokenAndKeepsTheRest() {
+        let store = Self.draftOnlyStore()
+        store.replaceDraft(with: "fix this /rev")
+
+        store.replaceTrailingToken("/rev", with: "/code-review ")
+
+        #expect(store.draft == "fix this /code-review ")
+    }
+
+    @Test func replaceTrailingTokenLeavesADraftThatNoLongerEndsWithIt() {
+        let store = Self.draftOnlyStore()
+        store.replaceDraft(with: "/rev then more")
+
+        store.replaceTrailingToken("/rev", with: "/code-review ")
+
+        #expect(store.draft == "/rev then more")
+    }
+
+    @Test func replaceTrailingTokenIgnoresAnEmptyToken() {
+        let store = Self.draftOnlyStore()
+        store.replaceDraft(with: "keep me")
+
+        store.replaceTrailingToken("", with: "/code-review ")
+
+        #expect(store.draft == "keep me")
+    }
+
+    private static func draftOnlyStore() -> AgentComposerStore {
+        AgentComposerStore(target: "w1:p1") { _ in
+            throw TransportError.timedOut
+        }
+    }
+
     private func waitUntil(
         _ comment: Comment,
         timeout: Duration = .seconds(2),

--- a/Tests/HeelerTests/SkillSuggestionTriggerTests.swift
+++ b/Tests/HeelerTests/SkillSuggestionTriggerTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@Suite("skill suggestion trigger")
+struct SkillSuggestionTriggerTests {
+    private static func skill(
+        _ name: String, prefix: String = "/", description: String? = nil
+    ) -> AgentSkill {
+        AgentSkill(
+            scope: .project, name: name, description: description,
+            commandPrefix: prefix)
+    }
+
+    // MARK: Detection
+
+    @Test func detectsAPrefixAtTheStartOfTheDraft() {
+        let trigger = SkillSuggestionTrigger.detect(draft: "/re", prefixes: ["/"])
+        #expect(trigger == SkillSuggestionTrigger(token: "/re", prefix: "/"))
+        #expect(trigger?.query == "re")
+    }
+
+    @Test func detectsAPrefixAfterWhitespaceAndNewlines() {
+        #expect(
+            SkillSuggestionTrigger.detect(draft: "fix this /rev", prefixes: ["/"])
+                == SkillSuggestionTrigger(token: "/rev", prefix: "/"))
+        #expect(
+            SkillSuggestionTrigger.detect(draft: "line one\n$pd", prefixes: ["$"])
+                == SkillSuggestionTrigger(token: "$pd", prefix: "$"))
+    }
+
+    @Test func aPrefixInsideATokenDoesNotTrigger() {
+        #expect(SkillSuggestionTrigger.detect(draft: "path/to", prefixes: ["/"]) == nil)
+        #expect(SkillSuggestionTrigger.detect(draft: "us$", prefixes: ["$"]) == nil)
+    }
+
+    @Test func anEmptyOrCompletedTokenDoesNotTrigger() {
+        #expect(SkillSuggestionTrigger.detect(draft: "", prefixes: ["/"]) == nil)
+        // The trailing space after an insertion ends the token, so the menu
+        // closes itself once a suggestion lands.
+        #expect(SkillSuggestionTrigger.detect(draft: "/review ", prefixes: ["/"]) == nil)
+    }
+
+    @Test func theLongestPrefixWins() {
+        #expect(
+            SkillSuggestionTrigger.detect(draft: "/skill:pd", prefixes: ["/", "/skill:"])
+                == SkillSuggestionTrigger(token: "/skill:pd", prefix: "/skill:"))
+    }
+
+    @Test func withoutAMatchingPrefixThereIsNoTrigger() {
+        #expect(SkillSuggestionTrigger.detect(draft: "$pdf", prefixes: ["/"]) == nil)
+        #expect(SkillSuggestionTrigger.detect(draft: "review", prefixes: ["/", "$"]) == nil)
+    }
+
+    // MARK: Filtering
+
+    @Test func aBarePrefixOffersEverySkillOnThatPrefix() {
+        let skills = [
+            Self.skill("code-review"),
+            Self.skill("tdd"),
+            Self.skill("pdf-tools", prefix: "$"),
+        ]
+        let trigger = SkillSuggestionTrigger(token: "/", prefix: "/")
+        #expect(trigger.matches(in: skills).map(\.name) == ["code-review", "tdd"])
+    }
+
+    @Test func codexTokensMatchOnlyDollarSkills() {
+        let skills = [
+            Self.skill("pdf-tools", prefix: "$"),
+            Self.skill("pdf-render"),
+        ]
+        let trigger = SkillSuggestionTrigger(token: "$pdf", prefix: "$")
+        #expect(trigger.matches(in: skills).map(\.name) == ["pdf-tools"])
+    }
+
+    @Test func typingFiltersByNameAndDescriptionCaseInsensitively() {
+        let skills = [
+            Self.skill("code-review", description: "Review a pull request"),
+            Self.skill("tdd", description: "REVIEW nothing, test first"),
+            Self.skill("deploy", description: nil),
+        ]
+        let trigger = SkillSuggestionTrigger(token: "/Rev", prefix: "/")
+        #expect(trigger.matches(in: skills).map(\.name) == ["code-review", "tdd"])
+    }
+
+    @Test func aPartialMultiCharacterPrefixStillOffersItsSkills() {
+        let skills = [Self.skill("web", prefix: "/skill:")]
+        let trigger = SkillSuggestionTrigger(token: "/sk", prefix: "/")
+        #expect(trigger.matches(in: skills).map(\.name) == ["web"])
+    }
+
+    @Test func anUnmatchedQueryOffersNothing() {
+        let skills = [Self.skill("code-review", description: "Review a pull request")]
+        let trigger = SkillSuggestionTrigger(token: "/zzz", prefix: "/")
+        #expect(trigger.matches(in: skills).isEmpty)
+    }
+}

--- a/Tests/HeelerTests/SkillsPaneStoreTests.swift
+++ b/Tests/HeelerTests/SkillsPaneStoreTests.swift
@@ -63,6 +63,43 @@ struct SkillsPaneStoreTests {
         #expect(store.skills.map(\.name) == ["kept"])
     }
 
+    @Test func matchingFiltersOverCommandAndDescription() async {
+        let store = SkillsPaneStore { _ in
+            [
+                AgentSkill(
+                    scope: .project, name: "code-review",
+                    description: "Review a pull request"),
+                AgentSkill(
+                    scope: .global, name: "tdd",
+                    description: "Red, green, refactor"),
+                AgentSkill(
+                    scope: .global, name: "pdf-tools", description: nil,
+                    commandPrefix: "$"),
+            ]
+        }
+        await store.loadIfNeeded()
+
+        #expect(store.matching("").map(\.name) == ["code-review", "tdd", "pdf-tools"])
+        #expect(store.matching("REVIEW").map(\.name) == ["code-review"])
+        #expect(store.matching("green").map(\.name) == ["tdd"])
+        #expect(store.matching("$pdf").map(\.name) == ["pdf-tools"])
+        #expect(store.matching("absent").isEmpty)
+    }
+
+    @Test func triggerPrefixesUniteTheCatalogAndTheLoadedSkillsLongestFirst() async {
+        let store = SkillsPaneStore(commandPrefixes: ["/", "/skill:", "/"]) { _ in
+            [
+                AgentSkill(
+                    scope: .global, name: "pdf-tools", description: nil,
+                    commandPrefix: "$")
+            ]
+        }
+        #expect(store.triggerPrefixes == ["/skill:", "/"])
+
+        await store.loadIfNeeded()
+        #expect(store.triggerPrefixes == ["/skill:", "$", "/"])
+    }
+
     @Test func cancellationReturnsToIdleSoTheNextAppearanceRetries() async {
         var attempts = 0
         let store = SkillsPaneStore { _ in


### PR DESCRIPTION
## Summary
- Adds inline Skill suggestions when the user types an Agent-kind invocation prefix in the Composer, filtering as they continue typing (refs #234).
- Adds a Skills entry in the Composer More menu that opens a searchable picker sharing the tools-keyboard Skills catalogue and insertion path.
- Uses each Skill’s `commandPrefix` (including Codex `$`) and inserts the full command into the draft without sending it; unsupported Agent kinds omit the action.

## Test plan
- [x] Type a supported prefix at a token boundary and confirm suggestions appear, filter, and insert without sending.
- [x] Open Composer More → Skills and confirm the picker works with software, hardware, and tools keyboards.
- [x] Confirm Codex inserts `$` (not `/`) and other kinds keep their own prefixes.
- [x] Dismiss suggestions / close the picker and confirm unrelated draft text is unchanged; unsupported kinds hide the Skills action.
- [x] Check VoiceOver / keyboard navigation for both entry points.
- [x] Run `SkillSuggestionTriggerTests`, `AgentComposerStoreTests`, and `SkillsPaneStoreTests`.