### PR TITLE
feat: group agents by host with collapsible sections

### DIFF
--- a/.testloop/reports/2026-08-27-issue-245-grouped-agents.md
+++ b/.testloop/reports/2026-08-27-issue-245-grouped-agents.md
@@ -1,0 +1,25 @@
+# testloop — 2026-08-27 — Issue #245 grouped Agents
+
+**Verdict:** pass · **Rounds:** 2
+
+## Covered
+
+- Switched between the flat Status Order list and the By Host presentation,
+  confirming Host headers, grouping, and the absence of duplicate Host status.
+- Collapsed and expanded a live Host section, including its Done-Agent
+  attention count and accessible name, value, and action hint.
+- Terminated, rebuilt, installed, and relaunched the app, then independently
+  confirmed that both presentation mode and per-Host collapse state persisted.
+- Restored the final app state to Status Order without opening an Agent or
+  changing Host or Agent data.
+
+## Found & fixed
+
+- None.
+
+## Still open
+
+- Host-filter composition was not exercised because only one Host was
+  configured.
+- Empty and unavailable Host presentation was not exercised because the live
+  Host was connected and non-empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Added
+
+- Console can switch between the flat status-sorted Agent list and a by-Host
+  grouped list with collapsible sections; collapsed Hosts still show a
+  Blocked/Done attention count, and both the presentation choice and per-Host
+  collapse state persist across launches. (#245)
+
 ## [0.1.2] - 2026-08-26
 
 ### Added

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,7 +84,7 @@ survives. Snapshot worktree metadata also describes the main checkout; only
 _Avoid_: sandbox, branch copy, checkout folder
 
 **Console**:
-The native dashboard surface: the flat, status-sorted list of Agents across Hosts, plus the Agent detail screen.
+The native dashboard surface: Agents across Hosts as either a flat status-sorted list or a by-Host grouped list with collapsible sections, plus the Agent detail screen.
 _Avoid_: dashboard, home
 
 **Pin**:

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		AA6498ABD1E1782C0B5D8F5B /* ConsoleStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00807A3942817BEE9800534F /* ConsoleStoreTests.swift */; };
 		AE7E2063C7A908DFECE9FB98 /* NotificationRelaySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A97F1827BC65B4A271F28C /* NotificationRelaySettings.swift */; };
 		AEE3EAD6534D2D9774BBDB1E /* SkillContentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB68C31A4C8A5EE1BAE32EC /* SkillContentSheet.swift */; };
+		AEFAF47E29B1ABADCC273B80 /* ConsoleListPresentationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D0218973C687D6D07E82963 /* ConsoleListPresentationStoreTests.swift */; };
 		AFA3583DF83EFBAFEEE91E28 /* TerminalAgentSwitcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA59306306EAEAA6DA78E337 /* TerminalAgentSwitcherTests.swift */; };
 		B253EC25B4FA08551D5E6B4B /* WeakNetworkProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44E8A7E5D2D96096928B69C /* WeakNetworkProxy.swift */; };
 		B2C0FB87155FFE531C2C6265 /* AgentNotificationRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1676B4E6BAB1C28E5596A7 /* AgentNotificationRouterTests.swift */; };
@@ -280,6 +281,7 @@
 		DF1D75FBECE8FABC8E3A093D /* AppForegroundRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B248F9372687FDBE3AD24A1 /* AppForegroundRecoveryTests.swift */; };
 		DF88C6F619C253A98F0EC3F6 /* NotificationDisclosureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5416AE7B7A89E2987620E65E /* NotificationDisclosureView.swift */; };
 		DFB9F3DD64996FFAF4E519EC /* pairing-code-v1.json in Resources */ = {isa = PBXBuildFile; fileRef = F9EF9F515ABC98C4B0B483C0 /* pairing-code-v1.json */; };
+		E118CE5CB81C21030F23BC84 /* ConsoleListPresentationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FEA2FB18C10525E4B4F1D8 /* ConsoleListPresentationStore.swift */; };
 		E1C95FE0F5AC6271001DBF60 /* AgentDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733AB85D0EBE3F90487289EA /* AgentDetailView.swift */; };
 		E2F51D71F8D6E3AF5FD1B9E8 /* SealedEnvelopeCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE9C95E2AC313465A7B38FD /* SealedEnvelopeCodec.swift */; };
 		E379C1AD65B445D4E08614CF /* AgentNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D3B8E2EB97A8376B333914 /* AgentNameTests.swift */; };
@@ -442,6 +444,7 @@
 		48F025CF6E2C3068BF911290 /* IBMPlexMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "IBMPlexMono-Regular.ttf"; sourceTree = "<group>"; };
 		4997A79DA8D98F7BA97E60F6 /* TerminalMouseReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalMouseReporting.swift; sourceTree = "<group>"; };
 		4AB8C5EA497D1094E86F69C4 /* WeakNetworkE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakNetworkE2ETests.swift; sourceTree = "<group>"; };
+		4D0218973C687D6D07E82963 /* ConsoleListPresentationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleListPresentationStoreTests.swift; sourceTree = "<group>"; };
 		4D6E7022FBB1A7A39C88ACA9 /* RenameStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameStoreTests.swift; sourceTree = "<group>"; };
 		4D961656A6D8B4F3964740BD /* HostOnboardingStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostOnboardingStoreTests.swift; sourceTree = "<group>"; };
 		4EEAD52089A35D4B2D47AF25 /* PairingConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingConnector.swift; sourceTree = "<group>"; };
@@ -492,6 +495,7 @@
 		764EB7D298185F64BA26C8B2 /* HerdrEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrEvents.swift; sourceTree = "<group>"; };
 		768235F2FBD7790800281BC3 /* PinnedAgentsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedAgentsStoreTests.swift; sourceTree = "<group>"; };
 		7683DF30B1A0E9FA0064AAA2 /* HeelerSSHTransportBehaviorE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHTransportBehaviorE2ETests.swift; sourceTree = "<group>"; };
+		76FEA2FB18C10525E4B4F1D8 /* ConsoleListPresentationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleListPresentationStore.swift; sourceTree = "<group>"; };
 		7780BE78D868DB0A8275E6FB /* Heeler.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Heeler.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		78F85C588963C3CE948AA9E4 /* AgentNotificationBannerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationBannerStore.swift; sourceTree = "<group>"; };
 		79662827F6A91D8EFBF112F7 /* HostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostListView.swift; sourceTree = "<group>"; };
@@ -716,6 +720,7 @@
 				239FD696B72E804AE3D85D72 /* ComposerStagingStoreTests.swift */,
 				86F44B0C95580FC88ED880FD /* ConsoleDetailPresentationTests.swift */,
 				512561E4D83FFB6575A1A8A5 /* ConsoleHostStatusPresentationTests.swift */,
