### PR TITLE
feat: redesign live activity presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ Entries reference the issue that motivated them.
 
 ### Changed
 
-- Live Activity Lock Screen and Dynamic Island use appearance-adaptive
-  system material and the shared Console status palette; the Lock Screen
-  shows up to four Agents in a dense hierarchy, stale updates retain an
-  out-of-date caption, and each visible Agent opens its detail while the
-  surrounding activity opens the Console. (#247)
+- Live Activity Lock Screen follows the iOS system Light/Dark appearance,
+  including on iOS versions where ActivityKit reports the wrong color scheme,
+  and shares the Console status palette; the Lock Screen shows up to four
+  Agents in a dense hierarchy, stale updates retain an out-of-date caption,
+  and each visible Agent opens its detail while the surrounding activity opens
+  the Console. (#247)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ Entries reference the issue that motivated them.
 ### Added
 
 - Console can switch between the flat status-sorted Agent list and a by-Host
-  grouped list with collapsible sections; collapsed Hosts still show a
-  Blocked/Done attention count, and both the presentation choice and per-Host
-  collapse state persist across launches. (#245)
+  grouped list with collapsible sections; collapsed Hosts show Live
+  Activity-style Blocked, Working, and Done count pills, and both the
+  presentation choice and per-Host collapse state persist across launches.
+  (#245)
 
 ## [0.1.2] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ Entries reference the issue that motivated them.
 
 - Live Activity Lock Screen and Dynamic Island use appearance-adaptive
   system material and the shared Console status palette; the Lock Screen
-  shows up to five Agents in a dense hierarchy, stale updates retain an
-  out-of-date caption, and the entire activity uses one large Console link
-  instead of undersized per-row targets. (#247)
+  shows up to four Agents in a dense hierarchy, stale updates retain an
+  out-of-date caption, and each visible Agent opens its detail while the
+  surrounding activity opens the Console. (#247)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Changed
+
+- Live Activity Lock Screen and Dynamic Island use appearance-adaptive
+  system material and the shared Console status palette; stale updates show
+  a reduced row budget and an out-of-date caption on the Lock Screen only.
+  (#247)
+
 ### Added
 
 - Console can switch between the flat status-sorted Agent list and a by-Host

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ Entries reference the issue that motivated them.
 ### Changed
 
 - Live Activity Lock Screen and Dynamic Island use appearance-adaptive
-  system material and the shared Console status palette; stale updates show
-  a reduced row budget and an out-of-date caption on the Lock Screen only.
-  (#247)
+  system material and the shared Console status palette; the Lock Screen
+  shows up to five Agents in a dense hierarchy, stale updates retain an
+  out-of-date caption, and the entire activity uses one large Console link
+  instead of undersized per-row targets. (#247)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ Entries reference the issue that motivated them.
 
 ### Changed
 
-- Live Activity Lock Screen follows iOS system Light/Dark changes, including
-  existing activities and iOS versions where ActivityKit reports the wrong
-  SwiftUI color scheme, and shares the Console status palette; the Lock Screen
-  shows up to four Agents in a dense hierarchy, stale updates retain an
-  out-of-date caption, and each visible Agent opens its detail while the
-  surrounding activity opens the Console. (#247)
+- Live Activity Lock Screen uses system semantic colors and shares the Console
+  status palette; it shows up to four Agents in a dense hierarchy, stale
+  updates retain an out-of-date caption, and each visible Agent opens its
+  detail while the surrounding activity opens the Console. An iOS 27
+  ActivityKit regression can still force the Dark appearance and prevent an
+  existing activity from refreshing after a system appearance change. (#247)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ Entries reference the issue that motivated them.
 
 ### Changed
 
-- Live Activity Lock Screen follows the iOS system Light/Dark appearance,
-  including on iOS versions where ActivityKit reports the wrong color scheme,
-  and shares the Console status palette; the Lock Screen shows up to four
-  Agents in a dense hierarchy, stale updates retain an out-of-date caption,
-  and each visible Agent opens its detail while the surrounding activity opens
-  the Console. (#247)
+- Live Activity Lock Screen follows iOS system Light/Dark changes, including
+  existing activities and iOS versions where ActivityKit reports the wrong
+  SwiftUI color scheme, and shares the Console status palette; the Lock Screen
+  shows up to four Agents in a dense hierarchy, stale updates retain an
+  out-of-date caption, and each visible Agent opens its detail while the
+  surrounding activity opens the Console. (#247)
 
 ### Added
 

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		0E50946869DD6FC41373079B /* HeelerSSHHostKeyPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E70C49925D454207F859F897 /* HeelerSSHHostKeyPolicyTests.swift */; };
 		0FCA9A08E011A847F31A4B85 /* AgentNotificationCenterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BABBDEFEDCB3D11EF1EFA7 /* AgentNotificationCenterDelegate.swift */; };
 		0FE90B9982AF87386D6898ED /* AgentActivityDecryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60468938DA99734F4DCBBEC /* AgentActivityDecryptor.swift */; };
+		10324EE6A79714E5D12220B6 /* AgentStatusPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A430D16838A39772ED0AA73 /* AgentStatusPalette.swift */; };
 		11F7B6617DA23C1B24E3A027 /* AgentActivityContentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29723E2E7A65ABAF27698733 /* AgentActivityContentBuilder.swift */; };
 		12B61E17D212416E86EE63ED /* AgentCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6803A0055A861DFCA2A67217 /* AgentCardView.swift */; };
 		13D6ADF6E19529103D2522DE /* SealedEnvelopeCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE9C95E2AC313465A7B38FD /* SealedEnvelopeCodec.swift */; };
@@ -48,6 +49,7 @@
 		24075F825EA192C037A09507 /* SnippetsManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB430B706185A38891A5DAC2 /* SnippetsManagementView.swift */; };
 		247E069905D31490FEF889CE /* ComposerStagingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D23517AF3A39615725A0ADC /* ComposerStagingStore.swift */; };
 		24B38E6323258B77CF7E17B8 /* NotificationPreferencesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C87F6E13D72316E56DC0C571 /* NotificationPreferencesStore.swift */; };
+		2566EFE94582C9CB4796E5ED /* AgentActivityPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39CBCF8D249D054DC71463E /* AgentActivityPresentationTests.swift */; };
 		25AE0EAE56CE592F547BE1F2 /* HostLatencyFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = E088B83BDB55BAFA2D41450F /* HostLatencyFormatting.swift */; };
 		268E43B24D46A51173DB8349 /* HostFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EF900D8EF7982B54965402 /* HostFormView.swift */; };
 		28155122AFE694FA3D41F172 /* ImageStagingE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A8ED9AD5019F303932B0F9C /* ImageStagingE2ETests.swift */; };
@@ -573,6 +575,7 @@
 		B24EF5EA39899292A1907226 /* StartAgentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStore.swift; sourceTree = "<group>"; };
 		B2627DBEB9BFBDC600F211A1 /* NotificationPrivacyCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPrivacyCopy.swift; sourceTree = "<group>"; };
 		B2DAE3FAB8786392318939A6 /* NotificationVectorFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationVectorFile.swift; sourceTree = "<group>"; };
+		B39CBCF8D249D054DC71463E /* AgentActivityPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentActivityPresentationTests.swift; sourceTree = "<group>"; };
 		B4EA32065B4A00D219B301CF /* HostKeyFingerprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostKeyFingerprint.swift; sourceTree = "<group>"; };
 		B52407E936051CF1EF746647 /* AgentComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentComposerView.swift; sourceTree = "<group>"; };
 		B5D958EC1516F09B78E346C6 /* NotificationRelaySettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRelaySettingsTests.swift; sourceTree = "<group>"; };
@@ -706,6 +709,7 @@
 				519305F6554977DB6C5E93F2 /* AgentActivityContentStateTests.swift */,
 				F7E3DCBFDF3ED4A63CBC1B3C /* AgentActivityEnvelopeTests.swift */,
 				3A62B60BB8431BE061FAA21B /* AgentActivityLinkTests.swift */,
+				B39CBCF8D249D054DC71463E /* AgentActivityPresentationTests.swift */,
 				362EF66CE6DA07688C3E5F63 /* AgentComposerStoreTests.swift */,
 				64D3B8E2EB97A8376B333914 /* AgentNameTests.swift */,
 				0A319930B80D42FB33DC8E42 /* AgentNotificationBannerStoreTests.swift */,
@@ -1412,6 +1416,7 @@
 				4AF54D36B8F0639880713FD1 /* AgentActivityLink.swift in Sources */,
 				33046B4CC05A07D26F088082 /* AgentLiveActivityWidget.swift in Sources */,
 				554C1ECECE17B440C8B37A3D /* AgentNotificationRenderer.swift in Sources */,
+				10324EE6A79714E5D12220B6 /* AgentStatusPalette.swift in Sources */,
 				8668C3C60FB9539A7DD1A4EC /* Base64URL.swift in Sources */,
 				B4720B610754009B9E30565F /* HeelerWidgetsBundle.swift in Sources */,
 				9E7AFEC6FD8926C79DCB9D1D /* HerdrAPITypes.swift in Sources */,
@@ -1607,6 +1612,7 @@
 				A1E5F3DFA582BFF8D2C00E00 /* AgentActivityContentStateTests.swift in Sources */,
 				FE66019721BB44E8BAD287DB /* AgentActivityEnvelopeTests.swift in Sources */,
 				0032AB8CC6C1DFDB893E35C6 /* AgentActivityLinkTests.swift in Sources */,
+				2566EFE94582C9CB4796E5ED /* AgentActivityPresentationTests.swift in Sources */,
 				6DA75E728052945BC787BBD3 /* AgentComposerStoreTests.swift in Sources */,
 				E379C1AD65B445D4E08614CF /* AgentNameTests.swift in Sources */,
 				6CD1D3CCDB58EBFF5350AC7F /* AgentNotificationBannerStoreTests.swift in Sources */,

--- a/Sources/Heeler/Console/ConsoleHostSectionHeaderPresentation.swift
+++ b/Sources/Heeler/Console/ConsoleHostSectionHeaderPresentation.swift
@@ -10,11 +10,11 @@ struct ConsoleHostSectionHeaderPresentation: Equatable {
     /// chip language rather than the longer flat-list issue sentences.
     let readinessText: String
     let isCollapsed: Bool
-    let attentionCount: Int
-    /// Visual badge only while collapsed; VoiceOver still hears attention
-    /// whenever the count is non-zero.
-    let showsAttentionBadge: Bool
-    let attentionText: String?
+    let statusItems: [ConsoleHostAgentStatusCount]
+    /// Visual status pills only while collapsed; VoiceOver still hears the
+    /// status breakdown whenever one of the counts is non-zero.
+    let showsStatusPills: Bool
+    let statusText: String?
     let disclosureSystemImage: String
     let accessibilityLabel: String
     let accessibilityValue: String
@@ -24,9 +24,10 @@ struct ConsoleHostSectionHeaderPresentation: Equatable {
         hostDisplayName = section.hostDisplayName
         readinessText = Self.readinessText(for: section)
         isCollapsed = section.isCollapsed
-        attentionCount = section.attentionCount
-        showsAttentionBadge = section.isCollapsed && section.attentionCount > 0
-        attentionText = Self.attentionText(count: section.attentionCount)
+        let projectedStatusItems = section.statusCounts.items
+        statusItems = projectedStatusItems
+        showsStatusPills = section.isCollapsed && !projectedStatusItems.isEmpty
+        statusText = Self.statusText(items: projectedStatusItems)
         disclosureSystemImage = section.isCollapsed ? "chevron.right" : "chevron.down"
         accessibilityValue = section.isCollapsed ? "Collapsed" : "Expanded"
         accessibilityHint =
@@ -35,8 +36,8 @@ struct ConsoleHostSectionHeaderPresentation: Equatable {
             : "Collapses this Host."
 
         var labelParts = [section.hostDisplayName, readinessText]
-        if let attentionText {
-            labelParts.append(attentionText)
+        if let statusText {
+            labelParts.append(statusText)
         }
         accessibilityLabel = labelParts.joined(separator: ", ")
     }
@@ -74,11 +75,8 @@ struct ConsoleHostSectionHeaderPresentation: Equatable {
         }
     }
 
-    static func attentionText(count: Int) -> String? {
-        guard count > 0 else { return nil }
-        if count == 1 {
-            return "1 Agent needs attention"
-        }
-        return "\(count) Agents need attention"
+    static func statusText(items: [ConsoleHostAgentStatusCount]) -> String? {
+        guard !items.isEmpty else { return nil }
+        return items.map { "\($0.count) \($0.status.rawValue)" }.joined(separator: ", ")
     }
 }

--- a/Sources/Heeler/Console/ConsoleListPresentationStore.swift
+++ b/Sources/Heeler/Console/ConsoleListPresentationStore.swift
@@ -30,9 +30,45 @@ struct ConsoleHostSection: Identifiable, Equatable {
     let statusPresentation: ConsoleHostStatusPresentation?
     let agents: [ConsoleAgent]
     let isCollapsed: Bool
-    let attentionCount: Int
+    let statusCounts: ConsoleHostAgentStatusCounts
 
     var id: Host.ID { hostID }
+}
+
+/// The Live Activity-eligible Agent statuses shown in a collapsed Host
+/// section. Keeping the same order and labels as the Live Activity makes the
+/// two summaries directly comparable.
+struct ConsoleHostAgentStatusCounts: Equatable {
+    let blocked: Int
+    let working: Int
+    let done: Int
+
+    init(blocked: Int = 0, working: Int = 0, done: Int = 0) {
+        self.blocked = blocked
+        self.working = working
+        self.done = done
+    }
+
+    init(agents: [ConsoleAgent]) {
+        blocked = agents.count { $0.agent.status == .blocked }
+        working = agents.count { $0.agent.status == .working }
+        done = agents.count { $0.agent.status == .done }
+    }
+
+    var items: [ConsoleHostAgentStatusCount] {
+        var items: [ConsoleHostAgentStatusCount] = []
+        if blocked > 0 { items.append(.init(status: .blocked, count: blocked)) }
+        if working > 0 { items.append(.init(status: .working, count: working)) }
+        if done > 0 { items.append(.init(status: .done, count: done)) }
+        return items
+    }
+}
+
+struct ConsoleHostAgentStatusCount: Identifiable, Equatable {
+    let status: AgentStatus
+    let count: Int
+
+    var id: String { status.rawValue }
 }
 
 /// Persists the Console presentation choice and per-Host collapsed state,
@@ -137,9 +173,7 @@ final class ConsoleListPresentationStore {
                     syncError: hostSyncErrors[host.id]),
                 agents: hostAgents,
                 isCollapsed: isCollapsed(host.id),
-                attentionCount: hostAgents.count {
-                    $0.agent.status == .blocked || $0.agent.status == .done
-                })
+                statusCounts: ConsoleHostAgentStatusCounts(agents: hostAgents))
         }
     }
 

--- a/Sources/Heeler/Console/ConsoleView.swift
+++ b/Sources/Heeler/Console/ConsoleView.swift
@@ -683,19 +683,15 @@ private struct ConsoleHostSectionHeaderView: View {
                     Text(presentation.hostDisplayName)
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(.primary)
+                        .lineLimit(1)
                     Text(presentation.readinessText)
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
                 Spacer(minLength: 0)
-                if presentation.showsAttentionBadge {
-                    Text("\(presentation.attentionCount)")
-                        .font(.caption2.weight(.semibold))
-                        .monospacedDigit()
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(.orange, in: Capsule())
+                if presentation.showsStatusPills {
+                    ConsoleHostStatusCountPills(items: presentation.statusItems)
                         .accessibilityHidden(true)
                 }
             }
@@ -708,5 +704,27 @@ private struct ConsoleHostSectionHeaderView: View {
         .accessibilityValue(presentation.accessibilityValue)
         .accessibilityHint(presentation.accessibilityHint)
         .accessibilityAddTraits(.isHeader)
+    }
+}
+
+/// Mirrors the Live Activity count chips so a collapsed Host communicates
+/// the same status distribution at a glance.
+private struct ConsoleHostStatusCountPills: View {
+    let items: [ConsoleHostAgentStatusCount]
+
+    var body: some View {
+        HStack(spacing: 5) {
+            ForEach(items) { item in
+                Text("\(item.count) \(item.status.rawValue)")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(Color(item.status.inkUIColor))
+                    .fixedSize()
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Color(item.status.tintUIColor).opacity(0.15),
+                        in: Capsule())
+            }
+        }
     }
 }

