### PR TITLE
fix(console): fall back to task title in switcher chips when workspace is ~

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fall back to task title or repo name in keyboard switcher chips when the
+  workspace label is a generic root/home path like `~`.
+
 ## [0.1.3] - 2026-08-28
 
 ### Changed

--- a/Sources/Heeler/Console/ConsoleAgent.swift
+++ b/Sources/Heeler/Console/ConsoleAgent.swift
@@ -63,9 +63,16 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
     /// The keyboard switcher's chip label. The project leads, as it does on
     /// the card, but without the card's `label · repo` pairing: a chip has
     /// room for one word, and a console full of `claude` is told apart by
-    /// where each one is working.
+    /// where each one is working. Generic home/root workspace labels like `~`
+    /// fall back to task title or repo name so chips remain distinctive.
     var switcherLabel: String {
-        workspaceLabel ?? repoName ?? agent.displayName
+        if let workspaceLabel, !workspaceLabel.isEmpty, workspaceLabel != "~" {
+            return workspaceLabel
+        }
+        if !agent.title.isEmpty {
+            return agent.title
+        }
+        return repoName ?? agent.displayName
     }
 
     /// The directory the skills probe treats as the agent's project root:

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -14,6 +14,7 @@ struct TerminalAgentSwitcherTests {
         workspace: String? = nil,
         repo: String? = nil,
         name: String? = nil,
+        title: String = "",
         status: AgentStatus = .idle,
         host: UUID = UUID()
     ) -> ConsoleAgent {
@@ -21,7 +22,7 @@ struct TerminalAgentSwitcherTests {
             hostID: host,
             hostName: "devbox",
             agent: Agent(
-                terminalID: "term_\(pane)", kind: "claude", title: "",
+                terminalID: "term_\(pane)", kind: "claude", title: title,
                 status: status, workspaceID: "w", tabID: "w:t", paneID: pane,
                 cwd: "/work", revision: 1, name: name),
             workspaceLabel: workspace,
@@ -46,12 +47,14 @@ struct TerminalAgentSwitcherTests {
 
     /// The project is what tells a console full of `claude` apart, so it
     /// leads; the agent's own name is the fallback when nothing named the
-    /// workspace.
+    /// workspace. Generic home labels like `~` fall back to the task title or repo.
     @Test func chipLabelsPreferTheProject() {
         #expect(Self.makeAgent(pane: "p1", workspace: "proj", repo: "repo").switcherLabel == "proj")
         #expect(Self.makeAgent(pane: "p2", repo: "repo").switcherLabel == "repo")
         #expect(Self.makeAgent(pane: "p3", name: "reviewer").switcherLabel == "reviewer")
         #expect(Self.makeAgent(pane: "p4").switcherLabel == "claude")
+        #expect(Self.makeAgent(pane: "p5", workspace: "~", title: "sync-tasks").switcherLabel == "sync-tasks")
+        #expect(Self.makeAgent(pane: "p6", workspace: "~", repo: "repo").switcherLabel == "repo")
     }
 
     private static func firstStrip(in view: UIView) -> TerminalAgentSwitcherBar? {


### PR DESCRIPTION
### Problem
When agents run in default home/root workspaces (`workspaceLabel == "~"`), every chip in the keyboard agent switcher strip displays `~` instead of the distinct task title or repository name, making it impossible to tell multi-agent panes apart at a glance.

### Solution
- Updated `ConsoleAgent.switcherLabel` to ignore generic root/home workspace labels (`~`) and fall back to the Agent's `title` (or `repoName` / `displayName`).
- Added unit tests in `TerminalAgentSwitcherTests` covering `~` fallback behavior for task titles and repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)