+				4D0218973C687D6D07E82963 /* ConsoleListPresentationStoreTests.swift */,
 				00807A3942817BEE9800534F /* ConsoleStoreTests.swift */,
 				7374E36C37E07625B05361AE /* ContentViewActivityDriverTests.swift */,
 				BEFE51A74497E9691DBD8D7D /* DemoScreenshotModeTests.swift */,
@@ -946,6 +951,7 @@
 				1D46328CE795C513FE11AD04 /* ClosePaneStore.swift */,
 				6D83F0739372AE699009E238 /* ConsoleAgent.swift */,
 				530D32C2D59D0DD128053804 /* ConsoleHostStatusPresentation.swift */,
+				76FEA2FB18C10525E4B4F1D8 /* ConsoleListPresentationStore.swift */,
 				A14FB8560976CE777FB5A105 /* ConsoleStore.swift */,
 				C74A32020C9520EB5629B071 /* ConsoleView.swift */,
 				2D6996CA1550E32EE6AC3669 /* GitBranchName.swift */,
@@ -1452,6 +1458,7 @@
 				6FB5BA238B79801E1FDA2849 /* ConsoleActivityDriver.swift in Sources */,
 				B92B65E584DB19D068C41180 /* ConsoleAgent.swift in Sources */,
 				7B1292E9A9C6175D1272755D /* ConsoleHostStatusPresentation.swift in Sources */,
+				E118CE5CB81C21030F23BC84 /* ConsoleListPresentationStore.swift in Sources */,
 				76D19F97EA2662895D730A98 /* ConsoleStore.swift in Sources */,
 				BC3CE4B2C61D43EB4BA6B66E /* ConsoleView.swift in Sources */,
 				F71F183E690597E106438E55 /* ContentView.swift in Sources */,
@@ -1612,6 +1619,7 @@
 				847FCB04EA7913ACB390C978 /* ComposerStagingStoreTests.swift in Sources */,
 				7A73A34256C7B55060AAE9DE /* ConsoleDetailPresentationTests.swift in Sources */,
 				F61261FF8A17C9C754B99ED9 /* ConsoleHostStatusPresentationTests.swift in Sources */,
+				AEFAF47E29B1ABADCC273B80 /* ConsoleListPresentationStoreTests.swift in Sources */,
 				AA6498ABD1E1782C0B5D8F5B /* ConsoleStoreTests.swift in Sources */,
 				8B171AB6CB0C087D059631C4 /* ContentViewActivityDriverTests.swift in Sources */,
 				F96B2A54E2C6FF38CF5407BA /* DemoScreenshotModeTests.swift in Sources */,

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		6DA75E728052945BC787BBD3 /* AgentComposerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362EF66CE6DA07688C3E5F63 /* AgentComposerStoreTests.swift */; };
 		6DF161C3190C2D5DD0204839 /* WorktreeDetailStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0123607D5AA9F2DD3E26902A /* WorktreeDetailStore.swift */; };
 		6E98D7E8429E2B28B6BDF82D /* AgentTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F234ED041A4A2835A59A7510 /* AgentTerminalView.swift */; };
+		6E9F5427AEA4BF21EA3C9353 /* ConsoleHostSectionHeaderPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107722DE7ECD0406951E6B74 /* ConsoleHostSectionHeaderPresentationTests.swift */; };
 		6FB5BA238B79801E1FDA2849 /* ConsoleActivityDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F7218F35AFEB5DCDF8BAF5 /* ConsoleActivityDriver.swift */; };
 		71661C1008468E60B82B74CD /* SSHTransportSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43AE8B2A62473EBA9EA090E /* SSHTransportSettings.swift */; };
 		7238C957097EADD61E823E9D /* NotificationEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61A04DBA56C56925B594FF1 /* NotificationEnvelope.swift */; };
@@ -297,6 +298,7 @@
 		EA83373CB743395BF9FF0689 /* ImagePreparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF5D79337402EF6FA70F9CA /* ImagePreparer.swift */; };
 		EB251CDACF88FD7F5864E728 /* SealedEnvelopeCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE9C95E2AC313465A7B38FD /* SealedEnvelopeCodec.swift */; };
 		ED24AA39EBC4BC6B7341EEFB /* TransportError+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8133B7654CEFC5533DCDCC5A /* TransportError+Presentation.swift */; };
+		ED78C30BC1FC7F679D392EDF /* ConsoleHostSectionHeaderPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85214981DECFA178F08F06F /* ConsoleHostSectionHeaderPresentation.swift */; };
 		F0A8E77693C3508A42EBF75F /* HostLiveActivityCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3C7B94577B96CE8B76F3BB /* HostLiveActivityCoordinator.swift */; };
 		F179667CF0A3DAD2F3F796E6 /* live-activity-content-v1.json in Resources */ = {isa = PBXBuildFile; fileRef = 9ED544C5E701A1ACD12C6F79 /* live-activity-content-v1.json */; };
 		F1896998EA513073CF4EE713 /* PushRegistrationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63F7D63E32AA0C85E9F8FBC /* PushRegistrationStore.swift */; };