--- a/Sources/Heeler/ContentView.swift
+++ b/Sources/Heeler/ContentView.swift
@@ -130,10 +130,9 @@ struct ContentView: View {
         .onChange(of: console.pins.revision) {
             liveActivities.pinsDidChange()
         }
-        // Live Activity taps: an agent row deep-links to that agent's
-        // detail through the same router notification taps use; a tap
-        // outside any row (compact island, banner chrome) lands on the
-        // Console.
+        // Live Activity taps land on the Console through one large system
+        // target. Notification links can still name an Agent and route to
+        // its detail through the same URL parser.
         .onOpenURL { url in
             guard let link = AgentActivityLink.target(from: url) else { return }
             notificationRouter.open(

--- a/Sources/Heeler/ContentView.swift
+++ b/Sources/Heeler/ContentView.swift
@@ -130,9 +130,9 @@ struct ContentView: View {
         .onChange(of: console.pins.revision) {
             liveActivities.pinsDidChange()
         }
-        // Live Activity taps land on the Console through one large system
-        // target. Notification links can still name an Agent and route to
-        // its detail through the same URL parser.
+        // Live Activity row links name an Agent; surrounding chrome,
+        // compact, and minimal presentations name only the Host and land on
+        // the Console. Notification links share the same URL parser.
         .onOpenURL { url in
             guard let link = AgentActivityLink.target(from: url) else { return }
             notificationRouter.open(

--- a/Sources/HeelerWidgets/AgentActivityDecryptor.swift
+++ b/Sources/HeelerWidgets/AgentActivityDecryptor.swift
@@ -57,16 +57,40 @@ enum AgentActivityPresentation: Equatable, Sendable {
     }
 
     /// Lock-screen rows, uniform type. Four two-line rows are the ~160pt
-    /// budget's ceiling; when the inventory is larger, three rows leave
-    /// height for the "+N more" line.
-    var lockScreenAgents: [AgentActivityDetails.AgentDetail] {
-        Array(agents.prefix(counts.total <= 4 ? 4 : 3))
+    /// budget's ceiling when fresh; stale never shows four rows.
+    func lockScreenAgents(isStale: Bool) -> [AgentActivityDetails.AgentDetail] {
+        let total = counts.total
+        guard total > 0 else { return [] }
+        let visible: Int
+        if isStale {
+            visible = min(total, 3)
+        } else {
+            visible = total <= 4 ? total : 3
+        }
+        return Array(agents.prefix(visible))
     }
 
     /// Inventory beyond the drawn lock-screen rows. Zero in counts-only.
-    var lockScreenOverflowCount: Int {
-        guard !lockScreenAgents.isEmpty else { return 0 }
-        return max(0, counts.total - lockScreenAgents.count)
+    func lockScreenOverflowCount(isStale: Bool) -> Int {
+        let shown = lockScreenAgents(isStale: isStale)
+        guard !shown.isEmpty else { return 0 }
+        return max(0, counts.total - shown.count)
+    }
+
+    /// Trailing caption2 on the lock screen: overflow, stale notice, or both.
+    func lockScreenTrailingCaption(isStale: Bool) -> String? {
+        let overflow = lockScreenOverflowCount(isStale: isStale)
+        let staleCaption = "May be out of date"
+        if isStale {
+            if overflow > 0 {
+                return "+\(overflow) more · \(staleCaption)"
+            }
+            return staleCaption
+        }
+        if overflow > 0 {
+            return "+\(overflow) more"
+        }
+        return nil
     }
 }
 
@@ -160,5 +184,13 @@ extension AgentActivityAttributes.ContentState.Counts {
         if working > 0 { items.append(("working", working)) }
         if done > 0 { items.append(("done", done)) }
         return items
+    }
+
+    /// First non-zero count in attention order: blocked, done, working.
+    var attentionStatusItem: (status: String, count: Int)? {
+        if blocked > 0 { return ("blocked", blocked) }
+        if done > 0 { return ("done", done) }
+        if working > 0 { return ("working", working) }
+        return nil
     }
 }

--- a/Sources/HeelerWidgets/AgentActivityDecryptor.swift
+++ b/Sources/HeelerWidgets/AgentActivityDecryptor.swift
@@ -56,17 +56,12 @@ enum AgentActivityPresentation: Equatable, Sendable {
         return max(0, counts.total - shown)
     }
 
-    /// Lock-screen rows, uniform type. Four two-line rows are the ~160pt
-    /// budget's ceiling when fresh; stale never shows four rows.
+    /// Lock-screen rows. The first row carries the full hierarchy while
+    /// secondary rows render compactly, leaving room for five fresh rows.
     func lockScreenAgents(isStale: Bool) -> [AgentActivityDetails.AgentDetail] {
         let total = counts.total
         guard total > 0 else { return [] }
-        let visible: Int
-        if isStale {
-            visible = min(total, 3)
-        } else {
-            visible = total <= 4 ? total : 3
-        }
+        let visible = min(total, isStale ? 4 : 5)
         return Array(agents.prefix(visible))
     }
 

--- a/Sources/HeelerWidgets/AgentActivityDecryptor.swift
+++ b/Sources/HeelerWidgets/AgentActivityDecryptor.swift
@@ -56,12 +56,13 @@ enum AgentActivityPresentation: Equatable, Sendable {
         return max(0, counts.total - shown)
     }
 
-    /// Lock-screen rows. The first row carries the full hierarchy while
-    /// secondary rows render compactly, leaving room for five fresh rows.
+    /// Lock-screen rows. Four is the largest set whose independent tap
+    /// targets and overflow/stale caption stay inside ActivityKit's 160 pt
+    /// presentation budget.
     func lockScreenAgents(isStale: Bool) -> [AgentActivityDetails.AgentDetail] {
         let total = counts.total
         guard total > 0 else { return [] }
-        let visible = min(total, isStale ? 4 : 5)
+        let visible = min(total, 4)
         return Array(agents.prefix(visible))
     }
 

--- a/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
+++ b/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
@@ -250,7 +250,7 @@ private struct AgentActivityCompactLeading: View {
                 .padding(.horizontal, 5)
                 .padding(.vertical, 1)
                 .background(
-                    AgentActivityStatusStyle.ink(for: item.status, on: .island).opacity(0.22),
+                    AgentActivityStatusStyle.wash(for: item.status, on: .island).opacity(0.22),
                     in: Capsule())
                 .accessibilityLabel("\(item.count) \(item.status)")
         }

--- a/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
+++ b/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
@@ -115,8 +115,8 @@ private struct AgentActivityLockScreenContainer: View {
 }
 
 enum AgentActivityLockScreenChrome {
-    /// Keep these semantic colors unresolved. WidgetKit can then resolve the
-    /// existing Live Activity again when the iOS system appearance changes.
+    /// Keep these semantic colors unresolved so SwiftUI can redraw the
+    /// lock-screen surface when the system appearance changes.
     static let backgroundColor = UIColor.systemBackground
     static let actionColor = UIColor.label
 }
@@ -127,32 +127,39 @@ struct AgentActivityLockScreenView: View {
     let isStale: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            header
-            ForEach(visibleAgents.dropFirst(), id: \.paneID) { agent in
-                AgentActivityLinkedRow(
-                    hostID: hostID,
-                    agent: agent,
-                    surface: .lockScreen,
-                    density: .compact,
-                    minimumHeight: rowMinimumHeight)
-            }
-            if let caption = presentation.lockScreenTrailingCaption(isStale: isStale) {
-                Text(caption)
-                    .font(.caption2)
-                    .foregroundStyle(AgentActivitySemanticStyle.secondary(on: .lockScreen))
-            }
-            #if DEBUG
-                if let reason = AgentActivityDecryptor.lastFailureReason {
-                    Text(reason)
+        ZStack {
+            Color(uiColor: AgentActivityLockScreenChrome.backgroundColor)
+                .ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: 2) {
+                header
+                ForEach(visibleAgents.dropFirst(), id: \.paneID) { agent in
+                    AgentActivityLinkedRow(
+                        hostID: hostID,
+                        agent: agent,
+                        surface: .lockScreen,
+                        density: .compact,
+                        minimumHeight: rowMinimumHeight)
+                }
+                if let caption = presentation.lockScreenTrailingCaption(isStale: isStale) {
+                    Text(caption)
                         .font(.caption2)
                         .foregroundStyle(AgentActivitySemanticStyle.secondary(on: .lockScreen))
-                        .lineLimit(3)
                 }
-            #endif
+                #if DEBUG
+                    if let reason = AgentActivityDecryptor.lastFailureReason {
+                        Text(reason)
+                            .font(.caption2)
+                            .foregroundStyle(
+                                AgentActivitySemanticStyle.secondary(on: .lockScreen)
+                            )
+                            .lineLimit(3)
+                    }
+                #endif
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
         .widgetURL(AgentActivityLink.consoleURL(hostID: hostID))
     }
 

--- a/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
+++ b/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
@@ -1,5 +1,6 @@
 import ActivityKit
 import SwiftUI
+import UIKit
 import WidgetKit
 
 /// Live Activity for one Host. Lock-screen banner is a uniform agent list
@@ -12,14 +13,64 @@ struct AgentLiveActivityWidget: Widget {
         ActivityConfiguration(for: AgentActivityAttributes.self) { context in
             AgentActivityLockScreenView(
                 presentation: AgentActivityDecryptor.presentation(for: context.state),
-                hostID: context.attributes.hostID
+                hostID: context.attributes.hostID,
+                isStale: context.isStale
             )
-            .activityBackgroundTint(AgentActivityChrome.backgroundTint)
-            .activitySystemActionForegroundColor(AgentActivityChrome.systemAction)
+            .activityBackgroundTint(nil)
+            .activitySystemActionForegroundColor(nil)
         } dynamicIsland: { context in
             AgentActivityIsland.make(
                 presentation: AgentActivityDecryptor.presentation(for: context.state),
                 hostID: context.attributes.hostID)
+        }
+    }
+}
+
+// MARK: - Surface seam
+
+enum AgentActivitySurface {
+    /// Lock Screen banner. Status colors follow the system appearance
+    /// (Latte in Light, Mocha in Dark) via AgentStatusPalette.
+    case lockScreen
+    /// Compact, minimal, and expanded Dynamic Island. Always Mocha,
+    /// resolved against a dark trait collection, ignoring ambient Light Mode.
+    case island
+}
+
+enum AgentActivityStatusStyle {
+    static func ink(for status: String, on surface: AgentActivitySurface) -> Color {
+        Color(uiColor: resolvedUIColor(for: status, role: .ink, on: surface))
+    }
+
+    static func wash(for status: String, on surface: AgentActivitySurface) -> Color {
+        Color(uiColor: resolvedUIColor(for: status, role: .wash, on: surface))
+    }
+
+    private enum Role { case ink, wash }
+
+    private static func resolvedUIColor(
+        for status: String, role: Role, on surface: AgentActivitySurface
+    ) -> UIColor {
+        let agentStatus = paletteStatus(for: status)
+        let uiColor: UIColor
+        switch role {
+        case .ink: uiColor = agentStatus.inkUIColor
+        case .wash: uiColor = agentStatus.tintUIColor
+        }
+        switch surface {
+        case .lockScreen:
+            return uiColor
+        case .island:
+            return uiColor.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark))
+        }
+    }
+
+    private static func paletteStatus(for status: String) -> AgentStatus {
+        switch status {
+        case "blocked", "done", "working":
+            return AgentStatus(rawValue: status)
+        default:
+            return .unknown
         }
     }
 }
@@ -29,15 +80,16 @@ struct AgentLiveActivityWidget: Widget {
 struct AgentActivityLockScreenView: View {
     let presentation: AgentActivityPresentation
     let hostID: String
+    let isStale: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             header
-            ForEach(presentation.lockScreenAgents.dropFirst(), id: \.paneID) { agent in
-                AgentActivityLinkedRow(hostID: hostID, agent: agent)
+            ForEach(visibleAgents.dropFirst(), id: \.paneID) { agent in
+                AgentActivityLinkedRow(hostID: hostID, agent: agent, surface: .lockScreen)
             }
-            if presentation.lockScreenOverflowCount > 0 {
-                Text("+\(presentation.lockScreenOverflowCount) more")
+            if let caption = presentation.lockScreenTrailingCaption(isStale: isStale) {
+                Text(caption)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
@@ -57,36 +109,44 @@ struct AgentActivityLockScreenView: View {
         .accessibilityLabel(lockScreenAccessibilityLabel)
     }
 
+    private var visibleAgents: [AgentActivityDetails.AgentDetail] {
+        presentation.lockScreenAgents(isStale: isStale)
+    }
+
     private var header: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             headline
             Spacer(minLength: 8)
-            AgentActivityCountChips(counts: presentation.counts)
+            AgentActivityCountChips(counts: presentation.counts, surface: .lockScreen)
         }
     }
 
     @ViewBuilder
     private var headline: some View {
-        if let first = presentation.lockScreenAgents.first {
-            AgentActivityLinkedRow(hostID: hostID, agent: first)
+        if let first = visibleAgents.first {
+            AgentActivityLinkedRow(hostID: hostID, agent: first, surface: .lockScreen)
         } else {
             Text(presentation.headerTitle)
                 .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.primary)
                 .lineLimit(1)
         }
     }
 
     private var lockScreenAccessibilityLabel: String {
         var parts = [
-            presentation.lockScreenAgents.first.map(Self.narration(for:))
+            visibleAgents.first.map(Self.narration(for:))
                 ?? presentation.headerTitle
         ]
         parts.append(contentsOf: presentation.counts.chipItems.map { "\($0.count) \($0.status)" })
-        for agent in presentation.lockScreenAgents.dropFirst() {
+        for agent in visibleAgents.dropFirst() {
             parts.append(Self.narration(for: agent))
         }
-        if presentation.lockScreenOverflowCount > 0 {
-            parts.append("\(presentation.lockScreenOverflowCount) more")
+        if presentation.lockScreenOverflowCount(isStale: isStale) > 0 {
+            parts.append("\(presentation.lockScreenOverflowCount(isStale: isStale)) more")
+        }
+        if isStale {
+            parts.append("may be out of date")
         }
         return parts.joined(separator: ", ")
     }
@@ -108,7 +168,7 @@ enum AgentActivityIsland {
             DynamicIslandExpandedRegion(.center) {
                 if let primary = presentation.primaryAgent {
                     AgentActivityLinked(hostID: hostID, paneID: primary.paneID) {
-                        AgentActivityHeadlineView(agent: primary)
+                        AgentActivityHeadlineView(agent: primary, surface: .island)
                     }
                 } else {
                     Text(presentation.headerTitle)
@@ -120,14 +180,15 @@ enum AgentActivityIsland {
             DynamicIslandExpandedRegion(.bottom) {
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(presentation.secondaryAgents, id: \.paneID) { agent in
-                        AgentActivityLinkedRow(hostID: hostID, agent: agent)
+                        AgentActivityLinkedRow(hostID: hostID, agent: agent, surface: .island)
                     }
                     if presentation.overflowCount > 0 {
                         Text("+\(presentation.overflowCount) more")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
-                    AgentActivityCountChips(counts: presentation.counts)
+                    AgentActivityCountChips(
+                        counts: presentation.counts, surface: .island, chipWashOpacity: 0.16)
                 }
             }
         } compactLeading: {
@@ -149,12 +210,32 @@ enum AgentActivityIsland {
                     )
                     .foregroundStyle(
                         presentation.counts.blocked > 0
-                            ? AgentActivityStatusStyle.ink(for: "blocked")
+                            ? AgentActivityStatusStyle.ink(for: "blocked", on: .island)
                             : Color.primary
                     )
-                    .accessibilityLabel("\(presentation.counts.total) agents")
+                    .accessibilityLabel(minimalAccessibilityLabel(counts: presentation.counts))
             }
         }
+        .keylineTint(islandKeylineTint(counts: presentation.counts))
+    }
+
+    private static func islandKeylineTint(
+        counts: AgentActivityAttributes.ContentState.Counts
+    ) -> Color {
+        if counts.blocked > 0 {
+            return AgentActivityStatusStyle.ink(for: "blocked", on: .island)
+        }
+        return AgentActivityStatusStyle.ink(for: "unknown", on: .island)
+    }
+
+    private static func minimalAccessibilityLabel(
+        counts: AgentActivityAttributes.ContentState.Counts
+    ) -> String {
+        var label = "\(counts.total) agents"
+        if counts.blocked > 0 {
+            label += ", \(counts.blocked) blocked"
+        }
+        return label
     }
 }
 
@@ -162,21 +243,16 @@ private struct AgentActivityCompactLeading: View {
     let counts: AgentActivityAttributes.ContentState.Counts
 
     var body: some View {
-        if counts.blocked > 0 {
-            Text("\(counts.blocked)")
+        if let item = counts.attentionStatusItem {
+            Text("\(item.count)")
                 .font(.caption.weight(.bold).monospacedDigit())
-                .foregroundStyle(AgentActivityStatusStyle.ink(for: "blocked"))
+                .foregroundStyle(AgentActivityStatusStyle.ink(for: item.status, on: .island))
                 .padding(.horizontal, 5)
                 .padding(.vertical, 1)
                 .background(
-                    AgentActivityStatusStyle.ink(for: "blocked").opacity(0.22),
+                    AgentActivityStatusStyle.ink(for: item.status, on: .island).opacity(0.22),
                     in: Capsule())
-                .accessibilityLabel("\(counts.blocked) blocked")
-        } else {
-            Image(systemName: "ellipsis")
-                .font(.caption.weight(.bold))
-                .foregroundStyle(AgentActivityStatusStyle.ink(for: "working"))
-                .accessibilityLabel("Working")
+                .accessibilityLabel("\(item.count) \(item.status)")
         }
     }
 }
@@ -213,30 +289,34 @@ private struct AgentActivityLinked<Content: View>: View {
 private struct AgentActivityLinkedRow: View {
     let hostID: String
     let agent: AgentActivityDetails.AgentDetail
+    let surface: AgentActivitySurface
 
     var body: some View {
         AgentActivityLinked(hostID: hostID, paneID: agent.paneID) {
-            AgentActivityRowView(agent: agent)
+            AgentActivityRowView(agent: agent, surface: surface)
         }
     }
 }
 
 private struct AgentActivityCountChips: View {
     let counts: AgentActivityAttributes.ContentState.Counts
+    let surface: AgentActivitySurface
+    var chipWashOpacity: Double = 0.15
 
     var body: some View {
         HStack(spacing: 5) {
             ForEach(counts.chipItems, id: \.status) { item in
                 Text("\(item.count) \(item.status)")
                     .font(.caption2.weight(.semibold))
-                    .foregroundStyle(AgentActivityStatusStyle.ink(for: item.status))
+                    .foregroundStyle(AgentActivityStatusStyle.ink(for: item.status, on: surface))
                     // Chips never compress or wrap; the row title truncates
                     // instead when all three statuses are present.
                     .fixedSize()
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
                     .background(
-                        AgentActivityStatusStyle.ink(for: item.status).opacity(0.16),
+                        AgentActivityStatusStyle.wash(for: item.status, on: surface)
+                            .opacity(chipWashOpacity),
                         in: Capsule())
             }
         }
@@ -252,8 +332,9 @@ private struct AgentActivityCountChips: View {
 /// missing title promotes the identity to the top line alone.
 private struct AgentActivityHeadlineView: View {
     let agent: AgentActivityDetails.AgentDetail
+    let surface: AgentActivitySurface
 
-    private var ink: Color { AgentActivityStatusStyle.ink(for: agent.status) }
+    private var ink: Color { AgentActivityStatusStyle.ink(for: agent.status, on: surface) }
     private var isBlocked: Bool { agent.status == "blocked" }
 
     var body: some View {
@@ -285,9 +366,11 @@ private struct AgentActivityHeadlineView: View {
 /// state, not "just finished".
 private struct AgentActivityRowView: View {
     let agent: AgentActivityDetails.AgentDetail
+    let surface: AgentActivitySurface
 
     private var isBlocked: Bool { agent.status == "blocked" }
-    private var ink: Color { AgentActivityStatusStyle.ink(for: agent.status) }
+    private var ink: Color { AgentActivityStatusStyle.ink(for: agent.status, on: surface) }
+    private var wash: Color { AgentActivityStatusStyle.wash(for: agent.status, on: surface) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
@@ -315,31 +398,10 @@ private struct AgentActivityRowView: View {
         .background {
             if isBlocked {
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(ink.opacity(0.16))
+                    .fill(wash.opacity(0.15))
             }
         }
     }
-}
-
-/// Mocha (dark) inks from the app's Catppuccin status palette. Live
-/// Activities sit on the dark tint below, so the light-mode latte inks
-/// would disappear; the widget does not import app-only files.
-enum AgentActivityStatusStyle {
-    static func ink(for status: String) -> Color {
-        switch status {
-        case "blocked": Color(red: 243 / 255, green: 139 / 255, blue: 168 / 255)
-        case "done": Color(red: 166 / 255, green: 227 / 255, blue: 161 / 255)
-        case "working": Color(red: 249 / 255, green: 226 / 255, blue: 175 / 255)
-        default: Color(red: 166 / 255, green: 173 / 255, blue: 200 / 255)
-        }
-    }
-}
-
-/// Deliberate lock-screen chrome: Catppuccin Mocha mantle behind the
-/// banner, Mocha text on the system End/expand controls.
-enum AgentActivityChrome {
-    static let backgroundTint = Color(red: 24 / 255, green: 24 / 255, blue: 37 / 255)
-    static let systemAction = Color(red: 205 / 255, green: 214 / 255, blue: 244 / 255)
 }
 
 // MARK: - Previews
@@ -347,21 +409,6 @@ enum AgentActivityChrome {
 /// Style gallery: every lock-screen state without a device, a push, or a
 /// live agent. Open this file's canvas in Xcode to review the banner.
 #if DEBUG
-    private func previewBanner(_ presentation: AgentActivityPresentation) -> some View {
-        AgentActivityLockScreenView(
-            presentation: presentation,
-            hostID: "6D8EC348-4DAF-455C-BA8F-5FCC41799C0E"
-        )
-        // The app preview host styles Links with the accent tint (and
-        // `.secondary` derives from it); the lock screen renders them
-        // chromeless. Normalize so the canvas matches the device.
-        .buttonStyle(.plain)
-        .tint(.primary)
-        .background(AgentActivityChrome.backgroundTint, in: RoundedRectangle(cornerRadius: 22))
-        .environment(\.colorScheme, .dark)
-        .padding()
-    }
-
     private func previewAgent(
         _ status: String, kind: String, name: String? = nil, pane: String, title: String? = nil
     ) -> AgentActivityDetails.AgentDetail {
@@ -369,8 +416,75 @@ enum AgentActivityChrome {
             paneID: pane, kind: kind, name: name, status: status, title: title)
     }
 
-    #Preview("Mixed statuses + overflow") {
-        previewBanner(
+    private func previewLockScreenBanner(
+        _ presentation: AgentActivityPresentation,
+        colorScheme: ColorScheme,
+        isStale: Bool = false
+    ) -> some View {
+        AgentActivityLockScreenView(
+            presentation: presentation,
+            hostID: "6D8EC348-4DAF-455C-BA8F-5FCC41799C0E",
+            isStale: isStale
+        )
+        .buttonStyle(.plain)
+        .tint(.primary)
+        .background(
+            colorScheme == .light
+                ? Color(white: 0.97)
+                : Color(red: 28 / 255, green: 28 / 255, blue: 30 / 255),
+            in: RoundedRectangle(cornerRadius: 22, style: .continuous)
+        )
+        .environment(\.colorScheme, colorScheme)
+        .padding()
+    }
+
+    private func previewIslandCompact(
+        counts: AgentActivityAttributes.ContentState.Counts,
+        colorScheme: ColorScheme = .light
+    ) -> some View {
+        HStack {
+            AgentActivityCompactLeading(counts: counts)
+            Spacer()
+            Text("\(counts.total)")
+                .font(.body.weight(.semibold).monospacedDigit())
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.black)
+        .environment(\.colorScheme, colorScheme)
+        .padding()
+    }
+
+    private func previewIslandExpanded(
+        _ presentation: AgentActivityPresentation,
+        colorScheme: ColorScheme = .light
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let primary = presentation.primaryAgent {
+                AgentActivityHeadlineView(agent: primary, surface: .island)
+            }
+            ForEach(presentation.secondaryAgents, id: \.paneID) { agent in
+                AgentActivityRowView(agent: agent, surface: .island)
+            }
+            if presentation.overflowCount > 0 {
+                Text("+\(presentation.overflowCount) more")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            AgentActivityCountChips(
+                counts: presentation.counts, surface: .island, chipWashOpacity: 0.16)
+        }
+        .padding()
+        .background(Color.black)
+        .environment(\.colorScheme, colorScheme)
+        .padding()
+    }
+
+    private let longGraphemeTitle = String(repeating: "锁", count: 80)
+    private let longGraphemeName = String(repeating: "屏", count: 80)
+
+    #Preview("P1 Mixed + overflow (Light)") {
+        previewLockScreenBanner(
             .detailed(
                 details: AgentActivityDetails(
                     hostName: "mbp",
@@ -384,12 +498,45 @@ enum AgentActivityChrome {
                         previewAgent(
                             "working", kind: "grok", name: "la-demo", pane: "w1:p3",
                             title: "Research ActivityKit budgets"),
+                        previewAgent(
+                            "working", kind: "codex", name: "fixer", pane: "w1:p4",
+                            title: "Chase the flaky pairing test"),
+                        previewAgent(
+                            "working", kind: "claude", pane: "w1:p5",
+                            title: "Refactor the transport queue"),
                     ]),
-                counts: .init(working: 3, blocked: 1, done: 2)))
+                counts: .init(working: 3, blocked: 1, done: 1)),
+            colorScheme: .light)
     }
 
-    #Preview("Single unnamed working") {
-        previewBanner(
+    #Preview("P1 Mixed + overflow (Dark)") {
+        previewLockScreenBanner(
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
+                            title: "Approve the transport refactor plan"),
+                        previewAgent(
+                            "done", kind: "droid", name: "doc-writer", pane: "w1:p2",
+                            title: "API reference draft finished"),
+                        previewAgent(
+                            "working", kind: "grok", name: "la-demo", pane: "w1:p3",
+                            title: "Research ActivityKit budgets"),
+                        previewAgent(
+                            "working", kind: "codex", name: "fixer", pane: "w1:p4",
+                            title: "Chase the flaky pairing test"),
+                        previewAgent(
+                            "working", kind: "claude", pane: "w1:p5",
+                            title: "Refactor the transport queue"),
+                    ]),
+                counts: .init(working: 3, blocked: 1, done: 1)),
+            colorScheme: .dark)
+    }
+
+    #Preview("P2 Single unnamed working (Light)") {
+        previewLockScreenBanner(
             .detailed(
                 details: AgentActivityDetails(
                     hostName: "mbp",
@@ -398,27 +545,26 @@ enum AgentActivityChrome {
                             "working", kind: "claude", pane: "w1:p1",
                             title: "◑ lockscreen-agent-live-activity")
                     ]),
-                counts: .init(working: 1, blocked: 0, done: 0)))
+                counts: .init(working: 1, blocked: 0, done: 0)),
+            colorScheme: .light)
     }
 
-    #Preview("Two working, names") {
-        previewBanner(
+    #Preview("P2 Single unnamed working (Dark)") {
+        previewLockScreenBanner(
             .detailed(
                 details: AgentActivityDetails(
                     hostName: "mbp",
                     agents: [
                         previewAgent(
                             "working", kind: "claude", pane: "w1:p1",
-                            title: "Refactor the transport queue"),
-                        previewAgent(
-                            "working", kind: "grok", name: "la-demo", pane: "w1:p2",
-                            title: "Write the landing copy"),
+                            title: "◑ lockscreen-agent-live-activity")
                     ]),
-                counts: .init(working: 2, blocked: 0, done: 0)))
+                counts: .init(working: 1, blocked: 0, done: 0)),
+            colorScheme: .dark)
     }
 
-    #Preview("Four rows, all fit") {
-        previewBanner(
+    #Preview("P3 Four rows (Light)") {
+        previewLockScreenBanner(
             .detailed(
                 details: AgentActivityDetails(
                     hostName: "mbp",
@@ -436,10 +582,231 @@ enum AgentActivityChrome {
                             "working", kind: "codex", name: "fixer", pane: "w1:p4",
                             title: "Chase the flaky pairing test"),
                     ]),
-                counts: .init(working: 3, blocked: 1, done: 0)))
+                counts: .init(working: 3, blocked: 1, done: 0)),
+            colorScheme: .light)
     }
 
-    #Preview("Counts only (undecryptable)") {
-        previewBanner(.countsOnly(counts: .init(working: 2, blocked: 1, done: 0)))
+    #Preview("P3 Four rows (Dark)") {
+        previewLockScreenBanner(
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
+                            title: "Approve the transport refactor plan"),
+                        previewAgent(
+                            "working", kind: "claude", pane: "w1:p2",
+                            title: "Refactor the transport queue"),
+                        previewAgent(
+                            "working", kind: "grok", name: "la-demo", pane: "w1:p3",
+                            title: "Write the landing copy"),
+                        previewAgent(
+                            "working", kind: "codex", name: "fixer", pane: "w1:p4",
+                            title: "Chase the flaky pairing test"),
+                    ]),
+                counts: .init(working: 3, blocked: 1, done: 0)),
+            colorScheme: .dark)
+    }
+
+    #Preview("P4 Counts only (Light)") {
+        previewLockScreenBanner(
+            .countsOnly(counts: .init(working: 2, blocked: 1, done: 0)),
+            colorScheme: .light)
+    }
+
+    #Preview("P4 Counts only (Dark)") {
+        previewLockScreenBanner(
+            .countsOnly(counts: .init(working: 2, blocked: 1, done: 0)),
+            colorScheme: .dark)
+    }
+
+    #Preview("P5 Long title (Light)") {
+        previewLockScreenBanner(
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
+                            title: longGraphemeTitle),
+                        previewAgent("working", kind: "grok", pane: "w1:p2", title: "Second row"),
+                    ]),
+                counts: .init(working: 1, blocked: 1, done: 1)),
+            colorScheme: .light)
+    }
+
+    #Preview("P5 Long title (Dark)") {
+        previewLockScreenBanner(
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
+                            title: longGraphemeTitle),
+                        previewAgent("working", kind: "grok", pane: "w1:p2", title: "Second row"),
+                    ]),
+                counts: .init(working: 1, blocked: 1, done: 1)),
+            colorScheme: .dark)
+    }
+
+    #Preview("P5a Long name with title (Light)") {
+        previewLockScreenBanner(
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "blocked", kind: "claude", name: longGraphemeName, pane: "w1:p1",
+                            title: "Approve the transport refactor plan"),
+                    ]),
+                counts: .init(working: 0, blocked: 1, done: 0)),
+            colorScheme: .light)
+    }
+
+    #Preview("P5a Long name with title (Dark)") {
+        previewLockScreenBanner(
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "blocked", kind: "claude", name: longGraphemeName, pane: "w1:p1",
+                            title: "Approve the transport refactor plan"),
+                    ]),
+                counts: .init(working: 0, blocked: 1, done: 0)),
+            colorScheme: .dark)
+    }
+
+    #Preview("P5b Long name, no title (Light)") {
+        previewLockScreenBanner(
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "working", kind: "claude", name: longGraphemeName, pane: "w1:p1"),
+                    ]),
+                counts: .init(working: 1, blocked: 0, done: 0)),
+            colorScheme: .light)
+    }
+
+    #Preview("P5b Long name, no title (Dark)") {
+        previewLockScreenBanner(
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "working", kind: "claude", name: longGraphemeName, pane: "w1:p1"),
+                    ]),
+                counts: .init(working: 1, blocked: 0, done: 0)),
+            colorScheme: .dark)
+    }
+
+    #Preview("P6 Stale max height (Light)") {
+        previewLockScreenBanner(
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent("blocked", kind: "claude", pane: "w1:p1", title: "First"),
+                        previewAgent("done", kind: "droid", pane: "w1:p2", title: "Second"),
+                        previewAgent("working", kind: "grok", pane: "w1:p3", title: "Third"),
+                        previewAgent("working", kind: "codex", pane: "w1:p4", title: "Fourth"),
+                        previewAgent("working", kind: "claude", pane: "w1:p5", title: "Fifth"),
+                    ]),
+                counts: .init(working: 3, blocked: 1, done: 1)),
+            colorScheme: .light,
+            isStale: true)
+    }
+
+    #Preview("P6 Stale max height (Dark)") {
+        previewLockScreenBanner(
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent("blocked", kind: "claude", pane: "w1:p1", title: "First"),
+                        previewAgent("done", kind: "droid", pane: "w1:p2", title: "Second"),
+                        previewAgent("working", kind: "grok", pane: "w1:p3", title: "Third"),
+                        previewAgent("working", kind: "codex", pane: "w1:p4", title: "Fourth"),
+                        previewAgent("working", kind: "claude", pane: "w1:p5", title: "Fifth"),
+                    ]),
+                counts: .init(working: 3, blocked: 1, done: 1)),
+            colorScheme: .dark,
+            isStale: true)
+    }
+
+    #Preview("P6b Stale three rows (Light)") {
+        previewLockScreenBanner(
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent("blocked", kind: "claude", pane: "w1:p1", title: "First"),
+                        previewAgent("done", kind: "droid", pane: "w1:p2", title: "Second"),
+                        previewAgent("working", kind: "grok", pane: "w1:p3", title: "Third"),
+                    ]),
+                counts: .init(working: 1, blocked: 1, done: 1)),
+            colorScheme: .light,
+            isStale: true)
+    }
+
+    #Preview("P6b Stale three rows (Dark)") {
+        previewLockScreenBanner(
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent("blocked", kind: "claude", pane: "w1:p1", title: "First"),
+                        previewAgent("done", kind: "droid", pane: "w1:p2", title: "Second"),
+                        previewAgent("working", kind: "grok", pane: "w1:p3", title: "Third"),
+                    ]),
+                counts: .init(working: 1, blocked: 1, done: 1)),
+            colorScheme: .dark,
+            isStale: true)
+    }
+
+    #Preview("P7 Compact blocked (Light island)") {
+        previewIslandCompact(counts: .init(working: 2, blocked: 1, done: 0))
+    }
+
+    #Preview("P8 Compact done + working") {
+        previewIslandCompact(counts: .init(working: 2, blocked: 0, done: 1))
+    }
+
+    #Preview("P9 Compact working only") {
+        previewIslandCompact(counts: .init(working: 3, blocked: 0, done: 0))
+    }
+
+    #Preview("P10 Minimal blocked (Light island)") {
+        Text("3")
+            .font(.body.weight(.bold).monospacedDigit())
+            .foregroundStyle(AgentActivityStatusStyle.ink(for: "blocked", on: .island))
+            .padding()
+            .background(Color.black)
+            .environment(\.colorScheme, .light)
+            .padding()
+    }
+
+    #Preview("P11 Expanded mixed (Light island)") {
+        previewIslandExpanded(
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
+                            title: "Approve the transport refactor plan"),
+                        previewAgent(
+                            "done", kind: "droid", name: "doc-writer", pane: "w1:p2",
+                            title: "API reference draft finished"),
+                        previewAgent(
+                            "working", kind: "grok", name: "la-demo", pane: "w1:p3",
+                            title: "Research ActivityKit budgets"),
+                    ]),
+                counts: .init(working: 1, blocked: 1, done: 1)))
     }
 #endif

--- a/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
+++ b/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
@@ -4,10 +4,10 @@ import UIKit
 import WidgetKit
 
 /// Live Activity for one Host. The lock-screen banner gives the leading
-/// agent a full two-line row and packs up to four more agents into compact
+/// agent a full two-line row and packs up to three more agents into compact
 /// rows. Rows arrive in the sender's pin-aware order and are rendered as
-/// given; Host identity is never rendered. The entire activity is one large
-/// interaction target that opens the Console.
+/// given; Host identity is never rendered. Agent rows deep-link to their
+/// detail while the surrounding chrome opens the Console.
 struct AgentLiveActivityWidget: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: AgentActivityAttributes.self) { context in
@@ -83,13 +83,15 @@ struct AgentActivityLockScreenView: View {
     let isStale: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 5) {
+        VStack(alignment: .leading, spacing: 2) {
             header
             ForEach(visibleAgents.dropFirst(), id: \.paneID) { agent in
-                AgentActivityRowView(
+                AgentActivityLinkedRow(
+                    hostID: hostID,
                     agent: agent,
                     surface: .lockScreen,
-                    density: .compact)
+                    density: .compact,
+                    minimumHeight: rowMinimumHeight)
             }
             if let caption = presentation.lockScreenTrailingCaption(isStale: isStale) {
                 Text(caption)
@@ -106,10 +108,8 @@ struct AgentActivityLockScreenView: View {
             #endif
         }
         .padding(.horizontal, 14)
-        .padding(.vertical, 10)
+        .padding(.vertical, 8)
         .widgetURL(AgentActivityLink.consoleURL(hostID: hostID))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(lockScreenAccessibilityLabel)
     }
 
     private var visibleAgents: [AgentActivityDetails.AgentDetail] {
@@ -127,7 +127,11 @@ struct AgentActivityLockScreenView: View {
     @ViewBuilder
     private var headline: some View {
         if let first = visibleAgents.first {
-            AgentActivityRowView(agent: first, surface: .lockScreen)
+            AgentActivityLinkedRow(
+                hostID: hostID,
+                agent: first,
+                surface: .lockScreen,
+                minimumHeight: rowMinimumHeight)
         } else {
             Text(presentation.headerTitle)
                 .font(.subheadline.weight(.semibold))
@@ -136,26 +140,8 @@ struct AgentActivityLockScreenView: View {
         }
     }
 
-    private var lockScreenAccessibilityLabel: String {
-        var parts = [
-            visibleAgents.first.map(Self.narration(for:))
-                ?? presentation.headerTitle
-        ]
-        parts.append(contentsOf: presentation.counts.chipItems.map { "\($0.count) \($0.status)" })
-        for agent in visibleAgents.dropFirst() {
-            parts.append(Self.narration(for: agent))
-        }
-        if presentation.lockScreenOverflowCount(isStale: isStale) > 0 {
-            parts.append("\(presentation.lockScreenOverflowCount(isStale: isStale)) more")
-        }
-        if isStale {
-            parts.append("may be out of date")
-        }
-        return parts.joined(separator: ", ")
-    }
-
-    private static func narration(for agent: AgentActivityDetails.AgentDetail) -> String {
-        AgentActivityNarration.rowLabel(for: agent)
+    private var rowMinimumHeight: CGFloat {
+        AgentActivityRowMetrics.lockScreenMinimumHeight(agentCount: visibleAgents.count)
     }
 }
 
@@ -166,7 +152,13 @@ enum AgentActivityIsland {
         DynamicIsland {
             DynamicIslandExpandedRegion(.center) {
                 if let primary = presentation.primaryAgent {
-                    AgentActivityHeadlineView(agent: primary, surface: .island)
+                    AgentActivityLinked(
+                        hostID: hostID,
+                        agent: primary,
+                        minimumHeight: AgentActivityRowMetrics.denseMinimumHeight
+                    ) {
+                        AgentActivityHeadlineView(agent: primary, surface: .island)
+                    }
                 } else {
                     Text(presentation.headerTitle)
                         .font(.headline)
@@ -177,7 +169,11 @@ enum AgentActivityIsland {
             DynamicIslandExpandedRegion(.bottom) {
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(presentation.secondaryAgents, id: \.paneID) { agent in
-                        AgentActivityRowView(agent: agent, surface: .island)
+                        AgentActivityLinkedRow(
+                            hostID: hostID,
+                            agent: agent,
+                            surface: .island,
+                            minimumHeight: AgentActivityRowMetrics.denseMinimumHeight)
                     }
                     if presentation.overflowCount > 0 {
                         Text("+\(presentation.overflowCount) more")
@@ -260,6 +256,57 @@ enum AgentActivityNarration {
 }
 
 // MARK: - Shared pieces
+
+enum AgentActivityRowMetrics {
+    /// Apple's default iOS control size when the presentation has room.
+    static let comfortableMinimumHeight: CGFloat = 44
+    /// Apple's documented minimum iOS control size for dense layouts.
+    static let denseMinimumHeight: CGFloat = 28
+
+    static func lockScreenMinimumHeight(agentCount: Int) -> CGFloat {
+        agentCount <= 3 ? comfortableMinimumHeight : denseMinimumHeight
+    }
+}
+
+/// Wraps row content in a deep link to that Agent's detail. The outer
+/// widgetURL remains the fallback for taps on the surrounding chrome.
+private struct AgentActivityLinked<Content: View>: View {
+    let hostID: String
+    let agent: AgentActivityDetails.AgentDetail
+    let minimumHeight: CGFloat
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        if let url = AgentActivityLink.agentURL(hostID: hostID, paneID: agent.paneID) {
+            Link(destination: url) {
+                content
+                    .frame(maxWidth: .infinity, minHeight: minimumHeight, alignment: .leading)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .tint(.primary)
+            .accessibilityLabel(AgentActivityNarration.rowLabel(for: agent))
+            .accessibilityHint("Opens this Agent in Heeler")
+        } else {
+            content
+                .frame(maxWidth: .infinity, minHeight: minimumHeight, alignment: .leading)
+        }
+    }
+}
+
+private struct AgentActivityLinkedRow: View {
+    let hostID: String
+    let agent: AgentActivityDetails.AgentDetail
+    let surface: AgentActivitySurface
+    var density: AgentActivityRowDensity = .full
+    let minimumHeight: CGFloat
+
+    var body: some View {
+        AgentActivityLinked(hostID: hostID, agent: agent, minimumHeight: minimumHeight) {
+            AgentActivityRowView(agent: agent, surface: surface, density: density)
+        }
+    }
+}
 
 private enum AgentActivityRowDensity: Equatable {
     case full

--- a/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
+++ b/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
@@ -74,66 +74,51 @@ enum AgentActivityStatusStyle {
     }
 }
 
+enum AgentActivitySemanticStyle {
+    static func primary(on surface: AgentActivitySurface) -> Color {
+        switch surface {
+        case .lockScreen:
+            Color(uiColor: .label)
+        case .island:
+            Color.primary
+        }
+    }
+
+    static func secondary(on surface: AgentActivitySurface) -> Color {
+        switch surface {
+        case .lockScreen:
+            Color(uiColor: .secondaryLabel)
+        case .island:
+            Color.secondary
+        }
+    }
+}
+
 // MARK: - Lock screen
 
 private struct AgentActivityLockScreenContainer: View {
-    @Environment(\.colorScheme) private var activityKitColorScheme
-
     let presentation: AgentActivityPresentation
     let hostID: String
     let isStale: Bool
 
     var body: some View {
-        let appearance = AgentActivityLockScreenAppearance.resolve(
-            screenStyle: UIScreen.main.traitCollection.userInterfaceStyle,
-            fallback: activityKitColorScheme)
-
         AgentActivityLockScreenView(
             presentation: presentation,
             hostID: hostID,
             isStale: isStale
         )
-        .environment(\.colorScheme, appearance.colorScheme)
-        .activityBackgroundTint(Color(uiColor: appearance.backgroundColor))
-        .activitySystemActionForegroundColor(Color(uiColor: appearance.actionColor))
+        .foregroundStyle(AgentActivitySemanticStyle.primary(on: .lockScreen))
+        .activityBackgroundTint(Color(uiColor: AgentActivityLockScreenChrome.backgroundColor))
+        .activitySystemActionForegroundColor(
+            Color(uiColor: AgentActivityLockScreenChrome.actionColor))
     }
 }
 
-enum AgentActivityLockScreenAppearance: Equatable {
-    case light
-    case dark
-
-    static func resolve(
-        screenStyle: UIUserInterfaceStyle,
-        fallback: ColorScheme
-    ) -> AgentActivityLockScreenAppearance {
-        switch screenStyle {
-        case .light:
-            return .light
-        case .dark:
-            return .dark
-        case .unspecified:
-            return fallback == .dark ? .dark : .light
-        @unknown default:
-            return fallback == .dark ? .dark : .light
-        }
-    }
-
-    var colorScheme: ColorScheme {
-        self == .dark ? .dark : .light
-    }
-
-    var backgroundColor: UIColor {
-        UIColor.systemBackground.resolvedColor(with: traitCollection)
-    }
-
-    var actionColor: UIColor {
-        UIColor.label.resolvedColor(with: traitCollection)
-    }
-
-    private var traitCollection: UITraitCollection {
-        UITraitCollection(userInterfaceStyle: self == .dark ? .dark : .light)
-    }
+enum AgentActivityLockScreenChrome {
+    /// Keep these semantic colors unresolved. WidgetKit can then resolve the
+    /// existing Live Activity again when the iOS system appearance changes.
+    static let backgroundColor = UIColor.systemBackground
+    static let actionColor = UIColor.label
 }
 
 struct AgentActivityLockScreenView: View {
@@ -155,13 +140,13 @@ struct AgentActivityLockScreenView: View {
             if let caption = presentation.lockScreenTrailingCaption(isStale: isStale) {
                 Text(caption)
                     .font(.caption2)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(AgentActivitySemanticStyle.secondary(on: .lockScreen))
             }
             #if DEBUG
                 if let reason = AgentActivityDecryptor.lastFailureReason {
                     Text(reason)
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(AgentActivitySemanticStyle.secondary(on: .lockScreen))
                         .lineLimit(3)
                 }
             #endif
@@ -194,7 +179,7 @@ struct AgentActivityLockScreenView: View {
         } else {
             Text(presentation.headerTitle)
                 .font(.subheadline.weight(.semibold))
-                .foregroundStyle(.primary)
+                .foregroundStyle(AgentActivitySemanticStyle.primary(on: .lockScreen))
                 .lineLimit(1)
         }
     }
@@ -214,6 +199,7 @@ enum AgentActivityIsland {
                     AgentActivityLinked(
                         hostID: hostID,
                         agent: primary,
+                        surface: .island,
                         minimumHeight: AgentActivityRowMetrics.denseMinimumHeight
                     ) {
                         AgentActivityHeadlineView(agent: primary, surface: .island)
@@ -332,6 +318,7 @@ enum AgentActivityRowMetrics {
 private struct AgentActivityLinked<Content: View>: View {
     let hostID: String
     let agent: AgentActivityDetails.AgentDetail
+    let surface: AgentActivitySurface
     let minimumHeight: CGFloat
     @ViewBuilder let content: Content
 
@@ -343,7 +330,7 @@ private struct AgentActivityLinked<Content: View>: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .tint(.primary)
+            .tint(AgentActivitySemanticStyle.primary(on: surface))
             .accessibilityLabel(AgentActivityNarration.rowLabel(for: agent))
             .accessibilityHint("Opens this Agent in Heeler")
         } else {
@@ -361,7 +348,12 @@ private struct AgentActivityLinkedRow: View {
     let minimumHeight: CGFloat
 
     var body: some View {
-        AgentActivityLinked(hostID: hostID, agent: agent, minimumHeight: minimumHeight) {
+        AgentActivityLinked(
+            hostID: hostID,
+            agent: agent,
+            surface: surface,
+            minimumHeight: minimumHeight
+        ) {
             AgentActivityRowView(agent: agent, surface: surface, density: density)
         }
     }
@@ -420,13 +412,14 @@ private struct AgentActivityHeadlineView: View {
                     .accessibilityHidden(true)
                 Text(agent.displayTitle ?? agent.displayName)
                     .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(isBlocked ? ink : Color.primary)
+                    .foregroundStyle(
+                        isBlocked ? ink : AgentActivitySemanticStyle.primary(on: surface))
                     .lineLimit(1)
             }
             if agent.displayTitle != nil {
                 Text(agent.displayName)
                     .font(.footnote)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(AgentActivitySemanticStyle.secondary(on: surface))
                     .lineLimit(1)
                     .padding(.leading, 15)
             }
@@ -484,7 +477,7 @@ private struct AgentActivityRowView: View {
                 if agent.displayTitle != nil {
                     Text(agent.displayName)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(AgentActivitySemanticStyle.secondary(on: surface))
                         .lineLimit(1)
                         .padding(.leading, 14)
                 }
@@ -497,7 +490,7 @@ private struct AgentActivityRowView: View {
                 if agent.displayTitle != nil {
                     Text("· \(agent.displayName)")
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(AgentActivitySemanticStyle.secondary(on: surface))
                         .lineLimit(1)
                 }
                 Spacer(minLength: 0)
@@ -515,7 +508,8 @@ private struct AgentActivityRowView: View {
     private var title: some View {
         Text(agent.displayTitle ?? agent.displayName)
             .font(.caption.weight(isBlocked ? .semibold : .regular))
-            .foregroundStyle(isBlocked ? ink : .primary)
+            .foregroundStyle(
+                isBlocked ? ink : AgentActivitySemanticStyle.primary(on: surface))
             .lineLimit(1)
     }
 

--- a/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
+++ b/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
@@ -152,11 +152,7 @@ struct AgentActivityLockScreenView: View {
     }
 
     private static func narration(for agent: AgentActivityDetails.AgentDetail) -> String {
-        var row = "\(agent.displayName), \(agent.status)"
-        if let title = agent.displayTitle {
-            row += ", \(title)"
-        }
-        return row
+        AgentActivityNarration.rowLabel(for: agent)
     }
 }
 
@@ -257,6 +253,16 @@ private struct AgentActivityCompactLeading: View {
     }
 }
 
+enum AgentActivityNarration {
+    static func rowLabel(for agent: AgentActivityDetails.AgentDetail) -> String {
+        var row = "\(agent.displayName), \(agent.status)"
+        if let title = agent.displayTitle {
+            row += ", \(title)"
+        }
+        return row
+    }
+}
+
 // MARK: - Shared pieces
 
 /// Applies the Console deep link inside a `body` so the MainActor-isolated
@@ -338,7 +344,7 @@ private struct AgentActivityHeadlineView: View {
     private var isBlocked: Bool { agent.status == "blocked" }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        let content = VStack(alignment: .leading, spacing: 2) {
             HStack(spacing: 7) {
                 Circle()
                     .fill(ink)
@@ -357,6 +363,12 @@ private struct AgentActivityHeadlineView: View {
                     .padding(.leading, 15)
             }
         }
+        switch surface {
+        case .island:
+            content.accessibilityLabel(AgentActivityNarration.rowLabel(for: agent))
+        case .lockScreen:
+            content
+        }
     }
 }
 
@@ -373,7 +385,7 @@ private struct AgentActivityRowView: View {
     private var wash: Color { AgentActivityStatusStyle.wash(for: agent.status, on: surface) }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 1) {
+        let content = VStack(alignment: .leading, spacing: 1) {
             HStack(spacing: 7) {
                 Circle()
                     .fill(ink)
@@ -401,6 +413,12 @@ private struct AgentActivityRowView: View {
                     .fill(wash.opacity(0.15))
             }
         }
+        switch surface {
+        case .island:
+            content.accessibilityLabel(AgentActivityNarration.rowLabel(for: agent))
+        case .lockScreen:
+            content
+        }
     }
 }
 
@@ -414,6 +432,148 @@ private struct AgentActivityRowView: View {
     ) -> AgentActivityDetails.AgentDetail {
         AgentActivityDetails.AgentDetail(
             paneID: pane, kind: kind, name: name, status: status, title: title)
+    }
+
+    private enum AgentActivityPreviewFixtures {
+        static let longGraphemeTitle = String(repeating: "锁", count: 80)
+        static let longGraphemeName = String(repeating: "屏", count: 80)
+
+        static var mixedOverflow: AgentActivityPresentation {
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
+                            title: "Approve the transport refactor plan"),
+                        previewAgent(
+                            "done", kind: "droid", name: "doc-writer", pane: "w1:p2",
+                            title: "API reference draft finished"),
+                        previewAgent(
+                            "working", kind: "grok", name: "la-demo", pane: "w1:p3",
+                            title: "Research ActivityKit budgets"),
+                        previewAgent(
+                            "working", kind: "codex", name: "fixer", pane: "w1:p4",
+                            title: "Chase the flaky pairing test"),
+                        previewAgent(
+                            "working", kind: "claude", pane: "w1:p5",
+                            title: "Refactor the transport queue"),
+                    ]),
+                counts: .init(working: 3, blocked: 1, done: 1))
+        }
+
+        static var singleUnnamedIdentityOnly: AgentActivityPresentation {
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [previewAgent("working", kind: "claude", pane: "w1:p1")]),
+                counts: .init(working: 1, blocked: 0, done: 0))
+        }
+
+        static var fourRows: AgentActivityPresentation {
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
+                            title: "Approve the transport refactor plan"),
+                        previewAgent(
+                            "working", kind: "claude", pane: "w1:p2",
+                            title: "Refactor the transport queue"),
+                        previewAgent(
+                            "working", kind: "grok", name: "la-demo", pane: "w1:p3",
+                            title: "Write the landing copy"),
+                        previewAgent(
+                            "working", kind: "codex", name: "fixer", pane: "w1:p4",
+                            title: "Chase the flaky pairing test"),
+                    ]),
+                counts: .init(working: 3, blocked: 1, done: 0))
+        }
+
+        static var countsOnly: AgentActivityPresentation {
+            .countsOnly(counts: .init(working: 2, blocked: 1, done: 0))
+        }
+
+        static var longTitle: AgentActivityPresentation {
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
+                            title: longGraphemeTitle),
+                        previewAgent("working", kind: "grok", pane: "w1:p2", title: "Second row"),
+                    ]),
+                counts: .init(working: 1, blocked: 1, done: 1))
+        }
+
+        static var longNameWithTitle: AgentActivityPresentation {
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "blocked", kind: "claude", name: longGraphemeName, pane: "w1:p1",
+                            title: "Approve the transport refactor plan"),
+                    ]),
+                counts: .init(working: 0, blocked: 1, done: 0))
+        }
+
+        static var longNameNoTitle: AgentActivityPresentation {
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "working", kind: "claude", name: longGraphemeName, pane: "w1:p1"),
+                    ]),
+                counts: .init(working: 1, blocked: 0, done: 0))
+        }
+
+        static var staleMaxHeight: AgentActivityPresentation {
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent("blocked", kind: "claude", pane: "w1:p1", title: "First"),
+                        previewAgent("done", kind: "droid", pane: "w1:p2", title: "Second"),
+                        previewAgent("working", kind: "grok", pane: "w1:p3", title: "Third"),
+                        previewAgent("working", kind: "codex", pane: "w1:p4", title: "Fourth"),
+                        previewAgent("working", kind: "claude", pane: "w1:p5", title: "Fifth"),
+                    ]),
+                counts: .init(working: 3, blocked: 1, done: 1))
+        }
+
+        static var staleThreeRows: AgentActivityPresentation {
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent("blocked", kind: "claude", pane: "w1:p1", title: "First"),
+                        previewAgent("done", kind: "droid", pane: "w1:p2", title: "Second"),
+                        previewAgent("working", kind: "grok", pane: "w1:p3", title: "Third"),
+                    ]),
+                counts: .init(working: 1, blocked: 1, done: 1))
+        }
+
+        static var expandedMixed: AgentActivityPresentation {
+            .detailed(
+                details: AgentActivityDetails(
+                    hostName: "mbp",
+                    agents: [
+                        previewAgent(
+                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
+                            title: "Approve the transport refactor plan"),
+                        previewAgent(
+                            "done", kind: "droid", name: "doc-writer", pane: "w1:p2",
+                            title: "API reference draft finished"),
+                        previewAgent(
+                            "working", kind: "grok", name: "la-demo", pane: "w1:p3",
+                            title: "Research ActivityKit budgets"),
+                    ]),
+                counts: .init(working: 1, blocked: 1, done: 1))
+        }
     }
 
     private func previewLockScreenBanner(
@@ -480,293 +640,82 @@ private struct AgentActivityRowView: View {
         .padding()
     }
 
-    private let longGraphemeTitle = String(repeating: "锁", count: 80)
-    private let longGraphemeName = String(repeating: "屏", count: 80)
-
     #Preview("P1 Mixed + overflow (Light)") {
-        previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent(
-                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
-                            title: "Approve the transport refactor plan"),
-                        previewAgent(
-                            "done", kind: "droid", name: "doc-writer", pane: "w1:p2",
-                            title: "API reference draft finished"),
-                        previewAgent(
-                            "working", kind: "grok", name: "la-demo", pane: "w1:p3",
-                            title: "Research ActivityKit budgets"),
-                        previewAgent(
-                            "working", kind: "codex", name: "fixer", pane: "w1:p4",
-                            title: "Chase the flaky pairing test"),
-                        previewAgent(
-                            "working", kind: "claude", pane: "w1:p5",
-                            title: "Refactor the transport queue"),
-                    ]),
-                counts: .init(working: 3, blocked: 1, done: 1)),
-            colorScheme: .light)
+        previewLockScreenBanner(AgentActivityPreviewFixtures.mixedOverflow, colorScheme: .light)
     }
 
     #Preview("P1 Mixed + overflow (Dark)") {