@@ -383,6 +385,7 @@
 		0DBBD602AA4969937A9306C3 /* HostCredentialsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostCredentialsProvider.swift; sourceTree = "<group>"; };
 		0E38A3F2A443D311C8FCC218 /* NotificationConfigFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationConfigFile.swift; sourceTree = "<group>"; };
 		0F7065C3BE109D2F52AE3BC2 /* HerdrAPITypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrAPITypes.swift; sourceTree = "<group>"; };
+		107722DE7ECD0406951E6B74 /* ConsoleHostSectionHeaderPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleHostSectionHeaderPresentationTests.swift; sourceTree = "<group>"; };
 		10AE622E38561E17538A561C /* HeelerSSHErrorMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHErrorMappingTests.swift; sourceTree = "<group>"; };
 		1142E803F7CA971D3CCDF2EB /* LiveActivityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityPreferences.swift; sourceTree = "<group>"; };
 		1187933BD5FAA5064BBF856F /* TerminalZoomSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalZoomSettingsTests.swift; sourceTree = "<group>"; };
@@ -595,6 +598,7 @@
 		C74CE585C09A319294FB635B /* TransportErrorPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportErrorPresentationTests.swift; sourceTree = "<group>"; };
 		C7BD377C8BB7AA8205DD8AFC /* RecentWorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentWorkspaceStore.swift; sourceTree = "<group>"; };
 		C82C6169E59B0000AA3FF5CC /* RenameSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameSheetView.swift; sourceTree = "<group>"; };
+		C85214981DECFA178F08F06F /* ConsoleHostSectionHeaderPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleHostSectionHeaderPresentation.swift; sourceTree = "<group>"; };
 		C87F6E13D72316E56DC0C571 /* NotificationPreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPreferencesStore.swift; sourceTree = "<group>"; };
 		C90B11BF4D2B2C45635B5EFE /* TerminalThemeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemeSettings.swift; sourceTree = "<group>"; };
 		C91F0473741A92D7EFA40CBA /* NotificationKeyMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationKeyMirror.swift; sourceTree = "<group>"; };
@@ -719,6 +723,7 @@
 				F4616CECA2722086A6B8B490 /* ComposerAttachmentTests.swift */,
 				239FD696B72E804AE3D85D72 /* ComposerStagingStoreTests.swift */,
 				86F44B0C95580FC88ED880FD /* ConsoleDetailPresentationTests.swift */,
+				107722DE7ECD0406951E6B74 /* ConsoleHostSectionHeaderPresentationTests.swift */,
 				512561E4D83FFB6575A1A8A5 /* ConsoleHostStatusPresentationTests.swift */,
 				4D0218973C687D6D07E82963 /* ConsoleListPresentationStoreTests.swift */,
 				00807A3942817BEE9800534F /* ConsoleStoreTests.swift */,
@@ -950,6 +955,7 @@
 				F07A0F64626D74A8EC9A1FE2 /* AttachTerminalStore.swift */,
 				1D46328CE795C513FE11AD04 /* ClosePaneStore.swift */,
 				6D83F0739372AE699009E238 /* ConsoleAgent.swift */,
+				C85214981DECFA178F08F06F /* ConsoleHostSectionHeaderPresentation.swift */,
 				530D32C2D59D0DD128053804 /* ConsoleHostStatusPresentation.swift */,
 				76FEA2FB18C10525E4B4F1D8 /* ConsoleListPresentationStore.swift */,
 				A14FB8560976CE777FB5A105 /* ConsoleStore.swift */,
@@ -1457,6 +1463,7 @@
 				247E069905D31490FEF889CE /* ComposerStagingStore.swift in Sources */,
 				6FB5BA238B79801E1FDA2849 /* ConsoleActivityDriver.swift in Sources */,
 				B92B65E584DB19D068C41180 /* ConsoleAgent.swift in Sources */,
+				ED78C30BC1FC7F679D392EDF /* ConsoleHostSectionHeaderPresentation.swift in Sources */,
 				7B1292E9A9C6175D1272755D /* ConsoleHostStatusPresentation.swift in Sources */,
 				E118CE5CB81C21030F23BC84 /* ConsoleListPresentationStore.swift in Sources */,
 				76D19F97EA2662895D730A98 /* ConsoleStore.swift in Sources */,
@@ -1618,6 +1625,7 @@
 				179292D9C3E605BC46282FE0 /* ComposerAttachmentTests.swift in Sources */,
 				847FCB04EA7913ACB390C978 /* ComposerStagingStoreTests.swift in Sources */,
 				7A73A34256C7B55060AAE9DE /* ConsoleDetailPresentationTests.swift in Sources */,
+				6E9F5427AEA4BF21EA3C9353 /* ConsoleHostSectionHeaderPresentationTests.swift in Sources */,
 				F61261FF8A17C9C754B99ED9 /* ConsoleHostStatusPresentationTests.swift in Sources */,
 				AEFAF47E29B1ABADCC273B80 /* ConsoleListPresentationStoreTests.swift in Sources */,
 				AA6498ABD1E1782C0B5D8F5B /* ConsoleStoreTests.swift in Sources */,