-        previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent(
-                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
-                            title: "Approve the transport refactor plan"),
-                        previewAgent(
-                            "done", kind: "droid", name: "doc-writer", pane: "w1:p2",
-                            title: "API reference draft finished"),
-                        previewAgent(
-                            "working", kind: "grok", name: "la-demo", pane: "w1:p3",
-                            title: "Research ActivityKit budgets"),
-                        previewAgent(
-                            "working", kind: "codex", name: "fixer", pane: "w1:p4",
-                            title: "Chase the flaky pairing test"),
-                        previewAgent(
-                            "working", kind: "claude", pane: "w1:p5",
-                            title: "Refactor the transport queue"),
-                    ]),
-                counts: .init(working: 3, blocked: 1, done: 1)),
-            colorScheme: .dark)
+        previewLockScreenBanner(AgentActivityPreviewFixtures.mixedOverflow, colorScheme: .dark)
     }
 
-    #Preview("P2 Single unnamed working (Light)") {
+    #Preview("P2 Unnamed identity only (Light)") {
         previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent(
-                            "working", kind: "claude", pane: "w1:p1",
-                            title: "◑ lockscreen-agent-live-activity")
-                    ]),
-                counts: .init(working: 1, blocked: 0, done: 0)),
-            colorScheme: .light)
+            AgentActivityPreviewFixtures.singleUnnamedIdentityOnly, colorScheme: .light)
     }
 
-    #Preview("P2 Single unnamed working (Dark)") {
+    #Preview("P2 Unnamed identity only (Dark)") {
         previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent(
-                            "working", kind: "claude", pane: "w1:p1",
-                            title: "◑ lockscreen-agent-live-activity")
-                    ]),
-                counts: .init(working: 1, blocked: 0, done: 0)),
-            colorScheme: .dark)
+            AgentActivityPreviewFixtures.singleUnnamedIdentityOnly, colorScheme: .dark)
     }
 
     #Preview("P3 Four rows (Light)") {
-        previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent(
-                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
-                            title: "Approve the transport refactor plan"),
-                        previewAgent(
-                            "working", kind: "claude", pane: "w1:p2",
-                            title: "Refactor the transport queue"),
-                        previewAgent(
-                            "working", kind: "grok", name: "la-demo", pane: "w1:p3",
-                            title: "Write the landing copy"),
-                        previewAgent(
-                            "working", kind: "codex", name: "fixer", pane: "w1:p4",
-                            title: "Chase the flaky pairing test"),
-                    ]),
-                counts: .init(working: 3, blocked: 1, done: 0)),
-            colorScheme: .light)
+        previewLockScreenBanner(AgentActivityPreviewFixtures.fourRows, colorScheme: .light)
     }
 
     #Preview("P3 Four rows (Dark)") {
-        previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent(
-                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
-                            title: "Approve the transport refactor plan"),
-                        previewAgent(
-                            "working", kind: "claude", pane: "w1:p2",
-                            title: "Refactor the transport queue"),
-                        previewAgent(
-                            "working", kind: "grok", name: "la-demo", pane: "w1:p3",
-                            title: "Write the landing copy"),
-                        previewAgent(
-                            "working", kind: "codex", name: "fixer", pane: "w1:p4",
-                            title: "Chase the flaky pairing test"),
-                    ]),
-                counts: .init(working: 3, blocked: 1, done: 0)),
-            colorScheme: .dark)
+        previewLockScreenBanner(AgentActivityPreviewFixtures.fourRows, colorScheme: .dark)
     }
 
     #Preview("P4 Counts only (Light)") {
-        previewLockScreenBanner(
-            .countsOnly(counts: .init(working: 2, blocked: 1, done: 0)),
-            colorScheme: .light)
+        previewLockScreenBanner(AgentActivityPreviewFixtures.countsOnly, colorScheme: .light)
     }
 
     #Preview("P4 Counts only (Dark)") {
-        previewLockScreenBanner(
-            .countsOnly(counts: .init(working: 2, blocked: 1, done: 0)),
-            colorScheme: .dark)
+        previewLockScreenBanner(AgentActivityPreviewFixtures.countsOnly, colorScheme: .dark)
     }
 
     #Preview("P5 Long title (Light)") {
-        previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent(
-                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
-                            title: longGraphemeTitle),
-                        previewAgent("working", kind: "grok", pane: "w1:p2", title: "Second row"),
-                    ]),
-                counts: .init(working: 1, blocked: 1, done: 1)),
-            colorScheme: .light)
+        previewLockScreenBanner(AgentActivityPreviewFixtures.longTitle, colorScheme: .light)
     }
 
     #Preview("P5 Long title (Dark)") {
-        previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent(
-                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
-                            title: longGraphemeTitle),
-                        previewAgent("working", kind: "grok", pane: "w1:p2", title: "Second row"),
-                    ]),
-                counts: .init(working: 1, blocked: 1, done: 1)),
-            colorScheme: .dark)
+        previewLockScreenBanner(AgentActivityPreviewFixtures.longTitle, colorScheme: .dark)
     }
 
     #Preview("P5a Long name with title (Light)") {
-        previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent(
-                            "blocked", kind: "claude", name: longGraphemeName, pane: "w1:p1",
-                            title: "Approve the transport refactor plan"),
-                    ]),
-                counts: .init(working: 0, blocked: 1, done: 0)),
-            colorScheme: .light)
+        previewLockScreenBanner(AgentActivityPreviewFixtures.longNameWithTitle, colorScheme: .light)
     }
 
     #Preview("P5a Long name with title (Dark)") {
-        previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent(
-                            "blocked", kind: "claude", name: longGraphemeName, pane: "w1:p1",
-                            title: "Approve the transport refactor plan"),
-                    ]),
-                counts: .init(working: 0, blocked: 1, done: 0)),
-            colorScheme: .dark)
+        previewLockScreenBanner(AgentActivityPreviewFixtures.longNameWithTitle, colorScheme: .dark)
     }
 
     #Preview("P5b Long name, no title (Light)") {
-        previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent(
-                            "working", kind: "claude", name: longGraphemeName, pane: "w1:p1"),
-                    ]),
-                counts: .init(working: 1, blocked: 0, done: 0)),
-            colorScheme: .light)
+        previewLockScreenBanner(AgentActivityPreviewFixtures.longNameNoTitle, colorScheme: .light)
     }
 
     #Preview("P5b Long name, no title (Dark)") {
-        previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent(
-                            "working", kind: "claude", name: longGraphemeName, pane: "w1:p1"),
-                    ]),
-                counts: .init(working: 1, blocked: 0, done: 0)),
-            colorScheme: .dark)
+        previewLockScreenBanner(AgentActivityPreviewFixtures.longNameNoTitle, colorScheme: .dark)
     }
 
     #Preview("P6 Stale max height (Light)") {
         previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent("blocked", kind: "claude", pane: "w1:p1", title: "First"),
-                        previewAgent("done", kind: "droid", pane: "w1:p2", title: "Second"),
-                        previewAgent("working", kind: "grok", pane: "w1:p3", title: "Third"),
-                        previewAgent("working", kind: "codex", pane: "w1:p4", title: "Fourth"),
-                        previewAgent("working", kind: "claude", pane: "w1:p5", title: "Fifth"),
-                    ]),
-                counts: .init(working: 3, blocked: 1, done: 1)),
-            colorScheme: .light,
-            isStale: true)
+            AgentActivityPreviewFixtures.staleMaxHeight, colorScheme: .light, isStale: true)
     }
 
     #Preview("P6 Stale max height (Dark)") {
         previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent("blocked", kind: "claude", pane: "w1:p1", title: "First"),
-                        previewAgent("done", kind: "droid", pane: "w1:p2", title: "Second"),
-                        previewAgent("working", kind: "grok", pane: "w1:p3", title: "Third"),
-                        previewAgent("working", kind: "codex", pane: "w1:p4", title: "Fourth"),
-                        previewAgent("working", kind: "claude", pane: "w1:p5", title: "Fifth"),
-                    ]),
-                counts: .init(working: 3, blocked: 1, done: 1)),
-            colorScheme: .dark,
-            isStale: true)
+            AgentActivityPreviewFixtures.staleMaxHeight, colorScheme: .dark, isStale: true)
     }
 
     #Preview("P6b Stale three rows (Light)") {
         previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent("blocked", kind: "claude", pane: "w1:p1", title: "First"),
-                        previewAgent("done", kind: "droid", pane: "w1:p2", title: "Second"),
-                        previewAgent("working", kind: "grok", pane: "w1:p3", title: "Third"),
-                    ]),
-                counts: .init(working: 1, blocked: 1, done: 1)),
-            colorScheme: .light,
-            isStale: true)
+            AgentActivityPreviewFixtures.staleThreeRows, colorScheme: .light, isStale: true)
     }
 
     #Preview("P6b Stale three rows (Dark)") {
         previewLockScreenBanner(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent("blocked", kind: "claude", pane: "w1:p1", title: "First"),
-                        previewAgent("done", kind: "droid", pane: "w1:p2", title: "Second"),
-                        previewAgent("working", kind: "grok", pane: "w1:p3", title: "Third"),
-                    ]),
-                counts: .init(working: 1, blocked: 1, done: 1)),
-            colorScheme: .dark,
-            isStale: true)
+            AgentActivityPreviewFixtures.staleThreeRows, colorScheme: .dark, isStale: true)
     }
 
     #Preview("P7 Compact blocked (Light island)") {
@@ -792,21 +741,6 @@ private struct AgentActivityRowView: View {
     }
 
     #Preview("P11 Expanded mixed (Light island)") {
-        previewIslandExpanded(
-            .detailed(
-                details: AgentActivityDetails(
-                    hostName: "mbp",
-                    agents: [
-                        previewAgent(
-                            "blocked", kind: "claude", name: "reviewer", pane: "w1:p1",
-                            title: "Approve the transport refactor plan"),
-                        previewAgent(
-                            "done", kind: "droid", name: "doc-writer", pane: "w1:p2",
-                            title: "API reference draft finished"),
-                        previewAgent(
-                            "working", kind: "grok", name: "la-demo", pane: "w1:p3",
-                            title: "Research ActivityKit budgets"),
-                    ]),
-                counts: .init(working: 1, blocked: 1, done: 1)))
+        previewIslandExpanded(AgentActivityPreviewFixtures.expandedMixed)
     }
 #endif