--- a/Sources/Heeler/Console/ConsoleHostSectionHeaderPresentation.swift
+++ b/Sources/Heeler/Console/ConsoleHostSectionHeaderPresentation.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Pure presentation values for one Console Host-section header (#245).
+///
+/// Built from a projected `ConsoleHostSection` so VoiceOver labels, readiness
+/// copy, and attention wording stay unit-testable without hosting a List.
+struct ConsoleHostSectionHeaderPresentation: Equatable {
+    let hostDisplayName: String
+    /// Short connection / Agent Inventory readiness, aligned with Host-list
+    /// chip language rather than the longer flat-list issue sentences.
+    let readinessText: String
+    let isCollapsed: Bool
+    let attentionCount: Int
+    /// Visual badge only while collapsed; VoiceOver still hears attention
+    /// whenever the count is non-zero.
+    let showsAttentionBadge: Bool
+    let attentionText: String?
+    let disclosureSystemImage: String
+    let accessibilityLabel: String
+    let accessibilityValue: String
+    let accessibilityHint: String
+
+    init(section: ConsoleHostSection) {
+        hostDisplayName = section.hostDisplayName
+        readinessText = Self.readinessText(for: section)
+        isCollapsed = section.isCollapsed
+        attentionCount = section.attentionCount
+        showsAttentionBadge = section.isCollapsed && section.attentionCount > 0
+        attentionText = Self.attentionText(count: section.attentionCount)
+        disclosureSystemImage = section.isCollapsed ? "chevron.right" : "chevron.down"
+        accessibilityValue = section.isCollapsed ? "Collapsed" : "Expanded"
+        accessibilityHint =
+            section.isCollapsed
+            ? "Expands this Host."
+            : "Collapses this Host."
+
+        var labelParts = [section.hostDisplayName, readinessText]
+        if let attentionText {
+            labelParts.append(attentionText)
+        }
+        accessibilityLabel = labelParts.joined(separator: ", ")
+    }
+
+    /// Honest short readiness: connected-empty is distinct from connecting,
+    /// loading, failed, and reconnecting.
+    static func readinessText(for section: ConsoleHostSection) -> String {
+        switch section.connectionStatus {
+        case .connected:
+            if section.isAwaitingSnapshot {
+                return "Loading Agents…"
+            }
+            if section.statusPresentation != nil {
+                return "Sync issue"
+            }
+            return section.agents.isEmpty ? "No Agents" : "Connected"
+        case .reconnecting:
+            return "Reconnecting…"
+        case .connecting:
+            if let presentation = section.statusPresentation,
+                presentation.severity != .informational
+            {
+                return "Unavailable"
+            }
+            return "Connecting…"
+        case .failed, .ended:
+            return "Unavailable"
+        case .suspended:
+            return "Paused"
+        case nil:
+            if section.statusPresentation != nil {
+                return "Unavailable"
+            }
+            return "Connecting…"
+        }
+    }
+
+    static func attentionText(count: Int) -> String? {
+        guard count > 0 else { return nil }
+        if count == 1 {
+            return "1 Agent needs attention"
+        }
+        return "\(count) Agents need attention"
+    }
+}

--- a/Sources/Heeler/Console/ConsoleHostStatusPresentation.swift
+++ b/Sources/Heeler/Console/ConsoleHostStatusPresentation.swift
@@ -103,6 +103,10 @@ struct ConsoleHostStatusPresentation: Equatable, Identifiable {
 /// "No Agents" is a known-empty snapshot, not an unknown inventory. Connecting,
 /// reconnecting, paused, failed, and Connected-awaiting-snapshot all produce
 /// condition rows, so those states take `.rows` rather than the empty claim.
+///
+/// Grouped presentation always takes `.rows` when any Host section is
+/// projected: empty and disconnected Hosts remain visible as sections rather
+/// than collapsing into the flat-list empty claim.
 enum ConsoleAgentsSurface: Equatable {
     case noHosts
     case noAgents
@@ -113,10 +117,14 @@ enum ConsoleAgentsSurface: Equatable {
         hostCount: Int,
         filteredHostName: String?,
         filteredAgentCount: Int,
-        visibleIssueCount: Int
+        visibleIssueCount: Int,
+        presentationMode: ConsoleListPresentationMode = .flat,
+        projectedSectionCount: Int = 0
     ) {
         if hostCount == 0 {
             self = .noHosts
+        } else if presentationMode == .grouped {
+            self = projectedSectionCount > 0 ? .rows : .noHosts
         } else if filteredAgentCount == 0 && visibleIssueCount == 0 {
             if let filteredHostName {
                 self = .noAgentsOnHost(filteredHostName)
@@ -125,6 +133,24 @@ enum ConsoleAgentsSurface: Equatable {
             }
         } else {
             self = .rows
+        }
+    }
+}
+
+/// Where Host connection/readiness issues appear for a presentation mode.
+///
+/// Grouped mode folds those conditions into section headers so the same
+/// failure or loading message is not also listed as a top-of-list row.
+enum ConsoleHostIssuePlacement: Equatable {
+    /// Flat list: global Host-issue rows above the Agent cards.
+    case flatIssueRows
+    /// Grouped list: Host readiness lives on each section header only.
+    case sectionHeaders
+
+    init(mode: ConsoleListPresentationMode) {
+        switch mode {
+        case .flat: self = .flatIssueRows
+        case .grouped: self = .sectionHeaders
         }
     }
 }

--- a/Sources/Heeler/Console/ConsoleListPresentationStore.swift
+++ b/Sources/Heeler/Console/ConsoleListPresentationStore.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Observation
+
+/// The two Console Agent-list presentations. Flat remains the default so
+/// introducing grouped-list support does not change the existing surface
+/// until the UI explicitly selects it.
+enum ConsoleListPresentationMode: String, CaseIterable, Identifiable, Sendable {
+    case flat
+    case grouped
+
+    var id: Self { self }
+}
+
+/// One Host section projected from the Host catalog and the Console's
+/// already-sorted Agent sequence. The section carries the inputs a header
+/// needs to present connection and Agent Inventory readiness honestly.
+struct ConsoleHostSection: Identifiable, Equatable {
+    let hostID: Host.ID
+    let hostDisplayName: String
+    let connectionStatus: EventsSessionStatus?
+    let isAwaitingSnapshot: Bool
+    let statusPresentation: ConsoleHostStatusPresentation?
+    let agents: [ConsoleAgent]
+    let isCollapsed: Bool
+    let attentionCount: Int
+
+    var id: Host.ID { hostID }
+}
+
+/// Persists the Console presentation choice and per-Host collapsed state,
+/// and projects grouped sections without taking ownership of Agent sorting.
+/// Collapsed Host ids are deliberately retained when a Host disconnects or
+/// leaves the catalog so a reconnect or later return restores the choice.
+@MainActor
+@Observable
+final class ConsoleListPresentationStore {
+    private static let modeDefaultsKey = "console-list.presentation-mode"
+    private static let collapsedHostsDefaultsKey = "console-list.collapsed-hosts"
+
+    private(set) var mode: ConsoleListPresentationMode
+    private var collapsedHostIDs: Set<Host.ID>
+    // UserDefaults is documented thread-safe; Sendable modulo that promise.
+    @ObservationIgnored private nonisolated(unsafe) let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        mode =
+            defaults.string(forKey: Self.modeDefaultsKey)
+            .flatMap(ConsoleListPresentationMode.init(rawValue:)) ?? .flat
+        collapsedHostIDs = Set(
+            (defaults.stringArray(forKey: Self.collapsedHostsDefaultsKey) ?? [])
+                .compactMap(UUID.init(uuidString:)))
+    }
+
+    func select(_ mode: ConsoleListPresentationMode) {
+        guard mode != self.mode else { return }
+        self.mode = mode
+        defaults.set(mode.rawValue, forKey: Self.modeDefaultsKey)
+    }
+
+    func isCollapsed(_ hostID: Host.ID) -> Bool {
+        collapsedHostIDs.contains(hostID)
+    }
+
+    func setCollapsed(_ collapsed: Bool, for hostID: Host.ID) {
+        let changed: Bool
+        if collapsed {
+            changed = collapsedHostIDs.insert(hostID).inserted
+        } else {
+            changed = collapsedHostIDs.remove(hostID) != nil
+        }
+        guard changed else { return }
+        persistCollapsedHostIDs()
+    }
+
+    func toggleCollapsed(_ hostID: Host.ID) {
+        setCollapsed(!isCollapsed(hostID), for: hostID)
+    }
+
+    /// Convenience contract for the Console UI. Reading these observable
+    /// inputs on each render makes status, inventory, and membership changes
+    /// re-project without a second cache to reconcile.
+    func sections(
+        hosts: [Host],
+        console: ConsoleStore,
+        filteredHostID: Host.ID? = nil
+    ) -> [ConsoleHostSection] {
+        sections(
+            hosts: hosts,
+            agents: console.agents,
+            hostStatuses: console.hostStatuses,
+            hostStandingFailures: console.hostStandingFailures,
+            hostsAwaitingSnapshot: console.hostsAwaitingSnapshot,
+            hostSyncErrors: console.hostSyncErrors,
+            filteredHostID: filteredHostID)
+    }
+
+    /// Projects one section per catalog Host, in catalog order. `agents` is
+    /// already pin/status sorted by ConsoleStore; filtering it in-place keeps
+    /// that exact relative order within every Host section.
+    func sections(
+        hosts: [Host],
+        agents: [ConsoleAgent],
+        hostStatuses: [Host.ID: EventsSessionStatus] = [:],
+        hostStandingFailures: [Host.ID: TransportError] = [:],
+        hostsAwaitingSnapshot: Set<Host.ID> = [],
+        hostSyncErrors: [Host.ID: String] = [:],
+        filteredHostID: Host.ID? = nil
+    ) -> [ConsoleHostSection] {
+        let agentsByHost = Dictionary(grouping: agents, by: \.hostID)
+        var projectedHostIDs: Set<Host.ID> = []
+
+        return hosts.compactMap { host in
+            guard filteredHostID == nil || host.id == filteredHostID else { return nil }
+            guard projectedHostIDs.insert(host.id).inserted else { return nil }
+
+            let hostAgents = agentsByHost[host.id] ?? []
+            let isAwaitingSnapshot = hostsAwaitingSnapshot.contains(host.id)
+            return ConsoleHostSection(
+                hostID: host.id,
+                hostDisplayName: host.displayName,
+                connectionStatus: hostStatuses[host.id],
+                isAwaitingSnapshot: isAwaitingSnapshot,
+                statusPresentation: ConsoleHostStatusPresentation(
+                    host: host,
+                    status: hostStatuses[host.id],
+                    standingFailure: hostStandingFailures[host.id],
+                    isAwaitingSnapshot: isAwaitingSnapshot,
+                    syncError: hostSyncErrors[host.id]),
+                agents: hostAgents,
+                isCollapsed: isCollapsed(host.id),
+                attentionCount: hostAgents.count {
+                    $0.agent.status == .blocked || $0.agent.status == .done
+                })
+        }
+    }
+
+    private func persistCollapsedHostIDs() {
+        defaults.set(
+            collapsedHostIDs.map(\.uuidString).sorted(),
+            forKey: Self.collapsedHostsDefaultsKey)
+    }
+}

--- a/Sources/Heeler/Console/ConsoleListPresentationStore.swift
+++ b/Sources/Heeler/Console/ConsoleListPresentationStore.swift
@@ -9,6 +9,14 @@ enum ConsoleListPresentationMode: String, CaseIterable, Identifiable, Sendable {
     case grouped
 
     var id: Self { self }
+
+    /// Toolbar / picker label for the presentation switcher.
+    var title: String {
+        switch self {
+        case .flat: "Status order"
+        case .grouped: "By Host"
+        }
+    }
 }
 
 /// One Host section projected from the Host catalog and the Console's

--- a/Sources/Heeler/Console/ConsoleView.swift
+++ b/Sources/Heeler/Console/ConsoleView.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
-/// The Console home screen (#8): the flat, status-sorted Agent list across
-/// every Host. Host management (#14) lives behind the toolbar button.
+/// The Console home screen (#8): Agents across every Host, shown either as
+/// the flat status-sorted list or grouped by Host with collapsible sections
+/// (#245). Host management (#14) lives behind the toolbar button.
 struct ConsoleView: View {
     let hosts: HostStore
     let console: ConsoleStore
@@ -27,9 +28,11 @@ struct ConsoleView: View {
     /// 1.2 s visual-feedback hold after `retryHost` returns. Distinct from
     /// `EventsSessionStatus.reconnecting`.
     @State private var manualReconnectInFlightHostIDs: Set<Host.ID> = []
-    /// Narrows the flat list to one Host; nil shows every Host. The list
-    /// stays flat either way — this is a filter, not a grouping level.
+    /// Narrows the Agent list to one Host; nil shows every Host. This is a
+    /// filter in both presentations, not a second grouping mechanism.
     @State private var hostFilter: Host.ID?
+    /// Owns flat/grouped mode and per-Host collapsed state (#245).
+    @State private var listPresentation = ConsoleListPresentationStore()
     /// Outlives the detail column's rebuilds, which is the whole point: it
     /// carries the raised keyboard from one Attach screen to the next.
     @State private var keyboardHandoff = TerminalKeyboardHandoff()
@@ -41,6 +44,7 @@ struct ConsoleView: View {
     /// from the middle of the screen to the middle of the terminal.
     @State private var keyboardInset = TerminalKeyboardInset()
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         // A split view instead of a plain stack for the iPad's sake: regular
@@ -69,6 +73,25 @@ struct ConsoleView: View {
                                     }
                                 }
                             }
+                        }
+                    }
+                    if !hosts.hosts.isEmpty {
+                        ToolbarItem(placement: .primaryAction) {
+                            Menu {
+                                Picker("Presentation", selection: presentationModeBinding) {
+                                    ForEach(ConsoleListPresentationMode.allCases) { mode in
+                                        Text(mode.title).tag(mode)
+                                    }
+                                }
+                            } label: {
+                                Label(
+                                    "Presentation",
+                                    systemImage: listPresentation.mode == .grouped
+                                        ? "list.bullet.rectangle"
+                                        : "list.bullet")
+                            }
+                            .accessibilityLabel("Agent list presentation")
+                            .accessibilityValue(listPresentation.mode.title)
                         }
                     }
                     ToolbarItem(placement: .primaryAction) {
@@ -304,38 +327,71 @@ struct ConsoleView: View {
             }
         case .rows:
             List(selection: selectedAgent) {
-                ForEach(visibleHostIssues) { issue in
-                    if issue.navigates {
-                        Button { presentHosts(issue.hostID) } label: {
-                            hostIssueRow(issue, showsChevron: true)
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityHint("Opens this Host's settings.")
-                    } else {
-                        hostIssueRow(issue, showsChevron: false)
-                    }
-                }
-                ForEach(filteredAgents) { agent in
-                    NavigationLink(value: agent.id) {
-                        AgentCardView(
-                            agent: agent,
-                            isPinned: console.pins.isPinned(
-                                hostID: agent.hostID, paneID: agent.agent.paneID))
-                    }
-                    .contextMenu {
-                        let pinned = console.pins.isPinned(
-                            hostID: agent.hostID, paneID: agent.agent.paneID)
-                        Button(
-                            pinned ? "Unpin" : "Pin",
-                            systemImage: pinned ? "pin.slash" : "pin"
-                        ) {
-                            console.togglePin(
-                                hostID: agent.hostID, paneID: agent.agent.paneID)
-                        }
-                    }
+                if listPresentation.mode == .flat {
+                    flatAgentListRows
+                } else {
+                    groupedAgentListRows
                 }
             }
             .listStyle(.plain)
+        }
+    }
+
+    @ViewBuilder
+    private var flatAgentListRows: some View {
+        ForEach(visibleHostIssues) { issue in
+            if issue.navigates {
+                Button { presentHosts(issue.hostID) } label: {
+                    hostIssueRow(issue, showsChevron: true)
+                }
+                .buttonStyle(.plain)
+                .accessibilityHint("Opens this Host's settings.")
+            } else {
+                hostIssueRow(issue, showsChevron: false)
+            }
+        }
+        ForEach(filteredAgents) { agent in
+            agentRow(agent)
+        }
+    }
+
+    @ViewBuilder
+    private var groupedAgentListRows: some View {
+        ForEach(hostSections) { section in
+            Section {
+                if !section.isCollapsed {
+                    ForEach(section.agents) { agent in
+                        agentRow(agent)
+                    }
+                }
+            } header: {
+                ConsoleHostSectionHeaderView(
+                    presentation: ConsoleHostSectionHeaderPresentation(section: section)
+                ) {
+                    toggleHostSection(section.hostID)
+                }
+                .textCase(nil)
+            }
+        }
+    }
+
+    private func agentRow(_ agent: ConsoleAgent) -> some View {
+        NavigationLink(value: agent.id) {
+            AgentCardView(
+                agent: agent,
+                isPinned: console.pins.isPinned(
+                    hostID: agent.hostID, paneID: agent.agent.paneID))
+        }
+        .contextMenu {
+            let pinned = console.pins.isPinned(
+                hostID: agent.hostID, paneID: agent.agent.paneID)
+            Button(
+                pinned ? "Unpin" : "Pin",
+                systemImage: pinned ? "pin.slash" : "pin"
+            ) {
+                console.togglePin(
+                    hostID: agent.hostID, paneID: agent.agent.paneID)
+            }
         }
     }
 
@@ -344,7 +400,32 @@ struct ConsoleView: View {
             hostCount: hosts.hosts.count,
             filteredHostName: hostFilter == nil ? nil : filteredHostName,
             filteredAgentCount: filteredAgents.count,
-            visibleIssueCount: visibleHostIssues.count)
+            visibleIssueCount: visibleHostIssues.count,
+            presentationMode: listPresentation.mode,
+            projectedSectionCount: hostSections.count)
+    }
+
+    private var hostSections: [ConsoleHostSection] {
+        listPresentation.sections(
+            hosts: hosts.hosts,
+            console: console,
+            filteredHostID: hostFilter)
+    }
+
+    private var presentationModeBinding: Binding<ConsoleListPresentationMode> {
+        Binding(
+            get: { listPresentation.mode },
+            set: { listPresentation.select($0) })
+    }
+
+    private func toggleHostSection(_ hostID: Host.ID) {
+        if reduceMotion {
+            listPresentation.toggleCollapsed(hostID)
+        } else {
+            withAnimation(.snappy) {
+                listPresentation.toggleCollapsed(hostID)
+            }
+        }
     }
 
     private var filteredAgents: [ConsoleAgent] {
@@ -582,5 +663,50 @@ struct MissingAgentPresentation: Equatable {
             hosts: hosts.hosts,
             hostsAwaitingSnapshot: console.hostsAwaitingSnapshot,
             hostStandingFailures: console.hostStandingFailures)
+    }
+}
+
+/// Collapsible Host-section header for the grouped Console list (#245).
+private struct ConsoleHostSectionHeaderView: View {
+    let presentation: ConsoleHostSectionHeaderPresentation
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onToggle) {
+            HStack(spacing: 8) {
+                Image(systemName: presentation.disclosureSystemImage)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 12, alignment: .center)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(presentation.hostDisplayName)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.primary)
+                    Text(presentation.readinessText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+                if presentation.showsAttentionBadge {
+                    Text("\(presentation.attentionCount)")
+                        .font(.caption2.weight(.semibold))
+                        .monospacedDigit()
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.orange, in: Capsule())
+                        .accessibilityHidden(true)
+                }
+            }
+            .contentShape(Rectangle())
+            .padding(.vertical, 4)
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(presentation.accessibilityLabel)
+        .accessibilityValue(presentation.accessibilityValue)
+        .accessibilityHint(presentation.accessibilityHint)
+        .accessibilityAddTraits(.isHeader)
     }
 }

--- a/Tests/HeelerTests/ConsoleHostSectionHeaderPresentationTests.swift
+++ b/Tests/HeelerTests/ConsoleHostSectionHeaderPresentationTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@Suite("Console host section header presentation")
+struct ConsoleHostSectionHeaderPresentationTests {
+    private let host = Host.fixture(name: "studio")
+
+    private func section(
+        status: EventsSessionStatus?,
+        isAwaitingSnapshot: Bool = false,
+        statusPresentation: ConsoleHostStatusPresentation? = nil,
+        agents: [ConsoleAgent] = [],
+        isCollapsed: Bool = false,
+        attentionCount: Int = 0
+    ) -> ConsoleHostSection {
+        ConsoleHostSection(
+            hostID: host.id,
+            hostDisplayName: host.displayName,
+            connectionStatus: status,
+            isAwaitingSnapshot: isAwaitingSnapshot,
+            statusPresentation: statusPresentation,
+            agents: agents,
+            isCollapsed: isCollapsed,
+            attentionCount: attentionCount)
+    }
+
+    private func consoleAgent(paneID: String, status: AgentStatus) -> ConsoleAgent {
+        ConsoleAgent(
+            hostID: host.id,
+            hostName: host.displayName,
+            agent: Agent(.fixture(paneID: paneID, status: status)),
+            workspaceLabel: nil,
+            repositoryCheckout: nil)
+    }
+
+    @Test func readinessDistinguishesConnectedEmptyFromLoadingAndFailed() throws {
+        let empty = ConsoleHostSectionHeaderPresentation(
+            section: section(status: .connected))
+        #expect(empty.readinessText == "No Agents")
+
+        let loading = ConsoleHostSectionHeaderPresentation(
+            section: section(status: .connected, isAwaitingSnapshot: true))
+        #expect(loading.readinessText == "Loading Agents…")
+
+        let failure = TransportError.streamLocalOpenFailed(path: "/tmp/herdr.sock")
+        let failedPresentation = try #require(
+            ConsoleHostStatusPresentation(
+                host: host, status: .failed(failure), syncError: nil))
+        let failed = ConsoleHostSectionHeaderPresentation(
+            section: section(
+                status: .failed(failure),
+                statusPresentation: failedPresentation))
+        #expect(failed.readinessText == "Unavailable")
+
+        let connected = ConsoleHostSectionHeaderPresentation(
+            section: section(
+                status: .connected,
+                agents: [consoleAgent(paneID: "p1", status: .working)]))
+        #expect(connected.readinessText == "Connected")
+    }
+
+    @Test func readinessMatchesHostChipLanguageForPendingStates() {
+        #expect(
+            ConsoleHostSectionHeaderPresentation(
+                section: section(status: .connecting)).readinessText == "Connecting…")
+        #expect(
+            ConsoleHostSectionHeaderPresentation(
+                section: section(
+                    status: .reconnecting(
+                        attempt: 1, delay: .seconds(1), failure: .timedOut))
+            ).readinessText == "Reconnecting…")
+        #expect(
+            ConsoleHostSectionHeaderPresentation(
+                section: section(status: .suspended)).readinessText == "Paused")
+    }
+
+    @Test func attentionBadgeIsCollapsedOnlyButVoiceOverKeepsTheCount() {
+        let expanded = ConsoleHostSectionHeaderPresentation(
+            section: section(
+                status: .connected,
+                isCollapsed: false,
+                attentionCount: 2))
+        #expect(!expanded.showsAttentionBadge)
+        #expect(expanded.attentionText == "2 Agents need attention")
+        #expect(expanded.accessibilityLabel.contains("2 Agents need attention"))
+        #expect(expanded.accessibilityValue == "Expanded")
+        #expect(expanded.accessibilityHint == "Collapses this Host.")
+        #expect(expanded.disclosureSystemImage == "chevron.down")
+
+        let collapsed = ConsoleHostSectionHeaderPresentation(
+            section: section(
+                status: .connected,
+                isCollapsed: true,
+                attentionCount: 1))
+        #expect(collapsed.showsAttentionBadge)
+        #expect(collapsed.attentionText == "1 Agent needs attention")
+        #expect(collapsed.accessibilityValue == "Collapsed")
+        #expect(collapsed.accessibilityHint == "Expands this Host.")
+        #expect(collapsed.disclosureSystemImage == "chevron.right")
+    }
+
+    @Test func accessibilityLabelNamesHostAndReadiness() {
+        let presentation = ConsoleHostSectionHeaderPresentation(
+            section: section(status: .connected))
+        #expect(presentation.accessibilityLabel.hasPrefix("studio, No Agents"))
+    }
+}
+
+@Suite("Console list presentation routing")
+struct ConsoleListPresentationRoutingTests {
+    @Test func groupedModeShowsSectionsInsteadOfFlatEmptyClaim() {
+        #expect(
+            ConsoleAgentsSurface(
+                hostCount: 2,
+                filteredHostName: nil,
+                filteredAgentCount: 0,
+                visibleIssueCount: 0) == .noAgents)
+        #expect(
+            ConsoleAgentsSurface(
+                hostCount: 2,
+                filteredHostName: nil,
+                filteredAgentCount: 0,
+                visibleIssueCount: 0,
+                presentationMode: .grouped,
+                projectedSectionCount: 2) == .rows)
+        #expect(
+            ConsoleAgentsSurface(
+                hostCount: 1,
+                filteredHostName: "studio",
+                filteredAgentCount: 0,
+                visibleIssueCount: 0) == .noAgentsOnHost("studio"))
+        #expect(
+            ConsoleAgentsSurface(
+                hostCount: 1,
+                filteredHostName: "studio",
+                filteredAgentCount: 0,
+                visibleIssueCount: 0,
+                presentationMode: .grouped,
+                projectedSectionCount: 1) == .rows)
+    }
+
+    @Test func hostIssuePlacementFollowsPresentationMode() {
+        #expect(ConsoleHostIssuePlacement(mode: .flat) == .flatIssueRows)
+        #expect(ConsoleHostIssuePlacement(mode: .grouped) == .sectionHeaders)
+    }
+
+    @Test func presentationModeTitlesAreStableForTheSwitcher() {
+        #expect(ConsoleListPresentationMode.flat.title == "Status order")
+        #expect(ConsoleListPresentationMode.grouped.title == "By Host")
+    }
+}