--- a/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
+++ b/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
@@ -27,9 +27,8 @@ struct AgentLiveActivityWidget: Widget {
 // MARK: - Surface seam
 
 enum AgentActivitySurface {
-    /// Lock Screen banner. Status colors follow the device appearance
-    /// (Latte in Light, Mocha in Dark) via AgentStatusPalette. The device
-    /// screen trait bypasses ActivityKit's incorrect iOS 26+ color scheme.
+    /// Lock Screen banner. Status colors remain dynamic so ActivityKit can
+    /// resolve Latte in Light appearance and Mocha in Dark appearance.
     case lockScreen
     /// Compact, minimal, and expanded Dynamic Island. Always Mocha,
     /// resolved against a dark trait collection, ignoring ambient Light Mode.
@@ -115,8 +114,8 @@ private struct AgentActivityLockScreenContainer: View {
 }
 
 enum AgentActivityLockScreenChrome {
-    /// Keep these semantic colors unresolved so SwiftUI can redraw the
-    /// lock-screen surface when the system appearance changes.
+    /// Keep these semantic colors unresolved so ActivityKit can apply the
+    /// system appearance when its host provides the correct trait collection.
     static let backgroundColor = UIColor.systemBackground
     static let actionColor = UIColor.label
 }

--- a/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
+++ b/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
@@ -3,11 +3,11 @@ import SwiftUI
 import UIKit
 import WidgetKit
 
-/// Live Activity for one Host. Lock-screen banner is a uniform agent list
-/// under a ~160pt budget: four rows when everything fits, three plus
-/// "+N more" otherwise. Rows arrive in the sender's pin-aware order and
-/// are rendered as given; Host identity is never rendered. Every agent row is a deep link into that
-/// agent's detail; taps outside a row land on the Console.
+/// Live Activity for one Host. The lock-screen banner gives the leading
+/// agent a full two-line row and packs up to four more agents into compact
+/// rows. Rows arrive in the sender's pin-aware order and are rendered as
+/// given; Host identity is never rendered. The entire activity is one large
+/// interaction target that opens the Console.
 struct AgentLiveActivityWidget: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: AgentActivityAttributes.self) { context in
@@ -83,10 +83,13 @@ struct AgentActivityLockScreenView: View {
     let isStale: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 5) {
             header
             ForEach(visibleAgents.dropFirst(), id: \.paneID) { agent in
-                AgentActivityLinkedRow(hostID: hostID, agent: agent, surface: .lockScreen)
+                AgentActivityRowView(
+                    agent: agent,
+                    surface: .lockScreen,
+                    density: .compact)
             }
             if let caption = presentation.lockScreenTrailingCaption(isStale: isStale) {
                 Text(caption)
@@ -103,7 +106,7 @@ struct AgentActivityLockScreenView: View {
             #endif
         }
         .padding(.horizontal, 14)
-        .padding(.vertical, 12)
+        .padding(.vertical, 10)
         .widgetURL(AgentActivityLink.consoleURL(hostID: hostID))
         .accessibilityElement(children: .combine)
         .accessibilityLabel(lockScreenAccessibilityLabel)
@@ -124,7 +127,7 @@ struct AgentActivityLockScreenView: View {
     @ViewBuilder
     private var headline: some View {
         if let first = visibleAgents.first {
-            AgentActivityLinkedRow(hostID: hostID, agent: first, surface: .lockScreen)
+            AgentActivityRowView(agent: first, surface: .lockScreen)
         } else {
             Text(presentation.headerTitle)
                 .font(.subheadline.weight(.semibold))
@@ -163,9 +166,7 @@ enum AgentActivityIsland {
         DynamicIsland {
             DynamicIslandExpandedRegion(.center) {
                 if let primary = presentation.primaryAgent {
-                    AgentActivityLinked(hostID: hostID, paneID: primary.paneID) {
-                        AgentActivityHeadlineView(agent: primary, surface: .island)
-                    }
+                    AgentActivityHeadlineView(agent: primary, surface: .island)
                 } else {
                     Text(presentation.headerTitle)
                         .font(.headline)
@@ -176,7 +177,7 @@ enum AgentActivityIsland {
             DynamicIslandExpandedRegion(.bottom) {
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(presentation.secondaryAgents, id: \.paneID) { agent in
-                        AgentActivityLinkedRow(hostID: hostID, agent: agent, surface: .island)
+                        AgentActivityRowView(agent: agent, surface: .island)
                     }
                     if presentation.overflowCount > 0 {
                         Text("+\(presentation.overflowCount) more")
@@ -188,31 +189,26 @@ enum AgentActivityIsland {
                 }
             }
         } compactLeading: {
-            AgentActivityConsoleLinked(hostID: hostID) {
-                AgentActivityCompactLeading(counts: presentation.counts)
-            }
+            AgentActivityCompactLeading(counts: presentation.counts)
         } compactTrailing: {
-            AgentActivityConsoleLinked(hostID: hostID) {
-                Text("\(presentation.counts.total)")
-                    .font(.body.weight(.semibold).monospacedDigit())
-                    .accessibilityLabel("\(presentation.counts.total) agents")
-            }
+            Text("\(presentation.counts.total)")
+                .font(.body.weight(.semibold).monospacedDigit())
+                .accessibilityLabel("\(presentation.counts.total) agents")
         } minimal: {
-            AgentActivityConsoleLinked(hostID: hostID) {
-                Text("\(presentation.counts.total)")
-                    .font(
-                        .body.weight(presentation.counts.blocked > 0 ? .bold : .semibold)
-                            .monospacedDigit()
-                    )
-                    .foregroundStyle(
-                        presentation.counts.blocked > 0
-                            ? AgentActivityStatusStyle.ink(for: "blocked", on: .island)
-                            : Color.primary
-                    )
-                    .accessibilityLabel(minimalAccessibilityLabel(counts: presentation.counts))
-            }
+            Text("\(presentation.counts.total)")
+                .font(
+                    .body.weight(presentation.counts.blocked > 0 ? .bold : .semibold)
+                        .monospacedDigit()
+                )
+                .foregroundStyle(
+                    presentation.counts.blocked > 0
+                        ? AgentActivityStatusStyle.ink(for: "blocked", on: .island)
+                        : Color.primary
+                )
+                .accessibilityLabel(minimalAccessibilityLabel(counts: presentation.counts))
         }
         .keylineTint(islandKeylineTint(counts: presentation.counts))
+        .widgetURL(AgentActivityLink.consoleURL(hostID: hostID))
     }
 
     private static func islandKeylineTint(
@@ -265,43 +261,9 @@ enum AgentActivityNarration {
 
 // MARK: - Shared pieces
 
-/// Applies the Console deep link inside a `body` so the MainActor-isolated
-/// `widgetURL` is reachable from the nonisolated DynamicIsland builders.
-private struct AgentActivityConsoleLinked<Content: View>: View {
-    let hostID: String
-    @ViewBuilder let content: Content
-
-    var body: some View {
-        content.widgetURL(AgentActivityLink.consoleURL(hostID: hostID))
-    }
-}
-
-/// Wraps row content in a deep link to that agent's detail; falls back to
-/// plain content when the URL cannot be built (never expected).
-private struct AgentActivityLinked<Content: View>: View {
-    let hostID: String
-    let paneID: String
-    @ViewBuilder let content: Content
-
-    var body: some View {
-        if let url = AgentActivityLink.agentURL(hostID: hostID, paneID: paneID) {
-            Link(destination: url) { content }
-        } else {
-            content
-        }
-    }
-}
-
-private struct AgentActivityLinkedRow: View {
-    let hostID: String
-    let agent: AgentActivityDetails.AgentDetail
-    let surface: AgentActivitySurface
-
-    var body: some View {
-        AgentActivityLinked(hostID: hostID, paneID: agent.paneID) {
-            AgentActivityRowView(agent: agent, surface: surface)
-        }
-    }
+private enum AgentActivityRowDensity: Equatable {
+    case full
+    case compact
 }
 
 private struct AgentActivityCountChips: View {
@@ -372,53 +334,87 @@ private struct AgentActivityHeadlineView: View {
     }
 }
 
-/// One agent row: the same two-line rule as the headline, smaller type —
-/// task title on top, identity (name, kind when unnamed) indented beneath.
-/// Status is painted, not narrated as an event — a done row is the current
-/// state, not "just finished".
+/// One agent row. Full density mirrors the headline hierarchy at smaller
+/// type; compact density keeps the title and identity on one line. Status
+/// is painted, not narrated as an event — a done row is the current state,
+/// not "just finished".
 private struct AgentActivityRowView: View {
     let agent: AgentActivityDetails.AgentDetail
     let surface: AgentActivitySurface
+    var density: AgentActivityRowDensity = .full
 
     private var isBlocked: Bool { agent.status == "blocked" }
     private var ink: Color { AgentActivityStatusStyle.ink(for: agent.status, on: surface) }
     private var wash: Color { AgentActivityStatusStyle.wash(for: agent.status, on: surface) }
 
     var body: some View {
-        let content = VStack(alignment: .leading, spacing: 1) {
-            HStack(spacing: 7) {
-                Circle()
-                    .fill(ink)
-                    .frame(width: 7, height: 7)
-                    .accessibilityHidden(true)
-                Text(agent.displayTitle ?? agent.displayName)
-                    .font(.caption.weight(isBlocked ? .semibold : .regular))
-                    .foregroundStyle(isBlocked ? ink : .primary)
-                    .lineLimit(1)
-                Spacer(minLength: 0)
+        let content = rowContent
+            .padding(.vertical, isBlocked ? blockedVerticalPadding : 0)
+            .padding(.horizontal, isBlocked ? 6 : 0)
+            .background {
+                if isBlocked {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(wash.opacity(0.15))
+                }
             }
-            if agent.displayTitle != nil {
-                Text(agent.displayName)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .padding(.leading, 14)
-            }
-        }
-        .padding(.vertical, isBlocked ? 3 : 0)
-        .padding(.horizontal, isBlocked ? 6 : 0)
-        .background {
-            if isBlocked {
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(wash.opacity(0.15))
-            }
-        }
         switch surface {
         case .island:
             content.accessibilityLabel(AgentActivityNarration.rowLabel(for: agent))
         case .lockScreen:
             content
         }
+    }
+
+    @ViewBuilder
+    private var rowContent: some View {
+        switch density {
+        case .full:
+            VStack(alignment: .leading, spacing: 1) {
+                HStack(spacing: 7) {
+                    statusDot
+                    title
+                    Spacer(minLength: 0)
+                }
+                if agent.displayTitle != nil {
+                    Text(agent.displayName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .padding(.leading, 14)
+                }
+            }
+        case .compact:
+            HStack(spacing: 7) {
+                statusDot
+                title
+                    .layoutPriority(1)
+                if agent.displayTitle != nil {
+                    Text("· \(agent.displayName)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    private var statusDot: some View {
+        Circle()
+            .fill(ink)
+            .frame(width: 7, height: 7)
+            .accessibilityHidden(true)
+    }
+
+    private var title: some View {
+        Text(agent.displayTitle ?? agent.displayName)
+            .font(.caption.weight(isBlocked ? .semibold : .regular))
+            .foregroundStyle(isBlocked ? ink : .primary)
+            .lineLimit(1)
+    }
+
+    private var blockedVerticalPadding: CGFloat {
+        density == .compact ? 2 : 3
     }
 }
 
@@ -459,7 +455,7 @@ private struct AgentActivityRowView: View {
                             "working", kind: "claude", pane: "w1:p5",
                             title: "Refactor the transport queue"),
                     ]),
-                counts: .init(working: 3, blocked: 1, done: 1))
+                counts: .init(working: 4, blocked: 1, done: 1))
         }
 
         static var singleUnnamedIdentityOnly: AgentActivityPresentation {
@@ -586,8 +582,6 @@ private struct AgentActivityRowView: View {
             hostID: "6D8EC348-4DAF-455C-BA8F-5FCC41799C0E",
             isStale: isStale
         )
-        .buttonStyle(.plain)
-        .tint(.primary)
         .background(
             colorScheme == .light
                 ? Color(white: 0.97)

--- a/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
+++ b/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
@@ -11,13 +11,11 @@ import WidgetKit
 struct AgentLiveActivityWidget: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: AgentActivityAttributes.self) { context in
-            AgentActivityLockScreenView(
+            AgentActivityLockScreenContainer(
                 presentation: AgentActivityDecryptor.presentation(for: context.state),
                 hostID: context.attributes.hostID,
                 isStale: context.isStale
             )
-            .activityBackgroundTint(nil)
-            .activitySystemActionForegroundColor(nil)
         } dynamicIsland: { context in
             AgentActivityIsland.make(
                 presentation: AgentActivityDecryptor.presentation(for: context.state),
@@ -29,8 +27,9 @@ struct AgentLiveActivityWidget: Widget {
 // MARK: - Surface seam
 
 enum AgentActivitySurface {
-    /// Lock Screen banner. Status colors follow the system appearance
-    /// (Latte in Light, Mocha in Dark) via AgentStatusPalette.
+    /// Lock Screen banner. Status colors follow the device appearance
+    /// (Latte in Light, Mocha in Dark) via AgentStatusPalette. The device
+    /// screen trait bypasses ActivityKit's incorrect iOS 26+ color scheme.
     case lockScreen
     /// Compact, minimal, and expanded Dynamic Island. Always Mocha,
     /// resolved against a dark trait collection, ignoring ambient Light Mode.
@@ -76,6 +75,66 @@ enum AgentActivityStatusStyle {
 }
 
 // MARK: - Lock screen
+
+private struct AgentActivityLockScreenContainer: View {
+    @Environment(\.colorScheme) private var activityKitColorScheme
+
+    let presentation: AgentActivityPresentation
+    let hostID: String
+    let isStale: Bool
+
+    var body: some View {
+        let appearance = AgentActivityLockScreenAppearance.resolve(
+            screenStyle: UIScreen.main.traitCollection.userInterfaceStyle,
+            fallback: activityKitColorScheme)
+
+        AgentActivityLockScreenView(
+            presentation: presentation,
+            hostID: hostID,
+            isStale: isStale
+        )
+        .environment(\.colorScheme, appearance.colorScheme)
+        .activityBackgroundTint(Color(uiColor: appearance.backgroundColor))
+        .activitySystemActionForegroundColor(Color(uiColor: appearance.actionColor))
+    }
+}
+
+enum AgentActivityLockScreenAppearance: Equatable {
+    case light
+    case dark
+
+    static func resolve(
+        screenStyle: UIUserInterfaceStyle,
+        fallback: ColorScheme
+    ) -> AgentActivityLockScreenAppearance {
+        switch screenStyle {
+        case .light:
+            return .light
+        case .dark:
+            return .dark
+        case .unspecified:
+            return fallback == .dark ? .dark : .light
+        @unknown default:
+            return fallback == .dark ? .dark : .light
+        }
+    }
+
+    var colorScheme: ColorScheme {
+        self == .dark ? .dark : .light
+    }
+
+    var backgroundColor: UIColor {
+        UIColor.systemBackground.resolvedColor(with: traitCollection)
+    }
+
+    var actionColor: UIColor {
+        UIColor.label.resolvedColor(with: traitCollection)
+    }
+
+    private var traitCollection: UITraitCollection {
+        UITraitCollection(userInterfaceStyle: self == .dark ? .dark : .light)
+    }
+}
 
 struct AgentActivityLockScreenView: View {
     let presentation: AgentActivityPresentation

--- a/Tests/HeelerTests/AgentActivityPresentationTests.swift
+++ b/Tests/HeelerTests/AgentActivityPresentationTests.swift
@@ -6,10 +6,25 @@ import UIKit
 
 @Suite("Agent activity presentation")
 struct AgentActivityPresentationTests {
+    private static let statuses: [(wire: String, palette: AgentStatus)] = [
+        ("blocked", .blocked),
+        ("done", .done),
+        ("working", .working),
+        ("unknown", .unknown),
+    ]
+
+    private func agentDetail(
+        paneID: String, status: String = "working"
+    ) -> AgentActivityDetails.AgentDetail {
+        AgentActivityDetails.AgentDetail(
+            paneID: paneID, kind: "claude", name: nil, status: status,
+            title: "Task \(paneID)")
+    }
+
     private func detailedPresentation(
         agentCount: Int, total: AgentActivityAttributes.ContentState.Counts
     ) -> AgentActivityPresentation {
-        let agents = (0..<agentCount).map { agent("w1:p\($0)", "working") }
+        let agents = (0..<agentCount).map { agentDetail(paneID: "w1:p\($0)") }
         return .detailed(
             details: AgentActivityDetails(hostName: "mbp", agents: agents),
             counts: total)
@@ -80,21 +95,66 @@ struct AgentActivityPresentationTests {
         #expect(workingOnly.attentionStatusItem?.count == 3)
     }
 
-    @Test func islandInkUsesMochaEvenWhenResolvedInLightMode() {
-        let lightTraits = UITraitCollection(userInterfaceStyle: .light)
-        let islandBlocked = AgentActivityStatusStyle.ink(for: "blocked", on: .island)
-        let lockScreenBlocked = AgentActivityStatusStyle.ink(for: "blocked", on: .lockScreen)
-
-        let islandUIColor = UIColor(islandBlocked)
-            .resolvedColor(with: lightTraits)
-        let lockScreenUIColor = UIColor(lockScreenBlocked)
-            .resolvedColor(with: lightTraits)
-
-        #expect(rgba(islandUIColor) == rgba(AgentStatus.blocked.inkUIColor, style: .dark))
-        #expect(rgba(lockScreenUIColor) != rgba(AgentStatus.blocked.inkUIColor, style: .dark))
+    @Test func narrationIncludesStatusForIslandAccessibility() {
+        let agent = agentDetail(paneID: "w1:p1", status: "blocked")
+        #expect(AgentActivityNarration.rowLabel(for: agent) == "claude, blocked, Task w1:p1")
     }
 
-    private func rgba(_ color: UIColor, style: UIUserInterfaceStyle) -> [Int] {
+    @Test func lockScreenInkMatchesPaletteForEachAppearance() {
+        for (wire, palette) in Self.statuses {
+            for style in [UIUserInterfaceStyle.light, .dark] {
+                let resolved = rgba(
+                    UIColor(AgentActivityStatusStyle.ink(for: wire, on: .lockScreen)),
+                    style)
+                #expect(resolved == rgba(palette.inkUIColor, style), "\(wire) ink \(style.rawValue)")
+            }
+        }
+    }
+
+    @Test func lockScreenWashMatchesPaletteForEachAppearance() {
+        for (wire, palette) in Self.statuses {
+            for style in [UIUserInterfaceStyle.light, .dark] {
+                let resolved = rgba(
+                    UIColor(AgentActivityStatusStyle.wash(for: wire, on: .lockScreen)),
+                    style)
+                #expect(resolved == rgba(palette.tintUIColor, style), "\(wire) wash \(style.rawValue)")
+            }
+        }
+    }
+
+    @Test func islandInkStaysMochaUnderLightAppearance() {
+        for (wire, palette) in Self.statuses {
+            let resolved = rgba(
+                UIColor(AgentActivityStatusStyle.ink(for: wire, on: .island)),
+                .light)
+            #expect(
+                resolved == rgba(palette.inkUIColor, .dark),
+                "\(wire) island ink must stay Mocha")
+        }
+    }
+
+    @Test func islandWashStaysMochaUnderLightAppearance() {
+        for (wire, palette) in Self.statuses {
+            let resolved = rgba(
+                UIColor(AgentActivityStatusStyle.wash(for: wire, on: .island)),
+                .light)
+            #expect(
+                resolved == rgba(palette.tintUIColor, .dark),
+                "\(wire) island wash must stay Mocha")
+        }
+    }
+
+    @Test func unknownWireStatusMapsToMutedPaletteRole() {
+        let bogus = "haunted"
+        #expect(
+            rgba(UIColor(AgentActivityStatusStyle.ink(for: bogus, on: .lockScreen)), .light)
+                == rgba(AgentStatus.unknown.inkUIColor, .light))
+        #expect(
+            rgba(UIColor(AgentActivityStatusStyle.wash(for: bogus, on: .island)), .light)
+                == rgba(AgentStatus.unknown.tintUIColor, .dark))
+    }
+
+    private func rgba(_ color: UIColor, _ style: UIUserInterfaceStyle) -> [Int] {
         rgba(color.resolvedColor(with: UITraitCollection(userInterfaceStyle: style)))
     }
 

--- a/Tests/HeelerTests/AgentActivityPresentationTests.swift
+++ b/Tests/HeelerTests/AgentActivityPresentationTests.swift
@@ -38,20 +38,20 @@ struct AgentActivityPresentationTests {
         #expect(presentation.lockScreenTrailingCaption(isStale: false) == nil)
     }
 
-    @Test func freshShowsFiveRowsWhenTotalIsFive() {
+    @Test func freshShowsFourRowsAndOverflowWhenTotalIsFive() {
         let presentation = detailedPresentation(
             agentCount: 5, total: .init(working: 5, blocked: 0, done: 0))
-        #expect(presentation.lockScreenAgents(isStale: false).count == 5)
-        #expect(presentation.lockScreenOverflowCount(isStale: false) == 0)
-        #expect(presentation.lockScreenTrailingCaption(isStale: false) == nil)
-    }
-
-    @Test func freshShowsFiveRowsAndOverflowWhenTotalExceedsEnvelopeLimit() {
-        let presentation = detailedPresentation(
-            agentCount: 5, total: .init(working: 6, blocked: 0, done: 0))
-        #expect(presentation.lockScreenAgents(isStale: false).count == 5)
+        #expect(presentation.lockScreenAgents(isStale: false).count == 4)
         #expect(presentation.lockScreenOverflowCount(isStale: false) == 1)
         #expect(presentation.lockScreenTrailingCaption(isStale: false) == "+1 more")
+    }
+
+    @Test func freshShowsFourRowsAndOverflowWhenTotalExceedsEnvelopeLimit() {
+        let presentation = detailedPresentation(
+            agentCount: 5, total: .init(working: 6, blocked: 0, done: 0))
+        #expect(presentation.lockScreenAgents(isStale: false).count == 4)
+        #expect(presentation.lockScreenOverflowCount(isStale: false) == 2)
+        #expect(presentation.lockScreenTrailingCaption(isStale: false) == "+2 more")
     }
 
     @Test func staleShowsFourRowsWhenTotalIsFour() {
@@ -114,6 +114,12 @@ struct AgentActivityPresentationTests {
     @Test func narrationIncludesStatusForIslandAccessibility() {
         let agent = agentDetail(paneID: "w1:p1", status: "blocked")
         #expect(AgentActivityNarration.rowLabel(for: agent) == "claude, blocked, Task w1:p1")
+    }
+
+    @Test func lockScreenRowsUseComfortableAndDenseAppleTargetHeights() {
+        #expect(AgentActivityRowMetrics.lockScreenMinimumHeight(agentCount: 1) == 44)
+        #expect(AgentActivityRowMetrics.lockScreenMinimumHeight(agentCount: 3) == 44)
+        #expect(AgentActivityRowMetrics.lockScreenMinimumHeight(agentCount: 4) == 28)
     }
 
     @Test func lockScreenInkMatchesPaletteForEachAppearance() {

--- a/Tests/HeelerTests/AgentActivityPresentationTests.swift
+++ b/Tests/HeelerTests/AgentActivityPresentationTests.swift
@@ -122,6 +122,52 @@ struct AgentActivityPresentationTests {
         #expect(AgentActivityRowMetrics.lockScreenMinimumHeight(agentCount: 4) == 28)
     }
 
+    @Test func deviceLightAppearanceOverridesIncorrectActivityKitDarkScheme() {
+        let appearance = AgentActivityLockScreenAppearance.resolve(
+            screenStyle: .light,
+            fallback: .dark)
+
+        #expect(appearance == .light)
+        #expect(appearance.colorScheme == .light)
+    }
+
+    @Test func deviceDarkAppearanceOverridesIncorrectActivityKitLightScheme() {
+        let appearance = AgentActivityLockScreenAppearance.resolve(
+            screenStyle: .dark,
+            fallback: .light)
+
+        #expect(appearance == .dark)
+        #expect(appearance.colorScheme == .dark)
+    }
+
+    @Test func unspecifiedDeviceAppearanceUsesActivityKitFallback() {
+        #expect(
+            AgentActivityLockScreenAppearance.resolve(
+                screenStyle: .unspecified,
+                fallback: .light
+            ) == .light)
+        #expect(
+            AgentActivityLockScreenAppearance.resolve(
+                screenStyle: .unspecified,
+                fallback: .dark
+            ) == .dark)
+    }
+
+    @Test func lockScreenChromeResolvesAgainstDeviceAppearance() {
+        #expect(
+            rgba(AgentActivityLockScreenAppearance.light.backgroundColor)
+                == rgba(UIColor.systemBackground, .light))
+        #expect(
+            rgba(AgentActivityLockScreenAppearance.dark.backgroundColor)
+                == rgba(UIColor.systemBackground, .dark))
+        #expect(
+            rgba(AgentActivityLockScreenAppearance.light.actionColor)
+                == rgba(UIColor.label, .light))
+        #expect(
+            rgba(AgentActivityLockScreenAppearance.dark.actionColor)
+                == rgba(UIColor.label, .dark))
+    }
+
     @Test func lockScreenInkMatchesPaletteForEachAppearance() {
         for (wire, palette) in Self.statuses {
             for style in [UIUserInterfaceStyle.light, .dark] {

--- a/Tests/HeelerTests/AgentActivityPresentationTests.swift
+++ b/Tests/HeelerTests/AgentActivityPresentationTests.swift
@@ -122,50 +122,32 @@ struct AgentActivityPresentationTests {
         #expect(AgentActivityRowMetrics.lockScreenMinimumHeight(agentCount: 4) == 28)
     }
 
-    @Test func deviceLightAppearanceOverridesIncorrectActivityKitDarkScheme() {
-        let appearance = AgentActivityLockScreenAppearance.resolve(
-            screenStyle: .light,
-            fallback: .dark)
-
-        #expect(appearance == .light)
-        #expect(appearance.colorScheme == .light)
-    }
-
-    @Test func deviceDarkAppearanceOverridesIncorrectActivityKitLightScheme() {
-        let appearance = AgentActivityLockScreenAppearance.resolve(
-            screenStyle: .dark,
-            fallback: .light)
-
-        #expect(appearance == .dark)
-        #expect(appearance.colorScheme == .dark)
-    }
-
-    @Test func unspecifiedDeviceAppearanceUsesActivityKitFallback() {
+    @Test func lockScreenChromeRemainsDynamicAcrossSystemAppearances() {
         #expect(
-            AgentActivityLockScreenAppearance.resolve(
-                screenStyle: .unspecified,
-                fallback: .light
-            ) == .light)
-        #expect(
-            AgentActivityLockScreenAppearance.resolve(
-                screenStyle: .unspecified,
-                fallback: .dark
-            ) == .dark)
-    }
-
-    @Test func lockScreenChromeResolvesAgainstDeviceAppearance() {
-        #expect(
-            rgba(AgentActivityLockScreenAppearance.light.backgroundColor)
+            rgba(AgentActivityLockScreenChrome.backgroundColor, .light)
                 == rgba(UIColor.systemBackground, .light))
         #expect(
-            rgba(AgentActivityLockScreenAppearance.dark.backgroundColor)
+            rgba(AgentActivityLockScreenChrome.backgroundColor, .dark)
                 == rgba(UIColor.systemBackground, .dark))
         #expect(
-            rgba(AgentActivityLockScreenAppearance.light.actionColor)
+            rgba(AgentActivityLockScreenChrome.actionColor, .light)
                 == rgba(UIColor.label, .light))
         #expect(
-            rgba(AgentActivityLockScreenAppearance.dark.actionColor)
+            rgba(AgentActivityLockScreenChrome.actionColor, .dark)
                 == rgba(UIColor.label, .dark))
+        #expect(
+            rgba(AgentActivityLockScreenChrome.backgroundColor, .light)
+                != rgba(AgentActivityLockScreenChrome.backgroundColor, .dark))
+    }
+
+    @Test func lockScreenSemanticTextRemainsDynamicAcrossSystemAppearances() {
+        let primary = UIColor(AgentActivitySemanticStyle.primary(on: .lockScreen))
+        let secondary = UIColor(AgentActivitySemanticStyle.secondary(on: .lockScreen))
+
+        #expect(rgba(primary, .light) == rgba(UIColor.label, .light))
+        #expect(rgba(primary, .dark) == rgba(UIColor.label, .dark))
+        #expect(rgba(secondary, .light) == rgba(UIColor.secondaryLabel, .light))
+        #expect(rgba(secondary, .dark) == rgba(UIColor.secondaryLabel, .dark))
     }
 
     @Test func lockScreenInkMatchesPaletteForEachAppearance() {

--- a/Tests/HeelerTests/AgentActivityPresentationTests.swift
+++ b/Tests/HeelerTests/AgentActivityPresentationTests.swift
@@ -38,18 +38,34 @@ struct AgentActivityPresentationTests {
         #expect(presentation.lockScreenTrailingCaption(isStale: false) == nil)
     }
 
-    @Test func freshShowsThreeRowsAndOverflowWhenTotalIsFiveOrMore() {
+    @Test func freshShowsFiveRowsWhenTotalIsFive() {
         let presentation = detailedPresentation(
             agentCount: 5, total: .init(working: 5, blocked: 0, done: 0))
-        #expect(presentation.lockScreenAgents(isStale: false).count == 3)
-        #expect(presentation.lockScreenOverflowCount(isStale: false) == 2)
-        #expect(presentation.lockScreenTrailingCaption(isStale: false) == "+2 more")
+        #expect(presentation.lockScreenAgents(isStale: false).count == 5)
+        #expect(presentation.lockScreenOverflowCount(isStale: false) == 0)
+        #expect(presentation.lockScreenTrailingCaption(isStale: false) == nil)
     }
 
-    @Test func staleNeverShowsFourRows() {
+    @Test func freshShowsFiveRowsAndOverflowWhenTotalExceedsEnvelopeLimit() {
+        let presentation = detailedPresentation(
+            agentCount: 5, total: .init(working: 6, blocked: 0, done: 0))
+        #expect(presentation.lockScreenAgents(isStale: false).count == 5)
+        #expect(presentation.lockScreenOverflowCount(isStale: false) == 1)
+        #expect(presentation.lockScreenTrailingCaption(isStale: false) == "+1 more")
+    }
+
+    @Test func staleShowsFourRowsWhenTotalIsFour() {
         let presentation = detailedPresentation(
             agentCount: 4, total: .init(working: 4, blocked: 0, done: 0))
-        #expect(presentation.lockScreenAgents(isStale: true).count == 3)
+        #expect(presentation.lockScreenAgents(isStale: true).count == 4)
+        #expect(presentation.lockScreenOverflowCount(isStale: true) == 0)
+        #expect(presentation.lockScreenTrailingCaption(isStale: true) == "May be out of date")
+    }
+
+    @Test func staleShowsFourRowsAndOverflowWhenTotalExceedsFour() {
+        let presentation = detailedPresentation(
+            agentCount: 5, total: .init(working: 5, blocked: 0, done: 0))
+        #expect(presentation.lockScreenAgents(isStale: true).count == 4)
         #expect(presentation.lockScreenOverflowCount(isStale: true) == 1)
         #expect(presentation.lockScreenTrailingCaption(isStale: true) == "+1 more · May be out of date")
     }

--- a/Tests/HeelerTests/AgentActivityPresentationTests.swift
+++ b/Tests/HeelerTests/AgentActivityPresentationTests.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import Testing
+import UIKit
+
+@testable import Heeler
+
+@Suite("Agent activity presentation")
+struct AgentActivityPresentationTests {
+    private func detailedPresentation(
+        agentCount: Int, total: AgentActivityAttributes.ContentState.Counts
+    ) -> AgentActivityPresentation {
+        let agents = (0..<agentCount).map { agent("w1:p\($0)", "working") }
+        return .detailed(
+            details: AgentActivityDetails(hostName: "mbp", agents: agents),
+            counts: total)
+    }
+
+    @Test func freshShowsFourRowsWhenTotalIsFour() {
+        let presentation = detailedPresentation(
+            agentCount: 4, total: .init(working: 4, blocked: 0, done: 0))
+        #expect(presentation.lockScreenAgents(isStale: false).count == 4)
+        #expect(presentation.lockScreenOverflowCount(isStale: false) == 0)
+        #expect(presentation.lockScreenTrailingCaption(isStale: false) == nil)
+    }
+
+    @Test func freshShowsThreeRowsAndOverflowWhenTotalIsFiveOrMore() {
+        let presentation = detailedPresentation(
+            agentCount: 5, total: .init(working: 5, blocked: 0, done: 0))
+        #expect(presentation.lockScreenAgents(isStale: false).count == 3)
+        #expect(presentation.lockScreenOverflowCount(isStale: false) == 2)
+        #expect(presentation.lockScreenTrailingCaption(isStale: false) == "+2 more")
+    }
+
+    @Test func staleNeverShowsFourRows() {
+        let presentation = detailedPresentation(
+            agentCount: 4, total: .init(working: 4, blocked: 0, done: 0))
+        #expect(presentation.lockScreenAgents(isStale: true).count == 3)
+        #expect(presentation.lockScreenOverflowCount(isStale: true) == 1)
+        #expect(presentation.lockScreenTrailingCaption(isStale: true) == "+1 more · May be out of date")
+    }
+
+    @Test func staleShowsAllRowsWhenTotalIsThreeOrLess() {
+        let presentation = detailedPresentation(
+            agentCount: 3, total: .init(working: 1, blocked: 1, done: 1))
+        #expect(presentation.lockScreenAgents(isStale: true).count == 3)
+        #expect(presentation.lockScreenOverflowCount(isStale: true) == 0)
+        #expect(presentation.lockScreenTrailingCaption(isStale: true) == "May be out of date")
+    }
+
+    @Test func staleCountsOnlyHasNoRowsAndNoOverflow() {
+        let presentation = AgentActivityPresentation.countsOnly(
+            counts: .init(working: 2, blocked: 1, done: 0))
+        #expect(presentation.lockScreenAgents(isStale: true).isEmpty)
+        #expect(presentation.lockScreenOverflowCount(isStale: true) == 0)
+        #expect(presentation.lockScreenTrailingCaption(isStale: true) == "May be out of date")
+    }
+
+    @Test func freshCountsOnlyHasNoRowsOrCaption() {
+        let presentation = AgentActivityPresentation.countsOnly(
+            counts: .init(working: 2, blocked: 1, done: 0))
+        #expect(presentation.lockScreenAgents(isStale: false).isEmpty)
+        #expect(presentation.lockScreenOverflowCount(isStale: false) == 0)
+        #expect(presentation.lockScreenTrailingCaption(isStale: false) == nil)
+    }
+
+    @Test func attentionOrderPrefersBlockedThenDoneThenWorking() {
+        let blockedFirst = AgentActivityAttributes.ContentState.Counts(
+            working: 2, blocked: 1, done: 0)
+        #expect(blockedFirst.attentionStatusItem?.status == "blocked")
+        #expect(blockedFirst.attentionStatusItem?.count == 1)
+
+        let doneBeforeWorking = AgentActivityAttributes.ContentState.Counts(
+            working: 2, blocked: 0, done: 1)
+        #expect(doneBeforeWorking.attentionStatusItem?.status == "done")
+        #expect(doneBeforeWorking.attentionStatusItem?.count == 1)
+
+        let workingOnly = AgentActivityAttributes.ContentState.Counts(
+            working: 3, blocked: 0, done: 0)
+        #expect(workingOnly.attentionStatusItem?.status == "working")
+        #expect(workingOnly.attentionStatusItem?.count == 3)
+    }
+
+    @Test func islandInkUsesMochaEvenWhenResolvedInLightMode() {
+        let lightTraits = UITraitCollection(userInterfaceStyle: .light)
+        let islandBlocked = AgentActivityStatusStyle.ink(for: "blocked", on: .island)
+        let lockScreenBlocked = AgentActivityStatusStyle.ink(for: "blocked", on: .lockScreen)
+
+        let islandUIColor = UIColor(islandBlocked)
+            .resolvedColor(with: lightTraits)
+        let lockScreenUIColor = UIColor(lockScreenBlocked)
+            .resolvedColor(with: lightTraits)
+
+        #expect(rgba(islandUIColor) == rgba(AgentStatus.blocked.inkUIColor, style: .dark))
+        #expect(rgba(lockScreenUIColor) != rgba(AgentStatus.blocked.inkUIColor, style: .dark))
+    }
+
+    private func rgba(_ color: UIColor, style: UIUserInterfaceStyle) -> [Int] {
+        rgba(color.resolvedColor(with: UITraitCollection(userInterfaceStyle: style)))
+    }
+
+    private func rgba(_ color: UIColor) -> [Int] {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return [
+            Int((red * 255).rounded()),
+            Int((green * 255).rounded()),
+            Int((blue * 255).rounded()),
+        ]
+    }
+}

--- a/Tests/HeelerTests/ConsoleHostSectionHeaderPresentationTests.swift
+++ b/Tests/HeelerTests/ConsoleHostSectionHeaderPresentationTests.swift
@@ -13,7 +13,7 @@ struct ConsoleHostSectionHeaderPresentationTests {
         statusPresentation: ConsoleHostStatusPresentation? = nil,
         agents: [ConsoleAgent] = [],
         isCollapsed: Bool = false,
-        attentionCount: Int = 0
+        statusCounts: ConsoleHostAgentStatusCounts = .init()
     ) -> ConsoleHostSection {
         ConsoleHostSection(
             hostID: host.id,
@@ -23,7 +23,7 @@ struct ConsoleHostSectionHeaderPresentationTests {
             statusPresentation: statusPresentation,
             agents: agents,
             isCollapsed: isCollapsed,
-            attentionCount: attentionCount)
+            statusCounts: statusCounts)
     }
 
     private func consoleAgent(paneID: String, status: AgentStatus) -> ConsoleAgent {
@@ -76,15 +76,18 @@ struct ConsoleHostSectionHeaderPresentationTests {
                 section: section(status: .suspended)).readinessText == "Paused")
     }
 
-    @Test func attentionBadgeIsCollapsedOnlyButVoiceOverKeepsTheCount() {
+    @Test func statusPillsAreCollapsedOnlyButVoiceOverKeepsTheBreakdown() {
+        let counts = ConsoleHostAgentStatusCounts(blocked: 1, working: 2, done: 3)
         let expanded = ConsoleHostSectionHeaderPresentation(
             section: section(
                 status: .connected,
                 isCollapsed: false,
-                attentionCount: 2))
-        #expect(!expanded.showsAttentionBadge)
-        #expect(expanded.attentionText == "2 Agents need attention")
-        #expect(expanded.accessibilityLabel.contains("2 Agents need attention"))
+                statusCounts: counts))
+        #expect(!expanded.showsStatusPills)
+        #expect(expanded.statusItems.map(\.status) == [.blocked, .working, .done])
+        #expect(expanded.statusItems.map(\.count) == [1, 2, 3])
+        #expect(expanded.statusText == "1 blocked, 2 working, 3 done")
+        #expect(expanded.accessibilityLabel.contains("1 blocked, 2 working, 3 done"))
         #expect(expanded.accessibilityValue == "Expanded")
         #expect(expanded.accessibilityHint == "Collapses this Host.")
         #expect(expanded.disclosureSystemImage == "chevron.down")
@@ -93,9 +96,9 @@ struct ConsoleHostSectionHeaderPresentationTests {
             section: section(
                 status: .connected,
                 isCollapsed: true,
-                attentionCount: 1))
-        #expect(collapsed.showsAttentionBadge)
-        #expect(collapsed.attentionText == "1 Agent needs attention")
+                statusCounts: counts))
+        #expect(collapsed.showsStatusPills)
+        #expect(collapsed.statusText == "1 blocked, 2 working, 3 done")
         #expect(collapsed.accessibilityValue == "Collapsed")
         #expect(collapsed.accessibilityHint == "Expands this Host.")
         #expect(collapsed.disclosureSystemImage == "chevron.right")

--- a/Tests/HeelerTests/ConsoleListPresentationStoreTests.swift
+++ b/Tests/HeelerTests/ConsoleListPresentationStoreTests.swift
@@ -148,7 +148,7 @@ struct ConsoleListPresentationStoreTests {
         #expect(sections[1].statusPresentation?.hostID == disconnected.id)
     }
 
-    @Test func attentionCountsBlockedAndDoneEvenWhenCollapsed() throws {
+    @Test func statusCountsMatchLiveActivityStatusesEvenWhenCollapsed() throws {
         let (defaults, cleanup) = try makeDefaults()
         defer { cleanup() }
         let host = Host.fixture()
@@ -165,6 +165,7 @@ struct ConsoleListPresentationStoreTests {
 
         let section = try #require(store.sections(hosts: [host], agents: agents).first)
         #expect(section.isCollapsed)
-        #expect(section.attentionCount == 2)
+        #expect(section.statusCounts == .init(blocked: 1, working: 1, done: 1))
+        #expect(section.statusCounts.items.map(\.status) == [.blocked, .working, .done])
     }
 }

--- a/docs/design/issue-247-live-activity-redesign.md
+++ b/docs/design/issue-247-live-activity-redesign.md
@@ -3,7 +3,7 @@
 Status: Implementation-ready
 Date: 2026-08-27
 Issue: [#247](https://github.com/zingerbee/Heeler/issues/247)
-Scope: visual and interaction spec for `Sources/HeelerWidgets/AgentLiveActivityWidget.swift` only. Wire contract, encryption, start/update/end, and row ordering are unchanged (ADR 0014, `docs/agents/live-activity-contract.md`).
+Scope: widget UI in `Sources/HeelerWidgets/AgentLiveActivityWidget.swift`, Lock Screen row-cap helpers in `Sources/HeelerWidgets/AgentActivityDecryptor.swift`, compiling the existing `Sources/Heeler/Console/AgentStatusPalette.swift` into the widget target, and the `project.yml` / `Heeler.xcodeproj` regeneration that target change requires. Wire contract, encryption, start/update/end, envelope row ordering, and chip enumeration order are unchanged (ADR 0014, `docs/agents/live-activity-contract.md`).
 
 This is not a one-line color swap. Light Mode is broken because the banner is a branded dark slab that ignores the system appearance, and the status inks were authored only for that slab. The redesign keeps Heeler's herdr-aligned status language and the existing aggregate list, and makes the Lock Screen presentation native, calm, information-dense, and legible in both appearances.
 
@@ -27,16 +27,17 @@ The Console already solved this with `AgentStatusPalette`: Mocha on dark, Latte 
 Grounded in issue #247, ADR 0014, `docs/agents/live-activity-contract.md`, and `Sources/HeelerWidgets/AgentLiveActivityWidget.swift`.
 
 - **One Live Activity per Host, aggregate list.** Not one activity per Agent. Envelope order is pin-aware, then `blocked > done > working`. The widget must not re-sort.
-- **Eligible statuses on the wire:** `working`, `blocked`, `done`. Idle and unknown are hidden. There is no `error`, `waiting`, or `disconnected` string in `ContentState`.
-- **Lock Screen budget:** ~160 pt height (Apple may truncate above that). Four two-line rows when `counts.total <= 4`, else three rows plus `+N more`. Horizontal padding is already 14 pt (HIG standard). Vertical padding 12 pt. Row spacing 8 pt.
+- **Attention order is Blocked, then Done, then Working.** Console sort buckets and the Live Activity envelope both use this because Blocked is waiting on an answer, Done has a result to read, and Working needs nothing (`Sources/Heeler/Console/ConsoleAgent.swift` `consoleSortBucket`; `docs/agents/live-activity-contract.md`). Any widget presentation that shows a *single* status count uses this order. Chip capsules are different: they enumerate every non-zero count and keep today's order (`blocked`, `working`, `done` in `chipItems`).
+- **Eligible statuses on the wire:** `working`, `blocked`, `done`. Idle and unknown are hidden. There is no `error`, `waiting`, or `disconnected` string in `ContentState`. The widget cannot represent disconnection as its own state (see Content-state matrix).
+- **Lock Screen budget:** Apple may truncate above 160 pt. Fresh (`isStale == false`): four two-line rows when `counts.total <= 4`, else three rows plus `+N more`. Stale (`context.isStale`): never four rows; the stale caption shares the trailing caption2 line with overflow (see Lock Screen anatomy). Horizontal padding is already 14 pt (HIG standard). Vertical padding 12 pt. Row spacing 8 pt.
 - **Hierarchy per row:** task `title` on top (status glyphs stripped), identity (`name` else `kind`) indented beneath; missing title promotes identity. Host name is never rendered.
 - **Deep links:** each row is a `Link` to that Agent's detail (`heeler://agent/{hostID}/{paneID}`). Taps outside a row, and every Dynamic Island compact/minimal tap, open the Console (`heeler://agent/{hostID}`).
-- **Counts chips** in urgency order: blocked, working, done. Zero counts omitted. Chips are `fixedSize()` so the title truncates first.
-- **Blocked is the only "please look" state:** title uses status ink, row gets a 6 pt continuous rounded wash. Working and done are painted, not announced as events.
-- **Counts-only fallback** when the envelope is absent or undecryptable (Watch Smart Stack, pre-first-unlock, unknown kid). Headline is the generic app name `"Heeler"`.
-- **Stale-date** is `timestamp + 900` seconds. `context.isStale` is unused. Ended activities dismiss immediately (`dismissal-date = timestamp`).
-- **Dynamic Island background cannot be customized.** HIG: compact, minimal, and expanded sit on an opaque black island. Status color on the island must remain the dark (Mocha) pastels even after Lock Screen Light Mode is fixed.
-- **No new dependencies, no contract change, no Host identity, no per-Agent activities.** Widget already compiles `HerdrAPITypes.swift` (so `AgentStatus` exists there) and does not import app-only UI files.
+- **Counts chips** enumerate non-zero counts in existing `chipItems` order (`blocked`, `working`, `done`). Zero counts omitted. Chips are `fixedSize()` so the title truncates first.
+- **Blocked is the only "please look" visual.** Title uses status ink, row gets a 6 pt continuous rounded wash. Done outranks Working for compact-leading *count* selection but stays quiet on the list (dot only, no wash). Working is painted, not announced as an event.
+- **Counts-only fallback** when the envelope is absent or undecryptable (Watch Smart Stack, pre-first-unlock, unknown kid). Headline is the generic app name `"Heeler"`. This is not a disconnected state.
+- **Stale content** is `context.isStale` from ActivityKit. Push updates set `stale-date = timestamp + 900`. Local `Activity.request` / `activity.update` from the app use `staleDate: nil` (`LiveActivityControlling.swift`), so a locally driven activity does not become stale on that timer. Ended activities dismiss immediately (`dismissal-date = timestamp`).
+- **Dynamic Island background cannot be customized.** HIG: compact, minimal, and expanded sit on an opaque black island. Status color on the island must remain the dark (Mocha) pastels even after Lock Screen Light Mode is fixed. Shared row/chip views must take an explicit surface so Light Mode cannot feed them Latte inks.
+- **No new dependencies, no contract change, no Host identity, no per-Agent activities.** Widget already compiles `HerdrAPITypes.swift` (so `AgentStatus` exists there). `AgentStatusPalette.swift` is the single hex owner and is compiled into the widget target (see Palette ownership).
 - **iOS 18+, iPhone.** StandBy scales the Lock Screen presentation 2x. Always-On reduces luminance. Physical Lock Screen was not exercised for this spec.
 
 ## Research method
@@ -62,8 +63,8 @@ Contrast figures in this document were computed from the hex values in `AgentSta
 | 11 | [iOS Lock Screen Live Activity (Tier App)](https://dribbble.com/shots/22610933-iOS-Lock-Screen-Live-Activity-Tier-App) | Dribbble | Dark branded banner with a hero number (`20m` / `9.3km`), two caption metrics, wordmark top-trailing. Working vs arrived are two layouts of the same skeleton. | **Apply:** hero number only when one metric *is* the activity (Heeler's analog is the count, and only in compact/minimal). **Do not copy:** hero type on the Lock Screen list, or a dark-only brand plate. |
 | 12 | [Live Activities widget — iOS 16](https://dribbble.com/shots/18460566-Live-Activities-widget-iOS-16) | Dribbble / Starbucks | Dark green branded banner on a *light* Lock Screen, wordmark, pickup location. Reads as an app sticker, not a system activity. | **Reject as a model.** This is the same failure mode as Heeler today: brand fill that ignores the wallpaper. |
 | 13 | [Apple Design Resources: Live Activities](https://www.figma.com/community/file/1367915437752334285/live-activities) | Figma Community / Apple | Official 2026 kit. Community comment (Kassandra Dower): kit still uses 18 pt Lock Screen margin and 48 pt island radius; HIG is 14 pt and 44 pt. | Trust the HIG numbers, not the kit's older spacing. Heeler already uses 14 pt horizontal padding — keep it. |
-| 14 | [Dynamic Island & Live Activities](https://www.figma.com/community/file/1362423678739956425/dynamic-island-live-activities) | Figma Community / Jasper | Pixel-perfect compact / minimal / expanded on black. Compact: circular progress leading, time trailing, snug to the camera. Expanded wraps the camera. Templates for 393 and 430 pt widths. | **Apply:** island content is bold, snug, balanced; compact is a single metric split across the camera. Heeler's split is "urgency count | total count." |
-| 15 | [Flighty compact Dynamic Island](https://mobbin.com/screens/4744a5f8-23f1-442b-93e1-0da560854f16) | Mobbin / Flighty | Production compact on a light Home Screen: leading `2:58h` in green, trailing yellow `B22` capsule. Black island, no extra padding against the camera, both sides similar width, color carries meaning. Tagged "Dynamic Island." | **Apply:** island always black; Mocha pastels on black; leading = most urgent live fact, trailing = identity/count. **Do not copy:** gate capsules or airline marks. |
+| 14 | [Dynamic Island & Live Activities](https://www.figma.com/community/file/1362423678739956425/dynamic-island-live-activities) | Figma Community / Jasper | Pixel-perfect compact / minimal / expanded on black. Compact: circular progress leading, time trailing, snug to the camera. Expanded wraps the camera. Templates for 393 and 430 pt widths. | **Apply:** island content is bold, snug, balanced; compact is a single metric split across the camera. Heeler's split is "attention count | total count." |
+| 15 | [Flighty compact Dynamic Island](https://mobbin.com/screens/4744a5f8-23f1-442b-93e1-0da560854f16) | Mobbin / Flighty | Production compact on a light Home Screen: leading `2:58h` in green, trailing yellow `B22` capsule. Black island, no extra padding against the camera, both sides similar width, color carries meaning. Tagged "Dynamic Island." | **Apply:** island always black; Mocha pastels on black; leading = most attention-worthy live fact, trailing = identity/count. **Do not copy:** gate capsules or airline marks. |
 | 16 | [Instacart compact Dynamic Island](https://mobbin.com/screens/fa7b983b-0f8c-4de1-8983-fe18948eac69) | Mobbin / Instacart | Production compact: uncontained carrot mark leading, `1h 16min` trailing, white Home Screen. Quiet. One fact. | **Apply:** no container around a glyph; trailing metric in regular white; do not put a Heeler app icon in a circle. Heeler has no ETA, so the trailing metric stays the agent total. |
 | 17 | [Delivery live activity in the Dynamic Island](https://www.behance.net/gallery/164717497/Delivery-live-activity-in-the-Dynamic-Island-on-iPhone) | Behance | Expanded island: brand mark leading, huge "Almost here!", "Arriving at 9:51 AM" secondary, `10 min` trailing, progress rail. Black expanded surface. | **Apply:** expanded is an enlargement of compact (status + metric), not a new poster. **Do not copy:** marketing headline, brand disc, or progress rail. |
 
@@ -72,12 +73,12 @@ Apple HIG Lock Screen gallery (same page as #1) also showed system examples: Foo
 ## Design principles
 
 1. **System surface, Heeler language.** Lock Screen chrome is the system Live Activity material. Heeler identity lives in status hue (the same Catppuccin roles as the Console and herdr), not in a branded plate.
-2. **One appearance model, two palettes.** The layout does not change between Light and Dark. Only tokens flip, the same way `AgentStatusPalette` already does.
-3. **Island is a different surface.** Dynamic Island is always black. It keeps Mocha inks even when the Lock Screen is Latte. Do not drive island color from `colorScheme`.
-4. **Glance, then identity.** Status and counts are the first read. Task title is the second. Agent name/kind is the third. Host is never shown.
-5. **Blocked is the only shout.** Working and done stay quiet. Blocked uses ink on the title and a wash behind the row. Color is never the only signal: VoiceOver already speaks the status word; keep that.
+2. **One appearance model, two palettes, one hex owner.** The layout does not change between Light and Dark. Only tokens flip, from `AgentStatusPalette`. The widget never duplicates those hexes.
+3. **Island is a different surface.** Dynamic Island is always black. It keeps Mocha inks even when the Lock Screen is Latte. Shared views take an explicit `AgentActivitySurface`; they must not read ambient `colorScheme` to pick status color.
+4. **Attention order is Blocked, then Done, then Working.** Same as Console and the envelope. Compact leading and any other single-count pick follow it. Blocked is the only shouted *visual* (wash + ink title).
+5. **Glance, then identity.** Status and counts are the first read. Task title is the second. Agent name/kind is the third. Host is never shown.
 6. **No extra chrome.** No app icon, no wordmark, no progress bar, no map, no buttons. The only actions are the existing deep links and the system End control.
-7. **Fit the 160 pt budget; do not fill it.** Four rows when they fit, three plus overflow otherwise. Shorter inventories stay short.
+7. **Fit the 160 pt budget; do not fill it.** Fresh: four rows when they fit, three plus overflow otherwise. Stale: three rows maximum, with overflow and the stale caption sharing one caption2 line. Shorter inventories stay short.
 8. **Do not copy another product's artwork.** Distill structure (headline / secondary / metric / snug island) and throw away brand fills, mascots, and steppers.
 
 ## Rejected alternatives
@@ -96,11 +97,71 @@ Apple HIG Lock Screen gallery (same page as #1) also showed system examples: Foo
 | App icon in a circle | HIG: logo mark without container; never the full icon. Heeler has no lock-screen mark that earns the space; counts do. |
 | Latte inks on the Dynamic Island | Island background is black and cannot be changed. Dark Latte inks (`#9F5300`, `#C70030`) on black are the wrong direction (3.5:1 and look like muddy brown/red, not herdr). |
 | Mocha pastels as Lock Screen text in Light Mode | 1.27–2.32:1 on white. Console already rejected this; that is why Latte inks exist. |
+| Duplicate the hex table in the widget | Two owners drift. `AgentStatusPalette` is the single owner; the widget compiles that file. |
+| Drive island inks from `colorScheme` / dynamic `UIColor` | Light Mode would select Latte on the black island. Surface is an explicit parameter, not the ambient appearance. |
+| Compact leading `blocked`, else `working`, else `done` | Reverses Console/envelope attention. Done has a result to read; Working needs nothing. |
+| Four rows plus a separate stale caption | Exceeds the existing ~160 pt ceiling. Stale reduces the row cap and shares the overflow line. |
+| Infer "disconnected" from counts-only | Counts-only is decrypt/envelope failure, not Host connection. The widget has no disconnected field. |
 | Replicate notification layout (app icon + title + body) | HIG: don't. Keep the two-line agent list. |
+
+## Palette ownership
+
+**One owner: `Sources/Heeler/Console/AgentStatusPalette.swift`.** Do not duplicate hexes in `AgentActivityStatusStyle`. Do not extract a third constants file.
+
+The widget appex cannot link the app target. Compile the palette file into the widget the same way `HerdrAPITypes.swift` already is:
+
+1. In `project.yml`, under `HeelerWidgets.sources`, add:
+   `Sources/Heeler/Console/AgentStatusPalette.swift`
+2. Regenerating the committed Xcode project is required. CI builds `Heeler.xcodeproj` and never runs xcodegen (`CLAUDE.md`). After the `project.yml` edit, run `xcodegen generate` (the `Makefile` `PROJECT` path already does this on documented `make` targets) and **commit the regenerated `Heeler.xcodeproj`** alongside `project.yml`.
+3. Do not change `AgentStatusPalette`'s Mocha/Latte values. App `AgentStatusPaletteTests` remains the hex and contrast source of truth.
+
+`AgentStatusPalette` exposes dynamic `UIColor`s that follow `userInterfaceStyle`. That is correct for Lock Screen and **wrong** for the island. The widget must not pass `Color(status.inkUIColor)` into island views. Resolution goes through the surface seam below.
+
+### Surface seam
+
+```swift
+enum AgentActivitySurface {
+    /// Lock Screen banner. Status colors follow the system appearance
+    /// (Latte in Light, Mocha in Dark) via AgentStatusPalette.
+    case lockScreen
+    /// Compact, minimal, and expanded Dynamic Island. Always Mocha,
+    /// resolved against a dark trait collection, ignoring ambient Light Mode.
+    case island
+}
+```
+
+`AgentActivityStatusStyle` is the only widget API for status color. It takes `surface` on every call:
+
+```swift
+enum AgentActivityStatusStyle {
+    static func ink(for status: String, on surface: AgentActivitySurface) -> Color
+    static func wash(for status: String, on surface: AgentActivitySurface) -> Color
+}
+```
+
+- `.lockScreen` → `Color(uiColor: AgentStatus(rawValue:).inkUIColor)` / `tintUIColor` (dynamic).
+- `.island` → the same `UIColor`, then `.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark))` before wrapping in `Color`. Ambient Light Mode cannot select Latte.
+
+Unknown status strings use the muted pair, same as the palette's `default`.
+
+### Shared components that must take `surface`
+
+These views render on both Lock Screen and expanded island today. Each gains a `surface: AgentActivitySurface` parameter and passes it into `AgentActivityStatusStyle` and any child. No default: a missing argument is a compile error, which is the point.
+
+| View | Lock Screen call site | Island call site |
+| --- | --- | --- |
+| `AgentActivityLinkedRow` | `AgentActivityLockScreenView` header + `ForEach` | Expanded `ForEach` of `secondaryAgents` |
+| `AgentActivityRowView` | via `LinkedRow` | via `LinkedRow` |
+| `AgentActivityHeadlineView` | not used on Lock Screen | Expanded `.center` |
+| `AgentActivityCountChips` | Lock Screen header trailing | Expanded `.bottom` |
+
+Island-only views (`AgentActivityCompactLeading`, compact trailing, minimal) pass `.island` into `AgentActivityStatusStyle` directly. They never use `Color(status.inkUIColor)` unscoped.
+
+`AgentActivityLinked` (the `Link` wrapper) does not take `surface`; it only wraps content.
 
 ## Semantic tokens
 
-Prefer system / dynamic colors wherever they satisfy the intent. Custom colors are only the Catppuccin status pair already used in the Console.
+Prefer system / dynamic colors wherever they satisfy the intent. Custom colors are only the Catppuccin status pair already owned by `AgentStatusPalette`.
 
 ### Surfaces and chrome
 
@@ -110,8 +171,8 @@ Prefer system / dynamic colors wherever they satisfy the intent. Custom colors a
 | `action.systemEnd` | System default | System default | `.activitySystemActionForegroundColor(nil)` |
 | `surface.island` | Opaque black (system) | Opaque black (system) | Do not tint. Cannot be customized. |
 | `text.primary` | `Color.primary` | `Color.primary` | System. On the island this is light-on-black. |
-| `text.secondary` | `Color.secondary` | `Color.secondary` | Overflow, identity, counts-only caption. |
-| `text.blocked` | Status ink (below) | Status ink (below) | Only on blocked titles. |
+| `text.secondary` | `Color.secondary` | `Color.secondary` | Overflow, identity, stale caption. |
+| `text.blocked` | Status ink for `.lockScreen` or `.island` | Status ink for that surface | Only on blocked titles. |
 
 Remove `AgentActivityChrome.backgroundTint` and `AgentActivityChrome.systemAction`. Do not replace them with other hexes.
 
@@ -130,14 +191,14 @@ Wash = capsule / row fill. Ink = text, dots, compact glyphs.
 | idle / unknown / other | wash | `#7F849C` | `#6C6F85` |
 | idle / unknown / other | ink | `#A6ADC8` | `#5C5F77` |
 
-Unknown strings in the envelope (defensive) use the muted pair, never blocked or done. Idle never appears in the activity; the muted pair is for `countsOnly` chrome and stale copy.
+Unknown strings in the envelope (defensive) use the muted pair, never blocked or done. Idle never appears in the activity; the muted pair is for counts-only chrome and stale copy.
 
-**Where each pair applies:**
+**Where each pair applies** is `AgentActivitySurface`, not a comment on the call site:
 
-- **Lock Screen:** resolve from `colorScheme` / `UITraitCollection.userInterfaceStyle`. Light → Latte, Dark → Mocha.
-- **Dynamic Island (compact, minimal, expanded):** always Mocha, regardless of system appearance.
+- **`.lockScreen`:** Light → Latte, Dark → Mocha, via the palette's dynamic `UIColor`.
+- **`.island`:** always Mocha, via dark-trait resolution.
 
-**Wash opacity:** 0.15 on Lock Screen chips and blocked-row fills (match `AgentStatusBadge`, which uses 0.15). Island chips may keep 0.22 on the compact blocked capsule so the fill reads on black; 0.16 is too timid there.
+**Wash opacity:** 0.15 on Lock Screen chips and blocked-row fills (match `AgentStatusBadge`, which uses 0.15). Island compact capsule uses 0.22 Mocha wash so the fill reads on black.
 
 ### Measured contrast (WCAG 2, sRGB)
 
@@ -168,39 +229,66 @@ Always-On and Increase Contrast were not measured on device. System material and
 │              identity]          [chips →]    │  header: first agent + chips
 │ [row 2: dot + title / identity]              │  8 pt stack spacing
 │ [row 3: …]                                   │
-│ [row 4 or "+N more"]                         │
-│ [optional stale caption]                     │
+│ [row 4  XOR  trailing caption2]              │  see row-cap rules
 └──────────────────────────────────────────────┘
   padding: 14 horizontal, 12 vertical
   height: system-sized, never above 160 pt
 ```
 
-Keep `AgentActivityLockScreenView`'s structure. Changes are tokens, type weight, compact-leading logic (island), stale caption, and previews.
+Keep `AgentActivityLockScreenView`'s stack. Changes are tokens, `surface: .lockScreen` on shared views, stale-aware row caps, a single trailing caption2, and previews.
 
-**Header.** First envelope agent is the headline row, same `AgentActivityLinkedRow` as today. Chips stay trailing, `fixedSize()`, never wrap. When `lockScreenAgents` is empty (counts-only), headline is `Text(presentation.headerTitle)` at `.subheadline.weight(.semibold)`, `Color.primary`, `lineLimit(1)`.
+**Header.** First visible agent is the headline row, `AgentActivityLinkedRow(..., surface: .lockScreen)`. Chips stay trailing, `AgentActivityCountChips(..., surface: .lockScreen)`, `fixedSize()`, never wrap. When no agents are visible (counts-only), headline is `Text(presentation.headerTitle)` at `.subheadline.weight(.semibold)`, `Color.primary`, `lineLimit(1)`.
 
-**Rows.** Uniform two-line rows in envelope order. Do not enlarge the first row's type relative to the rest; the current "headline is just the first row" treatment is correct for an aggregate list and matches the contract. Blocked wash stays.
+**Rows.** Uniform two-line rows in envelope order. Do not enlarge the first row's type relative to the rest. Blocked wash stays. Every `LinkedRow` / `RowView` gets `surface: .lockScreen`.
 
-**Overflow.** `+\(n) more` at `.caption2`, `text.secondary`. No chevron, no fake disclosure.
+**Row cap and overflow (stale-aware).** Replace the current `lockScreenAgents` / `lockScreenOverflowCount` (which key only on `counts.total`) with helpers that also take `isStale`. Suggested shape on `AgentActivityPresentation`:
 
-**Stale.** If `context.isStale`, a final caption: `May be out of date`, `.caption2`, `text.secondary`. Do not replace rows with this string. Pass `isStale` from `ActivityConfiguration` into the view; it is available on `ActivityViewContext`.
+```swift
+func lockScreenAgents(isStale: Bool) -> [AgentActivityDetails.AgentDetail]
+func lockScreenOverflowCount(isStale: Bool) -> Int
+```
 
-**DEBUG decrypt reason** stays Debug-only.
+Cap:
+
+| `isStale` | `counts.total` | Visible agent rows | Trailing caption2 |
+| --- | --- | --- | --- |
+| false | 0 | 0 (counts-only headline) | none, unless Debug decrypt copy |
+| false | 1…4 | `total` (all fit) | none |
+| false | ≥ 5 | 3 | `+N more` (`N = total − 3`) |
+| true | 0 | 0 | `May be out of date` |
+| true | 1…3 | `total` | `May be out of date` |
+| true | ≥ 4 | 3 | `+N more · May be out of date` (`N = total − 3`) |
+
+Overflow count is always `max(0, counts.total − visibleRows)` and is zero in counts-only, same as today.
+
+The stale caption never becomes a fifth content slot. Overflow and stale share one `.caption2` / `text.secondary` line, with a middle dot (` · `) when both apply. Do not draw a separate stale line under four rows. Do not drop overflow to keep a fourth row when stale: when `isStale && total >= 4`, show three rows and fold overflow into that trailing line.
+
+**Maximum-height cases (both must stay ≤ 160 pt):**
+
+1. Fresh, `total == 4`: four two-line rows, no caption2. This is today's designed ceiling.
+2. Fresh, `total >= 5`: three two-line rows + `+N more`.
+3. Stale, `total >= 4`: three two-line rows + `+N more · May be out of date`. One two-line row cheaper than case 1, caption2 same size as today's overflow. This is the tallest stale layout.
+
+DEBUG decrypt reason stays Debug-only and is out of the production height budget.
 
 **Padding.** Keep 14 / 12. Do not "fix" it to the Apple Figma kit's 18 pt.
 
 **Corner / materials.** Do not draw a custom rounded rectangle. The system provides the banner shape. Previews may fake a 22 pt continuous rounded rect so the canvas is readable; that shape is not production chrome.
 
+**`isStale` is Lock Screen-only.** Pass `context.isStale` into `AgentActivityLockScreenView`. Do not add it to `AgentActivityIsland.make`. Island presentations do not show a stale caption.
+
 ### Dynamic Island
+
+Island builders pass `surface: .island` into every shared row, headline, and chip. Compact and minimal call `AgentActivityStatusStyle` with `.island` directly.
 
 **Compact.** One fact split across the camera, both sides linking to the Console (already true; keep it).
 
 | Side | Content | Type | Color |
 | --- | --- | --- | --- |
-| Leading | Highest-urgency *non-zero* count as a snug capsule: blocked, else working, else done | `.caption.weight(.bold).monospacedDigit()` | Mocha ink for that status, 0.22 Mocha wash, `Capsule` |
+| Leading | First non-zero count in attention order: blocked, else done, else working | `.caption.weight(.bold).monospacedDigit()` | Mocha ink for that status, 0.22 Mocha wash, `Capsule` |
 | Trailing | `counts.total` | `.body.weight(.semibold).monospacedDigit()` | `Color.primary` |
 
-Replace the current generic `ellipsis` labeled "Working". That glyph lies when the inventory is all-done. Accessibility: leading `"\(n) blocked|working|done"`, trailing `"\(total) agents"`.
+Replace the current generic `ellipsis` labeled "Working". That glyph lies when the inventory is all-done, and picking Working before Done hid a result the user can read. Accessibility: leading `"\(n) blocked|done|working"`, trailing `"\(total) agents"`.
 
 Keep content snug; no extra padding against the camera. Capsule horizontal padding 5, vertical 1 (already).
 
@@ -208,14 +296,14 @@ Keep content snug; no extra padding against the camera. Capsule horizontal paddi
 
 **Expanded.** Keep current regions:
 
-- Center: primary agent as `AgentActivityHeadlineView` (or `"Heeler"` when counts-only), linked to that Agent.
-- Bottom: secondary agents (`rowLimit - 1` = 2), overflow line, then chips.
+- Center: primary agent as `AgentActivityHeadlineView(agent:surface: .island)` (or `"Heeler"` when counts-only), linked to that Agent.
+- Bottom: secondary agents (`rowLimit - 1` = 2) via `LinkedRow(..., surface: .island)`, overflow line, then `AgentActivityCountChips(..., surface: .island)`.
 
-Island type stays slightly larger than Lock Screen rows for the primary (`.subheadline` / `.footnote`) and `.caption` for secondaries. Status dots: 8 pt primary, 7 pt rows. All inks Mocha. Chips Mocha.
+Island type stays slightly larger than Lock Screen rows for the primary (`.subheadline` / `.footnote`) and `.caption` for secondaries. Status dots: 8 pt primary, 7 pt rows. All inks Mocha via `.island`.
 
-**Key line.** `.keylineTint` on the `DynamicIsland`: Mocha blocked ink when `counts.blocked > 0`, else Mocha muted ink `#A6ADC8`. HIG: tint the island key line to match content when the background is dark.
+**Key line.** `.keylineTint` on the `DynamicIsland`: Mocha blocked ink when `counts.blocked > 0`, else Mocha muted ink `#A6ADC8`. HIG: tint the island key line to match content when the background is dark. Resolve through `AgentActivityStatusStyle` with `.island`.
 
-**No** expanded buttons, no leading/trailing expanded artwork, no app icon.
+**No** expanded buttons, no leading/trailing expanded artwork, no app icon, no stale caption.
 
 ### Typography
 
@@ -225,10 +313,10 @@ HIG: medium weight or higher for key information; small text sparingly.
 | --- | --- | --- | --- |
 | Lock Screen / expanded title | `.subheadline` (primary), `.caption` (rows) | `.semibold` if blocked, else `.semibold` primary / `.regular` rows | `text.blocked` or `text.primary` |
 | Identity line | `.footnote` primary, `.caption` rows | Regular | `text.secondary` |
-| Chips | `.caption2` | `.semibold` | Status ink |
-| Overflow, stale | `.caption2` | Regular | `text.secondary` |
+| Chips | `.caption2` | `.semibold` | Status ink for the view's `surface` |
+| Overflow / stale trailing line | `.caption2` | Regular | `text.secondary` |
 | Compact trailing / minimal | `.body` | `.semibold` / `.bold` if blocked | See island rules |
-| Compact leading | `.caption` | `.bold` | Status ink |
+| Compact leading | `.caption` | `.bold` | Status ink on `.island` |
 
 Do not introduce a custom font. System text styles only, so Dynamic Type and the Lock Screen optical size stay native.
 
@@ -236,15 +324,15 @@ Do not introduce a custom font. System text styles only, so Dynamic Type and the
 
 - Status **dot**: 8×8 pt primary, 7×7 pt rows, `Circle().fill(ink)`, `accessibilityHidden(true)` (status is in the label).
 - **No** SF Symbol app logo. Compact leading is a count, not `ellipsis`.
-- If a working-only compact leading needs a glyph because the count is `1` and a single digit looks lost, still show `1` in the capsule. Do not bring the ellipsis back.
+- If a compact leading count is `1`, still show `1` in the capsule. Do not bring the ellipsis back.
 
 ### Chips
 
-Unchanged behavior, retokened:
+Unchanged enumeration, retokened through `surface`:
 
-- Render `counts.chipItems` in contract order (blocked, working, done).
-- `"\(count) \(status)"` with the status word as the wire string (`blocked`, `working`, `done`), not a localized paraphrase in this pass (the widget is English, matching current copy).
-- `fixedSize()`, padding 6 / 2, capsule, ink on 0.15 wash (Lock Screen) or Mocha ink on 0.16–0.22 wash (island).
+- Render `counts.chipItems` in existing order (`blocked`, `working`, `done`). This is an inventory, not a single-status pick, so it does not use attention order.
+- `"\(count) \(status)"` with the status word as the wire string, not a localized paraphrase in this pass (the widget is English, matching current copy).
+- `fixedSize()`, padding 6 / 2, capsule, ink on 0.15 wash (Lock Screen) or Mocha ink on 0.22 wash (compact capsule; expanded chips 0.16 Mocha is acceptable if 0.22 is too loud in the expanded bottom stack — pick 0.16 for expanded chips, 0.22 for compact leading only).
 - Combined accessibility label as today.
 
 ### Links and system actions
@@ -256,17 +344,17 @@ Unchanged behavior, retokened:
 
 ### Truncation
 
-- Titles and names: `lineLimit(1)`, tail truncation. Wire already caps at 80 graphemes; UI still truncates at the row width.
-- Chips never compress. Header `Spacer(minLength: 8)` stays so a long title yields to chips, not the reverse.
-- Overflow `+N more` is not truncated.
+- Titles and names: `lineLimit(1)`, tail truncation. Wire already caps at 80 graphemes; UI still truncates at the row width. This applies to a long `name` on the identity line and to a missing-title row where identity is promoted to the first line.
+- Chips never compress. Header `Spacer(minLength: 8)` stays so a long title or promoted name yields to chips, not the reverse.
+- Overflow / stale trailing line is not truncated.
 - Compact/minimal: monospaced digits, no shrinking below `.caption` / `.body`. Do not use `minimumScaleFactor` except the existing counts-only island headline (`0.7`).
 
 ### Accessibility
 
 - Keep `.accessibilityElement(children: .combine)` on the Lock Screen with the existing narration: primary, chips, remaining rows, overflow.
-- Append `"may be out of date"` when `isStale`.
+- When stale, append `"may be out of date"` to that combined label (whether or not overflow is on the same visible line).
 - Status must remain in the spoken string (`"reviewer, blocked, Approve the transport…"`). Dots stay hidden.
-- Compact/minimal already have labels; update them to match the new leading (status word, not "Working" for a done-only inventory).
+- Compact/minimal already have labels; update leading to the attention-order status word (not "Working" for a done-only or done+working inventory).
 - Do not rely on color alone: blocked wash + semibold + spoken status.
 - VoiceOver on a physical Lock Screen was not exercised.
 
@@ -276,36 +364,38 @@ Map the package's requested names onto the *actual* model. Do not invent wire st
 
 | Requested name | Actual model | Lock Screen | Compact / minimal | Expanded |
 | --- | --- | --- | --- | --- |
-| Working | `status == "working"` in envelope; `counts.working` | Latte/Mocha working ink on the dot; title `text.primary`; no wash | If no blocked: leading shows working count in Mocha yellow capsule | Same row language, Mocha |
-| Waiting | **Blocked.** herdr Blocked = waiting for human input (`CONTEXT.md`). No `waiting` string. | Blocked ink on title, 0.15 wash, 6 pt corner, 3/6 pt inset | Leading shows blocked count (highest urgency) | Blocked primary uses Mocha pink title |
-| Done | `status == "done"`; `counts.done` | Done ink on the dot only; title stays `text.primary` (state, not "just finished") | Leading shows done count only when blocked = working = 0 | Same |
+| Working | `status == "working"`; `counts.working` | Working ink on the dot via `.lockScreen`; title `text.primary`; no wash | Leading shows working count only when `blocked == 0` and `done == 0` | Same row language, `.island` Mocha |
+| Waiting | **Blocked.** herdr Blocked = waiting for human input (`CONTEXT.md`). No `waiting` string. | Blocked ink on title, 0.15 wash, 6 pt corner, 3/6 pt inset | Leading shows blocked count whenever `blocked > 0` | Blocked primary uses Mocha pink title |
+| Done | `status == "done"`; `counts.done` | Done ink on the dot only; title stays `text.primary` (state, not "just finished") | Leading shows done count when `blocked == 0` and `done > 0` (including when working is also non-zero) | Same |
 | Attention / error | **Blocked is attention.** There is no error status in `ContentState`. Unknown envelope strings use muted, never red. | Do not introduce a fourth hue | Do not paint blocked red for decrypt failure | Same |
-| Stale / disconnected | (a) `context.isStale` after 15 min without update; (b) `countsOnly` when the envelope cannot be opened | (a) rows remain, caption "May be out of date"; (b) `"Heeler"` + chips, no rows, no fake names | Still show counts. Counts are plaintext and survive (a) and (b). | `"Heeler"` in center when no primary agent |
+| Stale | `context.isStale == true`. Happens after content that *carried a stale date* crosses that date. Push updates set `stale-date = timestamp + 900`. Local request/update uses `staleDate: nil`, so those snapshots do not become stale on the 15-minute push timer. | Trailing caption2 per the row-cap table; rows still shown | Unchanged counts; no stale caption | Unchanged; no stale caption |
+| Disconnected | **No distinct representable widget state.** `ContentState` has only counts and an optional envelope. The coordinator holds the last activity while Agent inventory is unknown (`HostLiveActivityCoordinator.shouldDeferApply` / `isUnknownAgentInventory`). Do not infer disconnection from counts-only. | Last successfully delivered presentation, or counts-only if that is what was last delivered | Same | Same |
+| Counts-only | Envelope absent or undecryptable (`AgentActivityDecryptor`) | `"Heeler"` + chips, no agent rows, no fake names. Not a disconnected glyph. | Counts | `"Heeler"` in center when no primary agent |
 | Ended | Activity ends immediately (`dismissal-date = timestamp`). No ended presentation. | Not drawn. Do not add a summary banner. | Removed from the island immediately (system). | Removed |
 
 Idle and unknown Agents are not in the activity. An empty eligible inventory ends the activity (ADR 0014). Do not design an idle lock-screen state.
 
 ## SwiftUI implementation guidance
 
-Stay inside `Sources/HeelerWidgets/AgentLiveActivityWidget.swift` plus the smallest token sharing needed so widget hues cannot drift from `AgentStatusPalette`.
-
 1. **Chrome.** In `AgentLiveActivityWidget.body`, replace the two modifiers with `nil` (or delete them; default is system material / system End color). Remove `AgentActivityChrome` if nothing else references it.
 
-2. **Pass `context.isStale`** into `AgentActivityLockScreenView` and `AgentActivityIsland.make`. Thread it next to `presentation` and `hostID`. Do not put it on the wire.
+2. **Palette file in the widget target.** Add `Sources/Heeler/Console/AgentStatusPalette.swift` to `HeelerWidgets.sources` in `project.yml`. Run `xcodegen generate` and commit `Heeler.xcodeproj` with that change. Do not duplicate hexes.
 
-3. **Status style.** Replace the mocha-only `AgentActivityStatusStyle.ink(for:)` with two entry points, e.g. `lockScreenInk(for:)` and `islandInk(for:)`, plus matching `wash` colors. Lock Screen uses a dynamic `UIColor` / `Color` that flips Latte/Mocha with `userInterfaceStyle`. Island functions return Mocha only.
+3. **Surface parameter.** Add `AgentActivitySurface` and route every status color through `AgentActivityStatusStyle.ink/wash(for:on:)`. Thread `surface` into `AgentActivityLinkedRow`, `AgentActivityRowView`, `AgentActivityHeadlineView`, and `AgentActivityCountChips`. Lock Screen call sites pass `.lockScreen`; every island call site passes `.island`.
 
-4. **Do not invent new hexes.** Reuse the eight status pairs in `AgentStatusPalette`. Preferred: compile `Sources/Heeler/Console/AgentStatusPalette.swift` into the `HeelerWidgets` target (`project.yml` `HeelerWidgets.sources`). It already imports UIKit only and uses `AgentStatus` from `HerdrAPITypes`, which the widget already compiles. Then `Color(status.inkUIColor)` works in the widget. Acceptable fallback if that file pull is awkward: duplicate the hex table in `AgentActivityStatusStyle` with a comment that `AgentStatusPaletteTests` is the source of truth, and add a widget-side test or a shared hex constant file later. Do not add a package.
+4. **`isStale` is Lock Screen-only.** Pass `context.isStale` into `AgentActivityLockScreenView` only. Do not add it to `AgentActivityIsland.make`.
 
-5. **Compact leading.** Replace the `ellipsis` branch with the first non-zero of `blocked`, `working`, `done`. Keep the capsule treatment.
+5. **Row cap.** Change `AgentActivityPresentation.lockScreenAgents` / `lockScreenOverflowCount` to take `isStale` and implement the table in Lock Screen anatomy. The Lock Screen view uses those helpers and draws at most one trailing caption2.
 
-6. **Previews.** Stop forcing `.environment(\.colorScheme, .dark)` as the only gallery. Provide Light and Dark for at least: mixed + overflow, single working, counts-only, blocked-primary, stale (fake `isStale: true`), long title (80 graphemes). Light previews use a light rounded rect approximating system material, not Mocha mantle. Keep `.buttonStyle(.plain)` and `.tint(.primary)`.
+6. **Compact leading.** Replace the `ellipsis` branch with the first non-zero of `blocked`, then `done`, then `working`. Keep the capsule treatment. Mocha via `.island`.
 
-7. **No new frameworks.** No extra SF Symbols catalog, no extra fonts, no ActivityKit API beyond modifiers already in the file plus `keylineTint` and `isStale`.
+7. **Previews.** Stop forcing `.environment(\.colorScheme, .dark)` as the only gallery. Provide Light and Dark for the acceptance rows below, including stale maximum-height, 80-grapheme title, 80-grapheme name with title, and 80-grapheme name with title missing (identity promoted). Light Lock Screen previews use a light rounded rect approximating system material, not Mocha mantle. Island previews stay on black and must still use Mocha when the canvas environment is Light. Keep `.buttonStyle(.plain)` and `.tint(.primary)`.
 
-8. **Contract and coordinator stay put.** Do not change envelope shape, chip copy, row caps, deep links, or dismissal policy.
+8. **No new frameworks.** No extra SF Symbols catalog, no extra fonts, no ActivityKit API beyond modifiers already in the file plus `keylineTint` and Lock Screen `isStale`.
 
-Sketch (illustrative, not to paste blindly):
+9. **Contract and coordinator stay put.** Do not change envelope shape, `chipItems` order, deep links, or dismissal policy. Do not add a disconnected flag.
+
+Sketch (illustrative):
 
 ```swift
 ActivityConfiguration(for: AgentActivityAttributes.self) { context in
@@ -326,23 +416,35 @@ ActivityConfiguration(for: AgentActivityAttributes.self) { context in
 
 Widget `Link` views remain; `AgentActivityLinked` / `AgentActivityConsoleLinked` stay as the MainActor `widgetURL` seam.
 
+### Focused verification (implementer)
+
+Do not treat a full `make test` as required for this visual change. Run:
+
+- Existing `AgentStatusPaletteTests` (hexes and 4.5:1 ink-on-wash still hold after the file is shared).
+- Any existing widget/presentation tests that assert `lockScreenAgents` counts; update them for the `isStale` parameter and the stale cap.
+- Canvas rows P1–P11, P5a/P5b, and P6/P6b. Confirm an island preview in a Light environment still uses Mocha (`#F38BA8` / `#A6E3A1` / `#F9E2AF`), not Latte.
+- Physical Lock Screen Light/Dark remains required before closing #247 (D1, D2, D8).
+
 ## Preview and acceptance matrix
 
-Xcode canvas previews are the development check. They **do not** replace a physical Lock Screen. Label every Lock Screen row below as **device-required**.
+Xcode canvas previews are the development check. They **do not** replace a physical Lock Screen. Label every Lock Screen device row below as **device-required**.
 
 | # | Case | Light | Dark | Where | Pass if |
 | --- | --- | --- | --- | --- | --- |
-| P1 | Mixed blocked / working / done + overflow | Canvas | Canvas | Lock Screen preview | Light banner is light; chips and dots use Latte inks; blocked row wash is visible; `+N more` secondary |
+| P1 | Mixed blocked / working / done + overflow (fresh, `total >= 5`) | Canvas | Canvas | Lock Screen preview | Light banner is light; chips and dots use Latte inks; blocked row wash is visible; `+N more` secondary; no stale caption |
 | P2 | Single unnamed working | Canvas | Canvas | Lock Screen | Identity-only row, no wash, working dot visible |
-| P3 | Four rows, all fit | Canvas | Canvas | Lock Screen | No overflow line; four two-line rows; height feels inside 160 pt |
-| P4 | Counts-only | Canvas | Canvas | Lock Screen | Headline "Heeler", chips only, no ghost rows |
+| P3 | Four rows, all fit (fresh, `total == 4`) | Canvas | Canvas | Lock Screen | No overflow line; four two-line rows; this is a maximum-height case |
+| P4 | Counts-only, not stale | Canvas | Canvas | Lock Screen | Headline "Heeler", chips only, no ghost rows, no stale caption |
 | P5 | Long title (80 graphemes) + three chips | Canvas | Canvas | Lock Screen | Title truncates; chips fully visible |
-| P6 | Stale | Canvas | Canvas | Lock Screen | Caption "May be out of date"; rows still shown |
-| P7 | Blocked compact | Canvas (island is always dark) | — | Compact | Leading blocked count capsule, trailing total, both Console links |
-| P8 | Working-only compact (no blocked) | Canvas | — | Compact | Leading working count, not an ellipsis |
-| P9 | Done-only compact | Canvas | — | Compact | Leading done count, not "Working" |
-| P10 | Minimal blocked | Canvas | — | Minimal | Total in blocked Mocha ink, bold |
-| P11 | Expanded mixed | Canvas | — | Expanded | Primary + up to two secondaries + chips; Mocha inks; key line blocked when blocked > 0 |
+| P5a | Long agent name (80 graphemes) with a title | Canvas | Canvas | Lock Screen | Title on line 1, name on line 2, name truncates, chips fully visible |
+| P5b | Long agent name (80 graphemes), title missing (identity promoted) | Canvas | Canvas | Lock Screen | Name is the only line, truncates, chips fully visible |
+| P6 | Stale, `total >= 4` (maximum-height stale) | Canvas | Canvas | Lock Screen | Three two-line rows; one caption2 `+N more · May be out of date`; not four rows plus a second caption |
+| P6b | Stale, `total <= 3` | Canvas | Canvas | Lock Screen | All rows visible; caption2 is only `May be out of date` |
+| P7 | Blocked compact | Canvas (force Light environment too) | — | Compact | Leading blocked count capsule, trailing total, Mocha ink even if canvas is Light, both Console links |
+| P8 | Done + working, no blocked | Canvas | — | Compact | Leading **done** count, not working, not an ellipsis |
+| P9 | Working-only (`blocked == done == 0`) | Canvas | — | Compact | Leading working count, not an ellipsis |
+| P10 | Minimal blocked | Canvas Light environment | — | Minimal | Total in blocked Mocha ink, bold |
+| P11 | Expanded mixed in a Light environment | Canvas Light | — | Expanded | Primary + up to two secondaries + chips; **Mocha** inks, not Latte; key line blocked when blocked > 0 |
 | P12 | Contrast, Light Lock Screen | Compute + canvas | — | Lock Screen | Ink/wash pairs match the table (≥ 4.5:1 text, ≥ 3:1 dots) |
 | P13 | Contrast, Dark Lock Screen | — | Compute + canvas | Lock Screen | Mocha inks on system dark |
 | P14 | Contrast, island | — | Compute | Compact/minimal/expanded | Mocha inks on black |
@@ -359,17 +461,18 @@ Not exercised in this research pass: physical device, Always-On, StandBy, Increa
 
 ## Decisions for implementation
 
-No remaining product choices. Implement the following as specified:
+No remaining product or ownership choices. Implement the following as specified:
 
 1. Lock Screen background = system material (`activityBackgroundTint(nil)`). End button = system color (`activitySystemActionForegroundColor(nil)`).
-2. Lock Screen status tokens = existing `AgentStatusPalette` Latte/Mocha pairs, dynamic with appearance. Island status tokens = Mocha only.
-3. Keep the aggregate list, four/three-row budget, pin-aware envelope order, two-line title/identity, no Host name, existing deep links, no buttons, no logo, no progress bar.
-4. Compact leading = highest-urgency non-zero count (blocked, else working, else done). Never the working ellipsis.
-5. Show `May be out of date` when `context.isStale`. Do not add ended, error, waiting, or disconnected presentations.
-6. Chip wash opacity 0.15 on Lock Screen; blocked-row wash 0.15; island compact capsule 0.22.
-7. 14 pt horizontal, 12 pt vertical, 8 pt Lock Screen stack spacing, 7/8 pt dots.
-8. Share or duplicate `AgentStatusPalette` hexes; do not pick new hues.
-9. Add Light *and* Dark canvas previews, including stale and long titles.
-10. Physical Lock Screen Light/Dark remains a required acceptance check before treating #247 as done.
+2. Hex owner is `AgentStatusPalette.swift`. Add that file to `HeelerWidgets.sources` in `project.yml`, regenerate and commit `Heeler.xcodeproj`. Do not duplicate hexes.
+3. Every shared row, headline, and chip takes `surface: AgentActivitySurface`. Lock Screen passes `.lockScreen`. Compact, minimal, and expanded pass `.island`, which resolves Mocha against a dark trait collection. Ambient Light Mode must not tint the island.
+4. Keep the aggregate list, pin-aware envelope order, two-line title/identity, no Host name, existing deep links, no buttons, no logo, no progress bar. Chip enumeration stays `blocked`, `working`, `done`.
+5. Compact leading = first non-zero count in attention order: blocked, then done, then working. Never the working ellipsis. Never Working before Done.
+6. Fresh Lock Screen: four rows when `total <= 4`, else three plus `+N more`. Stale Lock Screen: never four rows; trailing caption2 is `May be out of date`, or `+N more · May be out of date` when `total >= 4`. Pass `isStale` only into the Lock Screen view.
+7. Disconnected has no widget presentation. Counts-only is decrypt/envelope failure, not disconnection. Stale is only `context.isStale` after content that included a stale date.
+8. Chip wash opacity 0.15 on Lock Screen; blocked-row wash 0.15; island compact capsule 0.22; expanded island chips 0.16.
+9. 14 pt horizontal, 12 pt vertical, 8 pt Lock Screen stack spacing, 7/8 pt dots.
+10. Canvas previews: Light and Dark Lock Screen, including P5/P5a/P5b long title and long name (with and without title), P6 stale maximum height, and island previews in a Light environment (Mocha).
+11. Physical Lock Screen Light/Dark remains a required acceptance check before treating #247 as done.
 
 Wire contract, ADR 0014, plugin, and relay are out of scope.

--- a/docs/design/issue-247-live-activity-redesign.md
+++ b/docs/design/issue-247-live-activity-redesign.md
@@ -29,7 +29,7 @@ Grounded in issue #247, ADR 0014, `docs/agents/live-activity-contract.md`, and `
 - **One Live Activity per Host, aggregate list.** Not one activity per Agent. Envelope order is pin-aware, then `blocked > done > working`. The widget must not re-sort.
 - **Attention order is Blocked, then Done, then Working.** Console sort buckets and the Live Activity envelope both use this because Blocked is waiting on an answer, Done has a result to read, and Working needs nothing (`Sources/Heeler/Console/ConsoleAgent.swift` `consoleSortBucket`; `docs/agents/live-activity-contract.md`). Any widget presentation that shows a *single* status count uses this order. Chip capsules are different: they enumerate every non-zero count and keep today's order (`blocked`, `working`, `done` in `chipItems`).
 - **Eligible statuses on the wire:** `working`, `blocked`, `done`. Idle and unknown are hidden. There is no `error`, `waiting`, or `disconnected` string in `ContentState`. The widget cannot represent disconnection as its own state (see Content-state matrix).
-- **Lock Screen budget:** Apple may truncate above 160 pt. The first row keeps the two-line hierarchy; up to four secondary rows use a compact single line. Fresh shows at most five rows, stale at most four, with overflow and stale state sharing one caption2 line. Padding is 14 pt horizontal / 10 pt vertical; row spacing is 5 pt.
+- **Lock Screen budget:** Apple may truncate above 160 pt. The first row keeps the two-line hierarchy; up to three secondary rows use a compact single line. The Lock Screen shows at most four independently linked rows, with overflow and stale state sharing one caption2 line. Padding is 14 pt horizontal / 8 pt vertical; row spacing is 2 pt.
 - **Hierarchy per row:** task `title` on top (status glyphs stripped), identity (`name` else `kind`) indented beneath; missing title promotes identity. Host name is never rendered.
 - **Deep links:** each row is a `Link` to that Agent's detail (`heeler://agent/{hostID}/{paneID}`). Taps outside a row, and every Dynamic Island compact/minimal tap, open the Console (`heeler://agent/{hostID}`).
 - **Counts chips** enumerate non-zero counts in existing `chipItems` order (`blocked`, `working`, `done`). Zero counts omitted. Chips are `fixedSize()` so the title truncates first.
@@ -77,8 +77,8 @@ Apple HIG Lock Screen gallery (same page as #1) also showed system examples: Foo
 3. **Island is a different surface.** Dynamic Island is always black. It keeps Mocha inks even when the Lock Screen is Latte. Shared views take an explicit `AgentActivitySurface`; they must not read ambient `colorScheme` to pick status color.
 4. **Attention order is Blocked, then Done, then Working.** Same as Console and the envelope. Compact leading and any other single-count pick follow it. Blocked is the only shouted *visual* (wash + ink title).
 5. **Glance, then identity.** Status and counts are the first read. Task title is the second. Agent name/kind is the third. Host is never shown.
-6. **One large interaction target.** No app icon, wordmark, progress bar, map, or row controls. Apple recommends a 44×44 pt default iOS target and prefers one interactive element in a Live Activity. The whole activity opens Console; rows are glanceable information.
-7. **Fit the 160 pt budget; do not fill it.** Fresh shows up to five rows using compact secondary rows. Stale shows up to four, with overflow and the stale caption sharing one caption2 line. Shorter inventories stay short.
+6. **Rows deep-link to Agents.** No app icon, wordmark, progress bar, map, or action buttons. Apple supports multiple `Link` controls in Lock Screen and expanded Live Activity presentations. One to three rows use the default 44 pt iOS control height; four rows use Apple's 28 pt minimum dense control height. Taps outside a row open Console.
+7. **Fit the 160 pt budget; do not fill it.** Lock Screen shows up to four rows using compact secondary rows, with overflow and the stale caption sharing one caption2 line. Shorter inventories stay short.
 8. **Do not copy another product's artwork.** Distill structure (headline / secondary / metric / snug island) and throw away brand fills, mascots, and steppers.
 
 ## Rejected alternatives
@@ -228,17 +228,17 @@ Always-On and Increase Contrast were not measured on device. System material and
 │              identity]          [chips →]    │  header: first agent + chips
 │ [row 2: dot + title · identity]               │  5 pt stack spacing
 │ [row 3: …]                                   │
-│ [row 4 / row 5 / trailing caption2]           │  see row-cap rules
+│ [row 4 / trailing caption2]                   │  see row-cap rules
 └──────────────────────────────────────────────┘
   padding: 14 horizontal, 10 vertical
   height: system-sized, never above 160 pt
 ```
 
-Keep `AgentActivityLockScreenView`'s stack. Changes are tokens, `surface: .lockScreen` on shared views, stale-aware row caps, a single trailing caption2, and previews.
+Keep `AgentActivityLockScreenView`'s stack. Changes are tokens, `surface: .lockScreen` on shared views, row deep links, a single trailing caption2, and previews.
 
 **Header.** First visible agent is the full-density `AgentActivityRowView(..., surface: .lockScreen)`. Chips stay trailing, `AgentActivityCountChips(..., surface: .lockScreen)`, `fixedSize()`, never wrap. When no agents are visible (counts-only), headline is `Text(presentation.headerTitle)` at `.subheadline.weight(.semibold)`, `Color.primary`, `lineLimit(1)`.
 
-**Rows.** The first row retains title over identity. Secondary rows place `title · identity` on one line in envelope order. Blocked wash stays. Rows are not independent controls; the complete activity is the sole Console link.
+**Rows.** The first row retains title over identity. Secondary rows place `title · identity` on one line in envelope order. Blocked wash stays. Each row is a full-width `Link` to that Agent; the complete activity keeps a Console `widgetURL` fallback for taps outside the rows.
 
 **Row cap and overflow (stale-aware).** Replace the current `lockScreenAgents` / `lockScreenOverflowCount` (which key only on `counts.total`) with helpers that also take `isStale`. Suggested shape on `AgentActivityPresentation`:
 
@@ -252,8 +252,8 @@ Cap:
 | `isStale` | `counts.total` | Visible agent rows | Trailing caption2 |
 | --- | --- | --- | --- |
 | false | 0 | 0 (counts-only headline) | none, unless Debug decrypt copy |
-| false | 1…5 | `total` (all fit) | none |
-| false | ≥ 6 | 5 | `+N more` (`N = total − 5`) |
+| false | 1…4 | `total` (all fit) | none |
+| false | ≥ 5 | 4 | `+N more` (`N = total − 4`) |
 | true | 0 | 0 | `May be out of date` |
 | true | 1…4 | `total` | `May be out of date` |
 | true | ≥ 5 | 4 | `+N more · May be out of date` (`N = total − 4`) |
@@ -262,10 +262,10 @@ Overflow count is always `max(0, counts.total − visibleRows)` and is zero in c
 
 Overflow and stale share one `.caption2` / `text.secondary` line, with a middle dot (` · `) when both apply. Do not draw a separate stale line. When `isStale && total >= 5`, show four rows and fold overflow into the trailing line.
 
-**Maximum-height cases (both must stay ≤ 160 pt):**
+**Maximum-height cases (all must stay ≤ 160 pt):**
 
-1. Fresh, `total == 5`: one full row plus four compact rows, no caption2.
-2. Fresh, `total >= 6`: one full row plus four compact rows and `+N more`.
+1. Fresh, `total == 4`: one full row plus three compact rows, no caption2.
+2. Fresh, `total >= 5`: one full row plus three compact rows and `+N more`.
 3. Stale, `total >= 5`: one full row plus three compact rows and `+N more · May be out of date`.
 
 DEBUG decrypt reason stays Debug-only and is out of the production height budget.
@@ -297,7 +297,7 @@ Keep content snug; no extra padding against the camera. Capsule horizontal paddi
 
 - Center: primary agent as `AgentActivityHeadlineView(agent:surface: .island)` (or `"Heeler"` when counts-only).
 - Bottom: secondary agents (`rowLimit - 1` = 2) via `AgentActivityRowView(..., surface: .island)`, overflow line, then `AgentActivityCountChips(..., surface: .island)`.
-- Interaction: one Console `widgetURL` on the complete `DynamicIsland`; no per-agent `Link` targets.
+- Interaction: Agent rows use per-Agent `Link` targets in the expanded presentation. One Console `widgetURL` on the complete `DynamicIsland` handles compact, minimal, and expanded chrome taps.
 
 Island type stays slightly larger than Lock Screen rows for the primary (`.subheadline` / `.footnote`) and `.caption` for secondaries. Status dots: 8 pt primary, 7 pt rows. All inks Mocha via `.island`.
 
@@ -338,7 +338,7 @@ Unchanged enumeration, retokened through `surface`:
 ### Interaction and system actions
 
 - Apply one Console `widgetURL` to the complete Lock Screen view and one to the complete `DynamicIsland`.
-- Do not add per-row `Link` controls. The activity itself is comfortably larger than Apple's recommended 44×44 pt iOS target, and one destination avoids adjacent-target mistakes.
+- Use full-width per-row `Link` controls. One to three Lock Screen rows use 44 pt minimum height; four rows use the documented 28 pt dense minimum. Link targets must not overlap. Compact and minimal presentations keep one Console target.
 - Do not add `Button` / App Intent controls.
 - System End: default color (`nil`). Verify on device that the generated End label is readable on both appearances; that is an acceptance item, not a token to pre-empt.
 
@@ -385,7 +385,7 @@ Idle and unknown Agents are not in the activity. An empty eligible inventory end
 
 4. **`isStale` is Lock Screen-only.** Pass `context.isStale` into `AgentActivityLockScreenView` only. Do not add it to `AgentActivityIsland.make`.
 
-5. **Row cap.** Change `AgentActivityPresentation.lockScreenAgents` / `lockScreenOverflowCount` to take `isStale` and implement the table in Lock Screen anatomy. The Lock Screen view uses those helpers and draws at most one trailing caption2.
+5. **Row cap.** `AgentActivityPresentation.lockScreenAgents` draws at most four independently linked rows. The Lock Screen view uses those helpers and draws at most one trailing caption2.
 
 6. **Compact leading.** Replace the `ellipsis` branch with the first non-zero of `blocked`, then `done`, then `working`. Keep the capsule treatment. Mocha via `.island`.
 
@@ -453,7 +453,7 @@ Xcode canvas previews are the development check. They **do not** replace a physi
 | D3 | Always-On reduced luminance | **Device-required** | **Device-required** | Lock Screen | Status dots still distinguishable |
 | D4 | Increase Contrast | **Device-required** | **Device-required** | Lock Screen | No lost text on washes |
 | D5 | StandBy (Lock Screen ×2) | **Device-required** | **Device-required** | StandBy | Default material blends; 14 pt inset does not clip |
-| D6 | Tap anywhere in activity | **Device-required** | | Lock Screen | Entire activity → Console; no adjacent row targets |
+| D6 | Tap Agent rows and surrounding chrome | **Device-required** | | Lock Screen | Each row → matching Agent detail; surrounding chrome → Console; no target overlap |
 | D7 | Compact tap both sides | **Device-required** | | Dynamic Island | Both sides → Console |
 | D8 | Light Mode while island is showing | **Device-required** | | Dynamic Island | Island stays black with Mocha inks; Lock Screen (if shown) is Latte |
 
@@ -466,12 +466,12 @@ No remaining product or ownership choices. Implement the following as specified:
 1. Lock Screen background = system material (`activityBackgroundTint(nil)`). End button = system color (`activitySystemActionForegroundColor(nil)`).
 2. Hex owner is `AgentStatusPalette.swift`. Add that file to `HeelerWidgets.sources` in `project.yml`, regenerate and commit `Heeler.xcodeproj`. Do not duplicate hexes.
 3. Every shared row, headline, and chip takes `surface: AgentActivitySurface`. Lock Screen passes `.lockScreen`. Compact, minimal, and expanded pass `.island`, which resolves Mocha against a dark trait collection. Ambient Light Mode must not tint the island.
-4. Keep the aggregate list, pin-aware envelope order, full first row, compact secondary rows, and no Host name, buttons, logo, or progress bar. Use one Console link for each presentation. Chip enumeration stays `blocked`, `working`, `done`.
+4. Keep the aggregate list, pin-aware envelope order, full first row, compact secondary rows, and no Host name, buttons, logo, or progress bar. Use per-Agent links on Lock Screen and expanded presentations, plus one Console fallback link for each presentation. Chip enumeration stays `blocked`, `working`, `done`.
 5. Compact leading = first non-zero count in attention order: blocked, then done, then working. Never the working ellipsis. Never Working before Done.
-6. Fresh Lock Screen: show up to five rows. Stale Lock Screen: show up to four; trailing caption2 is `May be out of date`, or `+N more · May be out of date` when `total >= 5`. Pass `isStale` only into the Lock Screen view.
+6. Lock Screen: show up to four rows. Stale trailing caption2 is `May be out of date`, or `+N more · May be out of date` when `total >= 5`. Pass `isStale` only into the Lock Screen view.
 7. Disconnected has no widget presentation. Counts-only is decrypt/envelope failure, not disconnection. Stale is only `context.isStale` after content that included a stale date.
 8. Chip wash opacity 0.15 on Lock Screen; blocked-row wash 0.15; island compact capsule 0.22; expanded island chips 0.16.
-9. 14 pt horizontal, 10 pt vertical, 5 pt Lock Screen stack spacing, 7/8 pt dots.
+9. 14 pt horizontal, 8 pt vertical, 2 pt Lock Screen stack spacing, 7/8 pt dots. Row target height is 44 pt for up to three rows and 28 pt for four rows.
 10. Canvas previews: Light and Dark Lock Screen, including P5/P5a/P5b long title and long name (with and without title), P6 stale maximum height, and island previews in a Light environment (Mocha).
 11. Physical Lock Screen Light/Dark remains a required acceptance check before treating #247 as done.
 

--- a/docs/design/issue-247-live-activity-redesign.md
+++ b/docs/design/issue-247-live-activity-redesign.md
@@ -72,7 +72,7 @@ Apple HIG Lock Screen gallery (same page as #1) also showed system examples: Foo
 
 ## Design principles
 
-1. **System surface, Heeler language.** Lock Screen chrome follows the device's iOS Light/Dark appearance. Heeler identity lives in status hue (the same Catppuccin roles as the Console and herdr), not in a branded plate. On iOS 26 and 27, ActivityKit can incorrectly report `.dark` through SwiftUI in system Light Mode; the widget therefore uses unresolved UIKit semantic colors rather than that environment value. Keeping those colors dynamic also lets an existing activity change when the system appearance changes.
+1. **System surface, Heeler language.** Lock Screen chrome is authored to follow the device's iOS Light/Dark appearance. Heeler identity lives in status hue (the same Catppuccin roles as the Console and herdr), not in a branded plate. On iOS 26 and 27, ActivityKit can incorrectly report `.dark` through SwiftUI in system Light Mode; the widget therefore uses unresolved UIKit semantic colors rather than that environment value. iOS 27 can also fail to invalidate an existing Live Activity after the system appearance changes. There is no public appearance-refresh API, so issue #247 remains open pending an Apple fix.
 2. **One appearance model, two palettes, one hex owner.** The layout does not change between Light and Dark. Only tokens flip, from `AgentStatusPalette`. The widget never duplicates those hexes.
 3. **Island is a different surface.** Dynamic Island is always black. It keeps Mocha inks even when the Lock Screen is Latte. Shared views take an explicit `AgentActivitySurface`; they must not read ambient `colorScheme` to pick status color.
 4. **Attention order is Blocked, then Done, then Working.** Same as Console and the envelope. Compact leading and any other single-count pick follow it. Blocked is the only shouted *visual* (wash + ink title).
@@ -166,7 +166,7 @@ Prefer system / dynamic colors wherever they satisfy the intent. Custom colors a
 
 | Token | Light | Dark | Implementation |
 | --- | --- | --- | --- |
-| `surface.lockScreen` | Dynamic `UIColor.systemBackground` | Dynamic `UIColor.systemBackground` | Keep unresolved and pass through `Color(uiColor:)` to `.activityBackgroundTint` |
+| `surface.lockScreen` | Dynamic `UIColor.systemBackground` | Dynamic `UIColor.systemBackground` | Keep unresolved; draw it in the root view and also pass it to `.activityBackgroundTint` |
 | `action.systemEnd` | Dynamic `UIColor.label` | Dynamic `UIColor.label` | Keep unresolved and pass through `Color(uiColor:)` to `.activitySystemActionForegroundColor` |
 | `surface.island` | Opaque black (system) | Opaque black (system) | Do not tint. Cannot be customized. |
 | `text.primary` | `Color.primary` | `Color.primary` | System. On the island this is light-on-black. |
@@ -377,7 +377,7 @@ Idle and unknown Agents are not in the activity. An empty eligible inventory end
 
 ## SwiftUI implementation guidance
 
-1. **Chrome.** In `AgentLiveActivityWidget.body`, pass unresolved `UIColor.systemBackground` and `UIColor.label` through `Color(uiColor:)` to the two ActivityKit modifiers. Use unresolved `UIColor.label` and `UIColor.secondaryLabel` for Lock Screen text, and keep the Catppuccin status colors dynamic. Do not inject a fixed `colorScheme`, resolve colors early, or consult Heeler's Appearance setting. Dynamic Island remains system-black and keeps its explicit Mocha treatment.
+1. **Chrome.** In `AgentLiveActivityWidget.body`, draw unresolved `UIColor.systemBackground` in the root Lock Screen view and also pass it to `.activityBackgroundTint`; pass unresolved `UIColor.label` to the system action modifier. Use unresolved `UIColor.label` and `UIColor.secondaryLabel` for Lock Screen text, and keep the Catppuccin status colors dynamic. Do not inject a fixed `colorScheme`, resolve colors early, or consult Heeler's Appearance setting. Dynamic Island remains system-black and keeps its explicit Mocha treatment. This prepares the view for the correct system trait but cannot force iOS 27 to refresh an existing activity.
 
 2. **Palette file in the widget target.** Add `Sources/Heeler/Console/AgentStatusPalette.swift` to `HeelerWidgets.sources` in `project.yml`. Run `xcodegen generate` and commit `Heeler.xcodeproj` with that change. Do not duplicate hexes.
 
@@ -461,7 +461,7 @@ Not exercised in this research pass: physical device, Always-On, StandBy, Increa
 
 No remaining product or ownership choices. Implement the following as specified:
 
-1. Lock Screen background, End button, semantic text, and status colors remain unresolved dynamic UIKit colors so an existing activity follows iOS Light/Dark changes. ActivityKit's SwiftUI `colorScheme` and Heeler's Appearance setting are not consulted.
+1. Lock Screen background, End button, semantic text, and status colors remain unresolved dynamic UIKit colors so they follow iOS Light/Dark when ActivityKit supplies and refreshes the correct appearance. ActivityKit's SwiftUI `colorScheme` and Heeler's Appearance setting are not consulted. Existing-activity refresh remains blocked by the verified iOS 27 regression.
 2. Hex owner is `AgentStatusPalette.swift`. Add that file to `HeelerWidgets.sources` in `project.yml`, regenerate and commit `Heeler.xcodeproj`. Do not duplicate hexes.
 3. Every shared row, headline, and chip takes `surface: AgentActivitySurface`. Lock Screen passes `.lockScreen`. Compact, minimal, and expanded pass `.island`, which resolves Mocha against a dark trait collection. Ambient Light Mode must not tint the island.
 4. Keep the aggregate list, pin-aware envelope order, full first row, compact secondary rows, and no Host name, buttons, logo, or progress bar. Use per-Agent links on Lock Screen and expanded presentations, plus one Console fallback link for each presentation. Chip enumeration stays `blocked`, `working`, `done`.

--- a/docs/design/issue-247-live-activity-redesign.md
+++ b/docs/design/issue-247-live-activity-redesign.md
@@ -72,7 +72,7 @@ Apple HIG Lock Screen gallery (same page as #1) also showed system examples: Foo
 
 ## Design principles
 
-1. **System surface, Heeler language.** Lock Screen chrome is the system Live Activity material. Heeler identity lives in status hue (the same Catppuccin roles as the Console and herdr), not in a branded plate.
+1. **System surface, Heeler language.** Lock Screen chrome follows the device's iOS Light/Dark appearance. Heeler identity lives in status hue (the same Catppuccin roles as the Console and herdr), not in a branded plate. On iOS 26 and 27, ActivityKit can incorrectly report `.dark` in system Light Mode; the widget resolves the concrete `UIScreen` trait instead of trusting that environment value.
 2. **One appearance model, two palettes, one hex owner.** The layout does not change between Light and Dark. Only tokens flip, from `AgentStatusPalette`. The widget never duplicates those hexes.
 3. **Island is a different surface.** Dynamic Island is always black. It keeps Mocha inks even when the Lock Screen is Latte. Shared views take an explicit `AgentActivitySurface`; they must not read ambient `colorScheme` to pick status color.
 4. **Attention order is Blocked, then Done, then Working.** Same as Console and the envelope. Compact leading and any other single-count pick follow it. Blocked is the only shouted *visual* (wash + ink title).
@@ -166,8 +166,8 @@ Prefer system / dynamic colors wherever they satisfy the intent. Custom colors a
 
 | Token | Light | Dark | Implementation |
 | --- | --- | --- | --- |
-| `surface.lockScreen` | System Live Activity material | System Live Activity material | `.activityBackgroundTint(nil)` |
-| `action.systemEnd` | System default | System default | `.activitySystemActionForegroundColor(nil)` |
+| `surface.lockScreen` | Resolved `UIColor.systemBackground` | Resolved `UIColor.systemBackground` | Resolve against `UIScreen.main.traitCollection.userInterfaceStyle`, then pass the concrete color to `.activityBackgroundTint` |
+| `action.systemEnd` | Resolved `UIColor.label` | Resolved `UIColor.label` | Resolve against the same device trait, then pass the concrete color to `.activitySystemActionForegroundColor` |
 | `surface.island` | Opaque black (system) | Opaque black (system) | Do not tint. Cannot be customized. |
 | `text.primary` | `Color.primary` | `Color.primary` | System. On the island this is light-on-black. |
 | `text.secondary` | `Color.secondary` | `Color.secondary` | Overflow, identity, stale caption. |
@@ -377,7 +377,7 @@ Idle and unknown Agents are not in the activity. An empty eligible inventory end
 
 ## SwiftUI implementation guidance
 
-1. **Chrome.** In `AgentLiveActivityWidget.body`, replace the two modifiers with `nil` (or delete them; default is system material / system End color). Remove `AgentActivityChrome` if nothing else references it.
+1. **Chrome.** In `AgentLiveActivityWidget.body`, resolve Lock Screen appearance from `UIScreen.main.traitCollection.userInterfaceStyle`, falling back to ActivityKit's `colorScheme` only when the screen trait is unspecified. Resolve `UIColor.systemBackground` and `UIColor.label` against that concrete appearance, pass them to the two ActivityKit modifiers, and inject the same `ColorScheme` into the Lock Screen content. Do not consult Heeler's Appearance setting. Dynamic Island remains system-black and does not use this resolver.
 
 2. **Palette file in the widget target.** Add `Sources/Heeler/Console/AgentStatusPalette.swift` to `HeelerWidgets.sources` in `project.yml`. Run `xcodegen generate` and commit `Heeler.xcodeproj` with that change. Do not duplicate hexes.
 
@@ -399,13 +399,11 @@ Sketch (illustrative):
 
 ```swift
 ActivityConfiguration(for: AgentActivityAttributes.self) { context in
-    AgentActivityLockScreenView(
+    AgentActivityLockScreenContainer(
         presentation: AgentActivityDecryptor.presentation(for: context.state),
         hostID: context.attributes.hostID,
         isStale: context.isStale
     )
-    .activityBackgroundTint(nil)
-    .activitySystemActionForegroundColor(nil)
 } dynamicIsland: { context in
     AgentActivityIsland.make(
         presentation: AgentActivityDecryptor.presentation(for: context.state),
@@ -463,7 +461,7 @@ Not exercised in this research pass: physical device, Always-On, StandBy, Increa
 
 No remaining product or ownership choices. Implement the following as specified:
 
-1. Lock Screen background = system material (`activityBackgroundTint(nil)`). End button = system color (`activitySystemActionForegroundColor(nil)`).
+1. Lock Screen background and End button use concrete system colors resolved from `UIScreen.main.traitCollection.userInterfaceStyle`. The ActivityKit environment is only a fallback for an unspecified screen trait. Heeler's Appearance setting is not consulted.
 2. Hex owner is `AgentStatusPalette.swift`. Add that file to `HeelerWidgets.sources` in `project.yml`, regenerate and commit `Heeler.xcodeproj`. Do not duplicate hexes.
 3. Every shared row, headline, and chip takes `surface: AgentActivitySurface`. Lock Screen passes `.lockScreen`. Compact, minimal, and expanded pass `.island`, which resolves Mocha against a dark trait collection. Ambient Light Mode must not tint the island.
 4. Keep the aggregate list, pin-aware envelope order, full first row, compact secondary rows, and no Host name, buttons, logo, or progress bar. Use per-Agent links on Lock Screen and expanded presentations, plus one Console fallback link for each presentation. Chip enumeration stays `blocked`, `working`, `done`.

--- a/docs/design/issue-247-live-activity-redesign.md
+++ b/docs/design/issue-247-live-activity-redesign.md
@@ -1,0 +1,375 @@
+# Issue #247 Live Activity redesign
+
+Status: Implementation-ready
+Date: 2026-08-27
+Issue: [#247](https://github.com/zingerbee/Heeler/issues/247)
+Scope: visual and interaction spec for `Sources/HeelerWidgets/AgentLiveActivityWidget.swift` only. Wire contract, encryption, start/update/end, and row ordering are unchanged (ADR 0014, `docs/agents/live-activity-contract.md`).
+
+This is not a one-line color swap. Light Mode is broken because the banner is a branded dark slab that ignores the system appearance, and the status inks were authored only for that slab. The redesign keeps Heeler's herdr-aligned status language and the existing aggregate list, and makes the Lock Screen presentation native, calm, information-dense, and legible in both appearances.
+
+## Problem
+
+Heeler's Lock Screen Live Activity always paints Catppuccin Mocha mantle (`#181825`) via `.activityBackgroundTint(AgentActivityChrome.backgroundTint)` in `AgentLiveActivityWidget.swift`. In iOS Light Mode the card sits on a light wallpaper as a dark island. Issue #247 reports that as inconsistent with system appearance: Light Mode should be a light banner with dark, legible text; Dark Mode may keep a dark banner; status chips, links, and the system End control must keep contrast in both.
+
+The widget comment at `AgentActivityStatusStyle` states the reason: Live Activities "sit on the dark tint below, so the light-mode latte inks would disappear." That is circular. The mocha pastels were chosen because the background was hardcoded dark. On a light surface those same pastels fail WCAG:
+
+| Pair | Contrast | Threshold |
+| --- | --- | --- |
+| Mocha working `#F9E2AF` on white | 1.27:1 | fails 4.5:1 text |
+| Mocha done `#A6E3A1` on white | 1.49:1 | fails 4.5:1 text |
+| Mocha blocked `#F38BA8` on white | 2.32:1 | fails 4.5:1 text |
+| Same mocha working on current mantle `#181825` | 13.81:1 | passes, which is why Dark Mode currently looks fine |
+
+The Console already solved this with `AgentStatusPalette`: Mocha on dark, Latte on light, plus darker Latte *inks* so capsule text clears 4.5:1 (`AgentStatusPaletteTests.inksStayLegibleOnTheirWashes`). The widget never received that split.
+
+## Current-state constraints
+
+Grounded in issue #247, ADR 0014, `docs/agents/live-activity-contract.md`, and `Sources/HeelerWidgets/AgentLiveActivityWidget.swift`.
+
+- **One Live Activity per Host, aggregate list.** Not one activity per Agent. Envelope order is pin-aware, then `blocked > done > working`. The widget must not re-sort.
+- **Eligible statuses on the wire:** `working`, `blocked`, `done`. Idle and unknown are hidden. There is no `error`, `waiting`, or `disconnected` string in `ContentState`.
+- **Lock Screen budget:** ~160 pt height (Apple may truncate above that). Four two-line rows when `counts.total <= 4`, else three rows plus `+N more`. Horizontal padding is already 14 pt (HIG standard). Vertical padding 12 pt. Row spacing 8 pt.
+- **Hierarchy per row:** task `title` on top (status glyphs stripped), identity (`name` else `kind`) indented beneath; missing title promotes identity. Host name is never rendered.
+- **Deep links:** each row is a `Link` to that Agent's detail (`heeler://agent/{hostID}/{paneID}`). Taps outside a row, and every Dynamic Island compact/minimal tap, open the Console (`heeler://agent/{hostID}`).
+- **Counts chips** in urgency order: blocked, working, done. Zero counts omitted. Chips are `fixedSize()` so the title truncates first.
+- **Blocked is the only "please look" state:** title uses status ink, row gets a 6 pt continuous rounded wash. Working and done are painted, not announced as events.
+- **Counts-only fallback** when the envelope is absent or undecryptable (Watch Smart Stack, pre-first-unlock, unknown kid). Headline is the generic app name `"Heeler"`.
+- **Stale-date** is `timestamp + 900` seconds. `context.isStale` is unused. Ended activities dismiss immediately (`dismissal-date = timestamp`).
+- **Dynamic Island background cannot be customized.** HIG: compact, minimal, and expanded sit on an opaque black island. Status color on the island must remain the dark (Mocha) pastels even after Lock Screen Light Mode is fixed.
+- **No new dependencies, no contract change, no Host identity, no per-Agent activities.** Widget already compiles `HerdrAPITypes.swift` (so `AgentStatus` exists there) and does not import app-only UI files.
+- **iOS 18+, iPhone.** StandBy scales the Lock Screen presentation 2x. Always-On reduces luminance. Physical Lock Screen was not exercised for this spec.
+
+## Research method
+
+Visual references were opened, inspected, and screenshot in an `ego-browser` task space named `issue-247 live activity research`. Search snippets were not treated as evidence. Refero search results were login-walled; Pttrns required signup; `screenlane.com` redirected to Page Flows and had no Live Activity library. Those three sites are recorded as not used.
+
+Contrast figures in this document were computed from the hex values in `AgentStatusPalette` / `AgentActivityStatusStyle` using WCAG 2 relative luminance, not estimated.
+
+## Reference table
+
+| # | URL | Website / product | Observed | Relevance to Heeler |
+| --- | --- | --- | --- | --- |
+| 1 | [HIG: Live Activities](https://developer.apple.com/design/human-interface-guidelines/live-activities) | Apple | Default Lock Screen is light in Light Mode, dark in Dark Mode. Custom backgrounds "sparingly." Compact/minimal/expanded backgrounds cannot be customized; island is black opaque. 14 pt Lock Screen margin. Medium-or-heavier type. Do not replicate notification layouts. Match the app in *both* appearances. Logo mark without a container; never the full app icon. Compact leading and trailing must read as one fact and open the same screen. Height 84–160 pt. | Primary constraint. Current Mocha mantle is the opposite of "use custom tint sparingly." Island stays black, so Latte inks cannot be used there. |
+| 2 | [`activityBackgroundTint(_:)`](https://developer.apple.com/documentation/swiftui/view/activitybackgroundtint(_:)) | Apple | `color: Color?`. "To use the system's default background material, pass `nil`." Pair with `activitySystemActionForegroundColor` when a custom tint is set. | Implementation: pass `nil` for both chrome modifiers. Do not pass `Color.clear`. |
+| 3 | [`activitySystemActionForegroundColor(_:)`](https://developer.apple.com/documentation/swiftui/view/activitysystemactionforegroundcolor(_:)) | Apple | End-button text. Pass `nil` for the system default. | Current Mocha text (`#CDD6F4`) is only correct on the hardcoded dark slab. |
+| 4 | [HIG: Dark Mode](https://developer.apple.com/design/human-interface-guidelines/dark-mode) | Apple | Respect the system appearance. Semantic / dynamic colors. Avoid hard-coded values. Minimum 4.5:1, 7:1 for small custom text. Dark is not a mechanical inversion of Light. | Widget currently ignores Light Mode entirely. Console palette already follows this; widget should too. |
+| 5 | [Displaying live data with Live Activities](https://developer.apple.com/documentation/activitykit/displaying-live-data-with-live-activities) | Apple | System may truncate above 160 pt. Example uses a *translucent* tint (`.opacity(0.25)`), not an opaque brand fill. Pass `context.isStale`. Accessibility labels are required per presentation. Compact leading/trailing form one cohesive view. | Keep the 4/3-row budget. Surface staleness. Do not add a 25% brand wash; default material is calmer and StandBy-safe. |
+| 6 | [WWDC23: Design dynamic Live Activities](https://developer.apple.com/videos/play/wwdc2023/10194/) | Apple | Session framing: glanceable Lock Screen, StandBy, Dynamic Island; chapters at Lock Screen 1:18, StandBy 6:00, Dynamic Island 7:37. Resources point at the HIG and ActivityKit article above. | Confirms Lock Screen is the starting canvas and that island layouts expand from compact, they do not restyle from scratch. |
+| 7 | [Live Activities on Zomato App](https://dribbble.com/shots/19855562-Live-Activities-on-Zomato-App) | Dribbble / Zomato | Dark branded banner: restaurant name as secondary, large status verb ("Preparing your order"), ETA as supporting, sequential progress. Designer write-up: glanceable status, mood board, state wireframes. | **Apply:** one glanceable status story, secondary identity. **Do not copy:** opaque branded dark fill, wordmark, or a progress rail (Heeler is not a sequential delivery). |
+| 8 | [Live Activity — Bank Card Delivery](https://dribbble.com/shots/26400783-Live-Activity-Bank-Card-Delivery) | Dribbble | Same layout in light *and* dark: light card with near-black title, dark card with white title. Headline is the state. Stepper icons, not a paragraph. Brand mark uncontained, top-leading. | **Apply:** one layout, two appearance palettes; state as headline; identity as secondary. **Do not copy:** rover illustration, stepper, or a custom light gray fill — system material already does that job. |
+| 9 | [Flight Tracking Live Activity](https://dribbble.com/shots/23686537-Live-Activity-Dynamic-Island-for-Flight-Tracking-App) | Dribbble | Dark Lock Screen card on a light wallpaper: origin/destination as the two poles, on-time in green, remaining time as the trailing metric, one progress bar. | **Apply:** dark *content* can sit on light wallpaper only when the *card* itself is the system material (this shot still uses an opaque dark card, which is the #247 bug). Green as "on time / done," a single primary metric. **Do not copy:** the dark slab or the progress bar. |
+| 10 | [Industry Examples of Live Activities](https://dribbble.com/shots/21011697-Industry-Examples-of-Live-Activities) | Dribbble / OneSignal | Light *and* dark cards in one board. Delivery examples: light surface, small status chip, thin progress. Sports: dense numerals, tiny status dots. Countdown: huge type. Promo cards: rejected by HIG ("don't display ads"). | **Apply:** light cards exist in the wild; chips + dots encode status; density belongs in type, not chrome. **Do not copy:** sale/promo layouts. |
+| 11 | [iOS Lock Screen Live Activity (Tier App)](https://dribbble.com/shots/22610933-iOS-Lock-Screen-Live-Activity-Tier-App) | Dribbble | Dark branded banner with a hero number (`20m` / `9.3km`), two caption metrics, wordmark top-trailing. Working vs arrived are two layouts of the same skeleton. | **Apply:** hero number only when one metric *is* the activity (Heeler's analog is the count, and only in compact/minimal). **Do not copy:** hero type on the Lock Screen list, or a dark-only brand plate. |
+| 12 | [Live Activities widget — iOS 16](https://dribbble.com/shots/18460566-Live-Activities-widget-iOS-16) | Dribbble / Starbucks | Dark green branded banner on a *light* Lock Screen, wordmark, pickup location. Reads as an app sticker, not a system activity. | **Reject as a model.** This is the same failure mode as Heeler today: brand fill that ignores the wallpaper. |
+| 13 | [Apple Design Resources: Live Activities](https://www.figma.com/community/file/1367915437752334285/live-activities) | Figma Community / Apple | Official 2026 kit. Community comment (Kassandra Dower): kit still uses 18 pt Lock Screen margin and 48 pt island radius; HIG is 14 pt and 44 pt. | Trust the HIG numbers, not the kit's older spacing. Heeler already uses 14 pt horizontal padding — keep it. |
+| 14 | [Dynamic Island & Live Activities](https://www.figma.com/community/file/1362423678739956425/dynamic-island-live-activities) | Figma Community / Jasper | Pixel-perfect compact / minimal / expanded on black. Compact: circular progress leading, time trailing, snug to the camera. Expanded wraps the camera. Templates for 393 and 430 pt widths. | **Apply:** island content is bold, snug, balanced; compact is a single metric split across the camera. Heeler's split is "urgency count | total count." |
+| 15 | [Flighty compact Dynamic Island](https://mobbin.com/screens/4744a5f8-23f1-442b-93e1-0da560854f16) | Mobbin / Flighty | Production compact on a light Home Screen: leading `2:58h` in green, trailing yellow `B22` capsule. Black island, no extra padding against the camera, both sides similar width, color carries meaning. Tagged "Dynamic Island." | **Apply:** island always black; Mocha pastels on black; leading = most urgent live fact, trailing = identity/count. **Do not copy:** gate capsules or airline marks. |
+| 16 | [Instacart compact Dynamic Island](https://mobbin.com/screens/fa7b983b-0f8c-4de1-8983-fe18948eac69) | Mobbin / Instacart | Production compact: uncontained carrot mark leading, `1h 16min` trailing, white Home Screen. Quiet. One fact. | **Apply:** no container around a glyph; trailing metric in regular white; do not put a Heeler app icon in a circle. Heeler has no ETA, so the trailing metric stays the agent total. |
+| 17 | [Delivery live activity in the Dynamic Island](https://www.behance.net/gallery/164717497/Delivery-live-activity-in-the-Dynamic-Island-on-iPhone) | Behance | Expanded island: brand mark leading, huge "Almost here!", "Arriving at 9:51 AM" secondary, `10 min` trailing, progress rail. Black expanded surface. | **Apply:** expanded is an enlargement of compact (status + metric), not a new poster. **Do not copy:** marketing headline, brand disc, or progress rail. |
+
+Apple HIG Lock Screen gallery (same page as #1) also showed system examples: Food Truck, Maps, Music, Sports, Find Items, Timer. Shared traits: system-sized type, short labels, no decorative chrome, light cards in Light Mode.
+
+## Design principles
+
+1. **System surface, Heeler language.** Lock Screen chrome is the system Live Activity material. Heeler identity lives in status hue (the same Catppuccin roles as the Console and herdr), not in a branded plate.
+2. **One appearance model, two palettes.** The layout does not change between Light and Dark. Only tokens flip, the same way `AgentStatusPalette` already does.
+3. **Island is a different surface.** Dynamic Island is always black. It keeps Mocha inks even when the Lock Screen is Latte. Do not drive island color from `colorScheme`.
+4. **Glance, then identity.** Status and counts are the first read. Task title is the second. Agent name/kind is the third. Host is never shown.
+5. **Blocked is the only shout.** Working and done stay quiet. Blocked uses ink on the title and a wash behind the row. Color is never the only signal: VoiceOver already speaks the status word; keep that.
+6. **No extra chrome.** No app icon, no wordmark, no progress bar, no map, no buttons. The only actions are the existing deep links and the system End control.
+7. **Fit the 160 pt budget; do not fill it.** Four rows when they fit, three plus overflow otherwise. Shorter inventories stay short.
+8. **Do not copy another product's artwork.** Distill structure (headline / secondary / metric / snug island) and throw away brand fills, mascots, and steppers.
+
+## Rejected alternatives
+
+| Alternative | Why rejected |
+| --- | --- |
+| Keep Mocha mantle in Light Mode | This is the bug. HIG default is appearance-adaptive. Mocha working text on white is 1.27:1. |
+| Custom Latte crust/base as Light tint, Mocha mantle as Dark tint | HIG: custom tints sparingly. StandBy prefers the default so the activity can scale into the bezel. A Catppuccin fill still reads as a sticker. System material already tracks wallpaper, tinted Lock Screens, and Always-On. |
+| `Color.clear` / fully transparent banner | Not the API for "system material." The documented value is `nil`. Clear also kills contrast on busy wallpapers. |
+| Translucent brand tint at 0.25 opacity (ActivityKit sample) | Sample is illustrating the modifier, not mandating a brand wash. Heeler has no single brand fill that works on every wallpaper at 0.25. |
+| Starbucks / Zomato / Tier opaque brand plate | Same failure as today. Issue #247's expected behavior is system-consistent Light/Dark, not a prettier dark card. |
+| Hero number / progress bar / map (Tier, Flighty concept, Uber Eats expanded) | Heeler tracks many Agents, not one trip. ADR 0014 already chose an aggregate list. A fake progress bar would lie. |
+| One Live Activity per Agent | Rejected in ADR 0014 (push topology and 160 pt budget). Out of scope. |
+| Show Host identity | Contract: never rendered. Wire still carries `host` for producers. |
+| Buttons (pause, contact, open) | HIG: one essential control, once-or-pause actions. Heeler's lock-screen action is "open the Agent." `Link` already does that. |
+| App icon in a circle | HIG: logo mark without container; never the full icon. Heeler has no lock-screen mark that earns the space; counts do. |
+| Latte inks on the Dynamic Island | Island background is black and cannot be changed. Dark Latte inks (`#9F5300`, `#C70030`) on black are the wrong direction (3.5:1 and look like muddy brown/red, not herdr). |
+| Mocha pastels as Lock Screen text in Light Mode | 1.27–2.32:1 on white. Console already rejected this; that is why Latte inks exist. |
+| Replicate notification layout (app icon + title + body) | HIG: don't. Keep the two-line agent list. |
+
+## Semantic tokens
+
+Prefer system / dynamic colors wherever they satisfy the intent. Custom colors are only the Catppuccin status pair already used in the Console.
+
+### Surfaces and chrome
+
+| Token | Light | Dark | Implementation |
+| --- | --- | --- | --- |
+| `surface.lockScreen` | System Live Activity material | System Live Activity material | `.activityBackgroundTint(nil)` |
+| `action.systemEnd` | System default | System default | `.activitySystemActionForegroundColor(nil)` |
+| `surface.island` | Opaque black (system) | Opaque black (system) | Do not tint. Cannot be customized. |
+| `text.primary` | `Color.primary` | `Color.primary` | System. On the island this is light-on-black. |
+| `text.secondary` | `Color.secondary` | `Color.secondary` | Overflow, identity, counts-only caption. |
+| `text.blocked` | Status ink (below) | Status ink (below) | Only on blocked titles. |
+
+Remove `AgentActivityChrome.backgroundTint` and `AgentActivityChrome.systemAction`. Do not replace them with other hexes.
+
+### Status (same hues as `AgentStatusPalette`)
+
+Wash = capsule / row fill. Ink = text, dots, compact glyphs.
+
+| Status | Role | Dark (Mocha) | Light (Latte) |
+| --- | --- | --- | --- |
+| blocked | wash | `#F38BA8` | `#D20F39` |
+| blocked | ink | `#F38BA8` | `#C70030` |
+| done | wash | `#A6E3A1` | `#40A02B` |
+| done | ink | `#A6E3A1` | `#0D7900` |
+| working | wash | `#F9E2AF` | `#DF8E1D` |
+| working | ink | `#F9E2AF` | `#9F5300` |
+| idle / unknown / other | wash | `#7F849C` | `#6C6F85` |
+| idle / unknown / other | ink | `#A6ADC8` | `#5C5F77` |
+
+Unknown strings in the envelope (defensive) use the muted pair, never blocked or done. Idle never appears in the activity; the muted pair is for `countsOnly` chrome and stale copy.
+
+**Where each pair applies:**
+
+- **Lock Screen:** resolve from `colorScheme` / `UITraitCollection.userInterfaceStyle`. Light → Latte, Dark → Mocha.
+- **Dynamic Island (compact, minimal, expanded):** always Mocha, regardless of system appearance.
+
+**Wash opacity:** 0.15 on Lock Screen chips and blocked-row fills (match `AgentStatusBadge`, which uses 0.15). Island chips may keep 0.22 on the compact blocked capsule so the fill reads on black; 0.16 is too timid there.
+
+### Measured contrast (WCAG 2, sRGB)
+
+Ink on solid surfaces, computed from the hexes above:
+
+| Pair | Ratio | Passes |
+| --- | --- | --- |
+| Latte working ink on white | 5.66:1 | AA text, AA non-text (dot 3:1) |
+| Latte blocked ink on white | 6.05:1 | AA |
+| Latte done ink on white | 5.60:1 | AA |
+| Latte muted ink on white | 6.25:1 | AA |
+| Latte working ink on 0.16 wash over white | 4.90:1 | AA text |
+| Latte blocked ink on 0.16 wash over white | 4.59:1 | AA text |
+| Mocha working on system dark `#1C1C1E` | 13.39:1 | AA |
+| Mocha blocked on system dark | 7.35:1 | AA |
+| Mocha working on black (island) | 16.53:1 | AA |
+| Mocha blocked on black (island) | 9.07:1 | AA |
+
+Always-On and Increase Contrast were not measured on device. System material and dynamic colors are the mitigation; physical-device check is still required.
+
+## Redesign spec
+
+### Lock Screen anatomy
+
+```
+┌──────────────────────────────────────────────┐  14 pt inset
+│ [primary row: dot + title                    │
+│              identity]          [chips →]    │  header: first agent + chips
+│ [row 2: dot + title / identity]              │  8 pt stack spacing
+│ [row 3: …]                                   │
+│ [row 4 or "+N more"]                         │
+│ [optional stale caption]                     │
+└──────────────────────────────────────────────┘
+  padding: 14 horizontal, 12 vertical
+  height: system-sized, never above 160 pt
+```
+
+Keep `AgentActivityLockScreenView`'s structure. Changes are tokens, type weight, compact-leading logic (island), stale caption, and previews.
+
+**Header.** First envelope agent is the headline row, same `AgentActivityLinkedRow` as today. Chips stay trailing, `fixedSize()`, never wrap. When `lockScreenAgents` is empty (counts-only), headline is `Text(presentation.headerTitle)` at `.subheadline.weight(.semibold)`, `Color.primary`, `lineLimit(1)`.
+
+**Rows.** Uniform two-line rows in envelope order. Do not enlarge the first row's type relative to the rest; the current "headline is just the first row" treatment is correct for an aggregate list and matches the contract. Blocked wash stays.
+
+**Overflow.** `+\(n) more` at `.caption2`, `text.secondary`. No chevron, no fake disclosure.
+
+**Stale.** If `context.isStale`, a final caption: `May be out of date`, `.caption2`, `text.secondary`. Do not replace rows with this string. Pass `isStale` from `ActivityConfiguration` into the view; it is available on `ActivityViewContext`.
+
+**DEBUG decrypt reason** stays Debug-only.
+
+**Padding.** Keep 14 / 12. Do not "fix" it to the Apple Figma kit's 18 pt.
+
+**Corner / materials.** Do not draw a custom rounded rectangle. The system provides the banner shape. Previews may fake a 22 pt continuous rounded rect so the canvas is readable; that shape is not production chrome.
+
+### Dynamic Island
+
+**Compact.** One fact split across the camera, both sides linking to the Console (already true; keep it).
+
+| Side | Content | Type | Color |
+| --- | --- | --- | --- |
+| Leading | Highest-urgency *non-zero* count as a snug capsule: blocked, else working, else done | `.caption.weight(.bold).monospacedDigit()` | Mocha ink for that status, 0.22 Mocha wash, `Capsule` |
+| Trailing | `counts.total` | `.body.weight(.semibold).monospacedDigit()` | `Color.primary` |
+
+Replace the current generic `ellipsis` labeled "Working". That glyph lies when the inventory is all-done. Accessibility: leading `"\(n) blocked|working|done"`, trailing `"\(total) agents"`.
+
+Keep content snug; no extra padding against the camera. Capsule horizontal padding 5, vertical 1 (already).
+
+**Minimal.** `counts.total`, monospaced. Weight `.bold` when `blocked > 0`, else `.semibold`. Foreground Mocha blocked ink when blocked, else `Color.primary`. No capsule (too wide for the detached pill). Accessibility: `"\(total) agents"` plus `"\(blocked) blocked"` when blocked > 0.
+
+**Expanded.** Keep current regions:
+
+- Center: primary agent as `AgentActivityHeadlineView` (or `"Heeler"` when counts-only), linked to that Agent.
+- Bottom: secondary agents (`rowLimit - 1` = 2), overflow line, then chips.
+
+Island type stays slightly larger than Lock Screen rows for the primary (`.subheadline` / `.footnote`) and `.caption` for secondaries. Status dots: 8 pt primary, 7 pt rows. All inks Mocha. Chips Mocha.
+
+**Key line.** `.keylineTint` on the `DynamicIsland`: Mocha blocked ink when `counts.blocked > 0`, else Mocha muted ink `#A6ADC8`. HIG: tint the island key line to match content when the background is dark.
+
+**No** expanded buttons, no leading/trailing expanded artwork, no app icon.
+
+### Typography
+
+HIG: medium weight or higher for key information; small text sparingly.
+
+| Element | Style | Weight | Color |
+| --- | --- | --- | --- |
+| Lock Screen / expanded title | `.subheadline` (primary), `.caption` (rows) | `.semibold` if blocked, else `.semibold` primary / `.regular` rows | `text.blocked` or `text.primary` |
+| Identity line | `.footnote` primary, `.caption` rows | Regular | `text.secondary` |
+| Chips | `.caption2` | `.semibold` | Status ink |
+| Overflow, stale | `.caption2` | Regular | `text.secondary` |
+| Compact trailing / minimal | `.body` | `.semibold` / `.bold` if blocked | See island rules |
+| Compact leading | `.caption` | `.bold` | Status ink |
+
+Do not introduce a custom font. System text styles only, so Dynamic Type and the Lock Screen optical size stay native.
+
+### Iconography
+
+- Status **dot**: 8×8 pt primary, 7×7 pt rows, `Circle().fill(ink)`, `accessibilityHidden(true)` (status is in the label).
+- **No** SF Symbol app logo. Compact leading is a count, not `ellipsis`.
+- If a working-only compact leading needs a glyph because the count is `1` and a single digit looks lost, still show `1` in the capsule. Do not bring the ellipsis back.
+
+### Chips
+
+Unchanged behavior, retokened:
+
+- Render `counts.chipItems` in contract order (blocked, working, done).
+- `"\(count) \(status)"` with the status word as the wire string (`blocked`, `working`, `done`), not a localized paraphrase in this pass (the widget is English, matching current copy).
+- `fixedSize()`, padding 6 / 2, capsule, ink on 0.15 wash (Lock Screen) or Mocha ink on 0.16–0.22 wash (island).
+- Combined accessibility label as today.
+
+### Links and system actions
+
+- Keep `Link` per agent row and `widgetURL` on the banner / compact / minimal for Console.
+- Keep `.buttonStyle(.plain)` and `.tint(.primary)` in *previews only*, so canvas Links are not accent-tinted. Production Lock Screen is already chromeless.
+- Do not add `Button` / App Intent controls.
+- System End: default color (`nil`). Verify on device that the generated End label is readable on both appearances; that is an acceptance item, not a token to pre-empt.
+
+### Truncation
+
+- Titles and names: `lineLimit(1)`, tail truncation. Wire already caps at 80 graphemes; UI still truncates at the row width.
+- Chips never compress. Header `Spacer(minLength: 8)` stays so a long title yields to chips, not the reverse.
+- Overflow `+N more` is not truncated.
+- Compact/minimal: monospaced digits, no shrinking below `.caption` / `.body`. Do not use `minimumScaleFactor` except the existing counts-only island headline (`0.7`).
+
+### Accessibility
+
+- Keep `.accessibilityElement(children: .combine)` on the Lock Screen with the existing narration: primary, chips, remaining rows, overflow.
+- Append `"may be out of date"` when `isStale`.
+- Status must remain in the spoken string (`"reviewer, blocked, Approve the transport…"`). Dots stay hidden.
+- Compact/minimal already have labels; update them to match the new leading (status word, not "Working" for a done-only inventory).
+- Do not rely on color alone: blocked wash + semibold + spoken status.
+- VoiceOver on a physical Lock Screen was not exercised.
+
+## Content-state matrix
+
+Map the package's requested names onto the *actual* model. Do not invent wire statuses.
+
+| Requested name | Actual model | Lock Screen | Compact / minimal | Expanded |
+| --- | --- | --- | --- | --- |
+| Working | `status == "working"` in envelope; `counts.working` | Latte/Mocha working ink on the dot; title `text.primary`; no wash | If no blocked: leading shows working count in Mocha yellow capsule | Same row language, Mocha |
+| Waiting | **Blocked.** herdr Blocked = waiting for human input (`CONTEXT.md`). No `waiting` string. | Blocked ink on title, 0.15 wash, 6 pt corner, 3/6 pt inset | Leading shows blocked count (highest urgency) | Blocked primary uses Mocha pink title |
+| Done | `status == "done"`; `counts.done` | Done ink on the dot only; title stays `text.primary` (state, not "just finished") | Leading shows done count only when blocked = working = 0 | Same |
+| Attention / error | **Blocked is attention.** There is no error status in `ContentState`. Unknown envelope strings use muted, never red. | Do not introduce a fourth hue | Do not paint blocked red for decrypt failure | Same |
+| Stale / disconnected | (a) `context.isStale` after 15 min without update; (b) `countsOnly` when the envelope cannot be opened | (a) rows remain, caption "May be out of date"; (b) `"Heeler"` + chips, no rows, no fake names | Still show counts. Counts are plaintext and survive (a) and (b). | `"Heeler"` in center when no primary agent |
+| Ended | Activity ends immediately (`dismissal-date = timestamp`). No ended presentation. | Not drawn. Do not add a summary banner. | Removed from the island immediately (system). | Removed |
+
+Idle and unknown Agents are not in the activity. An empty eligible inventory ends the activity (ADR 0014). Do not design an idle lock-screen state.
+
+## SwiftUI implementation guidance
+
+Stay inside `Sources/HeelerWidgets/AgentLiveActivityWidget.swift` plus the smallest token sharing needed so widget hues cannot drift from `AgentStatusPalette`.
+
+1. **Chrome.** In `AgentLiveActivityWidget.body`, replace the two modifiers with `nil` (or delete them; default is system material / system End color). Remove `AgentActivityChrome` if nothing else references it.
+
+2. **Pass `context.isStale`** into `AgentActivityLockScreenView` and `AgentActivityIsland.make`. Thread it next to `presentation` and `hostID`. Do not put it on the wire.
+
+3. **Status style.** Replace the mocha-only `AgentActivityStatusStyle.ink(for:)` with two entry points, e.g. `lockScreenInk(for:)` and `islandInk(for:)`, plus matching `wash` colors. Lock Screen uses a dynamic `UIColor` / `Color` that flips Latte/Mocha with `userInterfaceStyle`. Island functions return Mocha only.
+
+4. **Do not invent new hexes.** Reuse the eight status pairs in `AgentStatusPalette`. Preferred: compile `Sources/Heeler/Console/AgentStatusPalette.swift` into the `HeelerWidgets` target (`project.yml` `HeelerWidgets.sources`). It already imports UIKit only and uses `AgentStatus` from `HerdrAPITypes`, which the widget already compiles. Then `Color(status.inkUIColor)` works in the widget. Acceptable fallback if that file pull is awkward: duplicate the hex table in `AgentActivityStatusStyle` with a comment that `AgentStatusPaletteTests` is the source of truth, and add a widget-side test or a shared hex constant file later. Do not add a package.
+
+5. **Compact leading.** Replace the `ellipsis` branch with the first non-zero of `blocked`, `working`, `done`. Keep the capsule treatment.
+
+6. **Previews.** Stop forcing `.environment(\.colorScheme, .dark)` as the only gallery. Provide Light and Dark for at least: mixed + overflow, single working, counts-only, blocked-primary, stale (fake `isStale: true`), long title (80 graphemes). Light previews use a light rounded rect approximating system material, not Mocha mantle. Keep `.buttonStyle(.plain)` and `.tint(.primary)`.
+
+7. **No new frameworks.** No extra SF Symbols catalog, no extra fonts, no ActivityKit API beyond modifiers already in the file plus `keylineTint` and `isStale`.
+
+8. **Contract and coordinator stay put.** Do not change envelope shape, chip copy, row caps, deep links, or dismissal policy.
+
+Sketch (illustrative, not to paste blindly):
+
+```swift
+ActivityConfiguration(for: AgentActivityAttributes.self) { context in
+    AgentActivityLockScreenView(
+        presentation: AgentActivityDecryptor.presentation(for: context.state),
+        hostID: context.attributes.hostID,
+        isStale: context.isStale
+    )
+    .activityBackgroundTint(nil)
+    .activitySystemActionForegroundColor(nil)
+} dynamicIsland: { context in
+    AgentActivityIsland.make(
+        presentation: AgentActivityDecryptor.presentation(for: context.state),
+        hostID: context.attributes.hostID
+    )
+}
+```
+
+Widget `Link` views remain; `AgentActivityLinked` / `AgentActivityConsoleLinked` stay as the MainActor `widgetURL` seam.
+
+## Preview and acceptance matrix
+
+Xcode canvas previews are the development check. They **do not** replace a physical Lock Screen. Label every Lock Screen row below as **device-required**.
+
+| # | Case | Light | Dark | Where | Pass if |
+| --- | --- | --- | --- | --- | --- |
+| P1 | Mixed blocked / working / done + overflow | Canvas | Canvas | Lock Screen preview | Light banner is light; chips and dots use Latte inks; blocked row wash is visible; `+N more` secondary |
+| P2 | Single unnamed working | Canvas | Canvas | Lock Screen | Identity-only row, no wash, working dot visible |
+| P3 | Four rows, all fit | Canvas | Canvas | Lock Screen | No overflow line; four two-line rows; height feels inside 160 pt |
+| P4 | Counts-only | Canvas | Canvas | Lock Screen | Headline "Heeler", chips only, no ghost rows |
+| P5 | Long title (80 graphemes) + three chips | Canvas | Canvas | Lock Screen | Title truncates; chips fully visible |
+| P6 | Stale | Canvas | Canvas | Lock Screen | Caption "May be out of date"; rows still shown |
+| P7 | Blocked compact | Canvas (island is always dark) | — | Compact | Leading blocked count capsule, trailing total, both Console links |
+| P8 | Working-only compact (no blocked) | Canvas | — | Compact | Leading working count, not an ellipsis |
+| P9 | Done-only compact | Canvas | — | Compact | Leading done count, not "Working" |
+| P10 | Minimal blocked | Canvas | — | Minimal | Total in blocked Mocha ink, bold |
+| P11 | Expanded mixed | Canvas | — | Expanded | Primary + up to two secondaries + chips; Mocha inks; key line blocked when blocked > 0 |
+| P12 | Contrast, Light Lock Screen | Compute + canvas | — | Lock Screen | Ink/wash pairs match the table (≥ 4.5:1 text, ≥ 3:1 dots) |
+| P13 | Contrast, Dark Lock Screen | — | Compute + canvas | Lock Screen | Mocha inks on system dark |
+| P14 | Contrast, island | — | Compute | Compact/minimal/expanded | Mocha inks on black |
+| D1 | Light Mode Lock Screen on device | **Device-required** | | Lock Screen | Banner is light; End control readable; wallpaper not fighting a dark slab |
+| D2 | Dark Mode Lock Screen on device | | **Device-required** | Lock Screen | Dark system material, not necessarily `#181825`; chips readable |
+| D3 | Always-On reduced luminance | **Device-required** | **Device-required** | Lock Screen | Status dots still distinguishable |
+| D4 | Increase Contrast | **Device-required** | **Device-required** | Lock Screen | No lost text on washes |
+| D5 | StandBy (Lock Screen ×2) | **Device-required** | **Device-required** | StandBy | Default material blends; 14 pt inset does not clip |
+| D6 | Tap row / tap chrome | **Device-required** | | Lock Screen | Row → Agent detail; outside row → Console |
+| D7 | Compact tap both sides | **Device-required** | | Dynamic Island | Both sides → Console |
+| D8 | Light Mode while island is showing | **Device-required** | | Dynamic Island | Island stays black with Mocha inks; Lock Screen (if shown) is Latte |
+
+Not exercised in this research pass: physical device, Always-On, StandBy, Increase Contrast, VoiceOver, Night Mode StandBy, Watch Smart Stack. Canvas previews in Xcode were not generated here (no builds, per package).
+
+## Decisions for implementation
+
+No remaining product choices. Implement the following as specified:
+
+1. Lock Screen background = system material (`activityBackgroundTint(nil)`). End button = system color (`activitySystemActionForegroundColor(nil)`).
+2. Lock Screen status tokens = existing `AgentStatusPalette` Latte/Mocha pairs, dynamic with appearance. Island status tokens = Mocha only.
+3. Keep the aggregate list, four/three-row budget, pin-aware envelope order, two-line title/identity, no Host name, existing deep links, no buttons, no logo, no progress bar.
+4. Compact leading = highest-urgency non-zero count (blocked, else working, else done). Never the working ellipsis.
+5. Show `May be out of date` when `context.isStale`. Do not add ended, error, waiting, or disconnected presentations.
+6. Chip wash opacity 0.15 on Lock Screen; blocked-row wash 0.15; island compact capsule 0.22.
+7. 14 pt horizontal, 12 pt vertical, 8 pt Lock Screen stack spacing, 7/8 pt dots.
+8. Share or duplicate `AgentStatusPalette` hexes; do not pick new hues.
+9. Add Light *and* Dark canvas previews, including stale and long titles.
+10. Physical Lock Screen Light/Dark remains a required acceptance check before treating #247 as done.
+
+Wire contract, ADR 0014, plugin, and relay are out of scope.

--- a/docs/design/issue-247-live-activity-redesign.md
+++ b/docs/design/issue-247-live-activity-redesign.md
@@ -29,7 +29,7 @@ Grounded in issue #247, ADR 0014, `docs/agents/live-activity-contract.md`, and `
 - **One Live Activity per Host, aggregate list.** Not one activity per Agent. Envelope order is pin-aware, then `blocked > done > working`. The widget must not re-sort.
 - **Attention order is Blocked, then Done, then Working.** Console sort buckets and the Live Activity envelope both use this because Blocked is waiting on an answer, Done has a result to read, and Working needs nothing (`Sources/Heeler/Console/ConsoleAgent.swift` `consoleSortBucket`; `docs/agents/live-activity-contract.md`). Any widget presentation that shows a *single* status count uses this order. Chip capsules are different: they enumerate every non-zero count and keep today's order (`blocked`, `working`, `done` in `chipItems`).
 - **Eligible statuses on the wire:** `working`, `blocked`, `done`. Idle and unknown are hidden. There is no `error`, `waiting`, or `disconnected` string in `ContentState`. The widget cannot represent disconnection as its own state (see Content-state matrix).
-- **Lock Screen budget:** Apple may truncate above 160 pt. Fresh (`isStale == false`): four two-line rows when `counts.total <= 4`, else three rows plus `+N more`. Stale (`context.isStale`): never four rows; the stale caption shares the trailing caption2 line with overflow (see Lock Screen anatomy). Horizontal padding is already 14 pt (HIG standard). Vertical padding 12 pt. Row spacing 8 pt.
+- **Lock Screen budget:** Apple may truncate above 160 pt. The first row keeps the two-line hierarchy; up to four secondary rows use a compact single line. Fresh shows at most five rows, stale at most four, with overflow and stale state sharing one caption2 line. Padding is 14 pt horizontal / 10 pt vertical; row spacing is 5 pt.
 - **Hierarchy per row:** task `title` on top (status glyphs stripped), identity (`name` else `kind`) indented beneath; missing title promotes identity. Host name is never rendered.
 - **Deep links:** each row is a `Link` to that Agent's detail (`heeler://agent/{hostID}/{paneID}`). Taps outside a row, and every Dynamic Island compact/minimal tap, open the Console (`heeler://agent/{hostID}`).
 - **Counts chips** enumerate non-zero counts in existing `chipItems` order (`blocked`, `working`, `done`). Zero counts omitted. Chips are `fixedSize()` so the title truncates first.
@@ -77,8 +77,8 @@ Apple HIG Lock Screen gallery (same page as #1) also showed system examples: Foo
 3. **Island is a different surface.** Dynamic Island is always black. It keeps Mocha inks even when the Lock Screen is Latte. Shared views take an explicit `AgentActivitySurface`; they must not read ambient `colorScheme` to pick status color.
 4. **Attention order is Blocked, then Done, then Working.** Same as Console and the envelope. Compact leading and any other single-count pick follow it. Blocked is the only shouted *visual* (wash + ink title).
 5. **Glance, then identity.** Status and counts are the first read. Task title is the second. Agent name/kind is the third. Host is never shown.
-6. **No extra chrome.** No app icon, no wordmark, no progress bar, no map, no buttons. The only actions are the existing deep links and the system End control.
-7. **Fit the 160 pt budget; do not fill it.** Fresh: four rows when they fit, three plus overflow otherwise. Stale: three rows maximum, with overflow and the stale caption sharing one caption2 line. Shorter inventories stay short.
+6. **One large interaction target.** No app icon, wordmark, progress bar, map, or row controls. Apple recommends a 44×44 pt default iOS target and prefers one interactive element in a Live Activity. The whole activity opens Console; rows are glanceable information.
+7. **Fit the 160 pt budget; do not fill it.** Fresh shows up to five rows using compact secondary rows. Stale shows up to four, with overflow and the stale caption sharing one caption2 line. Shorter inventories stay short.
 8. **Do not copy another product's artwork.** Distill structure (headline / secondary / metric / snug island) and throw away brand fills, mascots, and steppers.
 
 ## Rejected alternatives
@@ -150,14 +150,13 @@ These views render on both Lock Screen and expanded island today. Each gains a `
 
 | View | Lock Screen call site | Island call site |
 | --- | --- | --- |
-| `AgentActivityLinkedRow` | `AgentActivityLockScreenView` header + `ForEach` | Expanded `ForEach` of `secondaryAgents` |
-| `AgentActivityRowView` | via `LinkedRow` | via `LinkedRow` |
+| `AgentActivityRowView` | header + compact `ForEach` | Expanded `ForEach` of `secondaryAgents` |
 | `AgentActivityHeadlineView` | not used on Lock Screen | Expanded `.center` |
 | `AgentActivityCountChips` | Lock Screen header trailing | Expanded `.bottom` |
 
 Island-only views (`AgentActivityCompactLeading`, compact trailing, minimal) pass `.island` into `AgentActivityStatusStyle` directly. They never use `Color(status.inkUIColor)` unscoped.
 
-`AgentActivityLinked` (the `Link` wrapper) does not take `surface`; it only wraps content.
+Rows are presentation-only. The Lock Screen view and `DynamicIsland` each apply one Console `widgetURL` to their complete presentation.
 
 ## Semantic tokens
 
@@ -227,19 +226,19 @@ Always-On and Increase Contrast were not measured on device. System material and
 ┌──────────────────────────────────────────────┐  14 pt inset
 │ [primary row: dot + title                    │
 │              identity]          [chips →]    │  header: first agent + chips
-│ [row 2: dot + title / identity]              │  8 pt stack spacing
+│ [row 2: dot + title · identity]               │  5 pt stack spacing
 │ [row 3: …]                                   │
-│ [row 4  XOR  trailing caption2]              │  see row-cap rules
+│ [row 4 / row 5 / trailing caption2]           │  see row-cap rules
 └──────────────────────────────────────────────┘
-  padding: 14 horizontal, 12 vertical
+  padding: 14 horizontal, 10 vertical
   height: system-sized, never above 160 pt
 ```
 
 Keep `AgentActivityLockScreenView`'s stack. Changes are tokens, `surface: .lockScreen` on shared views, stale-aware row caps, a single trailing caption2, and previews.
 
-**Header.** First visible agent is the headline row, `AgentActivityLinkedRow(..., surface: .lockScreen)`. Chips stay trailing, `AgentActivityCountChips(..., surface: .lockScreen)`, `fixedSize()`, never wrap. When no agents are visible (counts-only), headline is `Text(presentation.headerTitle)` at `.subheadline.weight(.semibold)`, `Color.primary`, `lineLimit(1)`.
+**Header.** First visible agent is the full-density `AgentActivityRowView(..., surface: .lockScreen)`. Chips stay trailing, `AgentActivityCountChips(..., surface: .lockScreen)`, `fixedSize()`, never wrap. When no agents are visible (counts-only), headline is `Text(presentation.headerTitle)` at `.subheadline.weight(.semibold)`, `Color.primary`, `lineLimit(1)`.
 
-**Rows.** Uniform two-line rows in envelope order. Do not enlarge the first row's type relative to the rest. Blocked wash stays. Every `LinkedRow` / `RowView` gets `surface: .lockScreen`.
+**Rows.** The first row retains title over identity. Secondary rows place `title · identity` on one line in envelope order. Blocked wash stays. Rows are not independent controls; the complete activity is the sole Console link.
 
 **Row cap and overflow (stale-aware).** Replace the current `lockScreenAgents` / `lockScreenOverflowCount` (which key only on `counts.total`) with helpers that also take `isStale`. Suggested shape on `AgentActivityPresentation`:
 
@@ -253,25 +252,25 @@ Cap:
 | `isStale` | `counts.total` | Visible agent rows | Trailing caption2 |
 | --- | --- | --- | --- |
 | false | 0 | 0 (counts-only headline) | none, unless Debug decrypt copy |
-| false | 1…4 | `total` (all fit) | none |
-| false | ≥ 5 | 3 | `+N more` (`N = total − 3`) |
+| false | 1…5 | `total` (all fit) | none |
+| false | ≥ 6 | 5 | `+N more` (`N = total − 5`) |
 | true | 0 | 0 | `May be out of date` |
-| true | 1…3 | `total` | `May be out of date` |
-| true | ≥ 4 | 3 | `+N more · May be out of date` (`N = total − 3`) |
+| true | 1…4 | `total` | `May be out of date` |
+| true | ≥ 5 | 4 | `+N more · May be out of date` (`N = total − 4`) |
 
 Overflow count is always `max(0, counts.total − visibleRows)` and is zero in counts-only, same as today.
 
-The stale caption never becomes a fifth content slot. Overflow and stale share one `.caption2` / `text.secondary` line, with a middle dot (` · `) when both apply. Do not draw a separate stale line under four rows. Do not drop overflow to keep a fourth row when stale: when `isStale && total >= 4`, show three rows and fold overflow into that trailing line.
+Overflow and stale share one `.caption2` / `text.secondary` line, with a middle dot (` · `) when both apply. Do not draw a separate stale line. When `isStale && total >= 5`, show four rows and fold overflow into the trailing line.
 
 **Maximum-height cases (both must stay ≤ 160 pt):**
 
-1. Fresh, `total == 4`: four two-line rows, no caption2. This is today's designed ceiling.
-2. Fresh, `total >= 5`: three two-line rows + `+N more`.
-3. Stale, `total >= 4`: three two-line rows + `+N more · May be out of date`. One two-line row cheaper than case 1, caption2 same size as today's overflow. This is the tallest stale layout.
+1. Fresh, `total == 5`: one full row plus four compact rows, no caption2.
+2. Fresh, `total >= 6`: one full row plus four compact rows and `+N more`.
+3. Stale, `total >= 5`: one full row plus three compact rows and `+N more · May be out of date`.
 
 DEBUG decrypt reason stays Debug-only and is out of the production height budget.
 
-**Padding.** Keep 14 / 12. Do not "fix" it to the Apple Figma kit's 18 pt.
+**Padding.** Keep 14 / 10. Do not "fix" it to the Apple Figma kit's 18 pt.
 
 **Corner / materials.** Do not draw a custom rounded rectangle. The system provides the banner shape. Previews may fake a 22 pt continuous rounded rect so the canvas is readable; that shape is not production chrome.
 
@@ -281,7 +280,7 @@ DEBUG decrypt reason stays Debug-only and is out of the production height budget
 
 Island builders pass `surface: .island` into every shared row, headline, and chip. Compact and minimal call `AgentActivityStatusStyle` with `.island` directly.
 
-**Compact.** One fact split across the camera, both sides linking to the Console (already true; keep it).
+**Compact.** One fact split across the camera. The whole presentation uses the same Console `widgetURL`.
 
 | Side | Content | Type | Color |
 | --- | --- | --- | --- |
@@ -296,8 +295,9 @@ Keep content snug; no extra padding against the camera. Capsule horizontal paddi
 
 **Expanded.** Keep current regions:
 
-- Center: primary agent as `AgentActivityHeadlineView(agent:surface: .island)` (or `"Heeler"` when counts-only), linked to that Agent.
-- Bottom: secondary agents (`rowLimit - 1` = 2) via `LinkedRow(..., surface: .island)`, overflow line, then `AgentActivityCountChips(..., surface: .island)`.
+- Center: primary agent as `AgentActivityHeadlineView(agent:surface: .island)` (or `"Heeler"` when counts-only).
+- Bottom: secondary agents (`rowLimit - 1` = 2) via `AgentActivityRowView(..., surface: .island)`, overflow line, then `AgentActivityCountChips(..., surface: .island)`.
+- Interaction: one Console `widgetURL` on the complete `DynamicIsland`; no per-agent `Link` targets.
 
 Island type stays slightly larger than Lock Screen rows for the primary (`.subheadline` / `.footnote`) and `.caption` for secondaries. Status dots: 8 pt primary, 7 pt rows. All inks Mocha via `.island`.
 
@@ -335,10 +335,10 @@ Unchanged enumeration, retokened through `surface`:
 - `fixedSize()`, padding 6 / 2, capsule, ink on 0.15 wash (Lock Screen) or Mocha ink on 0.22 wash (compact capsule; expanded chips 0.16 Mocha is acceptable if 0.22 is too loud in the expanded bottom stack — pick 0.16 for expanded chips, 0.22 for compact leading only).
 - Combined accessibility label as today.
 
-### Links and system actions
+### Interaction and system actions
 
-- Keep `Link` per agent row and `widgetURL` on the banner / compact / minimal for Console.
-- Keep `.buttonStyle(.plain)` and `.tint(.primary)` in *previews only*, so canvas Links are not accent-tinted. Production Lock Screen is already chromeless.
+- Apply one Console `widgetURL` to the complete Lock Screen view and one to the complete `DynamicIsland`.
+- Do not add per-row `Link` controls. The activity itself is comfortably larger than Apple's recommended 44×44 pt iOS target, and one destination avoids adjacent-target mistakes.
 - Do not add `Button` / App Intent controls.
 - System End: default color (`nil`). Verify on device that the generated End label is readable on both appearances; that is an acceptance item, not a token to pre-empt.
 
@@ -381,7 +381,7 @@ Idle and unknown Agents are not in the activity. An empty eligible inventory end
 
 2. **Palette file in the widget target.** Add `Sources/Heeler/Console/AgentStatusPalette.swift` to `HeelerWidgets.sources` in `project.yml`. Run `xcodegen generate` and commit `Heeler.xcodeproj` with that change. Do not duplicate hexes.
 
-3. **Surface parameter.** Add `AgentActivitySurface` and route every status color through `AgentActivityStatusStyle.ink/wash(for:on:)`. Thread `surface` into `AgentActivityLinkedRow`, `AgentActivityRowView`, `AgentActivityHeadlineView`, and `AgentActivityCountChips`. Lock Screen call sites pass `.lockScreen`; every island call site passes `.island`.
+3. **Surface parameter.** Add `AgentActivitySurface` and route every status color through `AgentActivityStatusStyle.ink/wash(for:on:)`. Thread `surface` into `AgentActivityRowView`, `AgentActivityHeadlineView`, and `AgentActivityCountChips`. Lock Screen call sites pass `.lockScreen`; every island call site passes `.island`.
 
 4. **`isStale` is Lock Screen-only.** Pass `context.isStale` into `AgentActivityLockScreenView` only. Do not add it to `AgentActivityIsland.make`.
 
@@ -393,7 +393,7 @@ Idle and unknown Agents are not in the activity. An empty eligible inventory end
 
 8. **No new frameworks.** No extra SF Symbols catalog, no extra fonts, no ActivityKit API beyond modifiers already in the file plus `keylineTint` and Lock Screen `isStale`.
 
-9. **Contract and coordinator stay put.** Do not change envelope shape, `chipItems` order, deep links, or dismissal policy. Do not add a disconnected flag.
+9. **Contract and coordinator stay put.** Do not change envelope shape, `chipItems` order, URL parsing, or dismissal policy. Do not add a disconnected flag.
 
 Sketch (illustrative):
 
@@ -414,7 +414,7 @@ ActivityConfiguration(for: AgentActivityAttributes.self) { context in
 }
 ```
 
-Widget `Link` views remain; `AgentActivityLinked` / `AgentActivityConsoleLinked` stay as the MainActor `widgetURL` seam.
+Rows stay presentation-only. `AgentActivityLockScreenView` and the returned `DynamicIsland` each own one Console `widgetURL`.
 
 ### Focused verification (implementer)
 
@@ -431,16 +431,16 @@ Xcode canvas previews are the development check. They **do not** replace a physi
 
 | # | Case | Light | Dark | Where | Pass if |
 | --- | --- | --- | --- | --- | --- |
-| P1 | Mixed blocked / working / done + overflow (fresh, `total >= 5`) | Canvas | Canvas | Lock Screen preview | Light banner is light; chips and dots use Latte inks; blocked row wash is visible; `+N more` secondary; no stale caption |
+| P1 | Mixed blocked / working / done + overflow (fresh, `total >= 6`) | Canvas | Canvas | Lock Screen preview | Light banner is light; chips and dots use Latte inks; blocked row wash is visible; `+N more` secondary; no stale caption |
 | P2 | Single unnamed working | Canvas | Canvas | Lock Screen | Identity-only row, no wash, working dot visible |
-| P3 | Four rows, all fit (fresh, `total == 4`) | Canvas | Canvas | Lock Screen | No overflow line; four two-line rows; this is a maximum-height case |
+| P3 | Four rows, all fit (fresh, `total == 4`) | Canvas | Canvas | Lock Screen | No overflow line; one full row plus three compact rows |
 | P4 | Counts-only, not stale | Canvas | Canvas | Lock Screen | Headline "Heeler", chips only, no ghost rows, no stale caption |
 | P5 | Long title (80 graphemes) + three chips | Canvas | Canvas | Lock Screen | Title truncates; chips fully visible |
 | P5a | Long agent name (80 graphemes) with a title | Canvas | Canvas | Lock Screen | Title on line 1, name on line 2, name truncates, chips fully visible |
 | P5b | Long agent name (80 graphemes), title missing (identity promoted) | Canvas | Canvas | Lock Screen | Name is the only line, truncates, chips fully visible |
-| P6 | Stale, `total >= 4` (maximum-height stale) | Canvas | Canvas | Lock Screen | Three two-line rows; one caption2 `+N more · May be out of date`; not four rows plus a second caption |
+| P6 | Stale, `total >= 5` (maximum-height stale) | Canvas | Canvas | Lock Screen | One full row plus three compact rows; one caption2 `+N more · May be out of date` |
 | P6b | Stale, `total <= 3` | Canvas | Canvas | Lock Screen | All rows visible; caption2 is only `May be out of date` |
-| P7 | Blocked compact | Canvas (force Light environment too) | — | Compact | Leading blocked count capsule, trailing total, Mocha ink even if canvas is Light, both Console links |
+| P7 | Blocked compact | Canvas (force Light environment too) | — | Compact | Leading blocked count capsule, trailing total, Mocha ink even if canvas is Light, one Console destination |
 | P8 | Done + working, no blocked | Canvas | — | Compact | Leading **done** count, not working, not an ellipsis |
 | P9 | Working-only (`blocked == done == 0`) | Canvas | — | Compact | Leading working count, not an ellipsis |
 | P10 | Minimal blocked | Canvas Light environment | — | Minimal | Total in blocked Mocha ink, bold |
@@ -453,7 +453,7 @@ Xcode canvas previews are the development check. They **do not** replace a physi
 | D3 | Always-On reduced luminance | **Device-required** | **Device-required** | Lock Screen | Status dots still distinguishable |
 | D4 | Increase Contrast | **Device-required** | **Device-required** | Lock Screen | No lost text on washes |
 | D5 | StandBy (Lock Screen ×2) | **Device-required** | **Device-required** | StandBy | Default material blends; 14 pt inset does not clip |
-| D6 | Tap row / tap chrome | **Device-required** | | Lock Screen | Row → Agent detail; outside row → Console |
+| D6 | Tap anywhere in activity | **Device-required** | | Lock Screen | Entire activity → Console; no adjacent row targets |
 | D7 | Compact tap both sides | **Device-required** | | Dynamic Island | Both sides → Console |
 | D8 | Light Mode while island is showing | **Device-required** | | Dynamic Island | Island stays black with Mocha inks; Lock Screen (if shown) is Latte |
 
@@ -466,12 +466,12 @@ No remaining product or ownership choices. Implement the following as specified:
 1. Lock Screen background = system material (`activityBackgroundTint(nil)`). End button = system color (`activitySystemActionForegroundColor(nil)`).
 2. Hex owner is `AgentStatusPalette.swift`. Add that file to `HeelerWidgets.sources` in `project.yml`, regenerate and commit `Heeler.xcodeproj`. Do not duplicate hexes.
 3. Every shared row, headline, and chip takes `surface: AgentActivitySurface`. Lock Screen passes `.lockScreen`. Compact, minimal, and expanded pass `.island`, which resolves Mocha against a dark trait collection. Ambient Light Mode must not tint the island.
-4. Keep the aggregate list, pin-aware envelope order, two-line title/identity, no Host name, existing deep links, no buttons, no logo, no progress bar. Chip enumeration stays `blocked`, `working`, `done`.
+4. Keep the aggregate list, pin-aware envelope order, full first row, compact secondary rows, and no Host name, buttons, logo, or progress bar. Use one Console link for each presentation. Chip enumeration stays `blocked`, `working`, `done`.
 5. Compact leading = first non-zero count in attention order: blocked, then done, then working. Never the working ellipsis. Never Working before Done.
-6. Fresh Lock Screen: four rows when `total <= 4`, else three plus `+N more`. Stale Lock Screen: never four rows; trailing caption2 is `May be out of date`, or `+N more · May be out of date` when `total >= 4`. Pass `isStale` only into the Lock Screen view.
+6. Fresh Lock Screen: show up to five rows. Stale Lock Screen: show up to four; trailing caption2 is `May be out of date`, or `+N more · May be out of date` when `total >= 5`. Pass `isStale` only into the Lock Screen view.
 7. Disconnected has no widget presentation. Counts-only is decrypt/envelope failure, not disconnection. Stale is only `context.isStale` after content that included a stale date.
 8. Chip wash opacity 0.15 on Lock Screen; blocked-row wash 0.15; island compact capsule 0.22; expanded island chips 0.16.
-9. 14 pt horizontal, 12 pt vertical, 8 pt Lock Screen stack spacing, 7/8 pt dots.
+9. 14 pt horizontal, 10 pt vertical, 5 pt Lock Screen stack spacing, 7/8 pt dots.
 10. Canvas previews: Light and Dark Lock Screen, including P5/P5a/P5b long title and long name (with and without title), P6 stale maximum height, and island previews in a Light environment (Mocha).
 11. Physical Lock Screen Light/Dark remains a required acceptance check before treating #247 as done.
 

--- a/docs/design/issue-247-live-activity-redesign.md
+++ b/docs/design/issue-247-live-activity-redesign.md
@@ -72,7 +72,7 @@ Apple HIG Lock Screen gallery (same page as #1) also showed system examples: Foo
 
 ## Design principles
 
-1. **System surface, Heeler language.** Lock Screen chrome follows the device's iOS Light/Dark appearance. Heeler identity lives in status hue (the same Catppuccin roles as the Console and herdr), not in a branded plate. On iOS 26 and 27, ActivityKit can incorrectly report `.dark` in system Light Mode; the widget resolves the concrete `UIScreen` trait instead of trusting that environment value.
+1. **System surface, Heeler language.** Lock Screen chrome follows the device's iOS Light/Dark appearance. Heeler identity lives in status hue (the same Catppuccin roles as the Console and herdr), not in a branded plate. On iOS 26 and 27, ActivityKit can incorrectly report `.dark` through SwiftUI in system Light Mode; the widget therefore uses unresolved UIKit semantic colors rather than that environment value. Keeping those colors dynamic also lets an existing activity change when the system appearance changes.
 2. **One appearance model, two palettes, one hex owner.** The layout does not change between Light and Dark. Only tokens flip, from `AgentStatusPalette`. The widget never duplicates those hexes.
 3. **Island is a different surface.** Dynamic Island is always black. It keeps Mocha inks even when the Lock Screen is Latte. Shared views take an explicit `AgentActivitySurface`; they must not read ambient `colorScheme` to pick status color.
 4. **Attention order is Blocked, then Done, then Working.** Same as Console and the envelope. Compact leading and any other single-count pick follow it. Blocked is the only shouted *visual* (wash + ink title).
@@ -166,8 +166,8 @@ Prefer system / dynamic colors wherever they satisfy the intent. Custom colors a
 
 | Token | Light | Dark | Implementation |
 | --- | --- | --- | --- |
-| `surface.lockScreen` | Resolved `UIColor.systemBackground` | Resolved `UIColor.systemBackground` | Resolve against `UIScreen.main.traitCollection.userInterfaceStyle`, then pass the concrete color to `.activityBackgroundTint` |
-| `action.systemEnd` | Resolved `UIColor.label` | Resolved `UIColor.label` | Resolve against the same device trait, then pass the concrete color to `.activitySystemActionForegroundColor` |
+| `surface.lockScreen` | Dynamic `UIColor.systemBackground` | Dynamic `UIColor.systemBackground` | Keep unresolved and pass through `Color(uiColor:)` to `.activityBackgroundTint` |
+| `action.systemEnd` | Dynamic `UIColor.label` | Dynamic `UIColor.label` | Keep unresolved and pass through `Color(uiColor:)` to `.activitySystemActionForegroundColor` |
 | `surface.island` | Opaque black (system) | Opaque black (system) | Do not tint. Cannot be customized. |
 | `text.primary` | `Color.primary` | `Color.primary` | System. On the island this is light-on-black. |
 | `text.secondary` | `Color.secondary` | `Color.secondary` | Overflow, identity, stale caption. |
@@ -377,7 +377,7 @@ Idle and unknown Agents are not in the activity. An empty eligible inventory end
 
 ## SwiftUI implementation guidance
 
-1. **Chrome.** In `AgentLiveActivityWidget.body`, resolve Lock Screen appearance from `UIScreen.main.traitCollection.userInterfaceStyle`, falling back to ActivityKit's `colorScheme` only when the screen trait is unspecified. Resolve `UIColor.systemBackground` and `UIColor.label` against that concrete appearance, pass them to the two ActivityKit modifiers, and inject the same `ColorScheme` into the Lock Screen content. Do not consult Heeler's Appearance setting. Dynamic Island remains system-black and does not use this resolver.
+1. **Chrome.** In `AgentLiveActivityWidget.body`, pass unresolved `UIColor.systemBackground` and `UIColor.label` through `Color(uiColor:)` to the two ActivityKit modifiers. Use unresolved `UIColor.label` and `UIColor.secondaryLabel` for Lock Screen text, and keep the Catppuccin status colors dynamic. Do not inject a fixed `colorScheme`, resolve colors early, or consult Heeler's Appearance setting. Dynamic Island remains system-black and keeps its explicit Mocha treatment.
 
 2. **Palette file in the widget target.** Add `Sources/Heeler/Console/AgentStatusPalette.swift` to `HeelerWidgets.sources` in `project.yml`. Run `xcodegen generate` and commit `Heeler.xcodeproj` with that change. Do not duplicate hexes.
 
@@ -461,7 +461,7 @@ Not exercised in this research pass: physical device, Always-On, StandBy, Increa
 
 No remaining product or ownership choices. Implement the following as specified:
 
-1. Lock Screen background and End button use concrete system colors resolved from `UIScreen.main.traitCollection.userInterfaceStyle`. The ActivityKit environment is only a fallback for an unspecified screen trait. Heeler's Appearance setting is not consulted.
+1. Lock Screen background, End button, semantic text, and status colors remain unresolved dynamic UIKit colors so an existing activity follows iOS Light/Dark changes. ActivityKit's SwiftUI `colorScheme` and Heeler's Appearance setting are not consulted.
 2. Hex owner is `AgentStatusPalette.swift`. Add that file to `HeelerWidgets.sources` in `project.yml`, regenerate and commit `Heeler.xcodeproj`. Do not duplicate hexes.
 3. Every shared row, headline, and chip takes `surface: AgentActivitySurface`. Lock Screen passes `.lockScreen`. Compact, minimal, and expanded pass `.island`, which resolves Mocha against a dark trait collection. Ambient Light Mode must not tint the island.
 4. Keep the aggregate list, pin-aware envelope order, full first row, compact secondary rows, and no Host name, buttons, logo, or progress bar. Use per-Agent links on Lock Screen and expanded presentations, plus one Console fallback link for each presentation. Chip enumeration stays `blocked`, `working`, `done`.

--- a/project.yml
+++ b/project.yml
@@ -154,6 +154,8 @@ targets:
       # HeelerNotificationCore needs it.
       - Sources/Heeler/Transport/Generated/HerdrAPITypes.swift
       - Sources/Heeler/Transport/JSONValue.swift
+      # Shared with the app Console; single hex owner for status colors (#247).
+      - Sources/Heeler/Console/AgentStatusPalette.swift
     entitlements:
       path: Sources/HeelerWidgets/HeelerWidgets.entitlements
       properties:


### PR DESCRIPTION
## Summary

- redesign the Lock Screen Live Activity and Dynamic Island around the shared Agent status palette
- show up to four Agents with compact overflow/status summaries and Apple-sized interaction targets
- deep-link visible Agent rows while keeping the surrounding activity linked to the Console
- keep Lock Screen colors as unresolved system semantic colors; Dynamic Island remains system-dark
- reuse the same Blocked, Working, and Done pills in collapsed By Host headers

## Platform limitation

The implementation no longer hard-codes a dark Lock Screen appearance or follows Heeler’s app Appearance setting. However, iOS 27 ActivityKit currently reports or renders a dark appearance in Light Mode and does not refresh an existing Live Activity after a system appearance change. Issue #247 remains open pending an Apple fix and a follow-up device regression test.

Related Apple reports:

- https://developer.apple.com/forums/thread/799684 (`FB20187110`)
- https://developer.apple.com/forums/thread/798130

## Verification

- `xcodebuild test -project Heeler.xcodeproj -scheme Heeler -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:HeelerTests/AgentActivityPresentationTests`\n  - 18 tests passed in 1 suite\n- Debug build and installation succeeded on a physical iPhone 17 Pro Max running iOS 27.0\n- physical-device review covered row density, interaction targets, overflow behavior, status pills, and Light/Dark rendering attempts\n- system appearance refresh remains not passed because of the documented iOS 27 ActivityKit regression\n\nDepends on #249.\n\nRefs #247