--- a/Tests/HeelerTests/ConsoleListPresentationStoreTests.swift
+++ b/Tests/HeelerTests/ConsoleListPresentationStoreTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@MainActor
+@Suite("Console list presentation store")
+struct ConsoleListPresentationStoreTests {
+    private func makeDefaults() throws -> (UserDefaults, cleanup: () -> Void) {
+        let suiteName = "hm-console-list-presentation-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        return (defaults, { defaults.removePersistentDomain(forName: suiteName) })
+    }
+
+    private func consoleAgent(
+        host: Host,
+        paneID: String,
+        status: AgentStatus
+    ) -> ConsoleAgent {
+        ConsoleAgent(
+            hostID: host.id,
+            hostName: host.displayName,
+            agent: Agent(.fixture(paneID: paneID, status: status)),
+            workspaceLabel: nil,
+            repositoryCheckout: nil)
+    }
+
+    @Test func presentationModeDefaultsToFlatAndPersists() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+
+        let store = ConsoleListPresentationStore(defaults: defaults)
+        #expect(store.mode == .flat)
+
+        store.select(.grouped)
+        #expect(ConsoleListPresentationStore(defaults: defaults).mode == .grouped)
+
+        store.select(.flat)
+        #expect(ConsoleListPresentationStore(defaults: defaults).mode == .flat)
+    }
+
+    @Test func collapsedStatePersistsAndIsIsolatedPerHost() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let hostA = Host.fixture(name: "alpha")
+        let hostB = Host.fixture(name: "beta")
+
+        let store = ConsoleListPresentationStore(defaults: defaults)
+        store.setCollapsed(true, for: hostA.id)
+
+        let reloaded = ConsoleListPresentationStore(defaults: defaults)
+        #expect(reloaded.isCollapsed(hostA.id))
+        #expect(!reloaded.isCollapsed(hostB.id))
+
+        reloaded.toggleCollapsed(hostB.id)
+        reloaded.toggleCollapsed(hostA.id)
+        let reloadedAgain = ConsoleListPresentationStore(defaults: defaults)
+        #expect(!reloadedAgain.isCollapsed(hostA.id))
+        #expect(reloadedAgain.isCollapsed(hostB.id))
+    }
+
+    @Test func sectionsFollowCatalogOrderAndFilterToAtMostOneHost() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let first = Host.fixture(name: "zeta")
+        let second = Host.fixture(name: "alpha")
+        let store = ConsoleListPresentationStore(defaults: defaults)
+
+        let all = store.sections(hosts: [first, second], agents: [])
+        #expect(all.map(\.hostID) == [first.id, second.id])
+
+        let filtered = store.sections(
+            hosts: [first, second], agents: [], filteredHostID: second.id)
+        #expect(filtered.map(\.hostID) == [second.id])
+
+        let missing = store.sections(
+            hosts: [first, second], agents: [], filteredHostID: UUID())
+        #expect(missing.isEmpty)
+    }
+
+    @Test func sectionsPreserveTheSuppliedAgentOrderWithinEachHost() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let hostA = Host.fixture(name: "alpha")
+        let hostB = Host.fixture(name: "beta")
+        let aIdle = consoleAgent(host: hostA, paneID: "opaque-A", status: .idle)
+        let bBlocked = consoleAgent(host: hostB, paneID: "%opaque-B", status: .blocked)
+        let aDone = consoleAgent(host: hostA, paneID: "opaque-C", status: .done)
+        let bWorking = consoleAgent(host: hostB, paneID: "opaque-D", status: .working)
+        let store = ConsoleListPresentationStore(defaults: defaults)
+
+        let sections = store.sections(
+            hosts: [hostA, hostB],
+            agents: [aIdle, bBlocked, aDone, bWorking])
+
+        #expect(sections[0].agents.map(\.agent.paneID) == ["opaque-A", "opaque-C"])
+        #expect(sections[1].agents.map(\.agent.paneID) == ["%opaque-B", "opaque-D"])
+    }
+
+    @Test func changedInputsReprojectMembershipAndReadiness() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let host = Host.fixture(name: "studio")
+        let working = consoleAgent(host: host, paneID: "pane-1", status: .working)
+        let done = consoleAgent(host: host, paneID: "pane-2", status: .done)
+        let store = ConsoleListPresentationStore(defaults: defaults)
+
+        let loading = store.sections(
+            hosts: [host],
+            agents: [working],
+            hostStatuses: [host.id: .connected],
+            hostsAwaitingSnapshot: [host.id])
+        #expect(loading[0].agents.map(\.id) == [working.id])
+        #expect(loading[0].isAwaitingSnapshot)
+        #expect(loading[0].statusPresentation?.message == "Loading Agents from studio…")
+
+        let refreshed = store.sections(
+            hosts: [host],
+            agents: [done],
+            hostStatuses: [host.id: .connected])
+        #expect(refreshed[0].agents.map(\.id) == [done.id])
+        #expect(!refreshed[0].isAwaitingSnapshot)
+        #expect(refreshed[0].statusPresentation == nil)
+    }
+
+    @Test func emptyAndDisconnectedHostsRemainSections() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let empty = Host.fixture(name: "empty")
+        let disconnected = Host.fixture(name: "offline")
+        let failure = TransportError.sshUnreachable(detail: "connection refused")
+        let store = ConsoleListPresentationStore(defaults: defaults)
+
+        let sections = store.sections(
+            hosts: [empty, disconnected],
+            agents: [],
+            hostStatuses: [
+                empty.id: .connected,
+                disconnected.id: .failed(failure),
+            ])
+
+        #expect(sections.count == 2)
+        #expect(sections.allSatisfy(\.agents.isEmpty))
+        #expect(sections[0].connectionStatus == .connected)
+        #expect(sections[0].statusPresentation == nil)
+        #expect(sections[1].connectionStatus == .failed(failure))
+        #expect(sections[1].statusPresentation?.hostID == disconnected.id)
+    }
+
+    @Test func attentionCountsBlockedAndDoneEvenWhenCollapsed() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let host = Host.fixture()
+        let agents = [
+            consoleAgent(host: host, paneID: "blocked", status: .blocked),
+            consoleAgent(host: host, paneID: "done", status: .done),
+            consoleAgent(host: host, paneID: "working", status: .working),
+            consoleAgent(host: host, paneID: "idle", status: .idle),
+            consoleAgent(
+                host: host, paneID: "unknown", status: AgentStatus(rawValue: "future")),
+        ]
+        let store = ConsoleListPresentationStore(defaults: defaults)
+        store.setCollapsed(true, for: host.id)
+
+        let section = try #require(store.sections(hosts: [host], agents: agents).first)
+        #expect(section.isCollapsed)
+        #expect(section.attentionCount == 2)
+    }
+}

--- a/Tests/HeelerTests/ConsoleListPresentationStoreTests.swift
+++ b/Tests/HeelerTests/ConsoleListPresentationStoreTests.swift
@@ -140,7 +140,8 @@ struct ConsoleListPresentationStoreTests {
             ])
 
         #expect(sections.count == 2)
-        #expect(sections.allSatisfy(\.agents.isEmpty))
+        #expect(sections[0].agents.isEmpty)
+        #expect(sections[1].agents.isEmpty)
         #expect(sections[0].connectionStatus == .connected)
         #expect(sections[0].statusPresentation == nil)
         #expect(sections[1].connectionStatus == .failed(failure))


### PR DESCRIPTION
## Summary

- add a persistent Console presentation switch between status order and By Host grouping
- add collapsible Host sections with honest loading, empty, disconnected, and failed states
- keep Blocked, Working, and Done counts visible as accessible status pills when collapsed

## Verification

- `xcodebuild test -project Heeler.xcodeproj -scheme Heeler -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:HeelerTests/ConsoleListPresentationStoreTests -only-testing:HeelerTests/ConsoleHostSectionHeaderPresentationTests`\n  - 11 tests passed in 2 suites\n- physical-device testloop passed in 2 rounds for presentation switching, grouping, collapse/expand, accessibility metadata, and persistence across relaunch\n- GUI acceptance did not exercise a multi-Host filter combination or empty/offline Hosts; those states are covered by focused tests\n\nCloses #245