### PR TITLE
feat: add Direct Input for Agent Attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Added
+
+- Agent detail can hide the Composer and type into the live Attach PTY with the
+  iOS keyboard plus Esc, Tab, Shift-Tab, and Enter shortcuts (Direct Input).
+  Composer stays the default; the draft is preserved across the mode switch.
+  (#251)
+
 ## [0.1.3] - 2026-08-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ Entries reference the issue that motivated them.
 
 - Agent detail can hide the Composer and type into the live Attach PTY with the
   iOS keyboard plus Esc, Tab, Shift-Tab, and Enter shortcuts (Direct Input).
-  The shortcut row sits above the Agent switcher strip; keyboard show/hide
-  stays on that strip. Composer stays the default; the draft is preserved
-  across the mode switch. (#251)
+  The shortcut row stays visible above the Agent switcher strip whenever
+  Direct Input is active; keyboard show/hide stays on that strip. Composer
+  stays the default; the draft is preserved across the mode switch. (#251)
 
 ## [0.1.3] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Entries reference the issue that motivated them.
 ### Added
 
 - Agent detail can hide the Composer and type into the live Attach PTY with the
-  iOS keyboard plus Esc, Tab, Shift-Tab, Enter, and arrow-key shortcuts
-  (Direct Input).
+  iOS keyboard plus Esc, Tab, Shift-Tab, Shift-Enter, Backspace, Enter, and
+  arrow-key shortcuts (Direct Input).
   The shortcut row stays visible above the Agent switcher strip whenever
   Direct Input is active; keyboard show/hide stays on that strip. Composer
   stays the default; hiding it hands the visible iOS keyboard directly to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Changed
+
+- Terminal Text Size defaults to 9 pt (was 14 pt). Existing saved sizes are
+  unchanged.
+
 ### Added
 
 - Agent detail can hide the Composer and type into the live Attach PTY with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ Entries reference the issue that motivated them.
 
 - Agent detail can hide the Composer and type into the live Attach PTY with the
   iOS keyboard plus Esc, Tab, Shift-Tab, and Enter shortcuts (Direct Input).
-  Composer stays the default; the draft is preserved across the mode switch.
-  (#251)
+  The shortcut row sits above the Agent switcher strip; keyboard show/hide
+  stays on that strip. Composer stays the default; the draft is preserved
+  across the mode switch. (#251)
 
 ## [0.1.3] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Entries reference the issue that motivated them.
 ### Added
 
 - Agent detail can hide the Composer and type into the live Attach PTY with the
-  iOS keyboard plus Esc, Tab, Shift-Tab, and Enter shortcuts (Direct Input).
+  iOS keyboard plus Esc, Tab, Shift-Tab, Enter, and arrow-key shortcuts
+  (Direct Input).
   The shortcut row stays visible above the Agent switcher strip whenever
   Direct Input is active; keyboard show/hide stays on that strip. Composer
   stays the default; hiding it hands the visible iOS keyboard directly to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,17 @@ Entries reference the issue that motivated them.
 
 ### Changed
 
-- Terminal Text Size defaults to 9 pt (was 14 pt). Existing saved sizes are
-  unchanged.
+- When no size has been saved, Terminal Text Size now defaults to 9 pt instead
+  of 14 pt. Existing saved sizes do not change. (PR #253)
 
 ### Added
 
-- Agent detail can hide the Composer and type into the live Attach PTY with the
-  iOS keyboard plus Esc, Tab, Shift-Tab, Shift-Enter, Backspace, Enter, and
-  arrow-key shortcuts (Direct Input).
-  The shortcut row stays visible above the Agent switcher strip whenever
-  Direct Input is active; keyboard show/hide stays on that strip. Composer
-  stays the default; hiding it hands the visible iOS keyboard directly to the
-  terminal without a dismiss/re-present jump, and preserves the draft. (#251)
+- Agent detail now offers Direct Input, which hides the Composer and routes iOS
+  keyboard input directly to the live Attach PTY. A persistent row above the
+  Agent switcher provides Esc, Tab, Shift-Tab, arrow keys, Backspace,
+  Shift-Enter, and Enter; keyboard show/hide controls remain in the switcher.
+  Composer remains the default. Switching modes preserves the draft and keeps
+  a visible iOS keyboard in place. (#251; PR #253)
 
 ## [0.1.3] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ Entries reference the issue that motivated them.
   iOS keyboard plus Esc, Tab, Shift-Tab, and Enter shortcuts (Direct Input).
   The shortcut row stays visible above the Agent switcher strip whenever
   Direct Input is active; keyboard show/hide stays on that strip. Composer
-  stays the default; the draft is preserved across the mode switch. (#251)
+  stays the default; hiding it hands the visible iOS keyboard directly to the
+  terminal without a dismiss/re-present jump, and preserves the draft. (#251)
 
 ## [0.1.3] - 2026-08-28
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -106,18 +106,23 @@ Blocked: Send then inserts the draft into Attach without Enter, and the tools
 keyboard submits or cancels. Delivered means the Host accepted the text into
 the pane — whether the Agent queues or acts on it is the Agent's business,
 and the Composer never claims otherwise.
+Composer remains the default authored-input path on Agent detail. Direct Input
+is an explicit, opt-in alternative that hides the Composer card without
+clearing or submitting the draft.
 _Avoid_: reply bar, compose bar (the shelved predecessors), input box, message box
 
 **Attach**:
-The realtime PTY stream behind Agent detail, Agent-specific and display-only.
-libghostty renders the complete TUI, owns local scrollback, and reports its
-grid size so the remote PTY resizes with the view. Authored input belongs to
-Composer.
+The realtime PTY stream behind Agent detail, Agent-specific. In Composer mode
+it is display-only: libghostty renders the complete TUI, owns local scrollback,
+and reports its grid size so the remote PTY resizes with the view, while
+authored input belongs to Composer. Direct Input is the scoped exception that
+lets the system keyboard type that same Attach PTY.
 Delivery is one `agent.prompt` request, except when Agent Status is Blocked, in
-which case Send inserts the draft into Attach without Enter and the tools
-keyboard submits or cancels. Only Composer's explicit tools-keyboard controls
-send terminal control sequences. The directly interactive surface on an
-ordinary shell is the Shell Terminal, never unqualified "Attach".
+which case Composer Send inserts the draft into Attach without Enter and the
+tools keyboard submits or cancels. Only Composer's explicit tools-keyboard
+controls (and Direct Input's shortcut row / system Return) send terminal
+control sequences. The directly interactive surface on an ordinary shell is
+the Shell Terminal, never unqualified "Attach".
 _Avoid_: takeover (that's herdr's flag, not our surface), connect
 
 **Attach Link**:
@@ -138,13 +143,24 @@ leaves the remote tab alive for desktop handoff.
 _Avoid_: Attach (that's the Agent-specific display surface), shell console,
 terminal pane view
 
+**Direct Input**:
+The opt-in Agent-detail mode that hides the Composer card and routes the
+system keyboard plus a compact app-owned shortcut row (Esc, Tab, Shift-Tab,
+Enter) into the live Attach PTY. The draft stays in `AgentComposerStore`
+untouched. Mode preference is app-wide, default off. Distinct from Shell
+Terminal (ordinary shell, no Agent semantics) and from Terminal Keyboard (the
+iOS/tools swap under Composer).
+_Avoid_: Keys mode, terminal mode, raw input, Attach mode
+
 **Terminal Keyboard**:
 The two keyboard modes below Composer, swapped in place at one shared measured
 height. The standard iOS keyboard edits the draft with composition,
 autocorrection, dictation, and language switching. The tools keyboard replaces
 it with a tabbed pad: Agent controls send key sequences directly to the pane,
 while Skills, Snippets, and terminal appearance edit the draft or the terminal
-and never touch the pane.
+and never touch the pane. Direct Input reuses the same measured footprint for
+an optional tools dock, but its primary shortcuts ride an app-content row
+above the system keyboard rather than replacing it.
 _Avoid_: desktop keyboard, reply keyboard, Keys mode (the direct-input predecessor)
 
 **Snippet**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -160,7 +160,7 @@ it with a tabbed pad: Agent controls send key sequences directly to the pane,
 while Skills, Snippets, and terminal appearance edit the draft or the terminal
 and never touch the pane. Direct Input reuses the same measured footprint for
 an optional tools dock, but its primary shortcuts ride an app-content row
-above the system keyboard rather than replacing it.
+above the Agent switcher strip rather than replacing the system keyboard.
 _Avoid_: desktop keyboard, reply keyboard, Keys mode (the direct-input predecessor)
 
 **Snippet**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -159,8 +159,8 @@ autocorrection, dictation, and language switching. The tools keyboard replaces
 it with a tabbed pad: Agent controls send key sequences directly to the pane,
 while Skills, Snippets, and terminal appearance edit the draft or the terminal
 and never touch the pane. Direct Input reuses the same measured footprint for
-an optional tools dock, but its primary shortcuts ride an app-content row
-above the Agent switcher strip rather than replacing the system keyboard.
+an optional tools dock, but its primary shortcuts persist in an app-content
+row above the Agent switcher strip rather than replacing the system keyboard.
 _Avoid_: desktop keyboard, reply keyboard, Keys mode (the direct-input predecessor)
 
 **Snippet**:

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		14500112C25383EFD80A7A32 /* AgentNotificationRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D5CBA3E14F186170A2EF2CA /* AgentNotificationRendererTests.swift */; };
 		14F3A10674FAF72C63042108 /* PairingConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EEAD52089A35D4B2D47AF25 /* PairingConnector.swift */; };
 		1566E45603CB8F83337BD9C3 /* TerminalAppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4273AC6F39EB1E015820E614 /* TerminalAppearanceSettingsView.swift */; };
+		15F48A8DDF0D76F41D8562A6 /* AgentInputModeSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D588CA22544907E638437FEA /* AgentInputModeSettingsTests.swift */; };
 		1706E607DD6100E20479457C /* GhosttyTerminal in Frameworks */ = {isa = PBXBuildFile; productRef = 19D717C20DA226346335AFF6 /* GhosttyTerminal */; };
 		172661D829E18F72C75B4F13 /* NotificationKeyMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91F0473741A92D7EFA40CBA /* NotificationKeyMirror.swift */; };
 		179292D9C3E605BC46282FE0 /* ComposerAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4616CECA2722086A6B8B490 /* ComposerAttachmentTests.swift */; };
@@ -70,6 +71,7 @@
 		3684BDED2C234F399A6758C9 /* GhosttyTheme in Frameworks */ = {isa = PBXBuildFile; productRef = E086C559FC229264CF662993 /* GhosttyTheme */; };
 		36FB81E449F98DC68A366C2E /* HerdrAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F7065C3BE109D2F52AE3BC2 /* HerdrAPITypes.swift */; };
 		388498BDF8F2848EA515819B /* HostOnboardingPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D6865847B4D827038D1AF0 /* HostOnboardingPresentationTests.swift */; };
+		390E9313FFE9AA540C6B6113 /* AgentInputModeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F641C391CC59D30055B5F85F /* AgentInputModeSettings.swift */; };
 		3ABBA2BF9C6B51EF1E0C7314 /* TerminalKeysKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC019B4A164A7B01F1D46344 /* TerminalKeysKeyboard.swift */; };
 		3BB63A16095664E8C760286C /* AgentComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52407E936051CF1EF746647 /* AgentComposerView.swift */; };
 		3C5AFE8D3844A13198DDBEEA /* AttachLinkIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5870640477FDEB252DEE80B7 /* AttachLinkIndex.swift */; };
@@ -156,6 +158,7 @@
 		76D19F97EA2662895D730A98 /* ConsoleStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14FB8560976CE777FB5A105 /* ConsoleStore.swift */; };
 		76EAFFA9DAD45987F02DC536 /* AsyncDeadline.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25E1DC34365B2E2FA6C5AA8 /* AsyncDeadline.swift */; };
 		77B45AA7E6B648D1C2531951 /* NotificationRegistrationCeremony.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03953ADE9FBC5162FBFF29F /* NotificationRegistrationCeremony.swift */; };
+		785A44749D305DC59153D679 /* AgentDirectInputChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F93F9925E94FF2C2B0254B /* AgentDirectInputChrome.swift */; };
 		78AB0CC85260D35A1178163A /* AgentComposerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276B4E744F8A3BF386189D8A /* AgentComposerStore.swift */; };
 		7A73A34256C7B55060AAE9DE /* ConsoleDetailPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F44B0C95580FC88ED880FD /* ConsoleDetailPresentationTests.swift */; };
 		7AAD57A0A0BF63FE16C76C17 /* TerminalStatusDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856C56B29DCF048C09AF7C1C /* TerminalStatusDialogTests.swift */; };
@@ -194,6 +197,7 @@
 		8F91EAC7F32AA058E7F23394 /* TerminalKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 247FF74AD248F26A072EA263 /* TerminalKeyboard.swift */; };
 		8F9D8B11EB35747E767118CB /* TerminalTitleGlyphs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651D511E8A282C4CB0214098 /* TerminalTitleGlyphs.swift */; };
 		91BF879F537B1B0DD0B5E78B /* HostConsoleProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E1434C9C39A6419A3A0D79 /* HostConsoleProjection.swift */; };
+		9271ADB70DD9860389821A92 /* AgentDetailStatusChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AA33CB009DE705AC691967 /* AgentDetailStatusChrome.swift */; };
 		950179DD8580B71A6BBAF0C2 /* HerdrAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F7065C3BE109D2F52AE3BC2 /* HerdrAPITypes.swift */; };
 		9583D6804B8922588AD7F154 /* HostDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D664871CA1A56418C106BC /* HostDraftTests.swift */; };
 		959E4E2F852C4CCF7A9770AA /* TerminalAttach.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB48C946E14722E93FAAA410 /* TerminalAttach.swift */; };
@@ -270,6 +274,7 @@
 		D7DD62B232DBA9CE8C89AFDD /* NotificationKeyMirrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D55C5296892657D59171DFE /* NotificationKeyMirrorTests.swift */; };
 		D868123FC703E505D48AFD85 /* HostOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC1C5701C464ADBBAE0525D /* HostOnboardingView.swift */; };
 		D8742E32B3BA3A76771BC2B7 /* JSONValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A3266F97C243598703DB0A /* JSONValue.swift */; };
+		D8B0D81D7F37A151754527F6 /* AgentDirectInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CBB19433AC9C494DFDC36FE /* AgentDirectInputTests.swift */; };
 		D8CEC323008C54CD8042970F /* FilePreparer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321E267EE49BFE4A60F3B7CB /* FilePreparer.swift */; };
 		D8E9ECA03166EA6AA2BAE712 /* SSHCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA0D80E59E5C49E5F164DB4 /* SSHCredentials.swift */; };
 		D8FA3A3189491AC2A765C6BC /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC80D00F652CB84103C246F /* SettingsView.swift */; };
@@ -314,6 +319,7 @@
 		F8D65F54BA2C27606B01EE73 /* RenameSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82C6169E59B0000AA3FF5CC /* RenameSheetView.swift */; };
 		F96B2A54E2C6FF38CF5407BA /* DemoScreenshotModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFE51A74497E9691DBD8D7D /* DemoScreenshotModeTests.swift */; };
 		FA19EF5420E1D4FFFEF78155 /* TerminalStatusDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DAC3DCDEF81B14A2019DDBE /* TerminalStatusDialog.swift */; };
+		FA4096D59D2F576F860238B6 /* AgentDirectInputPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF7CDC80C0B17DEDB5F55A8 /* AgentDirectInputPresentation.swift */; };
 		FB3A2B881CE2C93601F1A90F /* SkillFrontmatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB3A0C20671F436B322D0F3 /* SkillFrontmatter.swift */; };
 		FBC2F27922BF5A627A27C339 /* EventsSessionLatencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F565A5BE8CC4ABA3FA10D57 /* EventsSessionLatencyTests.swift */; };
 		FC3565466275E3A63ED59687 /* PairingCeremony.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CA687285B470E3968D1DB6 /* PairingCeremony.swift */; };
@@ -383,6 +389,7 @@
 		0AEC3D31861DABF40C05EE8D /* HostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStore.swift; sourceTree = "<group>"; };
 		0B248F9372687FDBE3AD24A1 /* AppForegroundRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppForegroundRecoveryTests.swift; sourceTree = "<group>"; };
 		0C833B5BA50276247A54258B /* FilePreparerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreparerTests.swift; sourceTree = "<group>"; };
+		0CBB19433AC9C494DFDC36FE /* AgentDirectInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDirectInputTests.swift; sourceTree = "<group>"; };
 		0DAC3DCDEF81B14A2019DDBE /* TerminalStatusDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalStatusDialog.swift; sourceTree = "<group>"; };
 		0DBBD602AA4969937A9306C3 /* HostCredentialsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostCredentialsProvider.swift; sourceTree = "<group>"; };
 		0E38A3F2A443D311C8FCC218 /* NotificationConfigFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationConfigFile.swift; sourceTree = "<group>"; };
@@ -591,6 +598,7 @@
 		BEFE51A74497E9691DBD8D7D /* DemoScreenshotModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoScreenshotModeTests.swift; sourceTree = "<group>"; };
 		BFB68C31A4C8A5EE1BAE32EC /* SkillContentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillContentSheet.swift; sourceTree = "<group>"; };
 		C17F006C341136811D0496E6 /* SnippetStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetStore.swift; sourceTree = "<group>"; };
+		C1AA33CB009DE705AC691967 /* AgentDetailStatusChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetailStatusChrome.swift; sourceTree = "<group>"; };
 		C25E1DC34365B2E2FA6C5AA8 /* AsyncDeadline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDeadline.swift; sourceTree = "<group>"; };
 		C2EF92E96C6A4905CD809C5C /* SkillsKeyboardPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsKeyboardPane.swift; sourceTree = "<group>"; };
 		C34D3B8FB6A7196FC48562D4 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -620,6 +628,7 @@
 		D419158B027AF5F38B73AD8B /* PairingCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCodeTests.swift; sourceTree = "<group>"; };
 		D43AE8B2A62473EBA9EA090E /* SSHTransportSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTransportSettings.swift; sourceTree = "<group>"; };
 		D4CA687285B470E3968D1DB6 /* PairingCeremony.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCeremony.swift; sourceTree = "<group>"; };
+		D588CA22544907E638437FEA /* AgentInputModeSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInputModeSettingsTests.swift; sourceTree = "<group>"; };
 		D5C058D102046A707547A0FD /* GeneratedWireTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedWireTypesTests.swift; sourceTree = "<group>"; };
 		D6EA52B6C673891A3ABBA27E /* AgentNotificationBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationBannerView.swift; sourceTree = "<group>"; };
 		D6F4E5BC2440CFE0FEB3591B /* HeelerSSHHostKeyVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHHostKeyVerifier.swift; sourceTree = "<group>"; };
@@ -637,8 +646,10 @@
 		E0B72AE2059C59D8A59C9B2A /* AppActivityCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActivityCoordinator.swift; sourceTree = "<group>"; };
 		E4F4EF125BAB77F0DE121AAB /* DeviceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceKey.swift; sourceTree = "<group>"; };
 		E70C49925D454207F859F897 /* HeelerSSHHostKeyPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHHostKeyPolicyTests.swift; sourceTree = "<group>"; };
+		E7F93F9925E94FF2C2B0254B /* AgentDirectInputChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDirectInputChrome.swift; sourceTree = "<group>"; };
 		E9B93EC423746B334EF06419 /* AgentSurfaceReplacementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSurfaceReplacementTests.swift; sourceTree = "<group>"; };
 		E9FD6FF5FE83C022600169BE /* AgentSkill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSkill.swift; sourceTree = "<group>"; };
+		EAF7CDC80C0B17DEDB5F55A8 /* AgentDirectInputPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDirectInputPresentation.swift; sourceTree = "<group>"; };
 		EB05396E5E55060B5A23621C /* NotificationKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationKeyStoreTests.swift; sourceTree = "<group>"; };
 		EB430B706185A38891A5DAC2 /* SnippetsManagementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsManagementView.swift; sourceTree = "<group>"; };
 		ED83CC7F1D133006430FD357 /* JetBrainsMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Regular.ttf"; sourceTree = "<group>"; };
@@ -652,6 +663,7 @@
 		F4926339DC2CC7D0D6B58069 /* Notices */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Notices; path = Sources/Heeler/Resources/Notices; sourceTree = SOURCE_ROOT; };
 		F61A04DBA56C56925B594FF1 /* NotificationEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationEnvelope.swift; sourceTree = "<group>"; };
 		F63F7D63E32AA0C85E9F8FBC /* PushRegistrationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushRegistrationStore.swift; sourceTree = "<group>"; };
+		F641C391CC59D30055B5F85F /* AgentInputModeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInputModeSettings.swift; sourceTree = "<group>"; };
 		F6F3B82DFAD293C0EE344804 /* AgentNotificationRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationRouting.swift; sourceTree = "<group>"; };
 		F75E8F9733C77314E6D222AC /* HeelerSSHNativeRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHNativeRuntimeTests.swift; sourceTree = "<group>"; };
 		F7E3DCBFDF3ED4A63CBC1B3C /* AgentActivityEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentActivityEnvelopeTests.swift; sourceTree = "<group>"; };
@@ -711,6 +723,8 @@
 				3A62B60BB8431BE061FAA21B /* AgentActivityLinkTests.swift */,
 				B39CBCF8D249D054DC71463E /* AgentActivityPresentationTests.swift */,
 				362EF66CE6DA07688C3E5F63 /* AgentComposerStoreTests.swift */,
+				0CBB19433AC9C494DFDC36FE /* AgentDirectInputTests.swift */,
+				D588CA22544907E638437FEA /* AgentInputModeSettingsTests.swift */,
 				64D3B8E2EB97A8376B333914 /* AgentNameTests.swift */,
 				0A319930B80D42FB33DC8E42 /* AgentNotificationBannerStoreTests.swift */,
 				9D5CBA3E14F186170A2EF2CA /* AgentNotificationRendererTests.swift */,
@@ -951,7 +965,10 @@
 				6803A0055A861DFCA2A67217 /* AgentCardView.swift */,
 				276B4E744F8A3BF386189D8A /* AgentComposerStore.swift */,
 				B52407E936051CF1EF746647 /* AgentComposerView.swift */,
+				C1AA33CB009DE705AC691967 /* AgentDetailStatusChrome.swift */,
 				733AB85D0EBE3F90487289EA /* AgentDetailView.swift */,
+				E7F93F9925E94FF2C2B0254B /* AgentDirectInputChrome.swift */,
+				EAF7CDC80C0B17DEDB5F55A8 /* AgentDirectInputPresentation.swift */,
 				4692E780178FDFA1CF9537B1 /* AgentName.swift */,
 				9A430D16838A39772ED0AA73 /* AgentStatusPalette.swift */,
 				F234ED041A4A2835A59A7510 /* AgentTerminalView.swift */,
@@ -1207,6 +1224,7 @@
 			isa = PBXGroup;
 			children = (
 				2782D0CCB8DD0CC97AF6932C /* AcknowledgementsView.swift */,
+				F641C391CC59D30055B5F85F /* AgentInputModeSettings.swift */,
 				DAEAF21DF91A1BCE4C9F79A3 /* AppAppearanceSettings.swift */,
 				B6C5732C32E96A6C433D82B7 /* LicenseNotices.swift */,
 				5416AE7B7A89E2987620E65E /* NotificationDisclosureView.swift */,
@@ -1445,7 +1463,11 @@
 				12B61E17D212416E86EE63ED /* AgentCardView.swift in Sources */,
 				78AB0CC85260D35A1178163A /* AgentComposerStore.swift in Sources */,
 				3BB63A16095664E8C760286C /* AgentComposerView.swift in Sources */,
+				9271ADB70DD9860389821A92 /* AgentDetailStatusChrome.swift in Sources */,
 				E1C95FE0F5AC6271001DBF60 /* AgentDetailView.swift in Sources */,
+				785A44749D305DC59153D679 /* AgentDirectInputChrome.swift in Sources */,
+				FA4096D59D2F576F860238B6 /* AgentDirectInputPresentation.swift in Sources */,
+				390E9313FFE9AA540C6B6113 /* AgentInputModeSettings.swift in Sources */,
 				86EA13918F2EE2103B2DEFB3 /* AgentLiveActivityWidget.swift in Sources */,
 				8EB4F2396CC905928797A622 /* AgentName.swift in Sources */,
 				72448624659DCDD94EF81DE8 /* AgentNotificationBannerStore.swift in Sources */,
@@ -1614,6 +1636,8 @@
 				0032AB8CC6C1DFDB893E35C6 /* AgentActivityLinkTests.swift in Sources */,
 				2566EFE94582C9CB4796E5ED /* AgentActivityPresentationTests.swift in Sources */,
 				6DA75E728052945BC787BBD3 /* AgentComposerStoreTests.swift in Sources */,
+				D8B0D81D7F37A151754527F6 /* AgentDirectInputTests.swift in Sources */,
+				15F48A8DDF0D76F41D8562A6 /* AgentInputModeSettingsTests.swift in Sources */,
 				E379C1AD65B445D4E08614CF /* AgentNameTests.swift in Sources */,
 				6CD1D3CCDB58EBFF5350AC7F /* AgentNotificationBannerStoreTests.swift in Sources */,
 				14500112C25383EFD80A7A32 /* AgentNotificationRendererTests.swift in Sources */,

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		24B38E6323258B77CF7E17B8 /* NotificationPreferencesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C87F6E13D72316E56DC0C571 /* NotificationPreferencesStore.swift */; };
 		2566EFE94582C9CB4796E5ED /* AgentActivityPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39CBCF8D249D054DC71463E /* AgentActivityPresentationTests.swift */; };
 		25AE0EAE56CE592F547BE1F2 /* HostLatencyFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = E088B83BDB55BAFA2D41450F /* HostLatencyFormatting.swift */; };
+		25BB985078F03303607B97D0 /* AgentActionMenuContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527A0944EDF47AC0D14E3B71 /* AgentActionMenuContent.swift */; };
 		268E43B24D46A51173DB8349 /* HostFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EF900D8EF7982B54965402 /* HostFormView.swift */; };
 		28155122AFE694FA3D41F172 /* ImageStagingE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A8ED9AD5019F303932B0F9C /* ImageStagingE2ETests.swift */; };
 		289D5FF53D330E3C7CA81707 /* TerminalScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847A1406F4AAEBF2F1EDFA1F /* TerminalScreenView.swift */; };
@@ -467,6 +468,7 @@
 		519305F6554977DB6C5E93F2 /* AgentActivityContentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentActivityContentStateTests.swift; sourceTree = "<group>"; };
 		51B4AAB6885E0EB9D8C4A131 /* InMemorySecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemorySecretStore.swift; sourceTree = "<group>"; };
 		51EE6515A20AFA09762788C5 /* SnippetsKeyboardPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnippetsKeyboardPane.swift; sourceTree = "<group>"; };
+		527A0944EDF47AC0D14E3B71 /* AgentActionMenuContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentActionMenuContent.swift; sourceTree = "<group>"; };
 		52D3780EB6489DF2E1EA1D77 /* AuthorizedKeysTestLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizedKeysTestLock.swift; sourceTree = "<group>"; };
 		530D32C2D59D0DD128053804 /* ConsoleHostStatusPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleHostStatusPresentation.swift; sourceTree = "<group>"; };
 		5416AE7B7A89E2987620E65E /* NotificationDisclosureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDisclosureView.swift; sourceTree = "<group>"; };
@@ -960,6 +962,7 @@
 		5880878B95ED812C768FF824 /* Console */ = {
 			isa = PBXGroup;
 			children = (
+				527A0944EDF47AC0D14E3B71 /* AgentActionMenuContent.swift */,
 				36B41E884E430DCF9BE26B91 /* AgentArgumentsField.swift */,
 				50F8ED10B8A8A33D307789E6 /* AgentAttachStore.swift */,
 				6803A0055A861DFCA2A67217 /* AgentCardView.swift */,
@@ -1453,6 +1456,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				693D650A778BAC6F2189F32A /* AcknowledgementsView.swift in Sources */,
+				25BB985078F03303607B97D0 /* AgentActionMenuContent.swift in Sources */,
 				8C7337318B1B3271FD4E85A6 /* AgentActivityAttributes.swift in Sources */,
 				11F7B6617DA23C1B24E3A027 /* AgentActivityContentBuilder.swift in Sources */,
 				0FE90B9982AF87386D6898ED /* AgentActivityDecryptor.swift in Sources */,

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -135,8 +135,6 @@ actor SessionDriver {
     private var sftpIdleWaiters: [UInt64: DriverWaiter] = [:]
 
 #if DEBUG
-    private var directTCPIPInboundBufferHighWaterMark = 0
-    private var nextDirectTCPIPInboundBufferFullHoldForTesting: (@Sendable () async -> Void)?
     private var nextSFTPWriteDelayForTesting: Duration?
     private var sftpWriteDelayIsActiveForTesting = false
     private var nextSessionWaitHoldForTesting: (@Sendable () async throws -> Void)?
@@ -1872,16 +1870,6 @@ actor SessionDriver {
     }
 
 #if DEBUG
-    func directTCPIPInboundBufferHighWaterMarkForTesting() -> Int {
-        directTCPIPInboundBufferHighWaterMark
-    }
-
-    func holdNextDirectTCPIPInboundBufferFullForTesting(
-        _ hold: @escaping @Sendable () async -> Void
-    ) {
-        nextDirectTCPIPInboundBufferFullHoldForTesting = hold
-    }
-
     func delayNextSFTPWriteForTesting(_ delay: Duration) {
         nextSFTPWriteDelayForTesting = delay
     }
@@ -2107,9 +2095,6 @@ actor SessionDriver {
             guard let channel else { throw SSHError.channelFailed }
             let transport = try DirectTCPIPByteTransport()
             let pumpDescriptor = try transport.takePumpDescriptor()
-#if DEBUG
-            directTCPIPInboundBufferHighWaterMark = 0
-#endif
             forwarding = true
             let task = Task { [self] in
                 await pumpDirectTCPIP(
@@ -2309,30 +2294,16 @@ actor SessionDriver {
             }
 
             if !outerEOF, toInner.count < bufferLimit {
-                let maximumReadCount = min(scratch.count, bufferLimit - toInner.count)
                 let readCount = scratch.withUnsafeMutableBytes { bytes -> Int in
                     guard let baseAddress = bytes.baseAddress else { return 0 }
                     return libssh2_channel_read_ex(
                         channel,
                         0,
                         baseAddress.assumingMemoryBound(to: CChar.self),
-                        maximumReadCount)
+                        bytes.count)
                 }
                 if readCount > 0 {
                     toInner.append(contentsOf: scratch.prefix(readCount))
-#if DEBUG
-                    directTCPIPInboundBufferHighWaterMark = max(
-                        directTCPIPInboundBufferHighWaterMark,
-                        toInner.count)
-                    if toInner.count >= bufferLimit,
-                        let hold = nextDirectTCPIPInboundBufferFullHoldForTesting
-                    {
-                        nextDirectTCPIPInboundBufferFullHoldForTesting = nil
-                        await hold()
-                        if Task.isCancelled { throw SSHError.cancelled }
-                        guard valid else { throw SSHError.connectionInvalidated }
-                    }
-#endif
                     madeProgress = true
                 } else if readCount != 0 && readCount != Int(LIBSSH2_ERROR_EAGAIN) {
                     throw SSHError.connectionFailed
@@ -2343,13 +2314,7 @@ actor SessionDriver {
                 }
             }
 
-            let shouldHoldBridgeWrites: Bool
-#if DEBUG
-            shouldHoldBridgeWrites = nextDirectTCPIPInboundBufferFullHoldForTesting != nil
-#else
-            shouldHoldBridgeWrites = false
-#endif
-            if !toInner.isEmpty, !shouldHoldBridgeWrites {
+            if !toInner.isEmpty {
                 switch try Self.writeBridge(toInner, descriptor: bridgeDescriptor) {
                 case .wrote(let written):
                     toInner.removeFirst(written)

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -135,6 +135,8 @@ actor SessionDriver {
     private var sftpIdleWaiters: [UInt64: DriverWaiter] = [:]
 
 #if DEBUG
+    private var directTCPIPInboundBufferHighWaterMark = 0
+    private var nextDirectTCPIPInboundBufferFullHoldForTesting: (@Sendable () async -> Void)?
     private var nextSFTPWriteDelayForTesting: Duration?
     private var sftpWriteDelayIsActiveForTesting = false
     private var nextSessionWaitHoldForTesting: (@Sendable () async throws -> Void)?
@@ -1870,6 +1872,16 @@ actor SessionDriver {
     }
 
 #if DEBUG
+    func directTCPIPInboundBufferHighWaterMarkForTesting() -> Int {
+        directTCPIPInboundBufferHighWaterMark
+    }
+
+    func holdNextDirectTCPIPInboundBufferFullForTesting(
+        _ hold: @escaping @Sendable () async -> Void
+    ) {
+        nextDirectTCPIPInboundBufferFullHoldForTesting = hold
+    }
+
     func delayNextSFTPWriteForTesting(_ delay: Duration) {
         nextSFTPWriteDelayForTesting = delay
     }
@@ -2095,6 +2107,9 @@ actor SessionDriver {
             guard let channel else { throw SSHError.channelFailed }
             let transport = try DirectTCPIPByteTransport()
             let pumpDescriptor = try transport.takePumpDescriptor()
+#if DEBUG
+            directTCPIPInboundBufferHighWaterMark = 0
+#endif
             forwarding = true
             let task = Task { [self] in
                 await pumpDirectTCPIP(
@@ -2294,16 +2309,30 @@ actor SessionDriver {
             }
 
             if !outerEOF, toInner.count < bufferLimit {
+                let maximumReadCount = min(scratch.count, bufferLimit - toInner.count)
                 let readCount = scratch.withUnsafeMutableBytes { bytes -> Int in
                     guard let baseAddress = bytes.baseAddress else { return 0 }
                     return libssh2_channel_read_ex(
                         channel,
                         0,
                         baseAddress.assumingMemoryBound(to: CChar.self),
-                        bytes.count)
+                        maximumReadCount)
                 }
                 if readCount > 0 {
                     toInner.append(contentsOf: scratch.prefix(readCount))
+#if DEBUG
+                    directTCPIPInboundBufferHighWaterMark = max(
+                        directTCPIPInboundBufferHighWaterMark,
+                        toInner.count)
+                    if toInner.count >= bufferLimit,
+                        let hold = nextDirectTCPIPInboundBufferFullHoldForTesting
+                    {
+                        nextDirectTCPIPInboundBufferFullHoldForTesting = nil
+                        await hold()
+                        if Task.isCancelled { throw SSHError.cancelled }
+                        guard valid else { throw SSHError.connectionInvalidated }
+                    }
+#endif
                     madeProgress = true
                 } else if readCount != 0 && readCount != Int(LIBSSH2_ERROR_EAGAIN) {
                     throw SSHError.connectionFailed
@@ -2314,7 +2343,13 @@ actor SessionDriver {
                 }
             }
 
-            if !toInner.isEmpty {
+            let shouldHoldBridgeWrites: Bool
+#if DEBUG
+            shouldHoldBridgeWrites = nextDirectTCPIPInboundBufferFullHoldForTesting != nil
+#else
+            shouldHoldBridgeWrites = false
+#endif
+            if !toInner.isEmpty, !shouldHoldBridgeWrites {
                 switch try Self.writeBridge(toInner, descriptor: bridgeDescriptor) {
                 case .wrote(let written):
                     toInner.removeFirst(written)

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -135,6 +135,8 @@ actor SessionDriver {
     private var sftpIdleWaiters: [UInt64: DriverWaiter] = [:]
 
 #if DEBUG
+    private var directTCPIPInboundBufferHighWaterMark = 0
+    private var nextDirectTCPIPInboundBufferFullHoldForTesting: (@Sendable () async -> Void)?
     private var nextSFTPWriteDelayForTesting: Duration?
     private var sftpWriteDelayIsActiveForTesting = false
     private var nextSessionWaitHoldForTesting: (@Sendable () async throws -> Void)?
@@ -1870,6 +1872,16 @@ actor SessionDriver {
     }
 
 #if DEBUG
+    func directTCPIPInboundBufferHighWaterMarkForTesting() -> Int {
+        directTCPIPInboundBufferHighWaterMark
+    }
+
+    func holdNextDirectTCPIPInboundBufferFullForTesting(
+        _ hold: @escaping @Sendable () async -> Void
+    ) {
+        nextDirectTCPIPInboundBufferFullHoldForTesting = hold
+    }
+
     func delayNextSFTPWriteForTesting(_ delay: Duration) {
         nextSFTPWriteDelayForTesting = delay
     }
@@ -2095,6 +2107,9 @@ actor SessionDriver {
             guard let channel else { throw SSHError.channelFailed }
             let transport = try DirectTCPIPByteTransport()
             let pumpDescriptor = try transport.takePumpDescriptor()
+#if DEBUG
+            directTCPIPInboundBufferHighWaterMark = 0
+#endif
             forwarding = true
             let task = Task { [self] in
                 await pumpDirectTCPIP(
@@ -2304,6 +2319,17 @@ actor SessionDriver {
                 }
                 if readCount > 0 {
                     toInner.append(contentsOf: scratch.prefix(readCount))
+#if DEBUG
+                    directTCPIPInboundBufferHighWaterMark = max(
+                        directTCPIPInboundBufferHighWaterMark,
+                        toInner.count)
+                    if toInner.count == bufferLimit,
+                        let hold = nextDirectTCPIPInboundBufferFullHoldForTesting
+                    {
+                        nextDirectTCPIPInboundBufferFullHoldForTesting = nil
+                        await hold()
+                    }
+#endif
                     madeProgress = true
                 } else if readCount != 0 && readCount != Int(LIBSSH2_ERROR_EAGAIN) {
                     throw SSHError.connectionFailed
@@ -2314,7 +2340,13 @@ actor SessionDriver {
                 }
             }
 
-            if !toInner.isEmpty {
+            let shouldHoldBridgeWrites: Bool
+#if DEBUG
+            shouldHoldBridgeWrites = nextDirectTCPIPInboundBufferFullHoldForTesting != nil
+#else
+            shouldHoldBridgeWrites = false
+#endif
+            if !toInner.isEmpty, !shouldHoldBridgeWrites {
                 switch try Self.writeBridge(toInner, descriptor: bridgeDescriptor) {
                 case .wrote(let written):
                     toInner.removeFirst(written)

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -2309,13 +2309,14 @@ actor SessionDriver {
             }
 
             if !outerEOF, toInner.count < bufferLimit {
+                let maximumReadCount = min(scratch.count, bufferLimit - toInner.count)
                 let readCount = scratch.withUnsafeMutableBytes { bytes -> Int in
                     guard let baseAddress = bytes.baseAddress else { return 0 }
                     return libssh2_channel_read_ex(
                         channel,
                         0,
                         baseAddress.assumingMemoryBound(to: CChar.self),
-                        bytes.count)
+                        maximumReadCount)
                 }
                 if readCount > 0 {
                     toInner.append(contentsOf: scratch.prefix(readCount))
@@ -2323,11 +2324,13 @@ actor SessionDriver {
                     directTCPIPInboundBufferHighWaterMark = max(
                         directTCPIPInboundBufferHighWaterMark,
                         toInner.count)
-                    if toInner.count == bufferLimit,
+                    if toInner.count >= bufferLimit,
                         let hold = nextDirectTCPIPInboundBufferFullHoldForTesting
                     {
                         nextDirectTCPIPInboundBufferFullHoldForTesting = nil
                         await hold()
+                        if Task.isCancelled { throw SSHError.cancelled }
+                        guard valid else { throw SSHError.connectionInvalidated }
                     }
 #endif
                     madeProgress = true

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
@@ -220,7 +220,6 @@ struct SessionDriverE2ETests {
         // the remote process and temp dir without a parsed PID handle.
         let directory = "/tmp/heeler-raw-tcp-\(UUID().uuidString)"
         let driver = SessionDriver()
-        let bufferFullHold = SessionWaitHold()
         var transport: DirectTCPIPByteTransport?
         var descriptor: Int32 = -1
         var primaryError: (any Error)?
@@ -240,9 +239,6 @@ struct SessionDriverE2ETests {
                 publicKey: environment.publicKeyBlob,
                 signer: { try privateKey.signature(for: $0) },
                 timeout: .seconds(5))
-            await driver.holdNextDirectTCPIPInboundBufferFullForTesting {
-                await bufferFullHold.waitUntilReleased()
-            }
             let opened = try await driver.openDirectTCPIP(
                 endpoint: SSHEndpoint(host: "127.0.0.1", port: launched.port),
                 timeout: .seconds(5))
@@ -250,14 +246,9 @@ struct SessionDriverE2ETests {
             descriptor = try opened.takeDescriptor()
 
             let preDrainState = try await launched.waitUntilStartedAndSettled(using: observer)
-            try #require(
+            #expect(
                 preDrainState == .blocked,
                 "the raw writer completed before the bounded pump was drained")
-            try await requireEventually(
-                "the pump should fill its one-megabyte inbound buffer before draining"
-            ) { await bufferFullHold.hasEntered }
-            #expect(await driver.directTCPIPInboundBufferHighWaterMarkForTesting() == 1_048_576)
-            await bufferFullHold.release()
 
             var offset = 0
             var firstMismatch: String?
@@ -302,7 +293,6 @@ struct SessionDriverE2ETests {
             transport = nil
             try await driver.close(timeout: .seconds(2))
         } catch {
-            await bufferFullHold.release()
             if descriptor >= 0 { Darwin.close(descriptor) }
             transport?.abort()
             await driver.invalidate()
@@ -1946,7 +1936,7 @@ private struct RawTCPWriter {
         let result = try await observer.execute(
             command,
             input: Data(pythonSource.utf8),
-            timeout: .seconds(20))
+            timeout: .seconds(10))
         let response = String(decoding: result.stdout, as: UTF8.self)
             .split(separator: "\n", omittingEmptySubsequences: true)
             .map(String.init)
@@ -2158,12 +2148,12 @@ while sent < payload_size:
             raise RuntimeError("raw writer socket closed")
         sent += written
     except BlockingIOError:
-        if not reported_block:
-            publish("blocked", sent)
-            reported_block = True
         _, writable, _ = select.select([], [connection], [], 1.0)
         if writable:
             continue
+        if not reported_block:
+            publish("blocked", sent)
+            reported_block = True
         connection.setblocking(True)
 
 connection.shutdown(socket.SHUT_WR)

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
@@ -220,6 +220,7 @@ struct SessionDriverE2ETests {
         // the remote process and temp dir without a parsed PID handle.
         let directory = "/tmp/heeler-raw-tcp-\(UUID().uuidString)"
         let driver = SessionDriver()
+        let bufferFullHold = SessionWaitHold()
         var transport: DirectTCPIPByteTransport?
         var descriptor: Int32 = -1
         var primaryError: (any Error)?
@@ -239,6 +240,9 @@ struct SessionDriverE2ETests {
                 publicKey: environment.publicKeyBlob,
                 signer: { try privateKey.signature(for: $0) },
                 timeout: .seconds(5))
+            await driver.holdNextDirectTCPIPInboundBufferFullForTesting {
+                await bufferFullHold.waitUntilReleased()
+            }
             let opened = try await driver.openDirectTCPIP(
                 endpoint: SSHEndpoint(host: "127.0.0.1", port: launched.port),
                 timeout: .seconds(5))
@@ -246,9 +250,14 @@ struct SessionDriverE2ETests {
             descriptor = try opened.takeDescriptor()
 
             let preDrainState = try await launched.waitUntilStartedAndSettled(using: observer)
-            #expect(
+            try #require(
                 preDrainState == .blocked,
                 "the raw writer completed before the bounded pump was drained")
+            try await requireEventually(
+                "the pump should fill its one-megabyte inbound buffer before draining"
+            ) { await bufferFullHold.hasEntered }
+            #expect(await driver.directTCPIPInboundBufferHighWaterMarkForTesting() == 1_048_576)
+            await bufferFullHold.release()
 
             var offset = 0
             var firstMismatch: String?
@@ -293,6 +302,7 @@ struct SessionDriverE2ETests {
             transport = nil
             try await driver.close(timeout: .seconds(2))
         } catch {
+            await bufferFullHold.release()
             if descriptor >= 0 { Darwin.close(descriptor) }
             transport?.abort()
             await driver.invalidate()

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
@@ -22,7 +22,7 @@ struct SessionDriverE2ETests {
         let environment = try #require(SessionDriverTestEnvironment.current)
         let connection = try await SSHConnection.connect(
             to: SSHEndpoint(host: "localhost", port: environment.endpoint.port),
-            timeout: .seconds(5))
+            timeout: .seconds(10))
 
         try await environment.authenticate(connection)
         let result = try await connection.execute(
@@ -220,35 +220,54 @@ struct SessionDriverE2ETests {
         // the remote process and temp dir without a parsed PID handle.
         let directory = "/tmp/heeler-raw-tcp-\(UUID().uuidString)"
         let driver = SessionDriver()
+        let bufferFullHold = SessionWaitHold()
         var transport: DirectTCPIPByteTransport?
         var descriptor: Int32 = -1
         var primaryError: (any Error)?
 
         do {
-            let launched = try await RawTCPWriter.launch(
-                directory: directory,
-                payloadSize: payloadSize,
-                using: observer)
+            let launched = try await runDirectTCPIPFixturePhase("launch raw writer") {
+                try await RawTCPWriter.launch(
+                    directory: directory,
+                    payloadSize: payloadSize,
+                    using: observer)
+            }
 
-            _ = try await driver.handshake(
-                endpoint: environment.endpoint,
-                timeout: .seconds(5))
+            _ = try await runDirectTCPIPFixturePhase("handshake") {
+                try await driver.handshake(
+                    endpoint: environment.endpoint,
+                    timeout: .seconds(10))
+            }
             let privateKey = environment.privateKey
-            try await driver.authenticate(
-                username: environment.username,
-                publicKey: environment.publicKeyBlob,
-                signer: { try privateKey.signature(for: $0) },
-                timeout: .seconds(5))
-            let opened = try await driver.openDirectTCPIP(
-                endpoint: SSHEndpoint(host: "127.0.0.1", port: launched.port),
-                timeout: .seconds(5))
+            try await runDirectTCPIPFixturePhase("authenticate") {
+                try await driver.authenticate(
+                    username: environment.username,
+                    publicKey: environment.publicKeyBlob,
+                    signer: { try privateKey.signature(for: $0) },
+                    timeout: .seconds(10))
+            }
+            await driver.holdNextDirectTCPIPInboundBufferFullForTesting {
+                await bufferFullHold.waitUntilReleased()
+            }
+            let opened = try await runDirectTCPIPFixturePhase("open direct TCP/IP") {
+                try await driver.openDirectTCPIP(
+                    endpoint: SSHEndpoint(host: "127.0.0.1", port: launched.port),
+                    timeout: .seconds(10))
+            }
             transport = opened
             descriptor = try opened.takeDescriptor()
 
-            let preDrainState = try await launched.waitUntilStartedAndSettled(using: observer)
-            #expect(
+            let preDrainState = try await runDirectTCPIPFixturePhase("observe backpressure") {
+                try await launched.waitUntilStartedAndSettled(using: observer)
+            }
+            try #require(
                 preDrainState == .blocked,
                 "the raw writer completed before the bounded pump was drained")
+            try await requireEventually(
+                "the pump should fill its one-megabyte inbound buffer before draining"
+            ) { await bufferFullHold.hasEntered }
+            #expect(await driver.directTCPIPInboundBufferHighWaterMarkForTesting() == 1_048_576)
+            await bufferFullHold.release()
 
             var offset = 0
             var firstMismatch: String?
@@ -293,6 +312,7 @@ struct SessionDriverE2ETests {
             transport = nil
             try await driver.close(timeout: .seconds(2))
         } catch {
+            await bufferFullHold.release()
             if descriptor >= 0 { Darwin.close(descriptor) }
             transport?.abort()
             await driver.invalidate()
@@ -1892,6 +1912,28 @@ private enum RawTCPWriterState: Equatable {
     case completed
 }
 
+private struct DirectTCPIPFixturePhaseError: Error, CustomStringConvertible {
+    let phase: String
+    let underlying: String
+
+    var description: String {
+        "Direct TCP/IP fixture failed during \(phase): \(underlying)"
+    }
+}
+
+private func runDirectTCPIPFixturePhase<Value>(
+    _ phase: String,
+    operation: () async throws -> Value
+) async throws -> Value {
+    do {
+        return try await operation()
+    } catch {
+        throw DirectTCPIPFixturePhaseError(
+            phase: phase,
+            underlying: String(describing: error))
+    }
+}
+
 private enum RawTCPWriterError: Error {
     case invalidLaunchResponse(String)
     case markerFailed(String)
@@ -1936,7 +1978,7 @@ private struct RawTCPWriter {
         let result = try await observer.execute(
             command,
             input: Data(pythonSource.utf8),
-            timeout: .seconds(10))
+            timeout: .seconds(20))
         let response = String(decoding: result.stdout, as: UTF8.self)
             .split(separator: "\n", omittingEmptySubsequences: true)
             .map(String.init)
@@ -2148,12 +2190,12 @@ while sent < payload_size:
             raise RuntimeError("raw writer socket closed")
         sent += written
     except BlockingIOError:
-        _, writable, _ = select.select([], [connection], [], 1.0)
-        if writable:
-            continue
         if not reported_block:
             publish("blocked", sent)
             reported_block = True
+        _, writable, _ = select.select([], [connection], [], 1.0)
+        if writable:
+            continue
         connection.setblocking(True)
 
 connection.shutdown(socket.SHUT_WR)
@@ -2632,7 +2674,7 @@ private struct SessionDriverTestEnvironment: Sendable {
     func connect() async throws -> SSHConnection {
         let connection = try await SSHConnection.connect(
             to: endpoint,
-            timeout: .seconds(5))
+            timeout: .seconds(10))
         try await authenticate(connection)
         return connection
     }
@@ -2643,6 +2685,6 @@ private struct SessionDriverTestEnvironment: Sendable {
             username: username,
             publicKey: publicKeyBlob,
             signer: { try privateKey.signature(for: $0) },
-            timeout: .seconds(5))
+            timeout: .seconds(10))
     }
 }

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
@@ -1946,7 +1946,7 @@ private struct RawTCPWriter {
         let result = try await observer.execute(
             command,
             input: Data(pythonSource.utf8),
-            timeout: .seconds(10))
+            timeout: .seconds(20))
         let response = String(decoding: result.stdout, as: UTF8.self)
             .split(separator: "\n", omittingEmptySubsequences: true)
             .map(String.init)

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
@@ -2148,12 +2148,12 @@ while sent < payload_size:
             raise RuntimeError("raw writer socket closed")
         sent += written
     except BlockingIOError:
-        _, writable, _ = select.select([], [connection], [], 1.0)
-        if writable:
-            continue
         if not reported_block:
             publish("blocked", sent)
             reported_block = True
+        _, writable, _ = select.select([], [connection], [], 1.0)
+        if writable:
+            continue
         connection.setblocking(True)
 
 connection.shutdown(socket.SHUT_WR)

--- a/Sources/Heeler/Console/AgentActionMenuContent.swift
+++ b/Sources/Heeler/Console/AgentActionMenuContent.swift
@@ -1,0 +1,194 @@
+import SwiftUI
+
+/// Shared Agent action-menu items for Composer and Direct Input. Ordering and
+/// sectioning stay identical across both surfaces; Direct Input only adds a
+/// restore-Composer hop for draft-owned actions.
+enum AgentActionMenuItem: Equatable, Hashable, Sendable, CaseIterable {
+    case addImage
+    case addFile
+    case openTerminal
+    case newAgent
+    case skills
+    case snippets
+    case worktreeDetails
+    case renameAgent
+    case renameWorkspace
+    case closeAgent
+
+    var title: String {
+        switch self {
+        case .addImage: "Add Image"
+        case .addFile: "Add File"
+        case .openTerminal: "Open Terminal"
+        case .newAgent: "New Agent"
+        case .skills: "Skills"
+        case .snippets: "Snippets"
+        case .worktreeDetails: "Worktree Details"
+        case .renameAgent: "Rename Agent"
+        case .renameWorkspace: "Rename Workspace"
+        case .closeAgent: "Close Agent"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .addImage: "photo"
+        case .addFile: "doc"
+        case .openTerminal: "apple.terminal"
+        case .newAgent: "plus"
+        case .skills: "sparkles"
+        case .snippets: "quote.bubble"
+        case .worktreeDetails: "arrow.triangle.branch"
+        case .renameAgent: "pencil"
+        case .renameWorkspace: "pencil.line"
+        case .closeAgent: "trash"
+        }
+    }
+
+    var role: ButtonRole? {
+        switch self {
+        case .closeAgent: .destructive
+        default: nil
+        }
+    }
+
+    /// Draft-owned: Skills, Snippets, and Add touch the Composer draft, so
+    /// Direct Input restores Composer before running them (ADR 0016).
+    var isDraftOwned: Bool {
+        switch self {
+        case .addImage, .addFile, .skills, .snippets:
+            true
+        case .openTerminal, .newAgent, .worktreeDetails, .renameAgent,
+            .renameWorkspace, .closeAgent:
+            false
+        }
+    }
+}
+
+enum AgentActionMenuSection: Equatable, Hashable, Sendable, CaseIterable {
+    /// Attachments for the draft.
+    case addAttachments
+    /// Session tools — Skills before Snippets matches the Keys keyboard tab order.
+    case sessionTools
+    /// Rename / close / worktree lifecycle.
+    case agentLifecycle
+
+    var items: [AgentActionMenuItem] {
+        switch self {
+        case .addAttachments:
+            [.addImage, .addFile]
+        case .sessionTools:
+            [.openTerminal, .newAgent, .skills, .snippets]
+        case .agentLifecycle:
+            [.worktreeDetails, .renameAgent, .renameWorkspace, .closeAgent]
+        }
+    }
+}
+
+/// Availability and visibility rules shared by Composer Add/More and Direct
+/// Input's combined More menu.
+enum AgentActionMenuPolicy {
+    static let composerAddSections: [AgentActionMenuSection] = [.addAttachments]
+    static let composerMoreSections: [AgentActionMenuSection] = [
+        .sessionTools, .agentLifecycle,
+    ]
+    static let directInputMoreSections: [AgentActionMenuSection] = [
+        .addAttachments, .sessionTools, .agentLifecycle,
+    ]
+
+    /// Optional entries hide entirely when their action is absent.
+    static func isVisible(
+        _ item: AgentActionMenuItem,
+        actions: AgentComposerActions
+    ) -> Bool {
+        switch item {
+        case .skills:
+            actions.showSkills != nil
+        case .worktreeDetails:
+            actions.showWorktreeDetails != nil
+        default:
+            true
+        }
+    }
+
+    static func isEnabled(
+        _ item: AgentActionMenuItem,
+        actions: AgentComposerActions
+    ) -> Bool {
+        switch item {
+        case .addImage, .addFile:
+            actions.canBegin
+        case .openTerminal:
+            actions.openTerminal != nil && !actions.isOpeningTerminal
+        default:
+            true
+        }
+    }
+
+    static func perform(
+        _ item: AgentActionMenuItem,
+        actions: AgentComposerActions
+    ) {
+        switch item {
+        case .addImage:
+            actions.addImage()
+        case .addFile:
+            actions.addFile()
+        case .openTerminal:
+            actions.openTerminal?()
+        case .newAgent:
+            actions.startAgent()
+        case .skills:
+            actions.showSkills?()
+        case .snippets:
+            actions.manageSnippets()
+        case .worktreeDetails:
+            actions.showWorktreeDetails?()
+        case .renameAgent:
+            actions.renameAgent()
+        case .renameWorkspace:
+            actions.renameWorkspace()
+        case .closeAgent:
+            actions.closeAgent()
+        }
+    }
+}
+
+/// One menu body for Composer Add, Composer More, and Direct Input More.
+struct AgentActionMenuContent: View {
+    let actions: AgentComposerActions
+    let sections: [AgentActionMenuSection]
+    /// When set, draft-owned items restore Composer before running (Direct Input).
+    var restoreComposerThen: ((@escaping () -> Void) -> Void)? = nil
+
+    var body: some View {
+        ForEach(sections, id: \.self) { section in
+            let visible = section.items.filter {
+                AgentActionMenuPolicy.isVisible($0, actions: actions)
+            }
+            if !visible.isEmpty {
+                Section {
+                    ForEach(visible, id: \.self) { item in
+                        button(for: item)
+                    }
+                }
+            }
+        }
+    }
+
+    private func button(for item: AgentActionMenuItem) -> some View {
+        Button(item.title, systemImage: item.systemImage, role: item.role) {
+            run(item)
+        }
+        .disabled(!AgentActionMenuPolicy.isEnabled(item, actions: actions))
+    }
+
+    private func run(_ item: AgentActionMenuItem) {
+        let action = { AgentActionMenuPolicy.perform(item, actions: actions) }
+        if item.isDraftOwned, let restoreComposerThen {
+            restoreComposerThen(action)
+        } else {
+            action()
+        }
+    }
+}

--- a/Sources/Heeler/Console/AgentActionMenuContent.swift
+++ b/Sources/Heeler/Console/AgentActionMenuContent.swift
@@ -152,6 +152,21 @@ enum AgentActionMenuPolicy {
             actions.closeAgent()
         }
     }
+
+    /// Production dispatch for menu taps. Direct Input supplies
+    /// `restoreComposerThen` so draft-owned actions restore Composer first.
+    static func dispatch(
+        _ item: AgentActionMenuItem,
+        actions: AgentComposerActions,
+        restoreComposerThen: ((@escaping () -> Void) -> Void)? = nil
+    ) {
+        let action = { perform(item, actions: actions) }
+        if item.isDraftOwned, let restoreComposerThen {
+            restoreComposerThen(action)
+        } else {
+            action()
+        }
+    }
 }
 
 /// One menu body for Composer Add, Composer More, and Direct Input More.
@@ -178,17 +193,11 @@ struct AgentActionMenuContent: View {
 
     private func button(for item: AgentActionMenuItem) -> some View {
         Button(item.title, systemImage: item.systemImage, role: item.role) {
-            run(item)
+            AgentActionMenuPolicy.dispatch(
+                item,
+                actions: actions,
+                restoreComposerThen: restoreComposerThen)
         }
         .disabled(!AgentActionMenuPolicy.isEnabled(item, actions: actions))
-    }
-
-    private func run(_ item: AgentActionMenuItem) {
-        let action = { AgentActionMenuPolicy.perform(item, actions: actions) }
-        if item.isDraftOwned, let restoreComposerThen {
-            restoreComposerThen(action)
-        } else {
-            action()
-        }
     }
 }

--- a/Sources/Heeler/Console/AgentComposerView.swift
+++ b/Sources/Heeler/Console/AgentComposerView.swift
@@ -173,14 +173,9 @@ struct AgentComposerView: View {
 
                         HStack(spacing: 8) {
                             Menu {
-                                Button("Add Image", systemImage: "photo") {
-                                    actions.addImage()
-                                }
-                                .disabled(!actions.canBegin)
-                                Button("Add File", systemImage: "doc") {
-                                    actions.addFile()
-                                }
-                                .disabled(!actions.canBegin)
+                                AgentActionMenuContent(
+                                    actions: actions,
+                                    sections: AgentActionMenuPolicy.composerAddSections)
                             } label: {
                                 Image(systemName: "plus")
                                     .font(.system(size: 15, weight: .semibold))
@@ -194,51 +189,9 @@ struct AgentComposerView: View {
                             .accessibilityHint("Adds an image or file to the draft")
 
                             Menu {
-                                Section {
-                                    Button("Open Terminal", systemImage: "apple.terminal") {
-                                        actions.openTerminal?()
-                                    }
-                                    .disabled(
-                                        actions.openTerminal == nil
-                                            || actions.isOpeningTerminal
-                                    )
-                                    Button("New Agent", systemImage: "plus") {
-                                        actions.startAgent()
-                                    }
-                                    // Skills before Snippets: the Keys
-                                    // keyboard's tab order.
-                                    if let showSkills = actions.showSkills {
-                                        Button("Skills", systemImage: "sparkles") {
-                                            showSkills()
-                                        }
-                                    }
-                                    Button("Snippets", systemImage: "quote.bubble") {
-                                        actions.manageSnippets()
-                                    }
-                                }
-                                Section {
-                                    if let showWorktreeDetails = actions.showWorktreeDetails {
-                                        Button(
-                                            "Worktree Details",
-                                            systemImage: "arrow.triangle.branch"
-                                        ) {
-                                            showWorktreeDetails()
-                                        }
-                                    }
-                                    Button("Rename Agent", systemImage: "pencil") {
-                                        actions.renameAgent()
-                                    }
-                                    Button("Rename Workspace", systemImage: "pencil.line") {
-                                        actions.renameWorkspace()
-                                    }
-                                    Button(
-                                        "Close Agent",
-                                        systemImage: "trash",
-                                        role: .destructive
-                                    ) {
-                                        actions.closeAgent()
-                                    }
-                                }
+                                AgentActionMenuContent(
+                                    actions: actions,
+                                    sections: AgentActionMenuPolicy.composerMoreSections)
                             } label: {
                                 Image(systemName: "ellipsis")
                                     .font(.system(size: 17, weight: .semibold))

--- a/Sources/Heeler/Console/AgentComposerView.swift
+++ b/Sources/Heeler/Console/AgentComposerView.swift
@@ -103,6 +103,10 @@ struct AgentComposerView: View {
     let prepareKeyboardPresentation: (AgentComposerKeyboardPresentation) -> Void
     /// Optional Hide Composer control on the switcher trail.
     var modeControl: TerminalAgentSwitcherModeControl? = nil
+    var keyboardHandoffID: UUID?
+    var isKeyboardHandoffCurrent: (UUID) -> Bool = { _ in false }
+    var onFirstResponderRequest: (UUID, Bool) -> Void = { _, _ in }
+    var onKeyboardHandoffSettled: (UUID) -> Void = { _ in }
     @State private var isInputFocused = false
     /// An explicit dismissal hides suggestions for the current trigger token;
     /// removing the token arms them again.
@@ -140,7 +144,11 @@ struct AgentComposerView: View {
                                     get: { store.draft },
                                     set: { store.replaceDraft(with: $0) }),
                                 isFocused: $isInputFocused,
-                                keyboardPresentation: keyboardPresentation)
+                                keyboardPresentation: keyboardPresentation,
+                                keyboardHandoffID: keyboardHandoffID,
+                                isKeyboardHandoffCurrent: isKeyboardHandoffCurrent,
+                                onFirstResponderRequest: onFirstResponderRequest,
+                                onKeyboardHandoffSettled: onKeyboardHandoffSettled)
                             if store.draft.isEmpty {
                                 Text("Message Agent")
                                     .foregroundStyle(.tertiary)
@@ -528,6 +536,10 @@ private struct AgentComposerTextEditor: UIViewRepresentable {
     @Binding var text: String
     @Binding var isFocused: Bool
     let keyboardPresentation: AgentComposerKeyboardPresentation
+    let keyboardHandoffID: UUID?
+    let isKeyboardHandoffCurrent: (UUID) -> Bool
+    let onFirstResponderRequest: (UUID, Bool) -> Void
+    let onKeyboardHandoffSettled: (UUID) -> Void
 
     func makeCoordinator() -> Coordinator {
         Coordinator(text: $text, isFocused: $isFocused)
@@ -542,6 +554,7 @@ private struct AgentComposerTextEditor: UIViewRepresentable {
         textView.textContainerInset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
         textView.textContainer.lineFragmentPadding = 0
         textView.accessibilityLabel = "Message the Agent"
+        textView.onKeyboardHandoffSettled = onKeyboardHandoffSettled
         return textView
     }
 
@@ -550,14 +563,27 @@ private struct AgentComposerTextEditor: UIViewRepresentable {
             textView.text = text
         }
         textView.updateKeyboard(presentation: keyboardPresentation)
+        textView.onKeyboardHandoffSettled = onKeyboardHandoffSettled
         let shouldFocus = isFocused
         guard shouldFocus != textView.isFirstResponder else { return }
         DispatchQueue.main.async { [weak textView] in
             guard let textView else { return }
             if shouldFocus {
-                textView.becomeFirstResponder()
+                if let keyboardHandoffID {
+                    guard textView.window != nil,
+                          isKeyboardHandoffCurrent(keyboardHandoffID)
+                    else {
+                        onFirstResponderRequest(keyboardHandoffID, false)
+                        return
+                    }
+                    onFirstResponderRequest(
+                        keyboardHandoffID,
+                        textView.requestKeyboardHandoff(id: keyboardHandoffID))
+                } else {
+                    textView.becomeFirstResponder()
+                }
             } else {
-                textView.resignFirstResponder()
+                _ = textView.resignFirstResponder()
             }
         }
     }
@@ -612,6 +638,58 @@ private struct AgentComposerTextEditor: UIViewRepresentable {
 final class AgentComposerUITextView: UITextView {
     private lazy var suppressedSoftKeyboard = TerminalSuppressedSoftKeyboardView()
     private var keyboardPresentation: AgentComposerKeyboardPresentation = .hidden
+    var onKeyboardHandoffSettled: ((UUID) -> Void)?
+    private var activeKeyboardHandoffID: UUID?
+
+    override init(frame: CGRect, textContainer: NSTextContainer?) {
+        super.init(frame: frame, textContainer: textContainer)
+        installKeyboardObservers()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        installKeyboardObservers()
+    }
+
+    private func installKeyboardObservers() {
+        for name: Notification.Name in [
+            UIResponder.keyboardDidShowNotification,
+            UIResponder.keyboardDidChangeFrameNotification,
+        ] {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(keyboardFrameDidSettle(_:)),
+                name: name,
+                object: nil)
+        }
+    }
+
+    @objc private func keyboardFrameDidSettle(_ notification: Notification) {
+        guard isFirstResponder, let window, window.isKeyWindow,
+              let endFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey]
+                as? CGRect
+        else { return }
+        let frameInWindow = window.convert(endFrame, from: window.screen.coordinateSpace)
+        guard TerminalKeyboardInset.keyboardFrame(
+            frameInWindow,
+            matches: window.keyboardLayoutGuide.layoutFrame,
+            in: window)
+        else { return }
+        guard let activeKeyboardHandoffID else { return }
+        self.activeKeyboardHandoffID = nil
+        onKeyboardHandoffSettled?(activeKeyboardHandoffID)
+    }
+
+    @discardableResult
+    func requestKeyboardHandoff(id: UUID) -> Bool {
+        guard window != nil else { return false }
+        activeKeyboardHandoffID = id
+        let accepted = becomeFirstResponder()
+        if !accepted {
+            activeKeyboardHandoffID = nil
+        }
+        return accepted
+    }
 
     func updateKeyboard(presentation: AgentComposerKeyboardPresentation) {
         guard presentation != keyboardPresentation else { return }

--- a/Sources/Heeler/Console/AgentComposerView.swift
+++ b/Sources/Heeler/Console/AgentComposerView.swift
@@ -101,6 +101,8 @@ struct AgentComposerView: View {
     let skills: SkillsPaneStore?
     @Binding var keyboardPresentation: AgentComposerKeyboardPresentation
     let prepareKeyboardPresentation: (AgentComposerKeyboardPresentation) -> Void
+    /// Optional Hide Composer control on the switcher trail.
+    var modeControl: TerminalAgentSwitcherModeControl? = nil
     @State private var isInputFocused = false
     /// An explicit dismissal hides suggestions for the current trigger token;
     /// removing the token arms them again.
@@ -288,7 +290,8 @@ struct AgentComposerView: View {
                         isKeyboardUp: isKeyboardPresented,
                         toggleKeyboard: dismissOrPresentKeyboard,
                         isToolsKeyboardPresented: isToolsKeyboardPresented,
-                        switchKeyboard: keyboardSwitchAction)
+                        switchKeyboard: keyboardSwitchAction,
+                        modeControl: modeControl)
                 }
                 .background(
                     .regularMaterial,

--- a/Sources/Heeler/Console/AgentComposerView.swift
+++ b/Sources/Heeler/Console/AgentComposerView.swift
@@ -115,15 +115,10 @@ struct AgentComposerView: View {
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 6) {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    statusLabel
-                    Spacer(minLength: 8)
-                    if let hostTelemetry {
-                        hostTelemetryLabel(hostTelemetry)
-                    }
-                }
-                .padding(.horizontal, 16)
-                .environment(\.colorScheme, chromeColorScheme)
+                AgentDetailStatusChrome(
+                    status: status,
+                    hostTelemetry: hostTelemetry,
+                    chromeColorScheme: chromeColorScheme)
 
                 VStack(spacing: 0) {
                     VStack(alignment: .leading, spacing: 8) {
@@ -427,44 +422,6 @@ struct AgentComposerView: View {
         Color(uiColor: .label).opacity(0.72)
     }
 
-    private var statusLabel: some View {
-        HStack(spacing: 4) {
-            if status == .working {
-                SolvingOrbView(size: 10)
-                    .accessibilityHidden(true)
-            } else {
-                Circle()
-                    .fill(Color(status.inkUIColor))
-                    .frame(width: 7, height: 7)
-                    .accessibilityHidden(true)
-            }
-            Text(status.rawValue.capitalized)
-        }
-        .font(.caption2.weight(.medium))
-        .foregroundStyle(Color(status.inkUIColor))
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Agent status")
-        .accessibilityValue(status.rawValue.capitalized)
-    }
-
-    /// Deliberately quieter than Agent Status: it never changes color with the
-    /// value and never animates, so a number that moves on its own cadence
-    /// cannot pull attention away from the Agent the user came here for.
-    private func hostTelemetryLabel(
-        _ telemetry: HostTelemetryPresentation
-    ) -> some View {
-        Text(telemetry.title)
-            .font(.caption2)
-            .monospacedDigit()
-            // One step brighter on dark themes: tertiary gray recedes into a
-            // near-black surface faster than it does into a light one.
-            .foregroundStyle(
-                chromeColorScheme == .dark
-                    ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tertiary))
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(telemetry.accessibilityLabel)
-            .accessibilityValue(telemetry.accessibilityValue)
-    }
 }
 
 /// The inline suggestion menu above the Composer's text area: the Skills the

--- a/Sources/Heeler/Console/AgentDetailStatusChrome.swift
+++ b/Sources/Heeler/Console/AgentDetailStatusChrome.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// Shared Agent Status + Host telemetry caption used by Composer and Direct
+/// Input. One presentation keeps accessibility and visual treatment aligned.
+struct AgentDetailStatusChrome: View {
+    let status: AgentStatus
+    let hostTelemetry: HostTelemetryPresentation?
+    let chromeColorScheme: ColorScheme
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            statusLabel
+            Spacer(minLength: 8)
+            if let hostTelemetry {
+                hostTelemetryLabel(hostTelemetry)
+            }
+        }
+        .padding(.horizontal, 16)
+        .environment(\.colorScheme, chromeColorScheme)
+    }
+
+    private var statusLabel: some View {
+        HStack(spacing: 4) {
+            if status == .working {
+                SolvingOrbView(size: 10)
+                    .accessibilityHidden(true)
+            } else {
+                Circle()
+                    .fill(Color(status.inkUIColor))
+                    .frame(width: 7, height: 7)
+                    .accessibilityHidden(true)
+            }
+            Text(status.rawValue.capitalized)
+        }
+        .font(.caption2.weight(.medium))
+        .foregroundStyle(Color(status.inkUIColor))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Agent status")
+        .accessibilityValue(status.rawValue.capitalized)
+    }
+
+    /// Deliberately quieter than Agent Status: it never changes color with the
+    /// value and never animates, so a number that moves on its own cadence
+    /// cannot pull attention away from the Agent the user came here for.
+    private func hostTelemetryLabel(
+        _ telemetry: HostTelemetryPresentation
+    ) -> some View {
+        Text(telemetry.title)
+            .font(.caption2)
+            .monospacedDigit()
+            // One step brighter on dark themes: tertiary gray recedes into a
+            // near-black surface faster than it does into a light one.
+            .foregroundStyle(
+                chromeColorScheme == .dark
+                    ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tertiary))
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(telemetry.accessibilityLabel)
+            .accessibilityValue(telemetry.accessibilityValue)
+    }
+}

--- a/Sources/Heeler/Console/AgentDetailView.swift
+++ b/Sources/Heeler/Console/AgentDetailView.swift
@@ -1,12 +1,13 @@
 import SwiftUI
 
-/// The default Agent detail surface. Ghostty renders the live Attach stream,
-/// while the local Composer owns every user-authored message and delivers it
-/// through one `agent.prompt` request, except when Agent Status is Blocked.
+/// The default Agent detail surface. Ghostty renders the live Attach stream.
+/// Composer owns authored delivery by default; Direct Input (ADR 0016) is an
+/// explicit opt-in that types the Attach PTY with the system keyboard.
 struct AgentDetailView: View {
     let agent: ConsoleAgent
     private let console: ConsoleStore
     private let terminal: TerminalSettings
+    private let inputMode: AgentInputModeSettings
     private let hosts: [Host]
     private let activity: AppActivityCoordinator
     private let keyboardHandoff: TerminalKeyboardHandoff
@@ -22,6 +23,7 @@ struct AgentDetailView: View {
         agent: ConsoleAgent,
         console: ConsoleStore,
         terminal: TerminalSettings,
+        inputMode: AgentInputModeSettings,
         hosts: [Host],
         activity: AppActivityCoordinator,
         keyboardHandoff: TerminalKeyboardHandoff,
@@ -36,6 +38,7 @@ struct AgentDetailView: View {
         self.agent = agent
         self.console = console
         self.terminal = terminal
+        self.inputMode = inputMode
         self.hosts = hosts
         self.activity = activity
         self.keyboardHandoff = keyboardHandoff
@@ -112,6 +115,7 @@ struct AgentDetailView: View {
                     agent: agent,
                     console: console,
                     terminal: terminal,
+                    inputMode: inputMode,
                     hosts: hosts,
                     activity: activity,
                     keyboardHandoff: keyboardHandoff,

--- a/Sources/Heeler/Console/AgentDetailView.swift
+++ b/Sources/Heeler/Console/AgentDetailView.swift
@@ -120,7 +120,9 @@ struct AgentDetailView: View {
                     activity: activity,
                     keyboardHandoff: keyboardHandoff,
                     keyboardInset: keyboardInset,
-                    isOnStage: isOnStage,
+                    isOnStage: {
+                        isOnStage() && openTerminal.shell == nil
+                    },
                     onSwitch: onSwitch,
                     onClosed: onClosed,
                     canOpenTerminal: openTerminal.canOpen,

--- a/Sources/Heeler/Console/AgentDirectInputChrome.swift
+++ b/Sources/Heeler/Console/AgentDirectInputChrome.swift
@@ -1,18 +1,21 @@
 import SwiftUI
 import UIKit
 
-/// Compact Agent-detail chrome for Direct Input: status, a shortcut row while
-/// the system keyboard is up, and the Agent switcher with Show Composer.
-/// App content rather than a keyboard accessory, so UIKit's candidate-row
-/// teardown cannot tear it down or leave a hollow gap.
+/// Compact Agent-detail chrome for Direct Input: status, Agent switcher with
+/// Show Composer, and a shortcut row while the software keyboard is up.
+/// Bottom-up order matches the approved geometry: system keyboard, shortcut
+/// row, switcher, status. App content rather than a keyboard accessory, so
+/// UIKit's candidate-row teardown cannot tear it down or leave a hollow gap.
 struct AgentDirectInputChrome: View {
     let status: AgentStatus
     let hostTelemetry: HostTelemetryPresentation?
     let chromeColorScheme: ColorScheme
     let switcher: TerminalAgentSwitcher
     let keyboardHandoff: TerminalKeyboardHandoff
+    /// Ghostty first-responder / tools intent for the switcher toggle glyph.
     let isKeyboardUp: Bool
     let isToolsKeyboardPresented: Bool
+    /// Software-keyboard shortcut row only — never hardware-first-responder.
     let showShortcutRow: Bool
     let actions: AgentComposerActions
     let toggleKeyboard: () -> Void
@@ -28,42 +31,13 @@ struct AgentDirectInputChrome: View {
         .escape, .tab, .shiftTab, .enter,
     ]
 
-    /// Same arithmetic Shell uses: a transient zero inset while first
-    /// responder is retained must not hide the chrome mid-swap.
-    static func keyboardPresentation(
-        usesToolsKeyboard: Bool,
-        insetHeight: CGFloat,
-        keyboardIsUp: Bool
-    ) -> AgentComposerKeyboardPresentation {
-        if usesToolsKeyboard { return .tools }
-        if insetHeight > 0 || keyboardIsUp { return .system }
-        return .hidden
-    }
-
-    /// Shortcut keys ride the system keyboard only. Tools mode already has
-    /// the pad; a dismissed keyboard must leave no hollow black bar.
-    static func showsShortcutRow(
-        presentation: AgentComposerKeyboardPresentation
-    ) -> Bool {
-        presentation == .system
-    }
-
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 6) {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    statusLabel
-                    Spacer(minLength: 8)
-                    if let hostTelemetry {
-                        hostTelemetryLabel(hostTelemetry)
-                    }
-                }
-                .padding(.horizontal, 16)
-                .environment(\.colorScheme, chromeColorScheme)
-
-                if showShortcutRow {
-                    shortcutRow
-                }
+                AgentDetailStatusChrome(
+                    status: status,
+                    hostTelemetry: hostTelemetry,
+                    chromeColorScheme: chromeColorScheme)
 
                 TerminalAgentSwitcherRow(
                     switcher: focusPreservingSwitcher,
@@ -72,6 +46,12 @@ struct AgentDirectInputChrome: View {
                     isToolsKeyboardPresented: isToolsKeyboardPresented,
                     switchKeyboard: switchKeyboard,
                     modeControl: modeControl)
+
+                // Adjacent to the software keyboard it augments — below the
+                // switcher in this top-to-bottom stack, above the keyboard.
+                if showShortcutRow {
+                    shortcutRow
+                }
             }
             .padding(.vertical, 8)
         }
@@ -87,8 +67,8 @@ struct AgentDirectInputChrome: View {
         }
         return .button(
             systemImage: "square.and.pencil",
-            accessibilityLabel: "Show Composer",
-            accessibilityHint: "Restores the Composer. The draft is unchanged.",
+            accessibilityLabel: AgentDirectInputPresentation.showComposerAccessibilityLabel,
+            accessibilityHint: AgentDirectInputPresentation.showComposerAccessibilityHint,
             action: showComposer)
     }
 
@@ -135,8 +115,10 @@ struct AgentDirectInputChrome: View {
                     .background(
                         Color(uiColor: .secondarySystemFill),
                         in: .rect(cornerRadius: 8))
-                    .accessibilityLabel("Show Composer")
-                    .accessibilityHint("Restores the Composer. The draft is unchanged.")
+                    .accessibilityLabel(
+                        AgentDirectInputPresentation.showComposerAccessibilityLabel)
+                    .accessibilityHint(
+                        AgentDirectInputPresentation.showComposerAccessibilityHint)
 
                 moreMenu
 
@@ -211,39 +193,5 @@ struct AgentDirectInputChrome: View {
         }
         .accessibilityLabel("More")
         .accessibilityHint("Opens Agent actions")
-    }
-
-    private var statusLabel: some View {
-        HStack(spacing: 4) {
-            if status == .working {
-                SolvingOrbView(size: 10)
-                    .accessibilityHidden(true)
-            } else {
-                Circle()
-                    .fill(Color(status.inkUIColor))
-                    .frame(width: 7, height: 7)
-                    .accessibilityHidden(true)
-            }
-            Text(status.rawValue.capitalized)
-        }
-        .font(.caption2.weight(.medium))
-        .foregroundStyle(Color(status.inkUIColor))
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Agent status")
-        .accessibilityValue(status.rawValue.capitalized)
-    }
-
-    private func hostTelemetryLabel(
-        _ telemetry: HostTelemetryPresentation
-    ) -> some View {
-        Text(telemetry.title)
-            .font(.caption2)
-            .monospacedDigit()
-            .foregroundStyle(
-                chromeColorScheme == .dark
-                    ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tertiary))
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(telemetry.accessibilityLabel)
-            .accessibilityValue(telemetry.accessibilityValue)
     }
 }

--- a/Sources/Heeler/Console/AgentDirectInputChrome.swift
+++ b/Sources/Heeler/Console/AgentDirectInputChrome.swift
@@ -89,21 +89,7 @@ struct AgentDirectInputChrome: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 6) {
                 ForEach(Self.shortcutKeys, id: \.self) { key in
-                    Button {
-                        UIDevice.current.playInputClick()
-                        sendQuickKey(key)
-                    } label: {
-                        Text(key.title ?? key.accessibilityLabel)
-                            .font(.caption.weight(.medium))
-                            .frame(minWidth: 44, minHeight: 44)
-                            .padding(.horizontal, 4)
-                    }
-                    .buttonStyle(.plain)
-                    .background(
-                        Color(uiColor: .secondarySystemFill),
-                        in: .rect(cornerRadius: 8))
-                    .accessibilityLabel(key.accessibilityLabel)
-                    .accessibilityHint("Sends this key directly to the Agent")
+                    shortcutKeyButton(key)
                 }
 
                 Spacer(minLength: 8)
@@ -139,9 +125,36 @@ struct AgentDirectInputChrome: View {
                 .frame(height: 1 / max(displayScale, 1))
         }
         .background(Color(uiColor: .secondarySystemBackground))
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier(
-            AgentDirectInputPresentation.shortcutRowAccessibilityIdentifier)
+    }
+
+    /// Escape carries the source-specific row identity so hosted a11y traversal
+    /// can discover the software-keyboard shortcut row. A `.contain` container
+    /// identifier does not materialize in that walk; Tools keypad Escape must
+    /// keep the shared spoken label without this identifier.
+    @ViewBuilder
+    private func shortcutKeyButton(_ key: AgentQuickKey) -> some View {
+        let button = Button {
+            UIDevice.current.playInputClick()
+            sendQuickKey(key)
+        } label: {
+            Text(key.title ?? key.accessibilityLabel)
+                .font(.caption.weight(.medium))
+                .frame(minWidth: 44, minHeight: 44)
+                .padding(.horizontal, 4)
+        }
+        .buttonStyle(.plain)
+        .background(
+            Color(uiColor: .secondarySystemFill),
+            in: .rect(cornerRadius: 8))
+        .accessibilityLabel(key.accessibilityLabel)
+        .accessibilityHint("Sends this key directly to the Agent")
+
+        if key == .escape {
+            button.accessibilityIdentifier(
+                AgentDirectInputPresentation.shortcutRowAccessibilityIdentifier)
+        } else {
+            button
+        }
     }
 
     private var moreMenu: some View {

--- a/Sources/Heeler/Console/AgentDirectInputChrome.swift
+++ b/Sources/Heeler/Console/AgentDirectInputChrome.swift
@@ -44,8 +44,9 @@ struct AgentDirectInputChrome: View {
     @Environment(\.displayScale) private var displayScale
 
     private static let shortcutKeys: [AgentQuickKey] = [
-        .escape, .tab, .shiftTab, .enter,
+        .escape, .tab, .shiftTab,
         .up, .down, .left, .right,
+        .backspace, .shiftEnter,
     ]
 
     private var presentation: AgentDirectInputChromeContext.Presentation {
@@ -107,6 +108,8 @@ struct AgentDirectInputChrome: View {
                 .padding(.trailing, 6)
             }
 
+            shortcutKeyButton(.enter)
+
             moreMenu
                 .frame(width: 44, height: 44)
                 .background(Color(uiColor: .secondarySystemBackground))
@@ -144,6 +147,8 @@ struct AgentDirectInputChrome: View {
             38
         case .shiftTab:
             46
+        case .shiftEnter:
+            54
         case .enter:
             42
         case .left, .up, .down, .right:

--- a/Sources/Heeler/Console/AgentDirectInputChrome.swift
+++ b/Sources/Heeler/Console/AgentDirectInputChrome.swift
@@ -34,11 +34,12 @@ struct AgentDirectInputChromeContext {
     let interactions: Interactions
 }
 
-/// Compact Agent-detail chrome for Direct Input: status, Agent switcher with
-/// Show Composer, and a shortcut row while the software keyboard is up.
-/// Bottom-up order matches the approved geometry: system keyboard, shortcut
-/// row, switcher, status. App content rather than a keyboard accessory, so
-/// UIKit's candidate-row teardown cannot tear it down or leave a hollow gap.
+/// Compact Agent-detail chrome for Direct Input: status, a shortcut row while
+/// the software keyboard is up, and the Agent switcher with Show Composer.
+/// Bottom-up order: system keyboard, switcher, shortcut row, status. The
+/// shortcut row sits immediately above the persistent Agent strip. App content
+/// rather than a keyboard accessory, so UIKit's candidate-row teardown cannot
+/// tear it down or leave a hollow gap.
 struct AgentDirectInputChrome: View {
     let context: AgentDirectInputChromeContext
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -64,6 +65,12 @@ struct AgentDirectInputChrome: View {
                     hostTelemetry: presentation.hostTelemetry,
                     chromeColorScheme: presentation.chromeColorScheme)
 
+                // Immediately above the Agent list/switcher strip. Keyboard
+                // show/hide stays on the switcher row — not duplicated here.
+                if presentation.showShortcutRow {
+                    shortcutRow
+                }
+
                 TerminalAgentSwitcherRow(
                     switcher: interactions.switcher,
                     isKeyboardUp: presentation.isKeyboardUp,
@@ -71,12 +78,6 @@ struct AgentDirectInputChrome: View {
                     isToolsKeyboardPresented: presentation.isToolsKeyboardPresented,
                     switchKeyboard: interactions.switchKeyboard,
                     modeControl: modeControl)
-
-                // Adjacent to the software keyboard it augments — below the
-                // switcher in this top-to-bottom stack, above the keyboard.
-                if presentation.showShortcutRow {
-                    shortcutRow
-                }
             }
             .padding(.vertical, 8)
         }
@@ -119,14 +120,6 @@ struct AgentDirectInputChrome: View {
                         AgentDirectInputPresentation.showComposerAccessibilityHint)
 
                 moreMenu
-
-                Button(action: interactions.toggleKeyboard) {
-                    Image(systemName: "keyboard.chevron.compact.down")
-                        .font(.system(size: 12, weight: .medium))
-                        .frame(width: 44, height: 44)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Dismiss keyboard")
             }
             .padding(.horizontal, 12)
         }

--- a/Sources/Heeler/Console/AgentDirectInputChrome.swift
+++ b/Sources/Heeler/Console/AgentDirectInputChrome.swift
@@ -33,7 +33,7 @@ struct AgentDirectInputChromeContext {
 }
 
 /// Compact Agent-detail chrome for Direct Input: status, a persistent shortcut
-/// row, and the Agent switcher with Show Composer.
+/// row, and the Agent switcher.
 /// Bottom-up order: system keyboard, switcher, shortcut row, status. The
 /// shortcut row sits immediately above the persistent Agent strip. App content
 /// rather than a keyboard accessory, so UIKit's candidate-row teardown cannot
@@ -45,6 +45,7 @@ struct AgentDirectInputChrome: View {
 
     private static let shortcutKeys: [AgentQuickKey] = [
         .escape, .tab, .shiftTab, .enter,
+        .up, .down, .left, .right,
     ]
 
     private var presentation: AgentDirectInputChromeContext.Presentation {
@@ -95,31 +96,22 @@ struct AgentDirectInputChrome: View {
     }
 
     private var shortcutRow: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 6) {
-                ForEach(Self.shortcutKeys, id: \.self) { key in
-                    shortcutKeyButton(key)
+        HStack(spacing: 0) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 4) {
+                    ForEach(Self.shortcutKeys, id: \.self) { key in
+                        shortcutKeyButton(key)
+                    }
                 }
-
-                Spacer(minLength: 8)
-
-                Button("Composer", action: interactions.showComposer)
-                    .font(.caption.weight(.semibold))
-                    .frame(minHeight: 44)
-                    .padding(.horizontal, 10)
-                    .background(
-                        Color(uiColor: .secondarySystemFill),
-                        in: .rect(cornerRadius: 8))
-                    .accessibilityLabel(
-                        AgentDirectInputPresentation.showComposerAccessibilityLabel)
-                    .accessibilityHint(
-                        AgentDirectInputPresentation.showComposerAccessibilityHint)
-
-                moreMenu
+                .padding(.leading, 8)
+                .padding(.trailing, 6)
             }
-            .padding(.horizontal, 12)
+
+            moreMenu
+                .frame(width: 44, height: 44)
+                .background(Color(uiColor: .secondarySystemBackground))
         }
-        .frame(height: 48)
+        .frame(height: 44)
         .background(alignment: .top) {
             Rectangle()
                 .fill(Color(uiColor: .separator))
@@ -133,17 +125,43 @@ struct AgentDirectInputChrome: View {
             UIDevice.current.playInputClick()
             interactions.sendQuickKey(key)
         } label: {
-            Text(key.title ?? key.accessibilityLabel)
-                .font(.caption.weight(.medium))
-                .frame(minWidth: 44, minHeight: 44)
-                .padding(.horizontal, 4)
+            shortcutKeyLabel(key)
+                .frame(minWidth: keyCapWidth(for: key), minHeight: 30)
+                .background(
+                    Color(uiColor: .secondarySystemFill),
+                    in: .rect(cornerRadius: 7))
         }
+        .frame(height: 44)
+        .contentShape(.rect)
         .buttonStyle(.plain)
-        .background(
-            Color(uiColor: .secondarySystemFill),
-            in: .rect(cornerRadius: 8))
         .accessibilityLabel(key.accessibilityLabel)
         .accessibilityHint("Sends this key directly to the Agent")
+    }
+
+    private func keyCapWidth(for key: AgentQuickKey) -> CGFloat {
+        switch key {
+        case .escape, .tab:
+            38
+        case .shiftTab:
+            46
+        case .enter:
+            42
+        case .left, .up, .down, .right:
+            30
+        case .backspace:
+            64
+        }
+    }
+
+    @ViewBuilder
+    private func shortcutKeyLabel(_ key: AgentQuickKey) -> some View {
+        if let systemImageName = key.systemImageName {
+            Image(systemName: systemImageName)
+                .font(.system(size: 12, weight: .semibold))
+        } else if let title = key.title {
+            Text(title)
+                .font(.caption.weight(.medium))
+        }
     }
 
     private var moreMenu: some View {
@@ -155,7 +173,8 @@ struct AgentDirectInputChrome: View {
         } label: {
             Image(systemName: "ellipsis")
                 .font(.system(size: 12, weight: .semibold))
-                .frame(width: 44, height: 44)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .contentShape(.rect)
         }
         .accessibilityLabel("More")
         .accessibilityHint("Opens Agent actions")

--- a/Sources/Heeler/Console/AgentDirectInputChrome.swift
+++ b/Sources/Heeler/Console/AgentDirectInputChrome.swift
@@ -13,8 +13,6 @@ struct AgentDirectInputChromeContext {
         /// Ghostty first-responder / tools intent for the switcher toggle glyph.
         let isKeyboardUp: Bool
         let isToolsKeyboardPresented: Bool
-        /// Software-keyboard shortcut row only — never hardware-first-responder.
-        let showShortcutRow: Bool
     }
 
     struct Interactions {
@@ -34,8 +32,8 @@ struct AgentDirectInputChromeContext {
     let interactions: Interactions
 }
 
-/// Compact Agent-detail chrome for Direct Input: status, a shortcut row while
-/// the software keyboard is up, and the Agent switcher with Show Composer.
+/// Compact Agent-detail chrome for Direct Input: status, a persistent shortcut
+/// row, and the Agent switcher with Show Composer.
 /// Bottom-up order: system keyboard, switcher, shortcut row, status. The
 /// shortcut row sits immediately above the persistent Agent strip. App content
 /// rather than a keyboard accessory, so UIKit's candidate-row teardown cannot
@@ -67,9 +65,7 @@ struct AgentDirectInputChrome: View {
 
                 // Immediately above the Agent list/switcher strip. Keyboard
                 // show/hide stays on the switcher row — not duplicated here.
-                if presentation.showShortcutRow {
-                    shortcutRow
-                }
+                shortcutRow
 
                 TerminalAgentSwitcherRow(
                     switcher: interactions.switcher,

--- a/Sources/Heeler/Console/AgentDirectInputChrome.swift
+++ b/Sources/Heeler/Console/AgentDirectInputChrome.swift
@@ -126,6 +126,7 @@ struct AgentDirectInputChrome: View {
             moreMenu
                 .frame(width: 44, height: 44)
         }
+        .padding(.leading, 4)
         .background(Color(uiColor: .secondarySystemBackground))
         .overlay(alignment: .leading) {
             LinearGradient(

--- a/Sources/Heeler/Console/AgentDirectInputChrome.swift
+++ b/Sources/Heeler/Console/AgentDirectInputChrome.swift
@@ -128,11 +128,9 @@ struct AgentDirectInputChrome: View {
             UIDevice.current.playInputClick()
             interactions.sendQuickKey(key)
         } label: {
-            shortcutKeyLabel(key)
-                .frame(minWidth: keyCapWidth(for: key), minHeight: 30)
-                .background(
-                    Color(uiColor: .secondarySystemFill),
-                    in: .rect(cornerRadius: 7))
+            shortcutKeyCap(minWidth: keyCapWidth(for: key)) {
+                shortcutKeyLabel(key)
+            }
         }
         .frame(height: 44)
         .contentShape(.rect)
@@ -169,6 +167,17 @@ struct AgentDirectInputChrome: View {
         }
     }
 
+    private func shortcutKeyCap<Content: View>(
+        minWidth: CGFloat,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        content()
+            .frame(minWidth: minWidth, minHeight: 30)
+            .background(
+                Color(uiColor: .secondarySystemFill),
+                in: .rect(cornerRadius: 7))
+    }
+
     private var moreMenu: some View {
         Menu {
             AgentActionMenuContent(
@@ -176,11 +185,14 @@ struct AgentDirectInputChrome: View {
                 sections: AgentActionMenuPolicy.directInputMoreSections,
                 restoreComposerThen: interactions.restoreComposerThen)
         } label: {
-            Image(systemName: "ellipsis")
-                .font(.system(size: 12, weight: .semibold))
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .contentShape(.rect)
+            shortcutKeyCap(minWidth: 30) {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .contentShape(.rect)
         }
+        .buttonStyle(.plain)
         .accessibilityLabel("More")
         .accessibilityHint("Opens Agent actions")
     }

--- a/Sources/Heeler/Console/AgentDirectInputChrome.swift
+++ b/Sources/Heeler/Console/AgentDirectInputChrome.swift
@@ -108,11 +108,7 @@ struct AgentDirectInputChrome: View {
                 .padding(.trailing, 6)
             }
 
-            shortcutKeyButton(.enter)
-
-            moreMenu
-                .frame(width: 44, height: 44)
-                .background(Color(uiColor: .secondarySystemBackground))
+            fixedShortcutButtons
         }
         .frame(height: 44)
         .background(alignment: .top) {
@@ -121,6 +117,26 @@ struct AgentDirectInputChrome: View {
                 .frame(height: 1 / max(displayScale, 1))
         }
         .background(Color(uiColor: .secondarySystemBackground))
+    }
+
+    private var fixedShortcutButtons: some View {
+        HStack(spacing: 0) {
+            shortcutKeyButton(.enter)
+
+            moreMenu
+                .frame(width: 44, height: 44)
+        }
+        .background(Color(uiColor: .secondarySystemBackground))
+        .overlay(alignment: .leading) {
+            LinearGradient(
+                colors: [.clear, Color(uiColor: .separator).opacity(0.7)],
+                startPoint: .leading,
+                endPoint: .trailing)
+                .frame(width: 8)
+                .offset(x: -8)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+        }
     }
 
     private func shortcutKeyButton(_ key: AgentQuickKey) -> some View {

--- a/Sources/Heeler/Console/AgentDirectInputChrome.swift
+++ b/Sources/Heeler/Console/AgentDirectInputChrome.swift
@@ -139,6 +139,9 @@ struct AgentDirectInputChrome: View {
                 .frame(height: 1 / max(displayScale, 1))
         }
         .background(Color(uiColor: .secondarySystemBackground))
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier(
+            AgentDirectInputPresentation.shortcutRowAccessibilityIdentifier)
     }
 
     private var moreMenu: some View {

--- a/Sources/Heeler/Console/AgentDirectInputChrome.swift
+++ b/Sources/Heeler/Console/AgentDirectInputChrome.swift
@@ -1,0 +1,249 @@
+import SwiftUI
+import UIKit
+
+/// Compact Agent-detail chrome for Direct Input: status, a shortcut row while
+/// the system keyboard is up, and the Agent switcher with Show Composer.
+/// App content rather than a keyboard accessory, so UIKit's candidate-row
+/// teardown cannot tear it down or leave a hollow gap.
+struct AgentDirectInputChrome: View {
+    let status: AgentStatus
+    let hostTelemetry: HostTelemetryPresentation?
+    let chromeColorScheme: ColorScheme
+    let switcher: TerminalAgentSwitcher
+    let keyboardHandoff: TerminalKeyboardHandoff
+    let isKeyboardUp: Bool
+    let isToolsKeyboardPresented: Bool
+    let showShortcutRow: Bool
+    let actions: AgentComposerActions
+    let toggleKeyboard: () -> Void
+    let switchKeyboard: (() -> Void)?
+    let sendQuickKey: (AgentQuickKey) -> Void
+    let showComposer: () -> Void
+    /// Routes More / Add actions that own the draft: restore Composer first.
+    let restoreComposerThen: (@escaping () -> Void) -> Void
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.displayScale) private var displayScale
+
+    private static let shortcutKeys: [AgentQuickKey] = [
+        .escape, .tab, .shiftTab, .enter,
+    ]
+
+    /// Same arithmetic Shell uses: a transient zero inset while first
+    /// responder is retained must not hide the chrome mid-swap.
+    static func keyboardPresentation(
+        usesToolsKeyboard: Bool,
+        insetHeight: CGFloat,
+        keyboardIsUp: Bool
+    ) -> AgentComposerKeyboardPresentation {
+        if usesToolsKeyboard { return .tools }
+        if insetHeight > 0 || keyboardIsUp { return .system }
+        return .hidden
+    }
+
+    /// Shortcut keys ride the system keyboard only. Tools mode already has
+    /// the pad; a dismissed keyboard must leave no hollow black bar.
+    static func showsShortcutRow(
+        presentation: AgentComposerKeyboardPresentation
+    ) -> Bool {
+        presentation == .system
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    statusLabel
+                    Spacer(minLength: 8)
+                    if let hostTelemetry {
+                        hostTelemetryLabel(hostTelemetry)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .environment(\.colorScheme, chromeColorScheme)
+
+                if showShortcutRow {
+                    shortcutRow
+                }
+
+                TerminalAgentSwitcherRow(
+                    switcher: focusPreservingSwitcher,
+                    isKeyboardUp: isKeyboardUp,
+                    toggleKeyboard: toggleKeyboard,
+                    isToolsKeyboardPresented: isToolsKeyboardPresented,
+                    switchKeyboard: switchKeyboard,
+                    modeControl: modeControl)
+            }
+            .padding(.vertical, 8)
+        }
+    }
+
+    private var modeControl: TerminalAgentSwitcherModeControl {
+        if horizontalSizeClass == .regular {
+            return .segmented(
+                selection: .direct,
+                select: { mode in
+                    if mode == .composer { showComposer() }
+                })
+        }
+        return .button(
+            systemImage: "square.and.pencil",
+            accessibilityLabel: "Show Composer",
+            accessibilityHint: "Restores the Composer. The draft is unchanged.",
+            action: showComposer)
+    }
+
+    private var focusPreservingSwitcher: TerminalAgentSwitcher {
+        TerminalAgentSwitcher(
+            items: switcher.items,
+            selectedID: switcher.selectedID,
+            onSelect: { id in
+                if isKeyboardUp {
+                    keyboardHandoff.arm(for: id)
+                }
+                switcher.onSelect(id)
+            },
+            onTogglePin: switcher.onTogglePin)
+    }
+
+    private var shortcutRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(Self.shortcutKeys, id: \.self) { key in
+                    Button {
+                        UIDevice.current.playInputClick()
+                        sendQuickKey(key)
+                    } label: {
+                        Text(key.title ?? key.accessibilityLabel)
+                            .font(.caption.weight(.medium))
+                            .frame(minWidth: 44, minHeight: 44)
+                            .padding(.horizontal, 4)
+                    }
+                    .buttonStyle(.plain)
+                    .background(
+                        Color(uiColor: .secondarySystemFill),
+                        in: .rect(cornerRadius: 8))
+                    .accessibilityLabel(key.accessibilityLabel)
+                    .accessibilityHint("Sends this key directly to the Agent")
+                }
+
+                Spacer(minLength: 8)
+
+                Button("Composer", action: showComposer)
+                    .font(.caption.weight(.semibold))
+                    .frame(minHeight: 44)
+                    .padding(.horizontal, 10)
+                    .background(
+                        Color(uiColor: .secondarySystemFill),
+                        in: .rect(cornerRadius: 8))
+                    .accessibilityLabel("Show Composer")
+                    .accessibilityHint("Restores the Composer. The draft is unchanged.")
+
+                moreMenu
+
+                Button(action: toggleKeyboard) {
+                    Image(systemName: "keyboard.chevron.compact.down")
+                        .font(.system(size: 12, weight: .medium))
+                        .frame(width: 44, height: 44)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss keyboard")
+            }
+            .padding(.horizontal, 12)
+        }
+        .frame(height: 48)
+        .background(alignment: .top) {
+            Rectangle()
+                .fill(Color(uiColor: .separator))
+                .frame(height: 1 / max(displayScale, 1))
+        }
+        .background(Color(uiColor: .secondarySystemBackground))
+    }
+
+    private var moreMenu: some View {
+        Menu {
+            Section {
+                Button("Add Image", systemImage: "photo") {
+                    restoreComposerThen { actions.addImage() }
+                }
+                .disabled(!actions.canBegin)
+                Button("Add File", systemImage: "doc") {
+                    restoreComposerThen { actions.addFile() }
+                }
+                .disabled(!actions.canBegin)
+            }
+            Section {
+                Button("Open Terminal", systemImage: "apple.terminal") {
+                    actions.openTerminal?()
+                }
+                .disabled(actions.openTerminal == nil || actions.isOpeningTerminal)
+                Button("New Agent", systemImage: "plus") {
+                    actions.startAgent()
+                }
+                if let showSkills = actions.showSkills {
+                    Button("Skills", systemImage: "sparkles") {
+                        restoreComposerThen(showSkills)
+                    }
+                }
+                Button("Snippets", systemImage: "quote.bubble") {
+                    restoreComposerThen(actions.manageSnippets)
+                }
+            }
+            Section {
+                if let showWorktreeDetails = actions.showWorktreeDetails {
+                    Button("Worktree Details", systemImage: "arrow.triangle.branch") {
+                        showWorktreeDetails()
+                    }
+                }
+                Button("Rename Agent", systemImage: "pencil") {
+                    actions.renameAgent()
+                }
+                Button("Rename Workspace", systemImage: "pencil.line") {
+                    actions.renameWorkspace()
+                }
+                Button("Close Agent", systemImage: "trash", role: .destructive) {
+                    actions.closeAgent()
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 12, weight: .semibold))
+                .frame(width: 44, height: 44)
+        }
+        .accessibilityLabel("More")
+        .accessibilityHint("Opens Agent actions")
+    }
+
+    private var statusLabel: some View {
+        HStack(spacing: 4) {
+            if status == .working {
+                SolvingOrbView(size: 10)
+                    .accessibilityHidden(true)
+            } else {
+                Circle()
+                    .fill(Color(status.inkUIColor))
+                    .frame(width: 7, height: 7)
+                    .accessibilityHidden(true)
+            }
+            Text(status.rawValue.capitalized)
+        }
+        .font(.caption2.weight(.medium))
+        .foregroundStyle(Color(status.inkUIColor))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Agent status")
+        .accessibilityValue(status.rawValue.capitalized)
+    }
+
+    private func hostTelemetryLabel(
+        _ telemetry: HostTelemetryPresentation
+    ) -> some View {
+        Text(telemetry.title)
+            .font(.caption2)
+            .monospacedDigit()
+            .foregroundStyle(
+                chromeColorScheme == .dark
+                    ? AnyShapeStyle(.secondary) : AnyShapeStyle(.tertiary))
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(telemetry.accessibilityLabel)
+            .accessibilityValue(telemetry.accessibilityValue)
+    }
+}

--- a/Sources/Heeler/Console/AgentDirectInputChrome.swift
+++ b/Sources/Heeler/Console/AgentDirectInputChrome.swift
@@ -18,8 +18,9 @@ struct AgentDirectInputChromeContext {
     }
 
     struct Interactions {
+        /// Switcher `onSelect` is `AgentTerminalView.switchToAgent`, the sole
+        /// production owner of Direct Input keyboard-claim arming.
         let switcher: TerminalAgentSwitcher
-        let keyboardHandoff: TerminalKeyboardHandoff
         let actions: AgentComposerActions
         let toggleKeyboard: () -> Void
         let switchKeyboard: (() -> Void)?
@@ -64,7 +65,7 @@ struct AgentDirectInputChrome: View {
                     chromeColorScheme: presentation.chromeColorScheme)
 
                 TerminalAgentSwitcherRow(
-                    switcher: focusPreservingSwitcher,
+                    switcher: interactions.switcher,
                     isKeyboardUp: presentation.isKeyboardUp,
                     toggleKeyboard: interactions.toggleKeyboard,
                     isToolsKeyboardPresented: presentation.isToolsKeyboardPresented,
@@ -94,19 +95,6 @@ struct AgentDirectInputChrome: View {
             accessibilityLabel: AgentDirectInputPresentation.showComposerAccessibilityLabel,
             accessibilityHint: AgentDirectInputPresentation.showComposerAccessibilityHint,
             action: interactions.showComposer)
-    }
-
-    private var focusPreservingSwitcher: TerminalAgentSwitcher {
-        TerminalAgentSwitcher(
-            items: interactions.switcher.items,
-            selectedID: interactions.switcher.selectedID,
-            onSelect: { id in
-                if presentation.isKeyboardUp {
-                    interactions.keyboardHandoff.arm(for: id)
-                }
-                interactions.switcher.onSelect(id)
-            },
-            onTogglePin: interactions.switcher.onTogglePin)
     }
 
     private var shortcutRow: some View {

--- a/Sources/Heeler/Console/AgentDirectInputChrome.swift
+++ b/Sources/Heeler/Console/AgentDirectInputChrome.swift
@@ -127,13 +127,8 @@ struct AgentDirectInputChrome: View {
         .background(Color(uiColor: .secondarySystemBackground))
     }
 
-    /// Escape carries the source-specific row identity so hosted a11y traversal
-    /// can discover the software-keyboard shortcut row. A `.contain` container
-    /// identifier does not materialize in that walk; Tools keypad Escape must
-    /// keep the shared spoken label without this identifier.
-    @ViewBuilder
     private func shortcutKeyButton(_ key: AgentQuickKey) -> some View {
-        let button = Button {
+        Button {
             UIDevice.current.playInputClick()
             sendQuickKey(key)
         } label: {
@@ -148,13 +143,6 @@ struct AgentDirectInputChrome: View {
             in: .rect(cornerRadius: 8))
         .accessibilityLabel(key.accessibilityLabel)
         .accessibilityHint("Sends this key directly to the Agent")
-
-        if key == .escape {
-            button.accessibilityIdentifier(
-                AgentDirectInputPresentation.shortcutRowAccessibilityIdentifier)
-        } else {
-            button
-        }
     }
 
     private var moreMenu: some View {

--- a/Sources/Heeler/Console/AgentDirectInputChrome.swift
+++ b/Sources/Heeler/Console/AgentDirectInputChrome.swift
@@ -1,29 +1,45 @@
 import SwiftUI
 import UIKit
 
+/// Cohesive seam between Agent detail and Direct Input chrome. Groups the
+/// live presentation gates from the interaction handlers so call sites pass
+/// one typed model instead of a flat fourteen-argument surface.
+@MainActor
+struct AgentDirectInputChromeContext {
+    struct Presentation {
+        let status: AgentStatus
+        let hostTelemetry: HostTelemetryPresentation?
+        let chromeColorScheme: ColorScheme
+        /// Ghostty first-responder / tools intent for the switcher toggle glyph.
+        let isKeyboardUp: Bool
+        let isToolsKeyboardPresented: Bool
+        /// Software-keyboard shortcut row only — never hardware-first-responder.
+        let showShortcutRow: Bool
+    }
+
+    struct Interactions {
+        let switcher: TerminalAgentSwitcher
+        let keyboardHandoff: TerminalKeyboardHandoff
+        let actions: AgentComposerActions
+        let toggleKeyboard: () -> Void
+        let switchKeyboard: (() -> Void)?
+        let sendQuickKey: (AgentQuickKey) -> Void
+        let showComposer: () -> Void
+        /// Routes More / Add actions that own the draft: restore Composer first.
+        let restoreComposerThen: (@escaping () -> Void) -> Void
+    }
+
+    let presentation: Presentation
+    let interactions: Interactions
+}
+
 /// Compact Agent-detail chrome for Direct Input: status, Agent switcher with
 /// Show Composer, and a shortcut row while the software keyboard is up.
 /// Bottom-up order matches the approved geometry: system keyboard, shortcut
 /// row, switcher, status. App content rather than a keyboard accessory, so
 /// UIKit's candidate-row teardown cannot tear it down or leave a hollow gap.
 struct AgentDirectInputChrome: View {
-    let status: AgentStatus
-    let hostTelemetry: HostTelemetryPresentation?
-    let chromeColorScheme: ColorScheme
-    let switcher: TerminalAgentSwitcher
-    let keyboardHandoff: TerminalKeyboardHandoff
-    /// Ghostty first-responder / tools intent for the switcher toggle glyph.
-    let isKeyboardUp: Bool
-    let isToolsKeyboardPresented: Bool
-    /// Software-keyboard shortcut row only — never hardware-first-responder.
-    let showShortcutRow: Bool
-    let actions: AgentComposerActions
-    let toggleKeyboard: () -> Void
-    let switchKeyboard: (() -> Void)?
-    let sendQuickKey: (AgentQuickKey) -> Void
-    let showComposer: () -> Void
-    /// Routes More / Add actions that own the draft: restore Composer first.
-    let restoreComposerThen: (@escaping () -> Void) -> Void
+    let context: AgentDirectInputChromeContext
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.displayScale) private var displayScale
 
@@ -31,25 +47,33 @@ struct AgentDirectInputChrome: View {
         .escape, .tab, .shiftTab, .enter,
     ]
 
+    private var presentation: AgentDirectInputChromeContext.Presentation {
+        context.presentation
+    }
+
+    private var interactions: AgentDirectInputChromeContext.Interactions {
+        context.interactions
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 6) {
                 AgentDetailStatusChrome(
-                    status: status,
-                    hostTelemetry: hostTelemetry,
-                    chromeColorScheme: chromeColorScheme)
+                    status: presentation.status,
+                    hostTelemetry: presentation.hostTelemetry,
+                    chromeColorScheme: presentation.chromeColorScheme)
 
                 TerminalAgentSwitcherRow(
                     switcher: focusPreservingSwitcher,
-                    isKeyboardUp: isKeyboardUp,
-                    toggleKeyboard: toggleKeyboard,
-                    isToolsKeyboardPresented: isToolsKeyboardPresented,
-                    switchKeyboard: switchKeyboard,
+                    isKeyboardUp: presentation.isKeyboardUp,
+                    toggleKeyboard: interactions.toggleKeyboard,
+                    isToolsKeyboardPresented: presentation.isToolsKeyboardPresented,
+                    switchKeyboard: interactions.switchKeyboard,
                     modeControl: modeControl)
 
                 // Adjacent to the software keyboard it augments — below the
                 // switcher in this top-to-bottom stack, above the keyboard.
-                if showShortcutRow {
+                if presentation.showShortcutRow {
                     shortcutRow
                 }
             }
@@ -62,27 +86,27 @@ struct AgentDirectInputChrome: View {
             return .segmented(
                 selection: .direct,
                 select: { mode in
-                    if mode == .composer { showComposer() }
+                    if mode == .composer { interactions.showComposer() }
                 })
         }
         return .button(
             systemImage: "square.and.pencil",
             accessibilityLabel: AgentDirectInputPresentation.showComposerAccessibilityLabel,
             accessibilityHint: AgentDirectInputPresentation.showComposerAccessibilityHint,
-            action: showComposer)
+            action: interactions.showComposer)
     }
 
     private var focusPreservingSwitcher: TerminalAgentSwitcher {
         TerminalAgentSwitcher(
-            items: switcher.items,
-            selectedID: switcher.selectedID,
+            items: interactions.switcher.items,
+            selectedID: interactions.switcher.selectedID,
             onSelect: { id in
-                if isKeyboardUp {
-                    keyboardHandoff.arm(for: id)
+                if presentation.isKeyboardUp {
+                    interactions.keyboardHandoff.arm(for: id)
                 }
-                switcher.onSelect(id)
+                interactions.switcher.onSelect(id)
             },
-            onTogglePin: switcher.onTogglePin)
+            onTogglePin: interactions.switcher.onTogglePin)
     }
 
     private var shortcutRow: some View {
@@ -94,7 +118,7 @@ struct AgentDirectInputChrome: View {
 
                 Spacer(minLength: 8)
 
-                Button("Composer", action: showComposer)
+                Button("Composer", action: interactions.showComposer)
                     .font(.caption.weight(.semibold))
                     .frame(minHeight: 44)
                     .padding(.horizontal, 10)
@@ -108,7 +132,7 @@ struct AgentDirectInputChrome: View {
 
                 moreMenu
 
-                Button(action: toggleKeyboard) {
+                Button(action: interactions.toggleKeyboard) {
                     Image(systemName: "keyboard.chevron.compact.down")
                         .font(.system(size: 12, weight: .medium))
                         .frame(width: 44, height: 44)
@@ -130,7 +154,7 @@ struct AgentDirectInputChrome: View {
     private func shortcutKeyButton(_ key: AgentQuickKey) -> some View {
         Button {
             UIDevice.current.playInputClick()
-            sendQuickKey(key)
+            interactions.sendQuickKey(key)
         } label: {
             Text(key.title ?? key.accessibilityLabel)
                 .font(.caption.weight(.medium))
@@ -147,49 +171,10 @@ struct AgentDirectInputChrome: View {
 
     private var moreMenu: some View {
         Menu {
-            Section {
-                Button("Add Image", systemImage: "photo") {
-                    restoreComposerThen { actions.addImage() }
-                }
-                .disabled(!actions.canBegin)
-                Button("Add File", systemImage: "doc") {
-                    restoreComposerThen { actions.addFile() }
-                }
-                .disabled(!actions.canBegin)
-            }
-            Section {
-                Button("Open Terminal", systemImage: "apple.terminal") {
-                    actions.openTerminal?()
-                }
-                .disabled(actions.openTerminal == nil || actions.isOpeningTerminal)
-                Button("New Agent", systemImage: "plus") {
-                    actions.startAgent()
-                }
-                if let showSkills = actions.showSkills {
-                    Button("Skills", systemImage: "sparkles") {
-                        restoreComposerThen(showSkills)
-                    }
-                }
-                Button("Snippets", systemImage: "quote.bubble") {
-                    restoreComposerThen(actions.manageSnippets)
-                }
-            }
-            Section {
-                if let showWorktreeDetails = actions.showWorktreeDetails {
-                    Button("Worktree Details", systemImage: "arrow.triangle.branch") {
-                        showWorktreeDetails()
-                    }
-                }
-                Button("Rename Agent", systemImage: "pencil") {
-                    actions.renameAgent()
-                }
-                Button("Rename Workspace", systemImage: "pencil.line") {
-                    actions.renameWorkspace()
-                }
-                Button("Close Agent", systemImage: "trash", role: .destructive) {
-                    actions.closeAgent()
-                }
-            }
+            AgentActionMenuContent(
+                actions: interactions.actions,
+                sections: AgentActionMenuPolicy.directInputMoreSections,
+                restoreComposerThen: interactions.restoreComposerThen)
         } label: {
             Image(systemName: "ellipsis")
                 .font(.system(size: 12, weight: .semibold))

--- a/Sources/Heeler/Console/AgentDirectInputPresentation.swift
+++ b/Sources/Heeler/Console/AgentDirectInputPresentation.swift
@@ -62,6 +62,10 @@ struct AgentDirectInputPresentation: Equatable, Sendable {
     static let showComposerAccessibilityLabel = "Show Composer"
     static let showComposerAccessibilityHint =
         "Restores the Composer. The draft is unchanged."
+    /// Source-specific identity for the software-keyboard shortcut-row
+    /// container. Distinct from Tools keypad Escape, which shares the spoken
+    /// accessibility label.
+    static let shortcutRowAccessibilityIdentifier = "direct-input.shortcut-row"
 }
 
 /// Survives same-screen terminal pipeline replacement so Direct Input can

--- a/Sources/Heeler/Console/AgentDirectInputPresentation.swift
+++ b/Sources/Heeler/Console/AgentDirectInputPresentation.swift
@@ -2,16 +2,15 @@ import CoreGraphics
 import Foundation
 import Observation
 
-/// Focused Direct Input chrome policy: software-keyboard coverage, shortcut
-/// row visibility, keyboard layout, and the Hide/Show accessibility copy the
-/// switcher control speaks. Separates Ghostty first-responder intent from the
-/// software keyboard footprint so a hardware keyboard cannot leave a stale gap.
+/// Focused Direct Input chrome policy: software-keyboard coverage, keyboard
+/// layout, and the Hide/Show accessibility copy the switcher control speaks.
+/// Separates Ghostty first-responder intent from the software keyboard
+/// footprint so a hardware keyboard cannot leave a stale gap.
 ///
 /// ``layout`` is the single production seam for the Agent detail bottom inset
 /// and tools dock height — `AgentTerminalView` consumes it directly.
 struct AgentDirectInputPresentation: Equatable, Sendable {
     var keyboardPresentation: AgentComposerKeyboardPresentation
-    var showsShortcutRow: Bool
     /// Production bottom inset / tools height. Do not rebuild this beside the view.
     var layout: AgentComposerKeyboardLayout
 
@@ -30,12 +29,6 @@ struct AgentDirectInputPresentation: Equatable, Sendable {
         return .hidden
     }
 
-    static func showsShortcutRow(
-        presentation: AgentComposerKeyboardPresentation
-    ) -> Bool {
-        presentation == .system
-    }
-
     static func resolve(
         usesToolsKeyboard: Bool,
         expectsSystemKeyboard: Bool,
@@ -52,7 +45,6 @@ struct AgentDirectInputPresentation: Equatable, Sendable {
             presentation: presentation)
         return AgentDirectInputPresentation(
             keyboardPresentation: presentation,
-            showsShortcutRow: showsShortcutRow(presentation: presentation),
             layout: layout)
     }
 

--- a/Sources/Heeler/Console/AgentDirectInputPresentation.swift
+++ b/Sources/Heeler/Console/AgentDirectInputPresentation.swift
@@ -1,0 +1,71 @@
+import CoreGraphics
+import Foundation
+import Observation
+
+/// Focused Direct Input chrome policy: software-keyboard coverage, shortcut
+/// row visibility, content inset, and the Hide/Show accessibility copy the
+/// switcher control speaks. Separates Ghostty first-responder intent from the
+/// software keyboard footprint so a hardware keyboard cannot leave a stale gap.
+struct AgentDirectInputPresentation: Equatable, Sendable {
+    var keyboardPresentation: AgentComposerKeyboardPresentation
+    var showsShortcutRow: Bool
+    var contentInset: CGFloat
+    var availableToolsHeight: CGFloat
+
+    /// Software keyboard coverage only. Tools mode is independent. First
+    /// responder alone never counts — that is hardware-keyboard territory.
+    static func keyboardPresentation(
+        usesToolsKeyboard: Bool,
+        softwareKeyboardHeight: CGFloat
+    ) -> AgentComposerKeyboardPresentation {
+        if usesToolsKeyboard { return .tools }
+        if softwareKeyboardHeight > 0 { return .system }
+        return .hidden
+    }
+
+    static func showsShortcutRow(
+        presentation: AgentComposerKeyboardPresentation
+    ) -> Bool {
+        presentation == .system
+    }
+
+    static func resolve(
+        usesToolsKeyboard: Bool,
+        currentHeight: CGFloat,
+        lastPresentedHeight: CGFloat
+    ) -> AgentDirectInputPresentation {
+        let presentation = keyboardPresentation(
+            usesToolsKeyboard: usesToolsKeyboard,
+            softwareKeyboardHeight: currentHeight)
+        let layout = AgentComposerKeyboardLayout(
+            currentHeight: currentHeight,
+            lastPresentedHeight: lastPresentedHeight,
+            presentation: presentation)
+        return AgentDirectInputPresentation(
+            keyboardPresentation: presentation,
+            showsShortcutRow: showsShortcutRow(presentation: presentation),
+            contentInset: layout.contentInset,
+            availableToolsHeight: layout.availableToolsHeight)
+    }
+
+    static let hideComposerAccessibilityLabel = "Hide Composer"
+    static let hideComposerAccessibilityHint =
+        "Hides the Composer and types into the Agent with the iOS keyboard."
+    static let showComposerAccessibilityLabel = "Show Composer"
+    static let showComposerAccessibilityHint =
+        "Restores the Composer. The draft is unchanged."
+}
+
+/// Survives same-screen terminal pipeline replacement so Direct Input can
+/// reclaim a keyboard that was up without raising one that was down. Distinct
+/// from ``TerminalKeyboardHandoff``, which carries intent across Agent switches
+/// that tear the whole view down.
+@MainActor
+@Observable
+final class DirectInputKeyboardIntent {
+    private(set) var wantsKeyboard = false
+
+    func setWantsKeyboard(_ wantsKeyboard: Bool) {
+        self.wantsKeyboard = wantsKeyboard
+    }
+}

--- a/Sources/Heeler/Console/AgentDirectInputPresentation.swift
+++ b/Sources/Heeler/Console/AgentDirectInputPresentation.swift
@@ -62,9 +62,9 @@ struct AgentDirectInputPresentation: Equatable, Sendable {
     static let showComposerAccessibilityLabel = "Show Composer"
     static let showComposerAccessibilityHint =
         "Restores the Composer. The draft is unchanged."
-    /// Source-specific identity for the software-keyboard shortcut-row
-    /// container. Distinct from Tools keypad Escape, which shares the spoken
-    /// accessibility label.
+    /// Source-specific identity for the software-keyboard shortcut-row Escape
+    /// control. Distinct from Tools keypad Escape, which shares the spoken
+    /// accessibility label but must not carry this identifier.
     static let shortcutRowAccessibilityIdentifier = "direct-input.shortcut-row"
 }
 

--- a/Sources/Heeler/Console/AgentDirectInputPresentation.swift
+++ b/Sources/Heeler/Console/AgentDirectInputPresentation.swift
@@ -62,6 +62,18 @@ struct AgentDirectInputPresentation: Equatable, Sendable {
     static let showComposerAccessibilityLabel = "Show Composer"
     static let showComposerAccessibilityHint =
         "Restores the Composer. The draft is unchanged."
+
+    /// Single production predicate for arming Direct Input keyboard handoff
+    /// across terminal replacement/reactivation and Agent-switch paths. Intent,
+    /// Ghostty first responder, tools keyboard, or measured software height.
+    static func shouldClaimKeyboard(
+        wantsKeyboard: Bool,
+        isKeyboardUp: Bool,
+        usesToolsKeyboard: Bool,
+        softwareKeyboardHeight: CGFloat
+    ) -> Bool {
+        wantsKeyboard || isKeyboardUp || usesToolsKeyboard || softwareKeyboardHeight > 0
+    }
 }
 
 /// Survives same-screen terminal pipeline replacement so Direct Input can

--- a/Sources/Heeler/Console/AgentDirectInputPresentation.swift
+++ b/Sources/Heeler/Console/AgentDirectInputPresentation.swift
@@ -62,10 +62,6 @@ struct AgentDirectInputPresentation: Equatable, Sendable {
     static let showComposerAccessibilityLabel = "Show Composer"
     static let showComposerAccessibilityHint =
         "Restores the Composer. The draft is unchanged."
-    /// Source-specific identity for the software-keyboard shortcut-row Escape
-    /// control. Distinct from Tools keypad Escape, which shares the spoken
-    /// accessibility label but must not carry this identifier.
-    static let shortcutRowAccessibilityIdentifier = "direct-input.shortcut-row"
 }
 
 /// Survives same-screen terminal pipeline replacement so Direct Input can

--- a/Sources/Heeler/Console/AgentDirectInputPresentation.swift
+++ b/Sources/Heeler/Console/AgentDirectInputPresentation.swift
@@ -3,23 +3,28 @@ import Foundation
 import Observation
 
 /// Focused Direct Input chrome policy: software-keyboard coverage, shortcut
-/// row visibility, content inset, and the Hide/Show accessibility copy the
+/// row visibility, keyboard layout, and the Hide/Show accessibility copy the
 /// switcher control speaks. Separates Ghostty first-responder intent from the
 /// software keyboard footprint so a hardware keyboard cannot leave a stale gap.
+///
+/// ``layout`` is the single production seam for the Agent detail bottom inset
+/// and tools dock height — `AgentTerminalView` consumes it directly.
 struct AgentDirectInputPresentation: Equatable, Sendable {
     var keyboardPresentation: AgentComposerKeyboardPresentation
     var showsShortcutRow: Bool
-    var contentInset: CGFloat
-    var availableToolsHeight: CGFloat
+    /// Production bottom inset / tools height. Do not rebuild this beside the view.
+    var layout: AgentComposerKeyboardLayout
 
-    /// Software keyboard coverage only. Tools mode is independent. First
-    /// responder alone never counts — that is hardware-keyboard territory.
+    /// Software keyboard coverage, with an explicit Tools→iOS pre-show hold so
+    /// the 60 ms inset coalesce cannot drop the terminal through `.hidden`.
+    /// First responder alone never counts — that is hardware-keyboard territory.
     static func keyboardPresentation(
         usesToolsKeyboard: Bool,
-        softwareKeyboardHeight: CGFloat
+        softwareKeyboardHeight: CGFloat,
+        expectsSystemKeyboard: Bool
     ) -> AgentComposerKeyboardPresentation {
         if usesToolsKeyboard { return .tools }
-        if softwareKeyboardHeight > 0 { return .system }
+        if softwareKeyboardHeight > 0 || expectsSystemKeyboard { return .system }
         return .hidden
     }
 
@@ -31,12 +36,14 @@ struct AgentDirectInputPresentation: Equatable, Sendable {
 
     static func resolve(
         usesToolsKeyboard: Bool,
+        expectsSystemKeyboard: Bool,
         currentHeight: CGFloat,
         lastPresentedHeight: CGFloat
     ) -> AgentDirectInputPresentation {
         let presentation = keyboardPresentation(
             usesToolsKeyboard: usesToolsKeyboard,
-            softwareKeyboardHeight: currentHeight)
+            softwareKeyboardHeight: currentHeight,
+            expectsSystemKeyboard: expectsSystemKeyboard)
         let layout = AgentComposerKeyboardLayout(
             currentHeight: currentHeight,
             lastPresentedHeight: lastPresentedHeight,
@@ -44,8 +51,7 @@ struct AgentDirectInputPresentation: Equatable, Sendable {
         return AgentDirectInputPresentation(
             keyboardPresentation: presentation,
             showsShortcutRow: showsShortcutRow(presentation: presentation),
-            contentInset: layout.contentInset,
-            availableToolsHeight: layout.availableToolsHeight)
+            layout: layout)
     }
 
     static let hideComposerAccessibilityLabel = "Hide Composer"

--- a/Sources/Heeler/Console/AgentDirectInputPresentation.swift
+++ b/Sources/Heeler/Console/AgentDirectInputPresentation.swift
@@ -17,7 +17,9 @@ struct AgentDirectInputPresentation: Equatable, Sendable {
 
     /// Software keyboard coverage, with an explicit Tools→iOS pre-show hold so
     /// the 60 ms inset coalesce cannot drop the terminal through `.hidden`.
-    /// First responder alone never counts — that is hardware-keyboard territory.
+    /// `expectsSystemKeyboard` is only valid until measured height becomes
+    /// positive; after that, height alone drives `.system`. First responder
+    /// alone never counts — that is hardware-keyboard territory.
     static func keyboardPresentation(
         usesToolsKeyboard: Bool,
         softwareKeyboardHeight: CGFloat,

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -619,7 +619,6 @@ struct AgentTerminalView: View {
                         showShortcutRow: directInputPresentation.showsShortcutRow),
                     interactions: .init(
                         switcher: agentSwitcher,
-                        keyboardHandoff: keyboardHandoff,
                         actions: composerActions,
                         toggleKeyboard: toggleDirectKeyboard,
                         switchKeyboard: directKeyboardSwitchAction,

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -43,6 +43,10 @@ struct AgentTerminalView: View {
     @State private var composerKeyboardPresentation: AgentComposerKeyboardPresentation = .hidden
     /// Direct Input's tools dock, separate from Composer focus presentation.
     @State private var usesDirectToolsKeyboard = false
+    /// Holds `.system` presentation across the Tools→iOS coalesce window so
+    /// the terminal does not expand then shrink while UIKit re-shows the
+    /// software keyboard. Never set for bare first-responder / hardware.
+    @State private var expectsDirectSystemKeyboard = false
     /// Survives same-screen terminal replacement so a raised Direct Input
     /// keyboard is reclaimed without raising one that was down.
     @State private var directKeyboardIntent = DirectInputKeyboardIntent()
@@ -391,11 +395,19 @@ struct AgentTerminalView: View {
         .onChange(of: attach.terminalID) { _, _ in
             guard isDirectInput else { return }
             usesDirectToolsKeyboard = false
+            expectsDirectSystemKeyboard = false
             keyboardControl.setKeyboardMode(.text)
             keyboardInset.resumeHeightCapture()
-            // Intent already armed (or persisted on directKeyboardIntent) before
-            // the replacement; claimsKeyboard consumes it on the new surface.
-            armDirectKeyboardClaimIfNeeded()
+            // Do not re-arm TerminalKeyboardHandoff here: claimsKeyboard already
+            // consumed any pre-armed token or reclaimed via same-screen intent.
+            // Arming again leaves a stale one-shot that can raise a dismissed
+            // keyboard on a later replacement.
+        }
+        .onChange(of: keyboardControl.isFirstResponder) { _, isUp in
+            // Tools→iOS keeps first responder across the coalesce window; a
+            // real dismiss resigns and must drop the pre-show `.system` hold.
+            guard isDirectInput, !isUp else { return }
+            expectsDirectSystemKeyboard = false
         }
     }
 
@@ -437,6 +449,7 @@ struct AgentTerminalView: View {
     private var directInputPresentation: AgentDirectInputPresentation {
         AgentDirectInputPresentation.resolve(
             usesToolsKeyboard: usesDirectToolsKeyboard,
+            expectsSystemKeyboard: expectsDirectSystemKeyboard,
             currentHeight: keyboardInset.height,
             lastPresentedHeight: keyboardInset.lastPresentedHeight)
     }
@@ -450,10 +463,8 @@ struct AgentTerminalView: View {
 
     private var composerKeyboardLayout: AgentComposerKeyboardLayout {
         if isDirectInput {
-            return AgentComposerKeyboardLayout(
-                currentHeight: keyboardInset.height,
-                lastPresentedHeight: keyboardInset.lastPresentedHeight,
-                presentation: directInputPresentation.keyboardPresentation)
+            // Single seam: never rebuild layout beside the resolved presentation.
+            return directInputPresentation.layout
         }
         return AgentComposerKeyboardLayout(
             currentHeight: keyboardInset.height,
@@ -655,10 +666,12 @@ struct AgentTerminalView: View {
                 prepareComposerKeyboardPresentation(.hidden)
                 composerKeyboardPresentation = .hidden
                 usesDirectToolsKeyboard = false
+                expectsDirectSystemKeyboard = false
                 keyboardControl.setKeyboardMode(.text)
                 inputMode.select(.direct)
             case .composer:
                 usesDirectToolsKeyboard = false
+                expectsDirectSystemKeyboard = false
                 directKeyboardIntent.setWantsKeyboard(false)
                 keyboardControl.setKeyboardMode(.text)
                 keyboardControl.dismissKeyboard()
@@ -697,12 +710,14 @@ struct AgentTerminalView: View {
             transaction.disablesAnimations = true
             withTransaction(transaction) {
                 usesDirectToolsKeyboard = false
+                expectsDirectSystemKeyboard = false
                 keyboardInset.resumeHeightCapture()
                 keyboardControl.setKeyboardMode(.text)
             }
             directKeyboardIntent.setWantsKeyboard(false)
             keyboardControl.dismissKeyboard()
         } else if keyboardControl.isKeyboardUp {
+            expectsDirectSystemKeyboard = false
             directKeyboardIntent.setWantsKeyboard(false)
             keyboardControl.dismissKeyboard()
         } else {
@@ -717,10 +732,14 @@ struct AgentTerminalView: View {
         transaction.disablesAnimations = true
         withTransaction(transaction) {
             if enteringTools {
+                expectsDirectSystemKeyboard = false
                 keyboardInset.pauseHeightCapture()
                 usesDirectToolsKeyboard = true
                 keyboardControl.setKeyboardMode(.controls)
             } else {
+                // Hold `.system` through UIKit's coalesce window so content
+                // inset stays at lastPresentedHeight instead of dipping to zero.
+                expectsDirectSystemKeyboard = true
                 keyboardInset.resumeHeightCapture()
                 usesDirectToolsKeyboard = false
                 keyboardControl.setKeyboardMode(.text)

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -615,8 +615,7 @@ struct AgentTerminalView: View {
                         chromeColorScheme: terminal.themes.selection(for: colorScheme)
                             .chromeColorScheme(for: colorScheme),
                         isKeyboardUp: directSwitcherKeyboardIsUp,
-                        isToolsKeyboardPresented: usesDirectToolsKeyboard,
-                        showShortcutRow: directInputPresentation.showsShortcutRow),
+                        isToolsKeyboardPresented: usesDirectToolsKeyboard),
                     interactions: .init(
                         switcher: agentSwitcher,
                         actions: composerActions,

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -12,10 +12,9 @@ final class AgentTerminalInteractionProbe {
     private var sendQuickKeyAction: ((AgentQuickKey) -> Void)?
     private var toggleDirectKeyboardAction: (() -> Void)?
     private var switchDirectKeyboardAction: (() -> Void)?
-    private var directInputChromeMountCount = 0
+    private(set) var directInputChromeMountCount = 0
 
     var isConnected: Bool { selectInputModeAction != nil }
-    var isDirectInputChromeMounted: Bool { directInputChromeMountCount > 0 }
 
     @discardableResult
     func selectInputMode(_ mode: AgentInputMode) -> Bool {
@@ -82,6 +81,15 @@ final class AgentTerminalInteractionProbe {
     }
 }
 
+@MainActor
+private final class WeakAgentTerminalInteractionProbe {
+    weak var value: AgentTerminalInteractionProbe?
+
+    init(_ value: AgentTerminalInteractionProbe) {
+        self.value = value
+    }
+}
+
 /// The live Ghostty surface used by Agent detail. Composer mode keeps the
 /// terminal display-only and routes authored text through the local draft;
 /// Direct Input (ADR 0016) enables Ghostty local input so the system keyboard
@@ -117,7 +125,7 @@ struct AgentTerminalView: View {
     private let isOpeningTerminal: Bool
     private let openTerminal: () -> Void
     private let composer: AgentComposerStore
-    private let interactionProbe: AgentTerminalInteractionProbe?
+    private let interactionProbe: WeakAgentTerminalInteractionProbe?
     @State private var attach: AgentAttachStore
     /// Nil for agent kinds without a skills source catalog; the Keys
     /// keyboard hides the Skills tab in that case.
@@ -215,7 +223,7 @@ struct AgentTerminalView: View {
         self.isOpeningTerminal = isOpeningTerminal
         self.openTerminal = openTerminal
         self.composer = composer
-        self.interactionProbe = interactionProbe
+        self.interactionProbe = interactionProbe.map(WeakAgentTerminalInteractionProbe.init)
         _attach = State(
             initialValue: attachStore ?? AgentAttachStore(
                 target: agent.agent.paneID,
@@ -518,7 +526,7 @@ struct AgentTerminalView: View {
         // calls must stay synchronous, because the spurious pair can land in
         // one transaction and rejoin() can only undo a leave it can see.
         .onAppear {
-            interactionProbe?.connect(selectInputMode: { mode in selectInputMode(mode) })
+            interactionProbe?.value?.connect(selectInputMode: { mode in selectInputMode(mode) })
             composer.bindAttachInput(attach.input)
             // Arm before rejoin so a full pipeline replacement can claim the
             // keyboard while Direct Input still owns raised intent.
@@ -526,7 +534,7 @@ struct AgentTerminalView: View {
             attach.rejoin()
         }
         .onDisappear {
-            interactionProbe?.disconnect()
+            interactionProbe?.value?.disconnect()
             attach.leave()
             Task { @MainActor in
                 await Task.yield()
@@ -788,14 +796,15 @@ struct AgentTerminalView: View {
                     showComposer: { selectInputMode(.composer) },
                     restoreComposerThen: restoreComposerThen)))
             .onAppear {
-                interactionProbe?.directInputChromeDidAppear(
+                interactionProbe?.value?.directInputChromeDidAppear(
                     sendQuickKey: { key in keyboardControl.sendQuickKey(key) },
                     toggleDirectKeyboard: { toggleDirectKeyboard() },
-                    switchDirectKeyboard: directKeyboardSwitchAction)
+                    switchDirectKeyboard: presentedDirectKeyboardSwitchAction)
             }
-            .onDisappear { interactionProbe?.directInputChromeDidDisappear() }
-            .onChange(of: isDirectKeyboardSwitchAvailable) { _, _ in
-                interactionProbe?.updateSwitchDirectKeyboard(directKeyboardSwitchAction)
+            .onDisappear { interactionProbe?.value?.directInputChromeDidDisappear() }
+            .onChange(of: isDirectKeyboardSwitchPresented) { _, _ in
+                interactionProbe?.value?.updateSwitchDirectKeyboard(
+                    presentedDirectKeyboardSwitchAction)
             }
             .onGeometryChange(for: CGFloat.self) { geometry in
                 geometry.size.height
@@ -850,6 +859,15 @@ struct AgentTerminalView: View {
     private var directKeyboardSwitchAction: (() -> Void)? {
         guard isDirectKeyboardSwitchAvailable else { return nil }
         return { switchDirectKeyboard() }
+    }
+
+    private var presentedDirectKeyboardSwitchAction: (() -> Void)? {
+        guard isDirectKeyboardSwitchPresented else { return nil }
+        return directKeyboardSwitchAction
+    }
+
+    private var isDirectKeyboardSwitchPresented: Bool {
+        directSwitcherKeyboardIsUp && isDirectKeyboardSwitchAvailable
     }
 
     private var isDirectKeyboardSwitchAvailable: Bool {

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -23,6 +23,9 @@ struct AgentTerminalView: View {
     /// same reason as the handoff: a switch that inherits a raised keyboard
     /// must lay the terminal out at the right height on its first frame.
     private let keyboardInset: TerminalKeyboardInset
+    /// Router truth used to distinguish a real navigation from SwiftUI's
+    /// same-screen disappear/appear churn.
+    private let isOnStage: () -> Bool
     /// Opens another Agent from the terminal's switcher strip. The owner moves
     /// the selection, exactly as a tap in the Agent list would.
     private let onSwitch: (ConsoleAgent.ID) -> Void
@@ -41,8 +44,22 @@ struct AgentTerminalView: View {
     @State private var skills: SkillsPaneStore?
     @State private var keyboardControl = TerminalKeyboardControl()
     @State private var composerKeyboardPresentation: AgentComposerKeyboardPresentation = .hidden
+    /// Keeps Composer mounted while its visible system keyboard moves to the
+    /// terminal. Direct Input becomes the rendered mode only after the
+    /// terminal confirms first-responder ownership.
+    @State private var composerToDirectHandoffID: UUID?
+    /// Keeps Direct Input active while the newly mounted Composer takes over
+    /// its visible software keyboard.
+    @State private var directToComposerHandoffID: UUID?
+    /// This view's handoff after the destination responder has accepted it but
+    /// before that responder's own keyboard frame settles. The inset is shared
+    /// by the Console, so ownership must never be inferred from its active ID.
+    @State private var settlingKeyboardHandoffID: UUID?
     /// Direct Input's tools dock, separate from Composer focus presentation.
     @State private var usesDirectToolsKeyboard = false
+    /// Keeps reverse-handoff preloading from adopting Composer's taller layout
+    /// before Composer actually owns keyboard input.
+    @State private var directInputChromeHeight: CGFloat?
     /// Holds `.system` presentation across the Tools→iOS coalesce window so
     /// the terminal does not expand then shrink while UIKit re-shows the
     /// software keyboard. Cleared once `keyboardInset.height` becomes positive
@@ -110,6 +127,7 @@ struct AgentTerminalView: View {
         self.activity = activity
         self.keyboardHandoff = keyboardHandoff
         self.keyboardInset = keyboardInset
+        self.isOnStage = isOnStage
         self.onSwitch = onSwitch
         self.onClosed = onClosed
         self.canOpenTerminal = canOpenTerminal
@@ -169,8 +187,23 @@ struct AgentTerminalView: View {
             attach.requestPaste(text, bracketedPaste: bracketed)
         }
         screen.keyboardControl = keyboardControl
-        screen.isLocalInputEnabled = isDirectInput
-        screen.claimsKeyboard = { [keyboardHandoff, agent, inputMode, directKeyboardIntent] in
+        // Agent input is natural-language authored text in both Composer and
+        // Direct Input. Matching traits lets UIKit retain one Apple keyboard
+        // context across the responder transfer; Shell terminals keep the
+        // command-oriented defaults.
+        screen.textInputStyle = .naturalLanguage
+        screen.isLocalInputEnabled = isDirectInput || composerToDirectHandoffID != nil
+        screen.claimsKeyboard = {
+            [
+                keyboardHandoff,
+                agent,
+                inputMode,
+                directKeyboardIntent,
+                composerToDirectHandoffID,
+            ] in
+            if composerToDirectHandoffID != nil {
+                return directKeyboardIntent.wantsKeyboard
+            }
             guard inputMode.isDirect else { return false }
             if keyboardHandoff.consume(agent.id) {
                 directKeyboardIntent.setWantsKeyboard(true)
@@ -179,6 +212,24 @@ struct AgentTerminalView: View {
             // Same-screen pipeline replacement: reclaim only while Direct
             // Input still owns raised intent. Cold persisted Direct stays down.
             return directKeyboardIntent.wantsKeyboard
+        }
+        screen.keyboardHandoffID = composerToDirectHandoffID
+        screen.isKeyboardHandoffCurrent = { id in
+            isOnStage()
+                && keyboardInset.activeResponderHandoffID == id
+                && composerToDirectHandoffID == id
+        }
+        screen.onKeyboardHandoffResult = { id, succeeded in
+            guard composerToDirectHandoffID == id else { return }
+            if succeeded {
+                settlingKeyboardHandoffID = id
+                applyInputMode(.direct, preservingKeyboardHandoff: true)
+            } else {
+                cancelKeyboardHandoff(id)
+            }
+        }
+        screen.onKeyboardHandoffSettled = { id in
+            endKeyboardHandoff(id)
         }
         screen.theme = terminal.themes.theme
         screen.fontSize = terminal.zoom.fontSize
@@ -393,8 +444,14 @@ struct AgentTerminalView: View {
         }
         .onDisappear {
             attach.leave()
+            Task { @MainActor in
+                await Task.yield()
+                guard !isOnStage() else { return }
+                cancelKeyboardHandoffs()
+            }
         }
         .onChange(of: attach.terminalID) { _, _ in
+            cancelKeyboardHandoffs()
             guard isDirectInput else { return }
             usesDirectToolsKeyboard = false
             expectsDirectSystemKeyboard = false
@@ -466,7 +523,7 @@ struct AgentTerminalView: View {
     }
 
     private var activeKeyboardPresentation: AgentComposerKeyboardPresentation {
-        if isDirectInput {
+        if isDirectInput, directToComposerHandoffID == nil {
             return directInputPresentation.keyboardPresentation
         }
         return composerKeyboardPresentation
@@ -606,40 +663,76 @@ struct AgentTerminalView: View {
 
     @ViewBuilder
     private var inputChrome: some View {
-        if isDirectInput {
-            AgentDirectInputChrome(
-                context: AgentDirectInputChromeContext(
-                    presentation: .init(
-                        status: agent.agent.status,
-                        hostTelemetry: hostTelemetry,
-                        chromeColorScheme: terminal.themes.selection(for: colorScheme)
-                            .chromeColorScheme(for: colorScheme),
-                        isKeyboardUp: directSwitcherKeyboardIsUp,
-                        isToolsKeyboardPresented: usesDirectToolsKeyboard),
-                    interactions: .init(
-                        switcher: agentSwitcher,
-                        actions: composerActions,
-                        toggleKeyboard: toggleDirectKeyboard,
-                        switchKeyboard: directKeyboardSwitchAction,
-                        sendQuickKey: keyboardControl.sendQuickKey,
-                        showComposer: { selectInputMode(.composer) },
-                        restoreComposerThen: restoreComposerThen)))
+        if isDirectInput, directToComposerHandoffID == nil {
+            directInputChrome
         } else {
-            AgentComposerView(
-                store: composer,
-                status: agent.agent.status,
-                hostTelemetry: hostTelemetry,
-                chromeColorScheme: terminal.themes.selection(for: colorScheme)
-                    .chromeColorScheme(for: colorScheme),
-                switcher: agentSwitcher,
-                keyboardHandoff: keyboardHandoff,
-                keyboardHeight: composerKeyboardLayout.availableToolsHeight,
-                actions: composerActions,
-                skills: skills,
-                keyboardPresentation: $composerKeyboardPresentation,
-                prepareKeyboardPresentation: prepareComposerKeyboardPresentation,
-                modeControl: composerModeControl)
+            ZStack(alignment: .bottom) {
+                composerChrome
+                    .opacity(directToComposerHandoffID == nil ? 1 : 0)
+                    .allowsHitTesting(directToComposerHandoffID == nil)
+                    .accessibilityHidden(directToComposerHandoffID != nil)
+                if directToComposerHandoffID != nil {
+                    // Composer is mounted underneath so its UITextView can take
+                    // first responder, but the visible chrome keeps describing
+                    // the terminal that still owns hardware input until then.
+                    directInputChrome
+                }
+            }
+            .frame(
+                height: directToComposerHandoffID == nil ? nil : directInputChromeHeight,
+                alignment: .bottom)
+            .clipped()
         }
+    }
+
+    private var directInputChrome: some View {
+        AgentDirectInputChrome(
+            context: AgentDirectInputChromeContext(
+                presentation: .init(
+                    status: agent.agent.status,
+                    hostTelemetry: hostTelemetry,
+                    chromeColorScheme: terminal.themes.selection(for: colorScheme)
+                        .chromeColorScheme(for: colorScheme),
+                    isKeyboardUp: directSwitcherKeyboardIsUp,
+                    isToolsKeyboardPresented: usesDirectToolsKeyboard),
+                interactions: .init(
+                    switcher: agentSwitcher,
+                    actions: composerActions,
+                    toggleKeyboard: toggleDirectKeyboard,
+                    switchKeyboard: directKeyboardSwitchAction,
+                    sendQuickKey: keyboardControl.sendQuickKey,
+                    showComposer: { selectInputMode(.composer) },
+                    restoreComposerThen: restoreComposerThen)))
+            .onGeometryChange(for: CGFloat.self) { geometry in
+                geometry.size.height
+            } action: { height in
+                directInputChromeHeight = height
+            }
+    }
+
+    private var composerChrome: some View {
+        AgentComposerView(
+            store: composer,
+            status: agent.agent.status,
+            hostTelemetry: hostTelemetry,
+            chromeColorScheme: terminal.themes.selection(for: colorScheme)
+                .chromeColorScheme(for: colorScheme),
+            switcher: agentSwitcher,
+            keyboardHandoff: keyboardHandoff,
+            keyboardHeight: composerKeyboardLayout.availableToolsHeight,
+            actions: composerActions,
+            skills: skills,
+            keyboardPresentation: $composerKeyboardPresentation,
+            prepareKeyboardPresentation: prepareComposerKeyboardPresentation,
+            modeControl: composerModeControl,
+            keyboardHandoffID: directToComposerHandoffID,
+            isKeyboardHandoffCurrent: { id in
+                isOnStage()
+                    && keyboardInset.activeResponderHandoffID == id
+                    && directToComposerHandoffID == id
+            },
+            onFirstResponderRequest: composerFirstResponderRequest,
+            onKeyboardHandoffSettled: composerKeyboardHandoffSettled)
     }
 
     private var composerModeControl: TerminalAgentSwitcherModeControl {
@@ -670,37 +763,76 @@ struct AgentTerminalView: View {
 
     private func selectInputMode(_ mode: AgentInputMode) {
         guard mode != inputMode.mode else { return }
-        let shouldHandoffSystemKeyboard = mode == .direct
-            && composerKeyboardPresentation == .system
-        let didHandoffSystemKeyboard: Bool
-        if shouldHandoffSystemKeyboard {
+        guard composerToDirectHandoffID == nil,
+              directToComposerHandoffID == nil,
+              settlingKeyboardHandoffID == nil
+        else { return }
+        if mode == .direct, composerKeyboardPresentation == .system {
             directKeyboardIntent.setWantsKeyboard(true)
             keyboardControl.setKeyboardMode(.text)
-            didHandoffSystemKeyboard = keyboardControl.handoffKeyboardToLocalInput()
-        } else {
-            didHandoffSystemKeyboard = false
+            let id = keyboardInset.beginResponderHandoff(
+                currentHeight: currentWindowKeyboardHeight
+            ) { expiredID in
+                cancelKeyboardHandoff(expiredID)
+            }
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                composerToDirectHandoffID = id
+            }
+            return
         }
+        if mode == .composer,
+           isDirectInput,
+           keyboardControl.isFirstResponder,
+           !usesDirectToolsKeyboard
+        {
+            let id = keyboardInset.beginResponderHandoff(
+                currentHeight: currentWindowKeyboardHeight
+            ) { expiredID in
+                cancelKeyboardHandoff(expiredID)
+            }
+            keyboardHandoff.arm(for: agent.id)
+            composerKeyboardPresentation = .system
+            directToComposerHandoffID = id
+            return
+        }
+        applyInputMode(mode)
+    }
+
+    private func applyInputMode(
+        _ mode: AgentInputMode,
+        preservingKeyboardHandoff: Bool = false
+    ) {
         var transaction = Transaction()
         transaction.disablesAnimations = true
         withTransaction(transaction) {
             switch mode {
             case .direct:
-                prepareComposerKeyboardPresentation(.hidden)
+                if !preservingKeyboardHandoff {
+                    prepareComposerKeyboardPresentation(.hidden)
+                }
                 composerKeyboardPresentation = .hidden
+                composerToDirectHandoffID = nil
                 usesDirectToolsKeyboard = false
                 expectsDirectSystemKeyboard = false
                 keyboardControl.setKeyboardMode(.text)
                 inputMode.select(.direct)
             case .composer:
+                directToComposerHandoffID = nil
                 usesDirectToolsKeyboard = false
                 expectsDirectSystemKeyboard = false
                 directKeyboardIntent.setWantsKeyboard(false)
                 keyboardControl.setKeyboardMode(.text)
-                keyboardControl.dismissKeyboard()
-                keyboardInset.resumeHeightCapture()
+                if !preservingKeyboardHandoff {
+                    keyboardControl.dismissKeyboard()
+                    keyboardInset.resumeHeightCapture()
+                }
                 inputMode.select(.composer)
                 // Composer onAppear consumes this and focuses the draft.
-                keyboardHandoff.arm(for: agent.id)
+                if !preservingKeyboardHandoff {
+                    keyboardHandoff.arm(for: agent.id)
+                }
             }
         }
         switch mode {
@@ -708,7 +840,7 @@ struct AgentTerminalView: View {
             UIAccessibility.post(
                 notification: .announcement,
                 argument: "Keyboard. Typing into the Agent.")
-            if !didHandoffSystemKeyboard {
+            if !keyboardControl.isFirstResponder {
                 Task { @MainActor in
                     await Task.yield()
                     directKeyboardIntent.setWantsKeyboard(true)
@@ -718,6 +850,65 @@ struct AgentTerminalView: View {
         case .composer:
             UIAccessibility.post(notification: .announcement, argument: "Composer.")
         }
+    }
+
+    private func cancelKeyboardHandoff(_ id: UUID) {
+        var ownsHandoff = false
+        if composerToDirectHandoffID == id {
+            composerToDirectHandoffID = nil
+            directKeyboardIntent.setWantsKeyboard(false)
+            ownsHandoff = true
+        }
+        if directToComposerHandoffID == id {
+            directToComposerHandoffID = nil
+            keyboardHandoff.cancel(for: agent.id)
+            ownsHandoff = true
+        }
+        if settlingKeyboardHandoffID == id {
+            settlingKeyboardHandoffID = nil
+            ownsHandoff = true
+        }
+        guard ownsHandoff else { return }
+        keyboardInset.cancelResponderHandoff(
+            id, currentHeight: currentWindowKeyboardHeight)
+    }
+
+    private func currentWindowKeyboardHeight() -> CGFloat? {
+        guard let window = keyboardControl.terminal?.window else { return nil }
+        let frame = window.bounds.intersection(window.keyboardLayoutGuide.layoutFrame)
+        let includesBottomSafeArea = abs(frame.maxY - window.bounds.maxY) <= 1
+        return TerminalKeyboardInset.insetHeight(
+            covered: frame.height,
+            bottomSafeArea: includesBottomSafeArea ? window.safeAreaInsets.bottom : 0)
+    }
+
+    private func cancelKeyboardHandoffs() {
+        if let id = composerToDirectHandoffID
+            ?? directToComposerHandoffID
+            ?? settlingKeyboardHandoffID
+        {
+            cancelKeyboardHandoff(id)
+        }
+    }
+
+    private func composerFirstResponderRequest(_ id: UUID, _ succeeded: Bool) {
+        guard directToComposerHandoffID == id else { return }
+        guard succeeded else {
+            cancelKeyboardHandoff(id)
+            return
+        }
+        settlingKeyboardHandoffID = id
+        applyInputMode(.composer, preservingKeyboardHandoff: true)
+    }
+
+    private func composerKeyboardHandoffSettled(_ id: UUID) {
+        endKeyboardHandoff(id)
+    }
+
+    private func endKeyboardHandoff(_ id: UUID) {
+        guard settlingKeyboardHandoffID == id else { return }
+        settlingKeyboardHandoffID = nil
+        keyboardInset.endResponderHandoff(id)
     }
 
     private func restoreComposerThen(_ action: @escaping () -> Void) {

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -670,6 +670,16 @@ struct AgentTerminalView: View {
 
     private func selectInputMode(_ mode: AgentInputMode) {
         guard mode != inputMode.mode else { return }
+        let shouldHandoffSystemKeyboard = mode == .direct
+            && composerKeyboardPresentation == .system
+        let didHandoffSystemKeyboard: Bool
+        if shouldHandoffSystemKeyboard {
+            directKeyboardIntent.setWantsKeyboard(true)
+            keyboardControl.setKeyboardMode(.text)
+            didHandoffSystemKeyboard = keyboardControl.handoffKeyboardToLocalInput()
+        } else {
+            didHandoffSystemKeyboard = false
+        }
         var transaction = Transaction()
         transaction.disablesAnimations = true
         withTransaction(transaction) {
@@ -698,10 +708,12 @@ struct AgentTerminalView: View {
             UIAccessibility.post(
                 notification: .announcement,
                 argument: "Keyboard. Typing into the Agent.")
-            Task { @MainActor in
-                await Task.yield()
-                directKeyboardIntent.setWantsKeyboard(true)
-                keyboardControl.requestKeyboard()
+            if !didHandoffSystemKeyboard {
+                Task { @MainActor in
+                    await Task.yield()
+                    directKeyboardIntent.setWantsKeyboard(true)
+                    keyboardControl.requestKeyboard()
+                }
             }
         case .composer:
             UIAccessibility.post(notification: .announcement, argument: "Composer.")

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -43,6 +43,9 @@ struct AgentTerminalView: View {
     @State private var composerKeyboardPresentation: AgentComposerKeyboardPresentation = .hidden
     /// Direct Input's tools dock, separate from Composer focus presentation.
     @State private var usesDirectToolsKeyboard = false
+    /// Survives same-screen terminal replacement so a raised Direct Input
+    /// keyboard is reclaimed without raising one that was down.
+    @State private var directKeyboardIntent = DirectInputKeyboardIntent()
     @State private var selectedPhoto: PhotosPickerItem?
     @State private var isSelectingPhoto = false
     @State private var isSelectingFile = false
@@ -161,9 +164,15 @@ struct AgentTerminalView: View {
         }
         screen.keyboardControl = keyboardControl
         screen.isLocalInputEnabled = isDirectInput
-        screen.claimsKeyboard = { [keyboardHandoff, agent, inputMode] in
+        screen.claimsKeyboard = { [keyboardHandoff, agent, inputMode, directKeyboardIntent] in
             guard inputMode.isDirect else { return false }
-            return keyboardHandoff.consume(agent.id)
+            if keyboardHandoff.consume(agent.id) {
+                directKeyboardIntent.setWantsKeyboard(true)
+                return true
+            }
+            // Same-screen pipeline replacement: reclaim only while Direct
+            // Input still owns raised intent. Cold persisted Direct stays down.
+            return directKeyboardIntent.wantsKeyboard
         }
         screen.theme = terminal.themes.theme
         screen.fontSize = terminal.zoom.fontSize
@@ -371,6 +380,9 @@ struct AgentTerminalView: View {
         // one transaction and rejoin() can only undo a leave it can see.
         .onAppear {
             composer.bindAttachInput(attach.input)
+            // Arm before rejoin so a full pipeline replacement can claim the
+            // keyboard while Direct Input still owns raised intent.
+            armDirectKeyboardClaimIfNeeded()
             attach.rejoin()
         }
         .onDisappear {
@@ -381,6 +393,9 @@ struct AgentTerminalView: View {
             usesDirectToolsKeyboard = false
             keyboardControl.setKeyboardMode(.text)
             keyboardInset.resumeHeightCapture()
+            // Intent already armed (or persisted on directKeyboardIntent) before
+            // the replacement; claimsKeyboard consumes it on the new surface.
+            armDirectKeyboardClaimIfNeeded()
         }
     }
 
@@ -419,21 +434,31 @@ struct AgentTerminalView: View {
             latency: console.hostLatencies[agent.hostID])
     }
 
+    private var directInputPresentation: AgentDirectInputPresentation {
+        AgentDirectInputPresentation.resolve(
+            usesToolsKeyboard: usesDirectToolsKeyboard,
+            currentHeight: keyboardInset.height,
+            lastPresentedHeight: keyboardInset.lastPresentedHeight)
+    }
+
     private var activeKeyboardPresentation: AgentComposerKeyboardPresentation {
         if isDirectInput {
-            return AgentDirectInputChrome.keyboardPresentation(
-                usesToolsKeyboard: usesDirectToolsKeyboard,
-                insetHeight: keyboardInset.height,
-                keyboardIsUp: keyboardControl.isKeyboardUp)
+            return directInputPresentation.keyboardPresentation
         }
         return composerKeyboardPresentation
     }
 
     private var composerKeyboardLayout: AgentComposerKeyboardLayout {
-        AgentComposerKeyboardLayout(
+        if isDirectInput {
+            return AgentComposerKeyboardLayout(
+                currentHeight: keyboardInset.height,
+                lastPresentedHeight: keyboardInset.lastPresentedHeight,
+                presentation: directInputPresentation.keyboardPresentation)
+        }
+        return AgentComposerKeyboardLayout(
             currentHeight: keyboardInset.height,
             lastPresentedHeight: keyboardInset.lastPresentedHeight,
-            presentation: activeKeyboardPresentation)
+            presentation: composerKeyboardPresentation)
     }
 
     private var composerActions: AgentComposerActions {
@@ -567,10 +592,9 @@ struct AgentTerminalView: View {
                     .chromeColorScheme(for: colorScheme),
                 switcher: agentSwitcher,
                 keyboardHandoff: keyboardHandoff,
-                isKeyboardUp: activeKeyboardPresentation != .hidden,
+                isKeyboardUp: directSwitcherKeyboardIsUp,
                 isToolsKeyboardPresented: usesDirectToolsKeyboard,
-                showShortcutRow: AgentDirectInputChrome.showsShortcutRow(
-                    presentation: activeKeyboardPresentation),
+                showShortcutRow: directInputPresentation.showsShortcutRow,
                 actions: composerActions,
                 toggleKeyboard: toggleDirectKeyboard,
                 switchKeyboard: directKeyboardSwitchAction,
@@ -603,10 +627,14 @@ struct AgentTerminalView: View {
         }
         return .button(
             systemImage: "rectangle.bottomhalf.inset.filled",
-            accessibilityLabel: "Hide Composer",
-            accessibilityHint:
-                "Hides the Composer and types into the Agent with the iOS keyboard.",
+            accessibilityLabel: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
+            accessibilityHint: AgentDirectInputPresentation.hideComposerAccessibilityHint,
             action: { selectInputMode(.direct) })
+    }
+
+    /// Switcher toggle glyph: first responder or tools, not software inset alone.
+    private var directSwitcherKeyboardIsUp: Bool {
+        keyboardControl.isKeyboardUp || usesDirectToolsKeyboard || keyboardInset.height > 0
     }
 
     private var directKeyboardSwitchAction: (() -> Void)? {
@@ -631,6 +659,7 @@ struct AgentTerminalView: View {
                 inputMode.select(.direct)
             case .composer:
                 usesDirectToolsKeyboard = false
+                directKeyboardIntent.setWantsKeyboard(false)
                 keyboardControl.setKeyboardMode(.text)
                 keyboardControl.dismissKeyboard()
                 keyboardInset.resumeHeightCapture()
@@ -646,6 +675,7 @@ struct AgentTerminalView: View {
                 argument: "Keyboard. Typing into the Agent.")
             Task { @MainActor in
                 await Task.yield()
+                directKeyboardIntent.setWantsKeyboard(true)
                 keyboardControl.requestKeyboard()
             }
         case .composer:
@@ -670,9 +700,14 @@ struct AgentTerminalView: View {
                 keyboardInset.resumeHeightCapture()
                 keyboardControl.setKeyboardMode(.text)
             }
+            directKeyboardIntent.setWantsKeyboard(false)
+            keyboardControl.dismissKeyboard()
+        } else if keyboardControl.isKeyboardUp {
+            directKeyboardIntent.setWantsKeyboard(false)
             keyboardControl.dismissKeyboard()
         } else {
-            keyboardControl.toggleKeyboard()
+            directKeyboardIntent.setWantsKeyboard(true)
+            keyboardControl.requestKeyboard()
         }
     }
 
@@ -692,15 +727,19 @@ struct AgentTerminalView: View {
             }
         }
         if enteringTools {
+            directKeyboardIntent.setWantsKeyboard(true)
             keyboardControl.requestKeyboard()
         }
     }
 
     private func armDirectKeyboardClaimIfNeeded() {
         guard isDirectInput else { return }
-        guard keyboardControl.isKeyboardUp || usesDirectToolsKeyboard
+        guard directKeyboardIntent.wantsKeyboard
+            || keyboardControl.isKeyboardUp
+            || usesDirectToolsKeyboard
             || keyboardInset.height > 0
         else { return }
+        directKeyboardIntent.setWantsKeyboard(true)
         keyboardHandoff.arm(for: agent.id)
     }
 
@@ -744,7 +783,9 @@ struct AgentTerminalView: View {
         // first responder with a hardware keyboard and a zero inset.
         let keyboardIsUp =
             isDirectInput
-            ? (keyboardControl.isKeyboardUp || usesDirectToolsKeyboard
+            ? (directKeyboardIntent.wantsKeyboard
+                || keyboardControl.isKeyboardUp
+                || usesDirectToolsKeyboard
                 || keyboardInset.height > 0)
             : keyboardInset.height > 0
         if keyboardIsUp {

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -608,21 +608,24 @@ struct AgentTerminalView: View {
     private var inputChrome: some View {
         if isDirectInput {
             AgentDirectInputChrome(
-                status: agent.agent.status,
-                hostTelemetry: hostTelemetry,
-                chromeColorScheme: terminal.themes.selection(for: colorScheme)
-                    .chromeColorScheme(for: colorScheme),
-                switcher: agentSwitcher,
-                keyboardHandoff: keyboardHandoff,
-                isKeyboardUp: directSwitcherKeyboardIsUp,
-                isToolsKeyboardPresented: usesDirectToolsKeyboard,
-                showShortcutRow: directInputPresentation.showsShortcutRow,
-                actions: composerActions,
-                toggleKeyboard: toggleDirectKeyboard,
-                switchKeyboard: directKeyboardSwitchAction,
-                sendQuickKey: keyboardControl.sendQuickKey,
-                showComposer: { selectInputMode(.composer) },
-                restoreComposerThen: restoreComposerThen)
+                context: AgentDirectInputChromeContext(
+                    presentation: .init(
+                        status: agent.agent.status,
+                        hostTelemetry: hostTelemetry,
+                        chromeColorScheme: terminal.themes.selection(for: colorScheme)
+                            .chromeColorScheme(for: colorScheme),
+                        isKeyboardUp: directSwitcherKeyboardIsUp,
+                        isToolsKeyboardPresented: usesDirectToolsKeyboard,
+                        showShortcutRow: directInputPresentation.showsShortcutRow),
+                    interactions: .init(
+                        switcher: agentSwitcher,
+                        keyboardHandoff: keyboardHandoff,
+                        actions: composerActions,
+                        toggleKeyboard: toggleDirectKeyboard,
+                        switchKeyboard: directKeyboardSwitchAction,
+                        sendQuickKey: keyboardControl.sendQuickKey,
+                        showComposer: { selectInputMode(.composer) },
+                        restoreComposerThen: restoreComposerThen)))
         } else {
             AgentComposerView(
                 store: composer,
@@ -764,10 +767,11 @@ struct AgentTerminalView: View {
 
     private func armDirectKeyboardClaimIfNeeded() {
         guard isDirectInput else { return }
-        guard directKeyboardIntent.wantsKeyboard
-            || keyboardControl.isKeyboardUp
-            || usesDirectToolsKeyboard
-            || keyboardInset.height > 0
+        guard AgentDirectInputPresentation.shouldClaimKeyboard(
+            wantsKeyboard: directKeyboardIntent.wantsKeyboard,
+            isKeyboardUp: keyboardControl.isKeyboardUp,
+            usesToolsKeyboard: usesDirectToolsKeyboard,
+            softwareKeyboardHeight: keyboardInset.height)
         else { return }
         directKeyboardIntent.setWantsKeyboard(true)
         keyboardHandoff.arm(for: agent.id)
@@ -813,10 +817,11 @@ struct AgentTerminalView: View {
         // first responder with a hardware keyboard and a zero inset.
         let keyboardIsUp =
             isDirectInput
-            ? (directKeyboardIntent.wantsKeyboard
-                || keyboardControl.isKeyboardUp
-                || usesDirectToolsKeyboard
-                || keyboardInset.height > 0)
+            ? AgentDirectInputPresentation.shouldClaimKeyboard(
+                wantsKeyboard: directKeyboardIntent.wantsKeyboard,
+                isKeyboardUp: keyboardControl.isKeyboardUp,
+                usesToolsKeyboard: usesDirectToolsKeyboard,
+                softwareKeyboardHeight: keyboardInset.height)
             : keyboardInset.height > 0
         if keyboardIsUp {
             keyboardHandoff.arm(for: id)

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -45,7 +45,9 @@ struct AgentTerminalView: View {
     @State private var usesDirectToolsKeyboard = false
     /// Holds `.system` presentation across the Tools→iOS coalesce window so
     /// the terminal does not expand then shrink while UIKit re-shows the
-    /// software keyboard. Never set for bare first-responder / hardware.
+    /// software keyboard. Cleared once `keyboardInset.height` becomes positive
+    /// (or on resign / mode change). Never set for bare first-responder /
+    /// hardware.
     @State private var expectsDirectSystemKeyboard = false
     /// Survives same-screen terminal replacement so a raised Direct Input
     /// keyboard is reclaimed without raising one that was down.
@@ -407,6 +409,15 @@ struct AgentTerminalView: View {
             // Tools→iOS keeps first responder across the coalesce window; a
             // real dismiss resigns and must drop the pre-show `.system` hold.
             guard isDirectInput, !isUp else { return }
+            expectsDirectSystemKeyboard = false
+        }
+        .onChange(of: keyboardInset.height) { _, height in
+            // Release the Tools→iOS pre-show hold only after the software
+            // keyboard has actually appeared. Clearing while height is still
+            // zero would dip through `.hidden`; clearing once height is
+            // positive keeps `.system` via the live measurement. A later
+            // hardware-keyboard hide can then drop to zero inset cleanly.
+            guard isDirectInput, expectsDirectSystemKeyboard, height > 0 else { return }
             expectsDirectSystemKeyboard = false
         }
     }

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -3,14 +3,15 @@ import SwiftUI
 import UIKit
 import UniformTypeIdentifiers
 
-/// The live Ghostty surface used by Agent detail. The terminal is display-only:
-/// it still renders, scrolls, opens links, and reports resize, while all
-/// authored input goes through Composer or its explicit terminal controls.
-/// Blocked Send is the one Composer path that types into this live PTY.
+/// The live Ghostty surface used by Agent detail. Composer mode keeps the
+/// terminal display-only and routes authored text through the local draft;
+/// Direct Input (ADR 0016) enables Ghostty local input so the system keyboard
+/// types the live Attach PTY while the Composer card stays hidden.
 struct AgentTerminalView: View {
     let agent: ConsoleAgent
     private let console: ConsoleStore
     private let terminal: TerminalSettings
+    private let inputMode: AgentInputModeSettings
     /// Passed through to the new-agent sheet, which keeps its Host picker for
     /// the Console's own entry point even though this screen pre-selects one.
     private let hosts: [Host]
@@ -40,6 +41,8 @@ struct AgentTerminalView: View {
     @State private var skills: SkillsPaneStore?
     @State private var keyboardControl = TerminalKeyboardControl()
     @State private var composerKeyboardPresentation: AgentComposerKeyboardPresentation = .hidden
+    /// Direct Input's tools dock, separate from Composer focus presentation.
+    @State private var usesDirectToolsKeyboard = false
     @State private var selectedPhoto: PhotosPickerItem?
     @State private var isSelectingPhoto = false
     @State private var isSelectingFile = false
@@ -59,6 +62,9 @@ struct AgentTerminalView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    private var isDirectInput: Bool { inputMode.isDirect }
 
     private var statusBarInset: CGFloat {
         UIApplication.shared.connectedScenes
@@ -73,6 +79,7 @@ struct AgentTerminalView: View {
         agent: ConsoleAgent,
         console: ConsoleStore,
         terminal: TerminalSettings,
+        inputMode: AgentInputModeSettings,
         hosts: [Host],
         activity: AppActivityCoordinator,
         keyboardHandoff: TerminalKeyboardHandoff,
@@ -89,6 +96,7 @@ struct AgentTerminalView: View {
         self.agent = agent
         self.console = console
         self.terminal = terminal
+        self.inputMode = inputMode
         self.hosts = hosts
         self.activity = activity
         self.keyboardHandoff = keyboardHandoff
@@ -148,8 +156,15 @@ struct AgentTerminalView: View {
         screen.onScroll = { sequence, rows in
             attach.scroll(sequence, rows: rows)
         }
+        screen.onPaste = { text, bracketed in
+            attach.requestPaste(text, bracketedPaste: bracketed)
+        }
         screen.keyboardControl = keyboardControl
-        screen.isLocalInputEnabled = false
+        screen.isLocalInputEnabled = isDirectInput
+        screen.claimsKeyboard = { [keyboardHandoff, agent, inputMode] in
+            guard inputMode.isDirect else { return false }
+            return keyboardHandoff.consume(agent.id)
+        }
         screen.theme = terminal.themes.theme
         screen.fontSize = terminal.zoom.fontSize
         screen.fontFamily = terminal.fonts.familyName
@@ -346,6 +361,7 @@ struct AgentTerminalView: View {
             handleActivation()
         }
         .onChange(of: console.hostConnectionGenerations[agent.hostID]) { _, generation in
+            armDirectKeyboardClaimIfNeeded()
             attach.transportGenerationDidChange(generation)
         }
         // Paired with the leave below: SwiftUI hands out onDisappear for
@@ -359,6 +375,12 @@ struct AgentTerminalView: View {
         }
         .onDisappear {
             attach.leave()
+        }
+        .onChange(of: attach.terminalID) { _, _ in
+            guard isDirectInput else { return }
+            usesDirectToolsKeyboard = false
+            keyboardControl.setKeyboardMode(.text)
+            keyboardInset.resumeHeightCapture()
         }
     }
 
@@ -381,7 +403,8 @@ struct AgentTerminalView: View {
                 TerminalSkillsContext(store: store) { skill in
                     viewingSkill = skill
                 }
-            }
+            },
+            includesDraftTools: !isDirectInput
         ) {
             isManagingSnippets = true
         }
@@ -396,11 +419,21 @@ struct AgentTerminalView: View {
             latency: console.hostLatencies[agent.hostID])
     }
 
+    private var activeKeyboardPresentation: AgentComposerKeyboardPresentation {
+        if isDirectInput {
+            return AgentDirectInputChrome.keyboardPresentation(
+                usesToolsKeyboard: usesDirectToolsKeyboard,
+                insetHeight: keyboardInset.height,
+                keyboardIsUp: keyboardControl.isKeyboardUp)
+        }
+        return composerKeyboardPresentation
+    }
+
     private var composerKeyboardLayout: AgentComposerKeyboardLayout {
         AgentComposerKeyboardLayout(
             currentHeight: keyboardInset.height,
             lastPresentedHeight: keyboardInset.lastPresentedHeight,
-            presentation: composerKeyboardPresentation)
+            presentation: activeKeyboardPresentation)
     }
 
     private var composerActions: AgentComposerActions {
@@ -465,19 +498,7 @@ struct AgentTerminalView: View {
         // down. It outlives the keyboard on purpose: an Agent is worth
         // switching to whether or not the user is typing.
         .safeAreaInset(edge: .bottom, spacing: 0) {
-            AgentComposerView(
-                store: composer,
-                status: agent.agent.status,
-                hostTelemetry: hostTelemetry,
-                chromeColorScheme: terminal.themes.selection(for: colorScheme)
-                    .chromeColorScheme(for: colorScheme),
-                switcher: agentSwitcher,
-                keyboardHandoff: keyboardHandoff,
-                keyboardHeight: composerKeyboardLayout.availableToolsHeight,
-                actions: composerActions,
-                skills: skills,
-                keyboardPresentation: $composerKeyboardPresentation,
-                prepareKeyboardPresentation: prepareComposerKeyboardPresentation)
+            inputChrome
         }
         // Not SwiftUI's keyboard avoidance: it retracts in two stages and the
         // terminal would resize twice per dismissal. See TerminalKeyboardInset.
@@ -495,9 +516,9 @@ struct AgentTerminalView: View {
                 height: composerKeyboardLayout.availableToolsHeight,
                 quickKeysEnabled: true,
                 sendQuickKey: keyboardControl.sendQuickKey)
-            .opacity(composerKeyboardPresentation == .tools ? 1 : 0)
-            .allowsHitTesting(composerKeyboardPresentation == .tools)
-            .accessibilityHidden(composerKeyboardPresentation != .tools)
+            .opacity(activeKeyboardPresentation == .tools ? 1 : 0)
+            .allowsHitTesting(activeKeyboardPresentation == .tools)
+            .accessibilityHidden(activeKeyboardPresentation != .tools)
         }
         // The navigation bar remains present only as the owner of the status
         // bar appearance. Its content stays hidden, while this inset keeps
@@ -536,8 +557,158 @@ struct AgentTerminalView: View {
         }
     }
 
+    @ViewBuilder
+    private var inputChrome: some View {
+        if isDirectInput {
+            AgentDirectInputChrome(
+                status: agent.agent.status,
+                hostTelemetry: hostTelemetry,
+                chromeColorScheme: terminal.themes.selection(for: colorScheme)
+                    .chromeColorScheme(for: colorScheme),
+                switcher: agentSwitcher,
+                keyboardHandoff: keyboardHandoff,
+                isKeyboardUp: activeKeyboardPresentation != .hidden,
+                isToolsKeyboardPresented: usesDirectToolsKeyboard,
+                showShortcutRow: AgentDirectInputChrome.showsShortcutRow(
+                    presentation: activeKeyboardPresentation),
+                actions: composerActions,
+                toggleKeyboard: toggleDirectKeyboard,
+                switchKeyboard: directKeyboardSwitchAction,
+                sendQuickKey: keyboardControl.sendQuickKey,
+                showComposer: { selectInputMode(.composer) },
+                restoreComposerThen: restoreComposerThen)
+        } else {
+            AgentComposerView(
+                store: composer,
+                status: agent.agent.status,
+                hostTelemetry: hostTelemetry,
+                chromeColorScheme: terminal.themes.selection(for: colorScheme)
+                    .chromeColorScheme(for: colorScheme),
+                switcher: agentSwitcher,
+                keyboardHandoff: keyboardHandoff,
+                keyboardHeight: composerKeyboardLayout.availableToolsHeight,
+                actions: composerActions,
+                skills: skills,
+                keyboardPresentation: $composerKeyboardPresentation,
+                prepareKeyboardPresentation: prepareComposerKeyboardPresentation,
+                modeControl: composerModeControl)
+        }
+    }
+
+    private var composerModeControl: TerminalAgentSwitcherModeControl {
+        if horizontalSizeClass == .regular {
+            return .segmented(
+                selection: inputMode.mode,
+                select: selectInputMode)
+        }
+        return .button(
+            systemImage: "rectangle.bottomhalf.inset.filled",
+            accessibilityLabel: "Hide Composer",
+            accessibilityHint:
+                "Hides the Composer and types into the Agent with the iOS keyboard.",
+            action: { selectInputMode(.direct) })
+    }
+
+    private var directKeyboardSwitchAction: (() -> Void)? {
+        guard composerKeyboardLayout.availableToolsHeight > 0
+            || keyboardInset.lastPresentedHeight > 0
+            || keyboardControl.isKeyboardUp
+        else { return nil }
+        return { switchDirectKeyboard() }
+    }
+
+    private func selectInputMode(_ mode: AgentInputMode) {
+        guard mode != inputMode.mode else { return }
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            switch mode {
+            case .direct:
+                prepareComposerKeyboardPresentation(.hidden)
+                composerKeyboardPresentation = .hidden
+                usesDirectToolsKeyboard = false
+                keyboardControl.setKeyboardMode(.text)
+                inputMode.select(.direct)
+            case .composer:
+                usesDirectToolsKeyboard = false
+                keyboardControl.setKeyboardMode(.text)
+                keyboardControl.dismissKeyboard()
+                keyboardInset.resumeHeightCapture()
+                inputMode.select(.composer)
+                // Composer onAppear consumes this and focuses the draft.
+                keyboardHandoff.arm(for: agent.id)
+            }
+        }
+        switch mode {
+        case .direct:
+            UIAccessibility.post(
+                notification: .announcement,
+                argument: "Keyboard. Typing into the Agent.")
+            Task { @MainActor in
+                await Task.yield()
+                keyboardControl.requestKeyboard()
+            }
+        case .composer:
+            UIAccessibility.post(notification: .announcement, argument: "Composer.")
+        }
+    }
+
+    private func restoreComposerThen(_ action: @escaping () -> Void) {
+        selectInputMode(.composer)
+        Task { @MainActor in
+            await Task.yield()
+            action()
+        }
+    }
+
+    private func toggleDirectKeyboard() {
+        if usesDirectToolsKeyboard {
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                usesDirectToolsKeyboard = false
+                keyboardInset.resumeHeightCapture()
+                keyboardControl.setKeyboardMode(.text)
+            }
+            keyboardControl.dismissKeyboard()
+        } else {
+            keyboardControl.toggleKeyboard()
+        }
+    }
+
+    private func switchDirectKeyboard() {
+        let enteringTools = !usesDirectToolsKeyboard
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            if enteringTools {
+                keyboardInset.pauseHeightCapture()
+                usesDirectToolsKeyboard = true
+                keyboardControl.setKeyboardMode(.controls)
+            } else {
+                keyboardInset.resumeHeightCapture()
+                usesDirectToolsKeyboard = false
+                keyboardControl.setKeyboardMode(.text)
+            }
+        }
+        if enteringTools {
+            keyboardControl.requestKeyboard()
+        }
+    }
+
+    private func armDirectKeyboardClaimIfNeeded() {
+        guard isDirectInput else { return }
+        guard keyboardControl.isKeyboardUp || usesDirectToolsKeyboard
+            || keyboardInset.height > 0
+        else { return }
+        keyboardHandoff.arm(for: agent.id)
+    }
+
     private func handleActivation() {
         let afterPossibleSuspension = activity.lastAbsenceMayHaveSuspended
+        if afterPossibleSuspension {
+            armDirectKeyboardClaimIfNeeded()
+        }
         attach.didBecomeActive(afterPossibleSuspension: afterPossibleSuspension)
     }
 
@@ -569,8 +740,14 @@ struct AgentTerminalView: View {
     private func switchToAgent(_ id: ConsoleAgent.ID) {
         guard id != agent.id else { return }
         // The strip outlives the keyboard, so a switch made with the keyboard
-        // down must not raise one on the other side.
-        if keyboardInset.height > 0 {
+        // down must not raise one on the other side. Direct Input may keep
+        // first responder with a hardware keyboard and a zero inset.
+        let keyboardIsUp =
+            isDirectInput
+            ? (keyboardControl.isKeyboardUp || usesDirectToolsKeyboard
+                || keyboardInset.height > 0)
+            : keyboardInset.height > 0
+        if keyboardIsUp {
             keyboardHandoff.arm(for: id)
         }
         onSwitch(id)

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -3,6 +3,85 @@ import SwiftUI
 import UIKit
 import UniformTypeIdentifiers
 
+/// Stable in-process seam for exercising Agent-detail behavior without relying
+/// on hosted SwiftUI accessibility. iOS 26 does not materialize those elements
+/// without an assistive client; button wiring remains UI-test coverage.
+@MainActor
+final class AgentTerminalInteractionProbe {
+    private var selectInputModeAction: ((AgentInputMode) -> Void)?
+    private var sendQuickKeyAction: ((AgentQuickKey) -> Void)?
+    private var toggleDirectKeyboardAction: (() -> Void)?
+    private var switchDirectKeyboardAction: (() -> Void)?
+    private var directInputChromeMountCount = 0
+
+    var isConnected: Bool { selectInputModeAction != nil }
+    var isDirectInputChromeMounted: Bool { directInputChromeMountCount > 0 }
+
+    @discardableResult
+    func selectInputMode(_ mode: AgentInputMode) -> Bool {
+        guard let selectInputModeAction else { return false }
+        selectInputModeAction(mode)
+        return true
+    }
+
+    @discardableResult
+    func sendQuickKey(_ key: AgentQuickKey) -> Bool {
+        guard let sendQuickKeyAction else { return false }
+        sendQuickKeyAction(key)
+        return true
+    }
+
+    @discardableResult
+    func toggleDirectKeyboard() -> Bool {
+        guard let toggleDirectKeyboardAction else { return false }
+        toggleDirectKeyboardAction()
+        return true
+    }
+
+    @discardableResult
+    func switchDirectKeyboard() -> Bool {
+        guard let switchDirectKeyboardAction else { return false }
+        switchDirectKeyboardAction()
+        return true
+    }
+
+    fileprivate func connect(selectInputMode: @escaping (AgentInputMode) -> Void) {
+        selectInputModeAction = selectInputMode
+    }
+
+    fileprivate func directInputChromeDidAppear(
+        sendQuickKey: @escaping (AgentQuickKey) -> Void,
+        toggleDirectKeyboard: @escaping () -> Void,
+        switchDirectKeyboard: (() -> Void)?
+    ) {
+        directInputChromeMountCount += 1
+        sendQuickKeyAction = sendQuickKey
+        toggleDirectKeyboardAction = toggleDirectKeyboard
+        switchDirectKeyboardAction = switchDirectKeyboard
+    }
+
+    fileprivate func disconnect() {
+        selectInputModeAction = nil
+        sendQuickKeyAction = nil
+        toggleDirectKeyboardAction = nil
+        switchDirectKeyboardAction = nil
+        directInputChromeMountCount = 0
+    }
+
+    fileprivate func directInputChromeDidDisappear() {
+        directInputChromeMountCount = max(0, directInputChromeMountCount - 1)
+        guard directInputChromeMountCount == 0 else { return }
+        sendQuickKeyAction = nil
+        toggleDirectKeyboardAction = nil
+        switchDirectKeyboardAction = nil
+    }
+
+    fileprivate func updateSwitchDirectKeyboard(_ action: (() -> Void)?) {
+        guard directInputChromeMountCount > 0 else { return }
+        switchDirectKeyboardAction = action
+    }
+}
+
 /// The live Ghostty surface used by Agent detail. Composer mode keeps the
 /// terminal display-only and routes authored text through the local draft;
 /// Direct Input (ADR 0016) enables Ghostty local input so the system keyboard
@@ -38,6 +117,7 @@ struct AgentTerminalView: View {
     private let isOpeningTerminal: Bool
     private let openTerminal: () -> Void
     private let composer: AgentComposerStore
+    private let interactionProbe: AgentTerminalInteractionProbe?
     @State private var attach: AgentAttachStore
     /// Nil for agent kinds without a skills source catalog; the Keys
     /// keyboard hides the Skills tab in that case.
@@ -117,7 +197,8 @@ struct AgentTerminalView: View {
         isOpeningTerminal: Bool = false,
         openTerminal: @escaping () -> Void = {},
         composer: AgentComposerStore,
-        attachStore: AgentAttachStore? = nil
+        attachStore: AgentAttachStore? = nil,
+        interactionProbe: AgentTerminalInteractionProbe? = nil
     ) {
         self.agent = agent
         self.console = console
@@ -134,6 +215,7 @@ struct AgentTerminalView: View {
         self.isOpeningTerminal = isOpeningTerminal
         self.openTerminal = openTerminal
         self.composer = composer
+        self.interactionProbe = interactionProbe
         _attach = State(
             initialValue: attachStore ?? AgentAttachStore(
                 target: agent.agent.paneID,
@@ -436,6 +518,7 @@ struct AgentTerminalView: View {
         // calls must stay synchronous, because the spurious pair can land in
         // one transaction and rejoin() can only undo a leave it can see.
         .onAppear {
+            interactionProbe?.connect(selectInputMode: { mode in selectInputMode(mode) })
             composer.bindAttachInput(attach.input)
             // Arm before rejoin so a full pipeline replacement can claim the
             // keyboard while Direct Input still owns raised intent.
@@ -443,6 +526,7 @@ struct AgentTerminalView: View {
             attach.rejoin()
         }
         .onDisappear {
+            interactionProbe?.disconnect()
             attach.leave()
             Task { @MainActor in
                 await Task.yield()
@@ -703,6 +787,16 @@ struct AgentTerminalView: View {
                     sendQuickKey: keyboardControl.sendQuickKey,
                     showComposer: { selectInputMode(.composer) },
                     restoreComposerThen: restoreComposerThen)))
+            .onAppear {
+                interactionProbe?.directInputChromeDidAppear(
+                    sendQuickKey: { key in keyboardControl.sendQuickKey(key) },
+                    toggleDirectKeyboard: { toggleDirectKeyboard() },
+                    switchDirectKeyboard: directKeyboardSwitchAction)
+            }
+            .onDisappear { interactionProbe?.directInputChromeDidDisappear() }
+            .onChange(of: isDirectKeyboardSwitchAvailable) { _, _ in
+                interactionProbe?.updateSwitchDirectKeyboard(directKeyboardSwitchAction)
+            }
             .onGeometryChange(for: CGFloat.self) { geometry in
                 geometry.size.height
             } action: { height in
@@ -754,11 +848,14 @@ struct AgentTerminalView: View {
     }
 
     private var directKeyboardSwitchAction: (() -> Void)? {
-        guard composerKeyboardLayout.availableToolsHeight > 0
+        guard isDirectKeyboardSwitchAvailable else { return nil }
+        return { switchDirectKeyboard() }
+    }
+
+    private var isDirectKeyboardSwitchAvailable: Bool {
+        composerKeyboardLayout.availableToolsHeight > 0
             || keyboardInset.lastPresentedHeight > 0
             || keyboardControl.isKeyboardUp
-        else { return nil }
-        return { switchDirectKeyboard() }
     }
 
     private func selectInputMode(_ mode: AgentInputMode) {

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -282,6 +282,9 @@ struct AgentTerminalView: View {
         // context across the responder transfer; Shell terminals keep the
         // command-oriented defaults.
         screen.textInputStyle = .naturalLanguage
+        // Keep the destination terminal enabled until Composer-to-Direct has
+        // fully settled. The reverse handoff must disable this outgoing
+        // terminal as soon as Composer accepts first responder.
         screen.isLocalInputEnabled = isDirectInput || composerToDirectHandoffID != nil
         screen.claimsKeyboard = {
             [
@@ -318,8 +321,13 @@ struct AgentTerminalView: View {
                 cancelKeyboardHandoff(id)
             }
         }
-        screen.onKeyboardHandoffSettled = { id in
-            endKeyboardHandoff(id)
+        screen.onKeyboardHandoffEnded = { id, outcome in
+            switch outcome {
+            case .settled, .timedOut:
+                endKeyboardHandoff(id)
+            case .cancelled:
+                cancelKeyboardHandoff(id)
+            }
         }
         screen.theme = terminal.themes.theme
         screen.fontSize = terminal.zoom.fontSize
@@ -885,7 +893,7 @@ struct AgentTerminalView: View {
         if mode == .direct, composerKeyboardPresentation == .system {
             directKeyboardIntent.setWantsKeyboard(true)
             keyboardControl.setKeyboardMode(.text)
-            let id = keyboardInset.beginResponderHandoff(
+            let id = keyboardInset.beginDestinationOwnedResponderHandoff(
                 currentHeight: currentWindowKeyboardHeight
             ) { expiredID in
                 cancelKeyboardHandoff(expiredID)
@@ -926,9 +934,9 @@ struct AgentTerminalView: View {
             case .direct:
                 if !preservingKeyboardHandoff {
                     prepareComposerKeyboardPresentation(.hidden)
+                    composerToDirectHandoffID = nil
                 }
                 composerKeyboardPresentation = .hidden
-                composerToDirectHandoffID = nil
                 usesDirectToolsKeyboard = false
                 expectsDirectSystemKeyboard = false
                 keyboardControl.setKeyboardMode(.text)
@@ -968,10 +976,13 @@ struct AgentTerminalView: View {
     }
 
     private func cancelKeyboardHandoff(_ id: UUID) {
+        let destinationAccepted = settlingKeyboardHandoffID == id
         var ownsHandoff = false
         if composerToDirectHandoffID == id {
             composerToDirectHandoffID = nil
-            directKeyboardIntent.setWantsKeyboard(false)
+            if !destinationAccepted {
+                directKeyboardIntent.setWantsKeyboard(false)
+            }
             ownsHandoff = true
         }
         if directToComposerHandoffID == id {
@@ -1023,6 +1034,9 @@ struct AgentTerminalView: View {
     private func endKeyboardHandoff(_ id: UUID) {
         guard settlingKeyboardHandoffID == id else { return }
         settlingKeyboardHandoffID = nil
+        if composerToDirectHandoffID == id {
+            composerToDirectHandoffID = nil
+        }
         keyboardInset.endResponderHandoff(id)
     }
 

--- a/Sources/Heeler/Console/ConsoleView.swift
+++ b/Sources/Heeler/Console/ConsoleView.swift
@@ -7,6 +7,7 @@ struct ConsoleView: View {
     let hosts: HostStore
     let console: ConsoleStore
     let terminal: TerminalSettings
+    let inputMode: AgentInputModeSettings
     let appearance: AppAppearanceSettings
     let pushRegistration: PushRegistrationStore
     let notificationPreferences: NotificationPreferencesStore
@@ -215,6 +216,7 @@ struct ConsoleView: View {
                     agent: agent,
                     console: console,
                     terminal: terminal,
+                    inputMode: inputMode,
                     hosts: hosts.hosts,
                     activity: activity,
                     keyboardHandoff: keyboardHandoff,

--- a/Sources/Heeler/Console/ConsoleView.swift
+++ b/Sources/Heeler/Console/ConsoleView.swift
@@ -226,6 +226,7 @@ struct ConsoleView: View {
                     // terminal on a spurious reappearance.
                     isOnStage: { [notificationRouter] in
                         notificationRouter.path.last == id
+                            && console.agents.contains(where: { $0.id == id })
                     },
                     onSwitch: { notificationRouter.path = [$0] },
                     onClosed: { notificationRouter.path = [] }

--- a/Sources/Heeler/ContentView.swift
+++ b/Sources/Heeler/ContentView.swift
@@ -18,6 +18,7 @@ struct ContentView: View {
     @State private var terminalFonts = TerminalFontSettings()
     @State private var snippets = SnippetStore()
     @State private var appearance = AppAppearanceSettings()
+    @State private var inputMode = AgentInputModeSettings()
     @State private var relaySettings: NotificationRelaySettings
     @State private var bannerStore: AgentNotificationBannerStore
     @State private var liveActivities: HostLiveActivityCoordinator
@@ -96,6 +97,7 @@ struct ContentView: View {
     var body: some View {
         ConsoleView(
             hosts: hostStore, console: console, terminal: terminal,
+            inputMode: inputMode,
             appearance: appearance,
             pushRegistration: pushRegistration,
             notificationPreferences: notificationPreferences,

--- a/Sources/Heeler/Demo/DemoScreenshotMode.swift
+++ b/Sources/Heeler/Demo/DemoScreenshotMode.swift
@@ -29,6 +29,7 @@
         @State private var terminalFonts: TerminalFontSettings
         @State private var snippets: SnippetStore
         @State private var appearance: AppAppearanceSettings
+        @State private var inputMode: AgentInputModeSettings
         @State private var pushRegistration: PushRegistrationStore
         @State private var notificationPreferences: NotificationPreferencesStore
         @State private var relaySettings: NotificationRelaySettings
@@ -46,6 +47,7 @@
             _terminalFonts = State(initialValue: composition.terminalFonts)
             _snippets = State(initialValue: composition.snippets)
             _appearance = State(initialValue: composition.appearance)
+            _inputMode = State(initialValue: composition.inputMode)
             _pushRegistration = State(initialValue: composition.pushRegistration)
             _notificationPreferences = State(initialValue: composition.notificationPreferences)
             _relaySettings = State(initialValue: composition.relaySettings)
@@ -66,6 +68,7 @@
                 hosts: hosts,
                 console: console,
                 terminal: terminal,
+                inputMode: inputMode,
                 appearance: appearance,
                 pushRegistration: pushRegistration,
                 notificationPreferences: notificationPreferences,
@@ -93,6 +96,7 @@
         let terminalFonts: TerminalFontSettings
         let snippets: SnippetStore
         let appearance: AppAppearanceSettings
+        let inputMode: AgentInputModeSettings
         let pushRegistration: PushRegistrationStore
         let notificationPreferences: NotificationPreferencesStore
         let relaySettings: NotificationRelaySettings
@@ -119,6 +123,7 @@
                 terminalFonts: TerminalFontSettings(defaults: defaults),
                 snippets: SnippetStore(defaults: defaults),
                 appearance: AppAppearanceSettings(defaults: defaults),
+                inputMode: AgentInputModeSettings(defaults: defaults),
                 pushRegistration: pushRegistration,
                 notificationPreferences: notificationPreferences,
                 relaySettings: relaySettings,

--- a/Sources/Heeler/Settings/AgentInputModeSettings.swift
+++ b/Sources/Heeler/Settings/AgentInputModeSettings.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Observation
+
+/// How Agent detail accepts authored input. Composer is the ADR 0013 default;
+/// Direct Input is the opt-in exception that routes the system keyboard into
+/// the live Attach PTY (ADR 0016).
+enum AgentInputMode: String, CaseIterable, Identifiable, Sendable {
+    case composer
+    case direct
+
+    var id: Self { self }
+
+    /// Short segment title for the iPad mode control. VoiceOver speaks this
+    /// value under the "Input mode" label.
+    var segmentTitle: String {
+        switch self {
+        case .composer: "Composer"
+        case .direct: "Keyboard"
+        }
+    }
+}
+
+/// App-wide Agent detail input mode. Persists across navigation, reconnect,
+/// and Agent switches. Default remains Composer; unknown stored values fall
+/// back to Composer rather than inventing Direct Input.
+@MainActor
+@Observable
+final class AgentInputModeSettings {
+    private static let defaultsKey = "agent-input-mode"
+
+    private(set) var mode: AgentInputMode
+    @ObservationIgnored private nonisolated(unsafe) let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        mode =
+            defaults.string(forKey: Self.defaultsKey)
+            .flatMap(AgentInputMode.init(rawValue:)) ?? .composer
+    }
+
+    var isDirect: Bool { mode == .direct }
+
+    func select(_ mode: AgentInputMode) {
+        guard mode != self.mode else { return }
+        self.mode = mode
+        defaults.set(mode.rawValue, forKey: Self.defaultsKey)
+    }
+}

--- a/Sources/Heeler/Settings/TerminalZoomSettings.swift
+++ b/Sources/Heeler/Settings/TerminalZoomSettings.swift
@@ -7,7 +7,7 @@ import Observation
 @MainActor
 @Observable
 final class TerminalZoomSettings {
-    static let defaultFontSize: Float = 14
+    static let defaultFontSize: Float = 9
     /// Whole points only. The low end goes all the way down to libghostty's
     /// own minimum: 4 pt is unreadable, but it fits a wide TUI on screen, and
     /// zooming out for the shape of a layout is a real thing people do.

--- a/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
+++ b/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
@@ -495,6 +495,19 @@ final class TerminalAgentChip: UIControl {
     }
 }
 
+/// Trailing control that enters or leaves Direct Input without living inside
+/// the chip scroller. Icon on compact width; segmented on regular width.
+enum TerminalAgentSwitcherModeControl {
+    case button(
+        systemImage: String,
+        accessibilityLabel: String,
+        accessibilityHint: String,
+        action: () -> Void)
+    case segmented(
+        selection: AgentInputMode,
+        select: (AgentInputMode) -> Void)
+}
+
 /// The resident Agent strip: the chips over their own fill, with the keyboard
 /// toggle pinned at the trailing edge — outside the scroll view, so the one
 /// control that summons the keyboard back can never scroll out of reach.
@@ -504,6 +517,8 @@ struct TerminalAgentSwitcherRow: View {
     let toggleKeyboard: () -> Void
     var isToolsKeyboardPresented = false
     var switchKeyboard: (() -> Void)?
+    /// Optional Hide Composer / Show Composer (or iPad Composer | Keyboard).
+    var modeControl: TerminalAgentSwitcherModeControl?
     /// Matches `UIPasteControl`'s fixed glyph size in the row below, or the
     /// two read as icons borrowed from different sets.
     private static let glyphPointSize: CGFloat = 12
@@ -519,6 +534,9 @@ struct TerminalAgentSwitcherRow: View {
             Rectangle()
                 .fill(Color(uiColor: .separator))
                 .frame(width: hairline, height: 20)
+            if let modeControl {
+                modeControlView(modeControl)
+            }
             if isKeyboardUp, let switchKeyboard {
                 Button(action: switchKeyboard) {
                     Image(
@@ -553,6 +571,34 @@ struct TerminalAgentSwitcherRow: View {
                 .frame(height: hairline)
         }
         .background(Color(uiColor: .secondarySystemBackground))
+    }
+
+    @ViewBuilder
+    private func modeControlView(_ control: TerminalAgentSwitcherModeControl) -> some View {
+        switch control {
+        case let .button(systemImage, accessibilityLabel, accessibilityHint, action):
+            Button(action: action) {
+                Image(systemName: systemImage)
+                    .font(.system(size: Self.glyphPointSize))
+                    .foregroundStyle(Color(uiColor: .label))
+                    .frame(width: 44, height: TerminalAgentSwitcherBar.preferredHeight)
+            }
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityHint(accessibilityHint)
+        case let .segmented(selection, select):
+            Picker("Input mode", selection: Binding(
+                get: { selection },
+                set: select)
+            ) {
+                ForEach(AgentInputMode.allCases) { mode in
+                    Text(mode.segmentTitle).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: 184)
+            .padding(.horizontal, 4)
+            .accessibilityLabel("Input mode")
+        }
     }
 
     private struct StripRepresentable: UIViewRepresentable {

--- a/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
+++ b/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
@@ -44,6 +44,11 @@ final class TerminalKeyboardHandoff {
         armedID = id
     }
 
+    func cancel(for id: ConsoleAgent.ID) {
+        guard armedID == id else { return }
+        armedID = nil
+    }
+
     /// Reads and clears the intent — a handoff is good for exactly one screen,
     /// so a later push from the Agent list starts with the keyboard down.
     func consume(_ id: ConsoleAgent.ID) -> Bool {

--- a/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
+++ b/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
@@ -524,9 +524,12 @@ struct TerminalAgentSwitcherRow: View {
     var switchKeyboard: (() -> Void)?
     /// Optional Hide Composer / Show Composer (or iPad Composer | Keyboard).
     var modeControl: TerminalAgentSwitcherModeControl?
-    /// Matches `UIPasteControl`'s fixed glyph size in the row below, or the
-    /// two read as icons borrowed from different sets.
+    /// Matches `UIPasteControl`'s fixed glyph size in the row below. The
+    /// optically smaller Composer symbol is corrected at its call site.
     private static let glyphPointSize: CGFloat = 12
+    private static let composerGlyphPointSize: CGFloat = 14
+    private static let glyphSlotSize: CGFloat = 18
+    private static let groupedGlyphOffset: CGFloat = 2
     @Environment(\.displayScale) private var displayScale
 
     private var hairline: CGFloat { 1 / max(displayScale, 1) }
@@ -543,30 +546,22 @@ struct TerminalAgentSwitcherRow: View {
                 modeControlView(modeControl)
             }
             if isKeyboardUp, let switchKeyboard {
-                Button(action: switchKeyboard) {
-                    Image(
-                        systemName: isToolsKeyboardPresented
-                            ? "keyboard" : "wrench.and.screwdriver"
-                    )
-                        .font(.system(size: Self.glyphPointSize))
-                        .foregroundStyle(Color(uiColor: .label))
-                        .frame(width: 44, height: TerminalAgentSwitcherBar.preferredHeight)
-                        .contentTransition(.symbolEffect(.replace))
-                }
-                .accessibilityLabel(
-                    isToolsKeyboardPresented ? "Show iOS keyboard" : "Show tools keyboard")
+                trailingIconButton(
+                    systemImage: isToolsKeyboardPresented
+                        ? "keyboard" : "wrench.and.screwdriver",
+                    pointSize: Self.glyphPointSize,
+                    horizontalOffset: 0,
+                    accessibilityLabel: isToolsKeyboardPresented
+                        ? "Show iOS keyboard" : "Show tools keyboard",
+                    action: switchKeyboard)
             }
-            Button(action: toggleKeyboard) {
-                Image(
-                    systemName: isKeyboardUp
-                        ? "keyboard.chevron.compact.down" : "keyboard"
-                )
-                .font(.system(size: Self.glyphPointSize))
-                .foregroundStyle(Color(uiColor: .label))
-                .frame(width: 44, height: TerminalAgentSwitcherBar.preferredHeight)
-                .contentTransition(.symbolEffect(.replace))
-            }
-            .accessibilityLabel(isKeyboardUp ? "Dismiss keyboard" : "Show keyboard")
+            trailingIconButton(
+                systemImage: isKeyboardUp
+                    ? "keyboard.chevron.compact.down" : "keyboard",
+                pointSize: Self.glyphPointSize,
+                horizontalOffset: -Self.groupedGlyphOffset,
+                accessibilityLabel: isKeyboardUp ? "Dismiss keyboard" : "Show keyboard",
+                action: toggleKeyboard)
             .padding(.trailing, 8)
         }
         .frame(height: TerminalAgentSwitcherBar.preferredHeight)
@@ -582,22 +577,13 @@ struct TerminalAgentSwitcherRow: View {
     private func modeControlView(_ control: TerminalAgentSwitcherModeControl) -> some View {
         switch control {
         case let .button(systemImage, accessibilityLabel, accessibilityHint, action):
-            // Visual bar stays `preferredHeight` (40); the control's conceptual
-            // hit target is 44×44 by expanding two points above and below.
-            Button(action: action) {
-                Image(systemName: systemImage)
-                    .font(.system(size: Self.glyphPointSize))
-                    .foregroundStyle(Color(uiColor: .label))
-                    .frame(
-                        width: 44,
-                        height: TerminalAgentSwitcherBar.preferredHeight)
-            }
-            .buttonStyle(.plain)
-            .frame(width: 44, height: 44)
-            .contentShape(Rectangle())
-            .padding(.vertical, (TerminalAgentSwitcherBar.preferredHeight - 44) / 2)
-            .accessibilityLabel(accessibilityLabel)
-            .accessibilityHint(accessibilityHint)
+            trailingIconButton(
+                systemImage: systemImage,
+                pointSize: Self.composerGlyphPointSize,
+                horizontalOffset: Self.groupedGlyphOffset,
+                accessibilityLabel: accessibilityLabel,
+                accessibilityHint: accessibilityHint,
+                action: action)
         case let .segmented(selection, select):
             Picker("Input mode", selection: Binding(
                 get: { selection },
@@ -611,6 +597,37 @@ struct TerminalAgentSwitcherRow: View {
             .frame(maxWidth: 184)
             .padding(.horizontal, 4)
             .accessibilityLabel("Input mode")
+        }
+    }
+
+    @ViewBuilder
+    private func trailingIconButton(
+        systemImage: String,
+        pointSize: CGFloat,
+        horizontalOffset: CGFloat,
+        accessibilityLabel: String,
+        accessibilityHint: String? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
+        let button = Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: pointSize))
+                .foregroundStyle(Color(uiColor: .label))
+                .frame(width: Self.glyphSlotSize, height: Self.glyphSlotSize)
+                .offset(x: horizontalOffset)
+                .frame(width: 44, height: TerminalAgentSwitcherBar.preferredHeight)
+                .contentTransition(.symbolEffect(.replace))
+        }
+        .buttonStyle(.plain)
+        .frame(width: 44, height: 44)
+        .contentShape(Rectangle())
+        .padding(.vertical, (TerminalAgentSwitcherBar.preferredHeight - 44) / 2)
+        .accessibilityLabel(accessibilityLabel)
+
+        if let accessibilityHint {
+            button.accessibilityHint(accessibilityHint)
+        } else {
+            button
         }
     }
 

--- a/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
+++ b/Sources/Heeler/Terminal/TerminalAgentSwitcher.swift
@@ -577,12 +577,20 @@ struct TerminalAgentSwitcherRow: View {
     private func modeControlView(_ control: TerminalAgentSwitcherModeControl) -> some View {
         switch control {
         case let .button(systemImage, accessibilityLabel, accessibilityHint, action):
+            // Visual bar stays `preferredHeight` (40); the control's conceptual
+            // hit target is 44×44 by expanding two points above and below.
             Button(action: action) {
                 Image(systemName: systemImage)
                     .font(.system(size: Self.glyphPointSize))
                     .foregroundStyle(Color(uiColor: .label))
-                    .frame(width: 44, height: TerminalAgentSwitcherBar.preferredHeight)
+                    .frame(
+                        width: 44,
+                        height: TerminalAgentSwitcherBar.preferredHeight)
             }
+            .buttonStyle(.plain)
+            .frame(width: 44, height: 44)
+            .contentShape(Rectangle())
+            .padding(.vertical, (TerminalAgentSwitcherBar.preferredHeight - 44) / 2)
             .accessibilityLabel(accessibilityLabel)
             .accessibilityHint(accessibilityHint)
         case let .segmented(selection, select):

--- a/Sources/Heeler/Terminal/TerminalByteFeed.swift
+++ b/Sources/Heeler/Terminal/TerminalByteFeed.swift
@@ -34,6 +34,13 @@ final class TerminalByteFeed {
         }
     }
 
+    /// Whether `candidate` is the surface currently receiving this feed's bytes.
+    /// The hosted terminal binds in `TerminalScreenView.makeUIView`; a
+    /// replacement pipeline's feed is not attached until that remount runs.
+    func isAttached(to candidate: any TerminalByteSink) -> Bool {
+        sink === candidate
+    }
+
     func write(_ data: Data) {
         guard !data.isEmpty else { return }
         if let sink {

--- a/Sources/Heeler/Terminal/TerminalKeyboard.swift
+++ b/Sources/Heeler/Terminal/TerminalKeyboard.swift
@@ -35,6 +35,7 @@ enum AgentQuickKey: CaseIterable, Hashable {
     case escape
     case tab
     case shiftTab
+    case shiftEnter
     case left
     case up
     case down
@@ -47,6 +48,7 @@ enum AgentQuickKey: CaseIterable, Hashable {
         case .escape: "Esc"
         case .tab: "Tab"
         case .shiftTab: "⇧Tab"
+        case .shiftEnter: "⇧Enter"
         case .enter: "Enter"
         case .backspace: "Backspace"
         case .left, .up, .down, .right: nil
@@ -59,7 +61,7 @@ enum AgentQuickKey: CaseIterable, Hashable {
         case .up: "arrow.up"
         case .down: "arrow.down"
         case .right: "arrow.right"
-        case .escape, .tab, .shiftTab, .enter, .backspace: nil
+        case .escape, .tab, .shiftTab, .shiftEnter, .enter, .backspace: nil
         }
     }
 
@@ -68,6 +70,7 @@ enum AgentQuickKey: CaseIterable, Hashable {
         case .escape: "Escape"
         case .tab: "Tab"
         case .shiftTab: "Shift Tab"
+        case .shiftEnter: "Shift Enter"
         case .left: "Left Arrow"
         case .up: "Up Arrow"
         case .down: "Down Arrow"
@@ -82,6 +85,9 @@ enum AgentQuickKey: CaseIterable, Hashable {
         case .escape: TerminalControlKey.escape.bytes(applicationCursor: applicationCursor)
         case .tab: TerminalControlKey.tab.bytes(applicationCursor: applicationCursor)
         case .shiftTab: TerminalEscapeSequences.shiftTab
+        // LF / Ctrl-J keeps the multiline action distinct from Enter's CR
+        // without depending on a negotiated enhanced-keyboard protocol.
+        case .shiftEnter: TerminalEscapeSequences.newLine
         case .left: TerminalControlKey.left.bytes(applicationCursor: applicationCursor)
         case .up: TerminalControlKey.up.bytes(applicationCursor: applicationCursor)
         case .down: TerminalControlKey.down.bytes(applicationCursor: applicationCursor)

--- a/Sources/Heeler/Terminal/TerminalKeyboard.swift
+++ b/Sources/Heeler/Terminal/TerminalKeyboard.swift
@@ -394,8 +394,7 @@ extension HeelerTerminalView {
     /// There is nothing to balance: the center drops an observer that
     /// deallocates.
     func installKeyboardSwitcher(notificationCenter: NotificationCenter = .default) {
-        inputAssistantItem.leadingBarButtonGroups = []
-        inputAssistantItem.trailingBarButtonGroups = []
+        installInputAssistantStyle()
         notificationCenter.addObserver(
             self, selector: #selector(textKeyboardFrameDidChange(_:)),
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil)
@@ -458,11 +457,15 @@ extension HeelerTerminalView {
     /// this terminal's handoff. A post carrying no frame cannot establish
     /// ownership and is ignored.
     private func notificationSettlesOwnKeyboard(_ notification: Notification) -> Bool {
-        guard isFirstResponder, let window else { return false }
+        guard isFirstResponder, let window, window.isKeyWindow else { return false }
         guard let endFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey]
             as? CGRect
         else { return false }
         let frameInWindow = window.convert(endFrame, from: window.screen.coordinateSpace)
-        return window.bounds.intersection(frameInWindow).height > 0
+        return TerminalKeyboardInset.keyboardFrame(
+            frameInWindow,
+            matches: keyboardLayoutFrameProvider?(window)
+                ?? window.keyboardLayoutGuide.layoutFrame,
+            in: window)
     }
 }

--- a/Sources/Heeler/Terminal/TerminalKeyboardInset.swift
+++ b/Sources/Heeler/Terminal/TerminalKeyboardInset.swift
@@ -32,6 +32,16 @@ final class TerminalKeyboardInset {
     @ObservationIgnored private var coalesceTask: Task<Void, Never>?
     @ObservationIgnored private let measure: @MainActor (CGRect) -> CGFloat?
     @ObservationIgnored private var capturesPresentedHeight = true
+    /// Composer-to-terminal responder handoff can publish transient show,
+    /// change-frame, and even hide notifications while the software keyboard
+    /// never visibly leaves. Keep the last settled footprint until the new
+    /// terminal confirms that its own keyboard frame settled.
+    private(set) var activeResponderHandoffID: UUID?
+    @ObservationIgnored private var responderHandoffFallbackTask: Task<Void, Never>?
+    @ObservationIgnored private var sawDismissDuringResponderHandoff = false
+    @ObservationIgnored var responderHandoffFallbackDelay = Duration.milliseconds(500)
+
+    var isHoldingHandoffHeight: Bool { activeResponderHandoffID != nil }
 
     init(
         notificationCenter: NotificationCenter = .default,
@@ -65,6 +75,7 @@ final class TerminalKeyboardInset {
     }
 
     private func keyboardWillPresent(endFrame: CGRect?) {
+        guard !isHoldingHandoffHeight else { return }
         guard capturesPresentedHeight else { return }
         guard let endFrame, let height = measure(endFrame), height > 0 else { return }
         coalesceTask?.cancel()
@@ -76,6 +87,10 @@ final class TerminalKeyboardInset {
     }
 
     private func keyboardWillDismiss() {
+        guard !isHoldingHandoffHeight else {
+            sawDismissDuringResponderHandoff = true
+            return
+        }
         coalesceTask?.cancel()
         coalesceTask = nil
         apply(0)
@@ -93,6 +108,62 @@ final class TerminalKeyboardInset {
 
     func resumeHeightCapture() {
         capturesPresentedHeight = true
+    }
+
+    /// Freezes the app-owned keyboard inset while UIKit transfers responder
+    /// ownership. All frames inside the handoff are transient by definition:
+    /// both endpoints use the same system keyboard, so retaining one would let
+    /// a candidate-row or another window's frame replace the settled height.
+    func beginResponderHandoff(
+        currentHeight: @escaping @MainActor () -> CGFloat? = { nil },
+        onFallback: @escaping @MainActor (UUID) -> Void = { _ in }
+    ) -> UUID {
+        let id = UUID()
+        coalesceTask?.cancel()
+        coalesceTask = nil
+        responderHandoffFallbackTask?.cancel()
+        activeResponderHandoffID = id
+        sawDismissDuringResponderHandoff = false
+        let fallbackDelay = responderHandoffFallbackDelay
+        responderHandoffFallbackTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: fallbackDelay)
+            guard !Task.isCancelled else { return }
+            guard let self, self.activeResponderHandoffID == id else { return }
+            self.responderHandoffFallbackTask = nil
+            self.activeResponderHandoffID = nil
+            let shouldApplyDismissal = self.sawDismissDuringResponderHandoff
+            self.sawDismissDuringResponderHandoff = false
+            if shouldApplyDismissal {
+                self.apply(max(0, currentHeight() ?? 0))
+            }
+            onFallback(id)
+        }
+        return id
+    }
+
+    /// Releases a responder-handoff freeze after the destination terminal's
+    /// own keyboard frame settles. The pre-handoff settled height stays
+    /// authoritative; a later ordinary keyboard event can replace it.
+    func endResponderHandoff(_ id: UUID) {
+        guard activeResponderHandoffID == id else { return }
+        responderHandoffFallbackTask?.cancel()
+        responderHandoffFallbackTask = nil
+        activeResponderHandoffID = nil
+        sawDismissDuringResponderHandoff = false
+    }
+
+    /// Cancels a transfer without committing any frame emitted while neither
+    /// responder had stable ownership.
+    func cancelResponderHandoff(
+        _ id: UUID,
+        currentHeight: @escaping @MainActor () -> CGFloat? = { nil }
+    ) {
+        guard activeResponderHandoffID == id else { return }
+        let shouldApplyDismissal = sawDismissDuringResponderHandoff
+        endResponderHandoff(id)
+        if shouldApplyDismissal {
+            apply(max(0, currentHeight() ?? 0))
+        }
     }
 
     private func apply(_ height: CGFloat) {
@@ -133,6 +204,30 @@ final class TerminalKeyboardInset {
 
     nonisolated static func insetHeight(covered: CGFloat, bottomSafeArea: CGFloat) -> CGFloat {
         max(0, covered - bottomSafeArea)
+    }
+
+    /// Normalizes docked keyboard frames to the content edge above the home
+    /// indicator while leaving floating keyboard geometry unchanged.
+    static func normalizedKeyboardFrame(_ frame: CGRect, in window: UIWindow) -> CGRect {
+        var visible = window.bounds.intersection(frame)
+        if abs(visible.maxY - window.bounds.maxY) <= 1 {
+            visible.size.height = max(
+                0, window.safeAreaLayoutGuide.layoutFrame.maxY - visible.minY)
+        }
+        return visible
+    }
+
+    static func keyboardFrame(
+        _ frame: CGRect, matches otherFrame: CGRect, in window: UIWindow
+    ) -> Bool {
+        let lhs = normalizedKeyboardFrame(frame, in: window)
+        let rhs = normalizedKeyboardFrame(otherFrame, in: window)
+        return lhs.height > 0
+            && rhs.height > 0
+            && abs(lhs.minX - rhs.minX) <= 1
+            && abs(lhs.minY - rhs.minY) <= 1
+            && abs(lhs.maxX - rhs.maxX) <= 1
+            && abs(lhs.maxY - rhs.maxY) <= 1
     }
 }
 

--- a/Sources/Heeler/Terminal/TerminalKeyboardInset.swift
+++ b/Sources/Heeler/Terminal/TerminalKeyboardInset.swift
@@ -40,6 +40,10 @@ final class TerminalKeyboardInset {
     @ObservationIgnored private var responderHandoffFallbackTask: Task<Void, Never>?
     @ObservationIgnored private var sawDismissDuringResponderHandoff = false
     @ObservationIgnored var responderHandoffFallbackDelay = Duration.milliseconds(500)
+    /// The destination terminal owns the primary 500ms timeout. This later
+    /// owner-side watchdog exists only for a destination that is deallocated
+    /// before its weakly captured timeout can report an outcome.
+    @ObservationIgnored var destinationResponderHandoffFallbackDelay = Duration.seconds(1)
 
     var isHoldingHandoffHeight: Bool { activeResponderHandoffID != nil }
 
@@ -118,12 +122,7 @@ final class TerminalKeyboardInset {
         currentHeight: @escaping @MainActor () -> CGFloat? = { nil },
         onFallback: @escaping @MainActor (UUID) -> Void = { _ in }
     ) -> UUID {
-        let id = UUID()
-        coalesceTask?.cancel()
-        coalesceTask = nil
-        responderHandoffFallbackTask?.cancel()
-        activeResponderHandoffID = id
-        sawDismissDuringResponderHandoff = false
+        let id = prepareResponderHandoff()
         let fallbackDelay = responderHandoffFallbackDelay
         responderHandoffFallbackTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: fallbackDelay)
@@ -138,6 +137,41 @@ final class TerminalKeyboardInset {
             }
             onFallback(id)
         }
+        return id
+    }
+
+    /// Starts a freeze whose destination owns the primary fallback. A later
+    /// owner-side watchdog prevents a deallocated destination from leaving
+    /// the shared inset and handoff token active forever.
+    func beginDestinationOwnedResponderHandoff(
+        currentHeight: @escaping @MainActor () -> CGFloat? = { nil },
+        onFallback: @escaping @MainActor (UUID) -> Void = { _ in }
+    ) -> UUID {
+        let id = prepareResponderHandoff()
+        let fallbackDelay = destinationResponderHandoffFallbackDelay
+        responderHandoffFallbackTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: fallbackDelay)
+            guard !Task.isCancelled else { return }
+            guard let self, self.activeResponderHandoffID == id else { return }
+            self.responderHandoffFallbackTask = nil
+            self.activeResponderHandoffID = nil
+            let shouldApplyDismissal = self.sawDismissDuringResponderHandoff
+            self.sawDismissDuringResponderHandoff = false
+            if shouldApplyDismissal, let height = currentHeight() {
+                self.apply(max(0, height))
+            }
+            onFallback(id)
+        }
+        return id
+    }
+
+    private func prepareResponderHandoff() -> UUID {
+        let id = UUID()
+        coalesceTask?.cancel()
+        coalesceTask = nil
+        responderHandoffFallbackTask?.cancel()
+        activeResponderHandoffID = id
+        sawDismissDuringResponderHandoff = false
         return id
     }
 
@@ -161,8 +195,8 @@ final class TerminalKeyboardInset {
         guard activeResponderHandoffID == id else { return }
         let shouldApplyDismissal = sawDismissDuringResponderHandoff
         endResponderHandoff(id)
-        if shouldApplyDismissal {
-            apply(max(0, currentHeight() ?? 0))
+        if shouldApplyDismissal, let height = currentHeight() {
+            apply(max(0, height))
         }
     }
 

--- a/Sources/Heeler/Terminal/TerminalKeysKeyboard.swift
+++ b/Sources/Heeler/Terminal/TerminalKeysKeyboard.swift
@@ -63,20 +63,32 @@ struct TerminalKeysContext {
     /// Opens the Snippets management surface. That means leaving the keyboard,
     /// so the screen owns the presentation and the keyboard only asks.
     let manageSnippets: () -> Void
+    /// Skills and Snippets insert into the Composer draft. Direct Input hides
+    /// that draft, so those tabs stay off until Composer is restored.
+    var includesDraftTools = true
 
     init(
         settings: TerminalSettings,
         skills: TerminalSkillsContext? = nil,
+        includesDraftTools: Bool = true,
         manageSnippets: @escaping () -> Void
     ) {
         self.settings = settings
         self.skills = skills
+        self.includesDraftTools = includesDraftTools
         self.manageSnippets = manageSnippets
     }
 
     var tabs: [TerminalKeysTab] {
         TerminalKeysTab.allCases.filter { tab in
-            tab != .skills || skills != nil
+            switch tab {
+            case .skills:
+                includesDraftTools && skills != nil
+            case .snippets:
+                includesDraftTools
+            case .controls, .appearance:
+                true
+            }
         }
     }
 }

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -259,18 +259,43 @@ struct TerminalScreenView: UIViewRepresentable {
 
 /// Bridges Ghostty's sendable session callbacks onto the UI's main-actor
 /// closures without making the transport layer depend on Ghostty types.
+private final class TerminalResizeSequence: @unchecked Sendable {
+    private let lock = NSLock()
+    private var latest: UInt64 = 0
+
+    func next() -> UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        latest &+= 1
+        return latest
+    }
+
+    func current() -> UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        return latest
+    }
+}
+
 @MainActor
-private final class TerminalSessionCallbackBridge {
+final class TerminalSessionCallbackBridge {
     var onSizeChanged: ((Int, Int) -> Void)?
     var onViewportTextChanged: ((String) -> Void)?
     var onSend: ((Data) -> Void)?
     var onScroll: ((Data, Int) -> Void)?
     var onPaste: ((String, Bool) -> Void)?
     var onViewport: ((InMemoryTerminalViewport) -> Void)?
+    var isSizeReportCurrent: ((_ columns: Int, _ rows: Int) -> Bool)?
     var onReliableInput: (() -> Void)?
     var onTerminalInput: ((Data) -> Void)?
+    nonisolated private let resizeSequence = TerminalResizeSequence()
+    private var pendingResizeReports: [UInt64: InMemoryTerminalViewport] = [:]
+    private var lastProcessedResizeSequence: UInt64 = 0
+    private var discardsResizeReportsThrough: UInt64 = 0
     private var defersSizeReports = false
     private var deferredSize: (columns: Int, rows: Int)?
+    private var finishesSizeReportDeferralThrough: UInt64?
+    private var suppressesDuplicateSize: (columns: Int, rows: Int)?
 
     init(
         onSizeChanged: ((Int, Int) -> Void)?,
@@ -299,34 +324,100 @@ private final class TerminalSessionCallbackBridge {
     }
 
     nonisolated func resize(_ viewport: InMemoryTerminalViewport) {
+        let sequence = resizeSequence.next()
         Task { @MainActor [weak self] in
-            guard let self else { return }
-            onViewport?(viewport)
-            let size = (columns: Int(viewport.columns), rows: Int(viewport.rows))
-            if defersSizeReports {
-                deferredSize = size
-            } else {
-                onSizeChanged?(size.columns, size.rows)
-            }
+            self?.receiveResize(viewport, sequence: sequence)
         }
     }
 
     func beginSizeReportDeferral() {
+        // A Ghostty resize may already have left its callback thread while its
+        // main-actor delivery is still queued. It describes the layout before
+        // this freeze and must not become the deferred result merely because
+        // its Task happens to run after the handoff begins.
+        discardsResizeReportsThrough = max(
+            discardsResizeReportsThrough, resizeSequence.current())
         defersSizeReports = true
         deferredSize = nil
+        finishesSizeReportDeferralThrough = nil
+        suppressesDuplicateSize = nil
     }
 
     func finishSizeReportDeferral() {
         guard defersSizeReports else { return }
-        defersSizeReports = false
-        guard let deferredSize else { return }
-        self.deferredSize = nil
-        onSizeChanged?(deferredSize.columns, deferredSize.rows)
+        // `resize` crosses onto the main actor asynchronously. Keep the freeze
+        // in force until every callback that had already left Ghostty when the
+        // thaw was requested has been consumed in sequence.
+        finishesSizeReportDeferralThrough = resizeSequence.current()
+        completeSizeReportDeferralIfReady()
+    }
+
+    func provideAuthoritativeDeferredSize(columns: Int, rows: Int) {
+        guard defersSizeReports else { return }
+        deferredSize = (columns, rows)
     }
 
     func cancelSizeReportDeferral() {
+        discardsResizeReportsThrough = max(
+            discardsResizeReportsThrough, resizeSequence.current())
         defersSizeReports = false
         deferredSize = nil
+        finishesSizeReportDeferralThrough = nil
+        suppressesDuplicateSize = nil
+    }
+
+    private func receiveResize(
+        _ viewport: InMemoryTerminalViewport,
+        sequence: UInt64
+    ) {
+        pendingResizeReports[sequence] = viewport
+
+        while let viewport = pendingResizeReports.removeValue(
+            forKey: lastProcessedResizeSequence &+ 1)
+        {
+            lastProcessedResizeSequence &+= 1
+            if lastProcessedResizeSequence > discardsResizeReportsThrough {
+                let size = (columns: Int(viewport.columns), rows: Int(viewport.rows))
+                if isSizeReportCurrent?(size.columns, size.rows) != false {
+                    onViewport?(viewport)
+                    if defersSizeReports {
+                        deferredSize = size
+                    } else {
+                        deliverSize(size)
+                    }
+                }
+            }
+            completeSizeReportDeferralIfReady()
+        }
+    }
+
+    private func completeSizeReportDeferralIfReady() {
+        guard let finishSequence = finishesSizeReportDeferralThrough,
+              lastProcessedResizeSequence >= finishSequence
+        else { return }
+        finishesSizeReportDeferralThrough = nil
+        defersSizeReports = false
+        guard let deferredSize else { return }
+        self.deferredSize = nil
+        guard let onSizeChanged else { return }
+        onSizeChanged(deferredSize.columns, deferredSize.rows)
+        // The surface delegate supplied the settled grid synchronously. The
+        // equivalent engine callback can still be in Ghostty's IO pipeline;
+        // consume that one duplicate when it arrives. A different current
+        // grid clears the token and is delivered normally.
+        suppressesDuplicateSize = deferredSize
+    }
+
+    private func deliverSize(_ size: (columns: Int, rows: Int)) {
+        if let suppressedSize = suppressesDuplicateSize {
+            suppressesDuplicateSize = nil
+            if suppressedSize.columns == size.columns,
+               suppressedSize.rows == size.rows
+            {
+                return
+            }
+        }
+        onSizeChanged?(size.columns, size.rows)
     }
 
     func paste(_ text: String, bracketed: Bool) {
@@ -438,6 +529,7 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     private var textInputStorage = ""
     private var textInputSelection = NSRange(location: 0, length: 0)
     private var terminalGridSize = (columns: 80, rows: 24)
+    private var hasTerminalGridMetrics = false
     private var terminalCellSize = CGSize(width: 8, height: 16)
     private var touchScrollAccumulator = TerminalTouchScrollAccumulator()
     private var touchScrollMomentumDisplayLink: CADisplayLink?
@@ -716,8 +808,9 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         inputAccessoryItems = []
         configuration = TerminalSurfaceOptions(backend: .inMemory(terminalSession))
         controller = terminalController
-        callbackBridge.onViewport = { [weak self] viewport in
-            self?.terminalGridSize = (Int(viewport.columns), Int(viewport.rows))
+        callbackBridge.isSizeReportCurrent = { [weak self] columns, rows in
+            guard let self, hasTerminalGridMetrics else { return true }
+            return terminalGridSize.columns == columns && terminalGridSize.rows == rows
         }
         callbackBridge.onReliableInput = { [weak self] in
             self?.reliableInputDidBegin()
@@ -1126,6 +1219,8 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     /// frame rather than through SwiftUI's two-stage avoidance — see
     /// ``TerminalKeyboardInset``.
     private func beginKeyboardTransitionLayoutDeferral(endsOnFrameChange: Bool = false) {
+        keyboardGridReportTask?.cancel()
+        keyboardGridReportTask = nil
         defersLayoutForKeyboardTransition = true
         keyboardTransitionEndsOnFrameChange = endsOnFrameChange
         didReloadInputViewsForKeyboardHandoff = false
@@ -1208,6 +1303,17 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         }
         setNeedsLayout()
         layoutIfNeeded()
+        if hasTerminalGridMetrics {
+            // A fresh surface can publish its first grid just before the
+            // handoff freeze begins. The bridge correctly rejects that queued
+            // pre-freeze callback, and libghostty may suppress an identical
+            // post-layout callback. Seed the deferral from the surface
+            // delegate's synchronous final metrics so Attach still receives
+            // its initial size, without letting the stale grid escape.
+            callbackBridge.provideAuthoritativeDeferredSize(
+                columns: terminalGridSize.columns,
+                rows: terminalGridSize.rows)
+        }
         scheduleGridReport(after: Self.gridSettleDelay)
         if inheritedTheKeyboard, let settledHandoffID {
             onKeyboardHandoffEnded?(settledHandoffID, handoffOutcome)
@@ -1504,6 +1610,7 @@ extension HeelerTerminalView: TerminalSurfaceOpenURLDelegate,
     /// 8×16 default.
     func terminalDidResize(_ size: TerminalGridMetrics) {
         terminalGridSize = (Int(size.columns), Int(size.rows))
+        hasTerminalGridMetrics = true
         guard size.cellWidthPixels > 0, size.cellHeightPixels > 0 else { return }
         let scale = window?.screen.nativeScale ?? traitCollection.displayScale
         guard scale > 0 else { return }

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -46,6 +46,14 @@ final class TerminalKeyboardControl {
         }
     }
 
+    func requestKeyboard() {
+        terminal?.requestKeyboard()
+    }
+
+    func dismissKeyboard() {
+        _ = terminal?.dismissKeyboard()
+    }
+
     func sendQuickKey(_ key: AgentQuickKey) {
         terminal?.sendQuickKey(key)
     }

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -1,4 +1,5 @@
 import GhosttyTerminal
+import Observation
 import SwiftUI
 import UIKit
 
@@ -30,12 +31,26 @@ struct TerminalClipboard {
 /// A handle on the live terminal for chrome that sits outside it. The reference
 /// is weak and set by the surface itself, so an Agent switch rebuilding the
 /// terminal cannot leave the keyboard toggle or Composer quick keys driving a
-/// dead one.
+/// dead one. First-responder state is observable so Direct Input chrome can
+/// refresh without waiting on an unrelated SwiftUI invalidation.
 @MainActor
+@Observable
 final class TerminalKeyboardControl {
-    weak var terminal: HeelerTerminalView?
+    weak var terminal: HeelerTerminalView? {
+        didSet {
+            oldValue?.onFirstResponderChange = nil
+            terminal?.onFirstResponderChange = { [weak self] in
+                self?.syncFirstResponder()
+            }
+            syncFirstResponder()
+        }
+    }
 
-    var isKeyboardUp: Bool { terminal?.isFirstResponder ?? false }
+    /// Ghostty first-responder intent. Distinct from software-keyboard inset:
+    /// a hardware keyboard can keep this true with a zero footprint.
+    private(set) var isFirstResponder = false
+
+    var isKeyboardUp: Bool { isFirstResponder }
 
     func toggleKeyboard() {
         guard let terminal else { return }
@@ -72,6 +87,12 @@ final class TerminalKeyboardControl {
 
     func paste(_ text: String) {
         terminal?.requestPaste(text)
+    }
+
+    private func syncFirstResponder() {
+        let next = terminal?.isFirstResponder ?? false
+        guard isFirstResponder != next else { return }
+        isFirstResponder = next
     }
 }
 
@@ -308,6 +329,8 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     /// was mid-conversation — dropping the keyboard would hide the switcher
     /// along with it.
     var raisesKeyboardWhenReady = false
+    /// Notifies ``TerminalKeyboardControl`` when first-responder intent changes.
+    var onFirstResponderChange: (() -> Void)?
     /// How many times the input views have been rebuilt. Nothing else observes
     /// the rebuild that republishes the keyboard's settled frame after a
     /// handoff, and a lost rebuild costs the terminal a toolbar's worth of
@@ -514,7 +537,9 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         if isFirstResponder, !responderGate.mayBecomeFirstResponder {
             return true
         }
-        return super.becomeFirstResponder()
+        let accepted = super.becomeFirstResponder()
+        onFirstResponderChange?()
+        return accepted
     }
 
     /// Ghostty's `touchesEnded` dismisses the keyboard after any body tap or
@@ -525,7 +550,11 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     @discardableResult
     override func resignFirstResponder() -> Bool {
         guard responderGate.mayResignFirstResponder else { return false }
-        return super.resignFirstResponder()
+        let resigned = super.resignFirstResponder()
+        if resigned {
+            onFirstResponderChange?()
+        }
+        return resigned
     }
 
     init(

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -771,6 +771,18 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         callbackBridge.paste(text, bracketed: usesBracketedPaste)
     }
 
+    /// Soft-keyboard Return arrives here as `"\n"` (UIKeyInput). Direct Input
+    /// and Shell treat Enter as PTY CR (`0x0D`), matching shortcut Enter and
+    /// `TerminalControlKey.enter` — not LF.
+    override func insertText(_ text: String) {
+        guard isLocalInputEnabled else { return }
+        if text == "\n" {
+            super.insertText("\r")
+            return
+        }
+        super.insertText(text)
+    }
+
     override func deleteBackward() {
         guard isLocalInputEnabled else { return }
 

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -692,7 +692,8 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
             },
             resize: { [weak callbackBridge] viewport in
                 callbackBridge?.resize(viewport)
-            })
+            },
+            suppressesPixelOnlyResizes: true)
         // Font size rides the controller's per-session configuration rather
         // than the surface's one-shot option, so later changes reach the live
         // surface through the same path the initial value took.
@@ -716,7 +717,7 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         configuration = TerminalSurfaceOptions(backend: .inMemory(terminalSession))
         controller = terminalController
         callbackBridge.onViewport = { [weak self] viewport in
-            self?.updateTouchScrollMetrics(viewport)
+            self?.terminalGridSize = (Int(viewport.columns), Int(viewport.rows))
         }
         callbackBridge.onReliableInput = { [weak self] in
             self?.reliableInputDidBegin()
@@ -1441,18 +1442,6 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         }
     }
 
-    /// Ghostty reports cell metrics in surface pixels; touches arrive in
-    /// points, so the grid has to be converted once per resize.
-    private func updateTouchScrollMetrics(_ viewport: InMemoryTerminalViewport) {
-        terminalGridSize = (Int(viewport.columns), Int(viewport.rows))
-        guard viewport.cellWidthPixels > 0, viewport.cellHeightPixels > 0 else { return }
-        let scale = window?.screen.nativeScale ?? traitCollection.displayScale
-        guard scale > 0 else { return }
-        terminalCellSize = CGSize(
-            width: CGFloat(viewport.cellWidthPixels) / scale,
-            height: CGFloat(viewport.cellHeightPixels) / scale)
-    }
-
     func startTouchScrollMomentum(velocityY: CGFloat) {
         guard abs(velocityY) >= 80 else {
             touchScrollAccumulator.reset()
@@ -1509,11 +1498,10 @@ extension HeelerTerminalView: TerminalSurfaceOpenURLDelegate,
 
     /// The one metrics source that still carries cell dimensions. Since
     /// GhosttyTerminal 1.4.0 the in-memory session's resize dispatches come
-    /// from the engine's receive-resize callback, which reports the grid and
-    /// total pixels but not the cell size — `updateTouchScrollMetrics` keeps
-    /// consuming those for columns and rows, while this delegate keeps
-    /// `terminalCellSize` real so tap-to-cell mapping and touch-scroll row
-    /// heights don't fall back to the 8×16 default.
+    /// from the engine's receive-resize callback, which reports the logical
+    /// grid to the Host, while this delegate keeps `terminalCellSize` real so
+    /// tap-to-cell mapping and touch-scroll row heights don't fall back to the
+    /// 8×16 default.
     func terminalDidResize(_ size: TerminalGridMetrics) {
         terminalGridSize = (Int(size.columns), Int(size.rows))
         guard size.cellWidthPixels > 0, size.cellHeightPixels > 0 else { return }

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -103,6 +103,12 @@ enum TerminalTextInputStyle: Equatable {
     case naturalLanguage
 }
 
+enum TerminalKeyboardHandoffOutcome: Equatable {
+    case settled
+    case timedOut
+    case cancelled
+}
+
 struct TerminalScreenView: UIViewRepresentable {
     let feed: TerminalByteFeed
     #if DEBUG
@@ -125,9 +131,10 @@ struct TerminalScreenView: UIViewRepresentable {
     var keyboardHandoffID: UUID?
     var isKeyboardHandoffCurrent: (@MainActor (_ id: UUID) -> Bool)?
     var onKeyboardHandoffResult: (@MainActor (_ id: UUID, _ succeeded: Bool) -> Void)?
-    /// Fires only after this terminal's own keyboard frame settles (or its
-    /// bounded production fallback ends the freeze).
-    var onKeyboardHandoffSettled: (@MainActor (_ id: UUID) -> Void)?
+    /// Reports whether this terminal settled the handoff or had to abandon it.
+    var onKeyboardHandoffEnded: (@MainActor (
+        _ id: UUID, _ outcome: TerminalKeyboardHandoffOutcome
+    ) -> Void)?
     /// Handed the surface once it exists, so the Agent strip's toggle can
     /// raise and lower this terminal's keyboard.
     var keyboardControl: TerminalKeyboardControl?
@@ -156,9 +163,10 @@ struct TerminalScreenView: UIViewRepresentable {
         // terminal's first appearance, not to every state change after it.
         view.raisesKeyboardWhenReady = claimsKeyboard?() ?? false
         keyboardControl?.terminal = view
-        view.onKeyboardHandoffSettled = { [weak view, weak keyboardControl] id in
-            guard let view, keyboardControl?.terminal === view else { return }
-            onKeyboardHandoffSettled?(id)
+        view.onKeyboardHandoffEnded = { [weak view, weak keyboardControl] id, outcome in
+            guard let view else { return }
+            if let keyboardControl, keyboardControl.terminal !== view { return }
+            onKeyboardHandoffEnded?(id, outcome)
         }
         view.setTextInputStyle(textInputStyle)
         view.setLocalInputEnabled(isLocalInputEnabled)
@@ -210,9 +218,10 @@ struct TerminalScreenView: UIViewRepresentable {
             onScroll: onScroll,
             onPaste: onPaste)
         keyboardControl?.terminal = view
-        view.onKeyboardHandoffSettled = { [weak view, weak keyboardControl] id in
-            guard let view, keyboardControl?.terminal === view else { return }
-            onKeyboardHandoffSettled?(id)
+        view.onKeyboardHandoffEnded = { [weak view, weak keyboardControl] id, outcome in
+            guard let view else { return }
+            if let keyboardControl, keyboardControl.terminal !== view { return }
+            onKeyboardHandoffEnded?(id, outcome)
         }
         let claimsKeyboardOnEnable = !view.isLocalInputEnabled
             && isLocalInputEnabled
@@ -376,7 +385,7 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     var onFirstResponderChange: (() -> Void)?
     /// Completes the app-owned inset freeze for a responder handoff after the
     /// terminal's own keyboard frame has settled.
-    var onKeyboardHandoffSettled: ((UUID) -> Void)?
+    var onKeyboardHandoffEnded: ((UUID, TerminalKeyboardHandoffOutcome) -> Void)?
     private var activeKeyboardHandoffID: UUID?
     /// How many times the input views have been rebuilt. Nothing else observes
     /// the rebuild that republishes the keyboard's settled frame after a
@@ -397,6 +406,12 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     /// destination-only frame; the handoff cannot settle before that second
     /// owned frame arrives.
     private var didReloadInputViewsForKeyboardHandoff = false
+    /// The first owned keyboard frame can arrive synchronously from
+    /// `becomeFirstResponder()`. Defer rebuilding until the responder-handoff
+    /// owner has accepted the request, and coalesce any duplicate first
+    /// frames that arrive in the meantime.
+    private var keyboardHandoffReloadIsScheduled = false
+    private var keyboardTransitionCycleID: UUID?
     private var keyboardTransitionFallbackTask: Task<Void, Never>?
     /// Test seam for process-wide keyboard notification ownership. Production
     /// reads the window-local layout guide directly.
@@ -829,7 +844,9 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     /// Raises the keyboard, and records that the user wants it up.
     func requestKeyboard() {
         guard isLocalInputEnabled else { return }
-        finishKeyboardTransitionLayout()
+        if activeKeyboardHandoffID == nil {
+            finishKeyboardTransitionLayout(handoffOutcome: .cancelled)
+        }
         raiseKeyboard()
     }
 
@@ -868,6 +885,9 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     func setLocalInputEnabled(_ isEnabled: Bool) {
         guard isLocalInputEnabled != isEnabled else { return }
         isLocalInputEnabled = isEnabled
+        if !isEnabled {
+            cancelKeyboardTransitionLayoutDeferral()
+        }
         if !isEnabled, isFirstResponder {
             _ = dismissKeyboard()
         }
@@ -1034,7 +1054,6 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         if window == nil {
             stopTouchScrollMomentum()
             responderGate.invalidateTouches()
-            cancelKeyboardTransitionLayoutDeferral()
         } else {
             inheritKeyboard()
         }
@@ -1109,13 +1128,15 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         defersLayoutForKeyboardTransition = true
         keyboardTransitionEndsOnFrameChange = endsOnFrameChange
         didReloadInputViewsForKeyboardHandoff = false
+        keyboardHandoffReloadIsScheduled = false
+        keyboardTransitionCycleID = UUID()
         callbackBridge.beginSizeReportDeferral()
         keyboardTransitionFallbackTask?.cancel()
         let fallbackDelay = keyboardTransitionFallbackDelay
         keyboardTransitionFallbackTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(fallbackDelay))
             guard !Task.isCancelled else { return }
-            self?.finishKeyboardTransitionLayout()
+            self?.finishKeyboardTransitionLayout(handoffOutcome: .timedOut)
         }
     }
 
@@ -1139,16 +1160,30 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     func keyboardFrameDidSettle() {
         guard keyboardTransitionEndsOnFrameChange else { return }
         guard didReloadInputViewsForKeyboardHandoff else {
-            // Set the phase first because UIKit may synchronously publish the
-            // repopulated frame from inside reloadInputViews().
-            didReloadInputViewsForKeyboardHandoff = true
-            UIView.performWithoutAnimation { reloadInputViews() }
+            guard !keyboardHandoffReloadIsScheduled,
+                  let cycleID = keyboardTransitionCycleID
+            else { return }
+            keyboardHandoffReloadIsScheduled = true
+            DispatchQueue.main.async { [weak self] in
+                guard let self,
+                      self.keyboardTransitionCycleID == cycleID,
+                      self.keyboardTransitionEndsOnFrameChange,
+                      self.keyboardHandoffReloadIsScheduled
+                else { return }
+                // Set the phase first because UIKit may synchronously publish
+                // the repopulated frame from inside reloadInputViews().
+                self.keyboardHandoffReloadIsScheduled = false
+                self.didReloadInputViewsForKeyboardHandoff = true
+                UIView.performWithoutAnimation { self.reloadInputViews() }
+            }
             return
         }
-        finishKeyboardTransitionLayout()
+        finishKeyboardTransitionLayout(handoffOutcome: .settled)
     }
 
-    func finishKeyboardTransitionLayout() {
+    func finishKeyboardTransitionLayout(
+        handoffOutcome: TerminalKeyboardHandoffOutcome = .settled
+    ) {
         guard defersLayoutForKeyboardTransition else { return }
         let inheritedTheKeyboard = keyboardTransitionEndsOnFrameChange
         let alreadyReloadedInputViews = didReloadInputViewsForKeyboardHandoff
@@ -1157,6 +1192,8 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         defersLayoutForKeyboardTransition = false
         keyboardTransitionEndsOnFrameChange = false
         didReloadInputViewsForKeyboardHandoff = false
+        keyboardHandoffReloadIsScheduled = false
+        keyboardTransitionCycleID = nil
         keyboardTransitionFallbackTask?.cancel()
         keyboardTransitionFallbackTask = nil
         if inheritedTheKeyboard, !alreadyReloadedInputViews {
@@ -1172,20 +1209,26 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         layoutIfNeeded()
         scheduleGridReport(after: Self.gridSettleDelay)
         if inheritedTheKeyboard, let settledHandoffID {
-            onKeyboardHandoffSettled?(settledHandoffID)
+            onKeyboardHandoffEnded?(settledHandoffID, handoffOutcome)
         }
     }
 
     private func cancelKeyboardTransitionLayoutDeferral() {
+        let cancelledHandoffID = activeKeyboardHandoffID
         activeKeyboardHandoffID = nil
         defersLayoutForKeyboardTransition = false
         keyboardTransitionEndsOnFrameChange = false
         didReloadInputViewsForKeyboardHandoff = false
+        keyboardHandoffReloadIsScheduled = false
+        keyboardTransitionCycleID = nil
         keyboardTransitionFallbackTask?.cancel()
         keyboardTransitionFallbackTask = nil
         keyboardGridReportTask?.cancel()
         keyboardGridReportTask = nil
         callbackBridge.cancelSizeReportDeferral()
+        if let cancelledHandoffID {
+            onKeyboardHandoffEnded?(cancelledHandoffID, .cancelled)
+        }
     }
 
     var usesApplicationCursorKeys: Bool {

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -65,17 +65,6 @@ final class TerminalKeyboardControl {
         terminal?.requestKeyboard()
     }
 
-    /// Transfers an already-present system keyboard to the terminal before
-    /// SwiftUI removes the previous responder. Enabling local input first lets
-    /// UIKit switch responders without dismissing and presenting the keyboard.
-    @discardableResult
-    func handoffKeyboardToLocalInput() -> Bool {
-        guard let terminal else { return false }
-        terminal.setLocalInputEnabled(true)
-        terminal.requestKeyboard()
-        return terminal.isFirstResponder
-    }
-
     func dismissKeyboard() {
         _ = terminal?.dismissKeyboard()
     }
@@ -109,6 +98,11 @@ final class TerminalKeyboardControl {
 
 /// The interactive Ghostty surface. PTY bytes flow into an in-memory Ghostty
 /// session, while its write and resize callbacks flow back to Attach.
+enum TerminalTextInputStyle: Equatable {
+    case terminal
+    case naturalLanguage
+}
+
 struct TerminalScreenView: UIViewRepresentable {
     let feed: TerminalByteFeed
     #if DEBUG
@@ -126,10 +120,19 @@ struct TerminalScreenView: UIViewRepresentable {
     /// closure rather than a stored flag keeps the answer tied to the
     /// surface's creation instead of to how often SwiftUI evaluates the body.
     var claimsKeyboard: (@MainActor () -> Bool)?
+    /// Reports whether an update-time responder handoff reached the current,
+    /// visible terminal. The owner keeps Composer mounted on failure.
+    var keyboardHandoffID: UUID?
+    var isKeyboardHandoffCurrent: (@MainActor (_ id: UUID) -> Bool)?
+    var onKeyboardHandoffResult: (@MainActor (_ id: UUID, _ succeeded: Bool) -> Void)?
+    /// Fires only after this terminal's own keyboard frame settles (or its
+    /// bounded production fallback ends the freeze).
+    var onKeyboardHandoffSettled: (@MainActor (_ id: UUID) -> Void)?
     /// Handed the surface once it exists, so the Agent strip's toggle can
     /// raise and lower this terminal's keyboard.
     var keyboardControl: TerminalKeyboardControl?
     var isLocalInputEnabled = true
+    var textInputStyle = TerminalTextInputStyle.terminal
     var theme: TerminalTheme = .default
     var fontSize: Float = TerminalZoomSettings.defaultFontSize
     var fontFamily: String?
@@ -153,6 +156,11 @@ struct TerminalScreenView: UIViewRepresentable {
         // terminal's first appearance, not to every state change after it.
         view.raisesKeyboardWhenReady = claimsKeyboard?() ?? false
         keyboardControl?.terminal = view
+        view.onKeyboardHandoffSettled = { [weak view, weak keyboardControl] id in
+            guard let view, keyboardControl?.terminal === view else { return }
+            onKeyboardHandoffSettled?(id)
+        }
+        view.setTextInputStyle(textInputStyle)
         view.setLocalInputEnabled(isLocalInputEnabled)
         // The feed holds the surface weakly so a replaced UIKit view cannot be
         // kept alive by an obsolete terminal pipeline.
@@ -202,12 +210,30 @@ struct TerminalScreenView: UIViewRepresentable {
             onScroll: onScroll,
             onPaste: onPaste)
         keyboardControl?.terminal = view
+        view.onKeyboardHandoffSettled = { [weak view, weak keyboardControl] id in
+            guard let view, keyboardControl?.terminal === view else { return }
+            onKeyboardHandoffSettled?(id)
+        }
         let claimsKeyboardOnEnable = !view.isLocalInputEnabled
             && isLocalInputEnabled
             && (claimsKeyboard?() ?? false)
+        view.setTextInputStyle(textInputStyle)
         view.setLocalInputEnabled(isLocalInputEnabled)
-        if claimsKeyboardOnEnable {
-            view.requestKeyboard()
+        if claimsKeyboardOnEnable, let keyboardHandoffID {
+            DispatchQueue.main.async { [weak view, weak keyboardControl] in
+                guard let view,
+                      view.window != nil,
+                      view.isLocalInputEnabled,
+                      keyboardControl?.terminal === view,
+                      isKeyboardHandoffCurrent?(keyboardHandoffID) == true
+                else {
+                    onKeyboardHandoffResult?(keyboardHandoffID, false)
+                    return
+                }
+                onKeyboardHandoffResult?(
+                    keyboardHandoffID,
+                    view.requestKeyboardHandoff(id: keyboardHandoffID))
+            }
         }
         view.applyTheme(theme)
         view.applyFontSize(fontSize)
@@ -348,6 +374,10 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     var raisesKeyboardWhenReady = false
     /// Notifies ``TerminalKeyboardControl`` when first-responder intent changes.
     var onFirstResponderChange: (() -> Void)?
+    /// Completes the app-owned inset freeze for a responder handoff after the
+    /// terminal's own keyboard frame has settled.
+    var onKeyboardHandoffSettled: ((UUID) -> Void)?
+    private var activeKeyboardHandoffID: UUID?
     /// How many times the input views have been rebuilt. Nothing else observes
     /// the rebuild that republishes the keyboard's settled frame after a
     /// handoff, and a lost rebuild costs the terminal a toolbar's worth of
@@ -363,6 +393,9 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     /// change instead.
     private var keyboardTransitionEndsOnFrameChange = false
     private var keyboardTransitionFallbackTask: Task<Void, Never>?
+    /// Test seam for process-wide keyboard notification ownership. Production
+    /// reads the window-local layout guide directly.
+    var keyboardLayoutFrameProvider: ((UIWindow) -> CGRect)?
     /// How long an unsettled handoff may keep the grid frozen before the
     /// freeze force-ends anyway — a leash for production, where the settle
     /// signal can fail to arrive. Tests stretch it so a loaded runner cannot
@@ -376,6 +409,9 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     private var responderGate = TerminalKeyboardResponderGate()
     private var viewportSnapshotTask: Task<Void, Never>?
     private(set) var isLocalInputEnabled = true
+    private var textInputStyle = TerminalTextInputStyle.terminal
+    private var defaultLeadingAssistantGroups: [UIBarButtonItemGroup]?
+    private var defaultTrailingAssistantGroups: [UIBarButtonItemGroup]?
     // Ghostty keeps only marked text in its UITextInput document. UIKit needs
     // committed text to remain in that document so Backspace can observe a
     // shrinking selection and continue its native key repeat.
@@ -402,6 +438,42 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
 
     override var inputView: UIView? {
         terminalInputView
+    }
+
+    override var autocorrectionType: UITextAutocorrectionType {
+        get { textInputStyle == .naturalLanguage ? .default : .no }
+        set {}
+    }
+
+    override var autocapitalizationType: UITextAutocapitalizationType {
+        get { textInputStyle == .naturalLanguage ? .sentences : .none }
+        set {}
+    }
+
+    override var spellCheckingType: UITextSpellCheckingType {
+        get { textInputStyle == .naturalLanguage ? .default : .no }
+        set {}
+    }
+
+    override var smartQuotesType: UITextSmartQuotesType {
+        get { textInputStyle == .naturalLanguage ? .default : .no }
+        set {}
+    }
+
+    override var smartDashesType: UITextSmartDashesType {
+        get { textInputStyle == .naturalLanguage ? .default : .no }
+        set {}
+    }
+
+    override var smartInsertDeleteType: UITextSmartInsertDeleteType {
+        get { textInputStyle == .naturalLanguage ? .default : .no }
+        set {}
+    }
+
+    @available(iOS 17.0, *)
+    override var inlinePredictionType: UITextInlinePredictionType {
+        get { textInputStyle == .naturalLanguage ? .default : .no }
+        set {}
     }
 
     override var beginningOfDocument: UITextPosition {
@@ -756,6 +828,21 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         raiseKeyboard()
     }
 
+    /// Transfers an already-visible keyboard to this terminal without
+    /// exposing the intermediate layouts UIKit publishes between responders.
+    @discardableResult
+    func requestKeyboardHandoff(id: UUID) -> Bool {
+        guard isLocalInputEnabled, window != nil else { return false }
+        activeKeyboardHandoffID = id
+        beginKeyboardTransitionLayoutDeferral(endsOnFrameChange: true)
+        raiseKeyboard()
+        guard isFirstResponder else {
+            cancelKeyboardTransitionLayoutDeferral()
+            return false
+        }
+        return true
+    }
+
     private func raiseKeyboard() {
         responderGate.beginUserDrivenChange(wantsKeyboard: true)
         defer { responderGate.endUserDrivenChange() }
@@ -778,6 +865,29 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         isLocalInputEnabled = isEnabled
         if !isEnabled, isFirstResponder {
             _ = dismissKeyboard()
+        }
+    }
+
+    func setTextInputStyle(_ style: TerminalTextInputStyle) {
+        guard textInputStyle != style else { return }
+        textInputStyle = style
+        applyInputAssistantStyle()
+    }
+
+    func installInputAssistantStyle() {
+        defaultLeadingAssistantGroups = inputAssistantItem.leadingBarButtonGroups
+        defaultTrailingAssistantGroups = inputAssistantItem.trailingBarButtonGroups
+        applyInputAssistantStyle()
+    }
+
+    private func applyInputAssistantStyle() {
+        switch textInputStyle {
+        case .terminal:
+            inputAssistantItem.leadingBarButtonGroups = []
+            inputAssistantItem.trailingBarButtonGroups = []
+        case .naturalLanguage:
+            inputAssistantItem.leadingBarButtonGroups = defaultLeadingAssistantGroups ?? []
+            inputAssistantItem.trailingBarButtonGroups = defaultTrailingAssistantGroups ?? []
         }
     }
 
@@ -1028,6 +1138,8 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     func finishKeyboardTransitionLayout() {
         guard defersLayoutForKeyboardTransition else { return }
         let inheritedTheKeyboard = keyboardTransitionEndsOnFrameChange
+        let settledHandoffID = activeKeyboardHandoffID
+        activeKeyboardHandoffID = nil
         defersLayoutForKeyboardTransition = false
         keyboardTransitionEndsOnFrameChange = false
         keyboardTransitionFallbackTask?.cancel()
@@ -1044,9 +1156,13 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         setNeedsLayout()
         layoutIfNeeded()
         scheduleGridReport(after: Self.gridSettleDelay)
+        if inheritedTheKeyboard, let settledHandoffID {
+            onKeyboardHandoffSettled?(settledHandoffID)
+        }
     }
 
     private func cancelKeyboardTransitionLayoutDeferral() {
+        activeKeyboardHandoffID = nil
         defersLayoutForKeyboardTransition = false
         keyboardTransitionEndsOnFrameChange = false
         keyboardTransitionFallbackTask?.cancel()

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -392,6 +392,11 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     /// an inherited keyboard never leaves, so its settled signal is the frame
     /// change instead.
     private var keyboardTransitionEndsOnFrameChange = false
+    /// An inherited keyboard first publishes the frame that still includes
+    /// both responders' accessories. Rebuilding the input views publishes the
+    /// destination-only frame; the handoff cannot settle before that second
+    /// owned frame arrives.
+    private var didReloadInputViewsForKeyboardHandoff = false
     private var keyboardTransitionFallbackTask: Task<Void, Never>?
     /// Test seam for process-wide keyboard notification ownership. Production
     /// reads the window-local layout guide directly.
@@ -1103,6 +1108,7 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     private func beginKeyboardTransitionLayoutDeferral(endsOnFrameChange: Bool = false) {
         defersLayoutForKeyboardTransition = true
         keyboardTransitionEndsOnFrameChange = endsOnFrameChange
+        didReloadInputViewsForKeyboardHandoff = false
         callbackBridge.beginSizeReportDeferral()
         keyboardTransitionFallbackTask?.cancel()
         let fallbackDelay = keyboardTransitionFallbackDelay
@@ -1132,19 +1138,28 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
     /// (#157).
     func keyboardFrameDidSettle() {
         guard keyboardTransitionEndsOnFrameChange else { return }
+        guard didReloadInputViewsForKeyboardHandoff else {
+            // Set the phase first because UIKit may synchronously publish the
+            // repopulated frame from inside reloadInputViews().
+            didReloadInputViewsForKeyboardHandoff = true
+            UIView.performWithoutAnimation { reloadInputViews() }
+            return
+        }
         finishKeyboardTransitionLayout()
     }
 
     func finishKeyboardTransitionLayout() {
         guard defersLayoutForKeyboardTransition else { return }
         let inheritedTheKeyboard = keyboardTransitionEndsOnFrameChange
+        let alreadyReloadedInputViews = didReloadInputViewsForKeyboardHandoff
         let settledHandoffID = activeKeyboardHandoffID
         activeKeyboardHandoffID = nil
         defersLayoutForKeyboardTransition = false
         keyboardTransitionEndsOnFrameChange = false
+        didReloadInputViewsForKeyboardHandoff = false
         keyboardTransitionFallbackTask?.cancel()
         keyboardTransitionFallbackTask = nil
-        if inheritedTheKeyboard {
+        if inheritedTheKeyboard, !alreadyReloadedInputViews {
             // Both terminals' accessories were on the keyboard while it
             // changed hands, and that is the frame the keyboard published:
             // one accessory too tall. UIKit does not publish another when the
@@ -1165,6 +1180,7 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         activeKeyboardHandoffID = nil
         defersLayoutForKeyboardTransition = false
         keyboardTransitionEndsOnFrameChange = false
+        didReloadInputViewsForKeyboardHandoff = false
         keyboardTransitionFallbackTask?.cancel()
         keyboardTransitionFallbackTask = nil
         keyboardGridReportTask?.cancel()

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -65,6 +65,17 @@ final class TerminalKeyboardControl {
         terminal?.requestKeyboard()
     }
 
+    /// Transfers an already-present system keyboard to the terminal before
+    /// SwiftUI removes the previous responder. Enabling local input first lets
+    /// UIKit switch responders without dismissing and presenting the keyboard.
+    @discardableResult
+    func handoffKeyboardToLocalInput() -> Bool {
+        guard let terminal else { return false }
+        terminal.setLocalInputEnabled(true)
+        terminal.requestKeyboard()
+        return terminal.isFirstResponder
+    }
+
     func dismissKeyboard() {
         _ = terminal?.dismissKeyboard()
     }
@@ -191,7 +202,13 @@ struct TerminalScreenView: UIViewRepresentable {
             onScroll: onScroll,
             onPaste: onPaste)
         keyboardControl?.terminal = view
+        let claimsKeyboardOnEnable = !view.isLocalInputEnabled
+            && isLocalInputEnabled
+            && (claimsKeyboard?() ?? false)
         view.setLocalInputEnabled(isLocalInputEnabled)
+        if claimsKeyboardOnEnable {
+            view.requestKeyboard()
+        }
         view.applyTheme(theme)
         view.applyFontSize(fontSize)
         view.applyFontFamily(fontFamily)

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -370,15 +370,21 @@ struct AgentDirectInputTests {
         await Task.yield()
         let heightWithSoftwareKeyboard = try #require(
             Self.terminals(in: controller.view).first).frame.height
+        let shortcutRowID =
+            AgentDirectInputPresentation.shortcutRowAccessibilityIdentifier
+        try #require(await Self.eventually {
+            Self.firstAccessible(identifier: shortcutRowID, in: controller.view) != nil
+        })
 
         try #require(
             Self.activateAccessibility(labeled: "Show tools keyboard", in: controller.view))
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         // Tools presentation hides the software-keyboard shortcut row; wait for
-        // that chrome transition rather than assuming one yield rebuilt a11y.
+        // that source-specific identity rather than the shared Escape label the
+        // Tools keypad also speaks.
         try #require(await Self.eventually {
-            Self.firstAccessible(labeled: "Escape", in: controller.view) == nil
+            Self.firstAccessible(identifier: shortcutRowID, in: controller.view) == nil
         })
 
         // UIKit tears the software keyboard down while Tools stays first
@@ -397,7 +403,8 @@ struct AgentDirectInputTests {
         // footprint even while measured height is still zero. Two-sided bound:
         // wiring the modifier to the raw zero height expands the terminal by
         // ~lastPresentedHeight and still satisfies a one-sided upper bound.
-        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
+        #expect(
+            Self.firstAccessible(identifier: shortcutRowID, in: controller.view) != nil)
         let midSwapTerminal = try #require(Self.terminals(in: controller.view).first)
         #expect(midSwapTerminal.isFirstResponder)
         #expect(abs(heightWithSoftwareKeyboard - midSwapTerminal.frame.height) <= 1)
@@ -414,7 +421,8 @@ struct AgentDirectInputTests {
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
-        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
+        #expect(
+            Self.firstAccessible(identifier: shortcutRowID, in: controller.view) != nil)
         let afterShow = try #require(Self.terminals(in: controller.view).first)
         #expect(afterShow.isFirstResponder)
         #expect(abs(afterShow.frame.height - heightWithSoftwareKeyboard) < 1)
@@ -428,7 +436,8 @@ struct AgentDirectInputTests {
         await Task.yield()
         let afterHardwareHide = try #require(Self.terminals(in: controller.view).first)
         #expect(afterHardwareHide.isFirstResponder)
-        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
+        #expect(
+            Self.firstAccessible(identifier: shortcutRowID, in: controller.view) == nil)
         #expect(afterHardwareHide.frame.height - heightWithSoftwareKeyboard >= 336)
 
         await owner.leave().value
@@ -627,8 +636,18 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
         })
+        // Hosted UI may still expose the predecessor surface briefly after the
+        // replacement Attach is live — wait for a distinct rendered terminal.
+        try #require(await Self.eventually {
+            Self.terminals(in: controller.view).contains {
+                ObjectIdentifier($0) != firstSurface
+            }
+        })
 
-        let replacement = try #require(Self.terminals(in: controller.view).first)
+        let replacement = try #require(
+            Self.terminals(in: controller.view).first {
+                ObjectIdentifier($0) != firstSurface
+            })
         #expect(ObjectIdentifier(replacement) != firstSurface)
         #expect(replacement.isLocalInputEnabled)
         try #require(await Self.eventually { replacement.isFirstResponder })
@@ -690,6 +709,9 @@ struct AgentDirectInputTests {
         // Production dismiss clears Direct Input raised intent. A leftover
         // TerminalKeyboardHandoff arm after the first replacement must not
         // resurrect the keyboard on the next pipeline rebuild.
+        try #require(await Self.eventually {
+            Self.firstAccessible(labeled: "Dismiss keyboard", in: controller.view) != nil
+        })
         try #require(
             Self.activateAccessibility(labeled: "Dismiss keyboard", in: controller.view))
         try #require(await Self.eventually { !afterFirst.isFirstResponder })
@@ -892,8 +914,20 @@ struct AgentDirectInputTests {
     }
 
     private static func firstAccessible(labeled label: String, in root: UIView) -> NSObject? {
+        firstAccessible(in: root) { $0.accessibilityLabel == label }
+    }
+
+    private static func firstAccessible(
+        identifier: String, in root: UIView
+    ) -> NSObject? {
+        firstAccessible(in: root) { $0.accessibilityIdentifier == identifier }
+    }
+
+    private static func firstAccessible(
+        in root: UIView, matching: (NSObject) -> Bool
+    ) -> NSObject? {
         func visit(_ node: NSObject) -> NSObject? {
-            if node.accessibilityLabel == label {
+            if matching(node) {
                 return node
             }
             if let elements = node.accessibilityElements {

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -1,0 +1,421 @@
+import Foundation
+import SwiftUI
+import Testing
+import UIKit
+
+@testable import Heeler
+
+@MainActor
+@Suite("Agent Direct Input")
+struct AgentDirectInputTests {
+    @Test func shortcutRowTracksSystemKeyboardPresentationOnly() {
+        #expect(AgentDirectInputChrome.showsShortcutRow(presentation: .system))
+        #expect(!AgentDirectInputChrome.showsShortcutRow(presentation: .hidden))
+        #expect(!AgentDirectInputChrome.showsShortcutRow(presentation: .tools))
+    }
+
+    @Test func directKeyboardPresentationMatchesShellArithmetic() {
+        #expect(
+            AgentDirectInputChrome.keyboardPresentation(
+                usesToolsKeyboard: false,
+                insetHeight: 0,
+                keyboardIsUp: true) == .system)
+        #expect(
+            AgentDirectInputChrome.keyboardPresentation(
+                usesToolsKeyboard: false,
+                insetHeight: 0,
+                keyboardIsUp: false) == .hidden)
+        #expect(
+            AgentDirectInputChrome.keyboardPresentation(
+                usesToolsKeyboard: true,
+                insetHeight: 0,
+                keyboardIsUp: true) == .tools)
+        #expect(
+            AgentDirectInputChrome.keyboardPresentation(
+                usesToolsKeyboard: false,
+                insetHeight: 336,
+                keyboardIsUp: false) == .system)
+    }
+
+    @Test func composerModeStillRejectsLocalGhosttyInput() async throws {
+        let transport = ScriptedTransport()
+        let composer = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+        composer.replaceDraft(with: "keep me")
+        let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
+        let (inputMode, cleanup) = try Self.makeInputMode()
+        defer { cleanup() }
+
+        let controller = UIHostingController(
+            rootView: Self.makeDetailView(
+                attachStore: owner,
+                composer: composer,
+                inputMode: inputMode))
+        let window = Self.makeLocalTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
+            rootViewController: controller)
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+        try #require(await Self.eventually { owner.terminalStatus == .live })
+
+        let terminal = try #require(Self.terminals(in: controller.view).first)
+        #expect(!terminal.isLocalInputEnabled)
+        terminal.requestKeyboard()
+        terminal.sendControlKey(.enter)
+        await Task.yield()
+        #expect(!terminal.isFirstResponder)
+        #expect(
+            await transport.attachInputs.allSatisfy {
+                if case .keystrokes = $0 { false } else { true }
+            })
+        #expect(composer.draft == "keep me")
+        #expect(await transport.agentPromptParams.isEmpty)
+
+        await owner.leave().value
+    }
+
+    @Test func directInputEnablesLocalInputAndSendsPtyBytes() async throws {
+        let transport = ScriptedTransport()
+        let composer = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+        composer.replaceDraft(with: "waiting draft")
+        let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
+        let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
+        defer { cleanup() }
+
+        let controller = UIHostingController(
+            rootView: Self.makeDetailView(
+                attachStore: owner,
+                composer: composer,
+                inputMode: inputMode))
+        let window = Self.makeLocalTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
+            rootViewController: controller)
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+        try #require(await Self.eventually { owner.terminalStatus == .live })
+
+        let terminal = try #require(Self.terminals(in: controller.view).first)
+        #expect(terminal.isLocalInputEnabled)
+        terminal.requestKeyboard()
+        #expect(terminal.isFirstResponder)
+
+        terminal.sendControlKey(.enter)
+        try #require(await Self.eventually {
+            await transport.attachInputs.contains(.keystrokes(Data([0x0D])))
+        })
+        #expect(composer.draft == "waiting draft")
+        #expect(await transport.agentPromptParams.isEmpty)
+
+        await owner.leave().value
+    }
+
+    @Test func modeSwitchPreservesDraftAndSendsNothing() async throws {
+        let transport = ScriptedTransport()
+        let composer = AgentComposerStore(target: "w1:p1") { params in
+            try await transport.promptAgent(params)
+        }
+        composer.replaceDraft(with: "do not send")
+        let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
+        let (inputMode, cleanup) = try Self.makeInputMode()
+        defer { cleanup() }
+
+        let controller = UIHostingController(
+            rootView: Self.makeDetailView(
+                attachStore: owner,
+                composer: composer,
+                inputMode: inputMode))
+        let window = Self.makeLocalTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
+            rootViewController: controller)
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+        try #require(await Self.eventually { owner.terminalStatus == .live })
+
+        inputMode.select(.direct)
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+        await Task.yield()
+
+        let terminal = try #require(Self.terminals(in: controller.view).first)
+        #expect(terminal.isLocalInputEnabled)
+        #expect(composer.draft == "do not send")
+        #expect(await transport.agentPromptParams.isEmpty)
+        #expect(
+            await transport.attachInputs.allSatisfy {
+                if case .keystrokes = $0 { false } else { true }
+            })
+
+        inputMode.select(.composer)
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+        await Task.yield()
+
+        let restored = try #require(Self.terminals(in: controller.view).first)
+        #expect(!restored.isLocalInputEnabled)
+        #expect(composer.draft == "do not send")
+        #expect(await transport.agentPromptParams.isEmpty)
+
+        await owner.leave().value
+    }
+
+    @Test func shortcutKeysWriteAgentQuickKeyBytes() async throws {
+        let transport = ScriptedTransport()
+        let composer = AgentComposerStore(target: "w1:p1") { _ in }
+        let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
+        let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
+        defer { cleanup() }
+
+        let controller = UIHostingController(
+            rootView: Self.makeDetailView(
+                attachStore: owner,
+                composer: composer,
+                inputMode: inputMode))
+        let window = Self.makeLocalTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
+            rootViewController: controller)
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+        try #require(await Self.eventually { owner.terminalStatus == .live })
+
+        let terminal = try #require(Self.terminals(in: controller.view).first)
+        terminal.sendQuickKey(.escape)
+        terminal.sendQuickKey(.tab)
+        terminal.sendQuickKey(.shiftTab)
+        terminal.sendQuickKey(.enter)
+
+        try #require(await Self.eventually {
+            let inputs = await transport.attachInputs
+            return inputs.contains(.keystrokes(Data([0x1B])))
+                && inputs.contains(.keystrokes(Data([0x09])))
+                && inputs.contains(.keystrokes(Data([0x1B, 0x5B, 0x5A])))
+                && inputs.contains(.keystrokes(Data([0x0D])))
+        })
+        #expect(await transport.agentPromptParams.isEmpty)
+
+        await owner.leave().value
+    }
+
+    @Test func blockedStatusStaysInDirectInput() async throws {
+        let transport = ScriptedTransport()
+        let composer = AgentComposerStore(target: "w1:p1", initialStatus: .blocked) { _ in }
+        let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
+        let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
+        defer { cleanup() }
+
+        let controller = UIHostingController(
+            rootView: Self.makeDetailView(
+                agent: Self.makeAgent(status: .blocked),
+                attachStore: owner,
+                composer: composer,
+                inputMode: inputMode))
+        let window = Self.makeLocalTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
+            rootViewController: controller)
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+        try #require(await Self.eventually { owner.terminalStatus == .live })
+
+        #expect(inputMode.mode == .direct)
+        let terminal = try #require(Self.terminals(in: controller.view).first)
+        #expect(terminal.isLocalInputEnabled)
+        terminal.sendQuickKey(.enter)
+        try #require(await Self.eventually {
+            await transport.attachInputs.contains(.keystrokes(Data([0x0D])))
+        })
+        #expect(await transport.agentPromptParams.isEmpty)
+
+        await owner.leave().value
+    }
+
+    @Test func directHandoffClaimsGhosttyKeyboard() async throws {
+        let handoff = TerminalKeyboardHandoff()
+        let agent = Self.makeAgent(status: .idle)
+        handoff.arm(for: agent.id)
+
+        let transport = ScriptedTransport()
+        let composer = AgentComposerStore(target: "w1:p1") { _ in }
+        let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
+        let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
+        defer { cleanup() }
+
+        let controller = UIHostingController(
+            rootView: Self.makeDetailView(
+                agent: agent,
+                attachStore: owner,
+                composer: composer,
+                inputMode: inputMode,
+                keyboardHandoff: handoff))
+        let window = Self.makeLocalTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
+            rootViewController: controller)
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+        try #require(await Self.eventually { owner.terminalStatus == .live })
+
+        let terminal = try #require(Self.terminals(in: controller.view).first)
+        #expect(terminal.isLocalInputEnabled)
+        #expect(terminal.isFirstResponder)
+        #expect(!handoff.consume(agent.id))
+
+        await owner.leave().value
+    }
+
+    @Test func directToolsContextHidesDraftInsertTabs() throws {
+        let suiteName = "direct-tabs-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settings = TerminalSettings(
+            themes: TerminalThemeSettings(defaults: defaults),
+            zoom: TerminalZoomSettings(defaults: defaults),
+            fonts: TerminalFontSettings(defaults: defaults),
+            snippets: SnippetStore(defaults: defaults))
+        let skills = TerminalSkillsContext(
+            store: SkillsPaneStore(commandPrefixes: ["/"]) { _ in [] })
+        let direct = TerminalKeysContext(
+            settings: settings,
+            skills: skills,
+            includesDraftTools: false,
+            manageSnippets: {})
+        #expect(direct.tabs == [.controls, .appearance])
+
+        let composer = TerminalKeysContext(
+            settings: settings,
+            skills: skills,
+            includesDraftTools: true,
+            manageSnippets: {})
+        #expect(composer.tabs == [.controls, .skills, .snippets, .appearance])
+    }
+
+    @Test func hideAndShowComposerAccessibilityCopy() {
+        #expect(AgentInputMode.composer.segmentTitle == "Composer")
+        #expect(AgentInputMode.direct.segmentTitle == "Keyboard")
+        #expect(AgentQuickKey.escape.accessibilityLabel == "Escape")
+        #expect(AgentQuickKey.tab.accessibilityLabel == "Tab")
+        #expect(AgentQuickKey.shiftTab.accessibilityLabel == "Shift Tab")
+        #expect(AgentQuickKey.enter.accessibilityLabel == "Enter")
+    }
+
+    private static func makeInputMode(
+        initial: AgentInputMode = .composer
+    ) throws -> (AgentInputModeSettings, () -> Void) {
+        let suiteName = "direct-mode-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        let settings = AgentInputModeSettings(defaults: defaults)
+        if initial != .composer {
+            settings.select(initial)
+        }
+        return (settings, { defaults.removePersistentDomain(forName: suiteName) })
+    }
+
+    private static func makeLiveAttach(
+        transport: ScriptedTransport,
+        composer: AgentComposerStore
+    ) async throws -> AgentAttachStore {
+        let owner = AgentAttachStore(
+            target: "w1:p1",
+            paneTitle: "Claude",
+            transportGeneration: 1,
+            isOnStage: { true },
+            runTerminal: { request, handler in
+                let session = try await transport.attachTerminal(request)
+                try await handler.runEndingSession(session)
+            },
+            stageImage: { _, _ in throw TransportError.cancelled },
+            stageFile: { _, _ in throw TransportError.cancelled },
+            composer: composer,
+            closePane: {})
+        owner.rejoin()
+        try #require(await Self.eventually {
+            await transport.attachRequests.count == 1
+        })
+        #expect(await transport.emitAttachOutput(Data("live".utf8)))
+        try #require(await Self.eventually { owner.terminalStatus == .live })
+        return owner
+    }
+
+    private static func makeDetailView(
+        agent: ConsoleAgent? = nil,
+        attachStore: AgentAttachStore,
+        composer: AgentComposerStore,
+        inputMode: AgentInputModeSettings,
+        keyboardHandoff: TerminalKeyboardHandoff = TerminalKeyboardHandoff()
+    ) -> AgentTerminalView {
+        let defaults = UserDefaults(suiteName: "direct-detail-\(UUID())") ?? .standard
+        let console = ConsoleStore(snapshotRetryDelay: .seconds(30)) { _, subscriptions in
+            EventsSession(
+                subscriptions: subscriptions,
+                connect: { throw TransportError.sshUnreachable(detail: "fixture") },
+                reconnectPolicy: .default,
+                keepalive: .default)
+        }
+        let terminal = TerminalSettings(
+            themes: TerminalThemeSettings(defaults: defaults),
+            zoom: TerminalZoomSettings(defaults: defaults),
+            fonts: TerminalFontSettings(defaults: defaults),
+            snippets: SnippetStore(defaults: defaults))
+        return AgentTerminalView(
+            agent: agent ?? makeAgent(status: .idle),
+            console: console,
+            terminal: terminal,
+            inputMode: inputMode,
+            hosts: [],
+            activity: AppActivityCoordinator(),
+            keyboardHandoff: keyboardHandoff,
+            keyboardInset: TerminalKeyboardInset(),
+            isOnStage: { true },
+            onSwitch: { _ in },
+            onClosed: {},
+            composer: composer,
+            attachStore: attachStore)
+    }
+
+    private static func makeAgent(status: AgentStatus) -> ConsoleAgent {
+        ConsoleAgent(
+            hostID: UUID(),
+            hostName: "devbox",
+            agent: Agent(
+                terminalID: "term_w1:p1", kind: "claude", title: "",
+                status: status, workspaceID: "w", tabID: "w:t", paneID: "w1:p1",
+                cwd: "/work", revision: 1, name: nil),
+            workspaceLabel: nil,
+            repositoryCheckout: nil,
+            lastOutputSnippet: nil)
+    }
+
+    private static func terminals(in root: UIView) -> [HeelerTerminalView] {
+        var found: [HeelerTerminalView] = []
+        func walk(_ view: UIView) {
+            if let terminal = view as? HeelerTerminalView {
+                found.append(terminal)
+            }
+            view.subviews.forEach(walk)
+        }
+        walk(root)
+        return found
+    }
+
+    private static func makeLocalTestWindow(
+        frame: CGRect,
+        rootViewController: UIViewController
+    ) -> UIWindow {
+        let window = UIWindow(frame: frame)
+        window.rootViewController = rootViewController
+        window.makeKeyAndVisible()
+        return window
+    }
+
+    private static func eventually(
+        timeout: Duration = .seconds(5),
+        _ condition: @escaping () async -> Bool
+    ) async throws -> Bool {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if await condition() { return true }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        return await condition()
+    }
+}

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -238,8 +238,9 @@ struct AgentDirectInputTests {
         terminal.requestKeyboard()
         try #require(await Self.eventually { terminal.isFirstResponder })
 
-        // System Return / Ghostty local-input path — not the app shortcut row.
-        terminal.sendControlKey(TerminalControlKey.enter)
+        // Soft-keyboard Return enters through UIKeyInput.insertText("\n"),
+        // not sendControlKey / sendQuickKey. Production maps that to PTY CR.
+        (terminal as UIKeyInput).insertText("\n")
         try #require(await Self.eventually {
             await transport.attachInputs.contains(
                 TerminalAttachInput.keystrokes(Data([0x0D])))
@@ -281,6 +282,8 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually { terminal.isFirstResponder })
 
         #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
+        controller.view.layoutIfNeeded()
+        let heightBeforeKeyboard = terminal.frame.height
 
         center.post(
             name: UIResponder.keyboardWillShowNotification, object: nil,
@@ -292,6 +295,8 @@ struct AgentDirectInputTests {
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
+        let heightWithKeyboard = try #require(Self.terminals(in: controller.view).first)
+            .frame.height
 
         for label in ["Escape", "Tab", "Shift Tab", "Enter"] {
             try #require(Self.activateAccessibility(labeled: label, in: controller.view))
@@ -307,20 +312,19 @@ struct AgentDirectInputTests {
         })
         #expect(await transport.agentPromptParams.isEmpty)
 
+        // Rendered production inset: AgentTerminalKeyboardInsetModifier must
+        // shrink the hosted terminal by the software-keyboard height.
+        #expect(heightBeforeKeyboard - heightWithKeyboard >= 336)
+
         center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
         #expect(inset.height == 0)
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
         #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
-        // Production consumes presentation.layout — zero height must not keep
-        // lastPresentedHeight as the bottom inset.
-        let dismissed = AgentDirectInputPresentation.resolve(
-            usesToolsKeyboard: false,
-            expectsSystemKeyboard: false,
-            currentHeight: inset.height,
-            lastPresentedHeight: inset.lastPresentedHeight)
-        #expect(dismissed.layout.contentInset == 0)
+        let heightAfterHide = try #require(Self.terminals(in: controller.view).first)
+            .frame.height
+        #expect(abs(heightAfterHide - heightBeforeKeyboard) < 1)
 
         await owner.leave().value
     }
@@ -364,6 +368,8 @@ struct AgentDirectInputTests {
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
+        let heightWithSoftwareKeyboard = try #require(
+            Self.terminals(in: controller.view).first).frame.height
 
         try #require(
             Self.activateAccessibility(labeled: "Show tools keyboard", in: controller.view))
@@ -387,12 +393,38 @@ struct AgentDirectInputTests {
         // Pre-show `.system` hold: shortcut row stays adjacent to the keyboard
         // footprint even while measured height is still zero.
         #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
-        let midSwap = AgentDirectInputPresentation.resolve(
-            usesToolsKeyboard: false,
-            expectsSystemKeyboard: true,
-            currentHeight: inset.height,
-            lastPresentedHeight: inset.lastPresentedHeight)
-        #expect(midSwap.layout.contentInset == 336)
+        let midSwapTerminal = try #require(Self.terminals(in: controller.view).first)
+        #expect(midSwapTerminal.isFirstResponder)
+        #expect(heightWithSoftwareKeyboard - midSwapTerminal.frame.height <= 1)
+
+        // Software keyboard actually appears — hold must release without a
+        // transient `.hidden` dip (row and inset stay).
+        center.post(
+            name: UIResponder.keyboardWillShowNotification, object: nil,
+            userInfo: [
+                UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                    x: 0, y: 500, width: 402, height: 370)
+            ])
+        try #require(await Self.eventually { inset.height == 336 })
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+        await Task.yield()
+        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
+        let afterShow = try #require(Self.terminals(in: controller.view).first)
+        #expect(afterShow.isFirstResponder)
+        #expect(abs(afterShow.frame.height - heightWithSoftwareKeyboard) < 1)
+
+        // Hardware keyboard hides the software keyboard while Ghostty remains
+        // first responder. Released hold must not keep a stale inset or row.
+        center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
+        #expect(inset.height == 0)
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+        await Task.yield()
+        let afterHardwareHide = try #require(Self.terminals(in: controller.view).first)
+        #expect(afterHardwareHide.isFirstResponder)
+        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
+        #expect(afterHardwareHide.frame.height - heightWithSoftwareKeyboard >= 336)
 
         await owner.leave().value
     }
@@ -431,6 +463,11 @@ struct AgentDirectInputTests {
             ])
         try #require(await Self.eventually { inset.height == 336 })
         #expect(inset.lastPresentedHeight == 336)
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+        await Task.yield()
+        let heightWithSoftwareKeyboard = try #require(
+            Self.terminals(in: controller.view).first).frame.height
 
         center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
         #expect(inset.height == 0)
@@ -443,16 +480,11 @@ struct AgentDirectInputTests {
         controller.view.layoutIfNeeded()
         await Task.yield()
 
-        let presentation = AgentDirectInputPresentation.resolve(
-            usesToolsKeyboard: false,
-            expectsSystemKeyboard: false,
-            currentHeight: inset.height,
-            lastPresentedHeight: inset.lastPresentedHeight)
-        #expect(terminal.isFirstResponder)
-        #expect(presentation.keyboardPresentation == .hidden)
-        #expect(!presentation.showsShortcutRow)
-        #expect(presentation.layout.contentInset == 0)
+        let hardwareTerminal = try #require(Self.terminals(in: controller.view).first)
+        #expect(hardwareTerminal.isFirstResponder)
         #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
+        // No software keyboard: production inset must not reserve lastPresentedHeight.
+        #expect(hardwareTerminal.frame.height - heightWithSoftwareKeyboard >= 336)
 
         await owner.leave().value
     }
@@ -484,7 +516,9 @@ struct AgentDirectInputTests {
         #expect(terminal.isLocalInputEnabled)
         terminal.requestPaste("git status\ngit diff")
         let pending = try #require(owner.pendingPaste)
-        #expect(pending.text == "git status\ngit diff")
+        #expect(pending.preview == "git status\ngit diff")
+        #expect(pending.lineCount == 2)
+        #expect(pending.characterCount == "git status\ngit diff".count)
         #expect(
             await transport.attachInputs.allSatisfy {
                 if case .keystrokes = $0 { false } else { true }

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -407,14 +407,10 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually { keyboardTransitions.hasStableTail() })
         keyboardTransitions.reset()
 
-        if #available(iOS 27, *) {
-            try #require(
-                Self.activateAccessibility(
-                    labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
-                    in: controller.view))
-        } else {
-            try #require(interactions.selectInputMode(.direct))
-        }
+        try #require(try await Self.activateControl(
+            labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
+            in: controller.view,
+            probe: { interactions.selectInputMode(.direct) }))
         // The measured keyboard stays in place while SwiftUI updates the
         // existing terminal and transfers first responder to it.
         #expect(inset.height == keyboardHeight)
@@ -448,14 +444,10 @@ struct AgentDirectInputTests {
             })
 
         keyboardTransitions.reset()
-        if #available(iOS 27, *) {
-            try #require(
-                Self.activateAccessibility(
-                    labeled: AgentDirectInputPresentation.showComposerAccessibilityLabel,
-                    in: controller.view))
-        } else {
-            try #require(interactions.selectInputMode(.composer))
-        }
+        try #require(try await Self.activateControl(
+            labeled: AgentDirectInputPresentation.showComposerAccessibilityLabel,
+            in: controller.view,
+            probe: { interactions.selectInputMode(.composer) }))
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually {
@@ -492,6 +484,21 @@ struct AgentDirectInputTests {
     }
 
     @Test func coldPersistedDirectDoesNotRaiseKeyboard() async throws {
+        let center = NotificationCenter()
+        let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 336 }
+        center.post(
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil,
+            userInfo: [
+                UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                    x: 0, y: 500, width: 402, height: 370)
+            ])
+        try await Task.sleep(for: .milliseconds(70))
+        #expect(inset.height == 336)
+        center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
+        #expect(inset.height == 0)
+        #expect(inset.lastPresentedHeight == 336)
+
         let transport = ScriptedTransport()
         let composer = AgentComposerStore(target: "w1:p1") { _ in
             Agent(.fixture(paneID: "w1:p1"))
@@ -506,6 +513,7 @@ struct AgentDirectInputTests {
                 attachStore: owner,
                 composer: composer,
                 inputMode: inputMode,
+                keyboardInset: inset,
                 interactionProbe: interactions))
         let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
@@ -522,11 +530,14 @@ struct AgentDirectInputTests {
         #expect(terminal.isLocalInputEnabled)
         #expect(!terminal.isFirstResponder)
         if #available(iOS 27, *) {
+            try #require(
+                try await Self.waitForAccessible(
+                    labeled: "Escape",
+                    in: controller.view) != nil)
             #expect(
                 Self.firstAccessible(
                     labeled: "Show tools keyboard",
                     in: controller.view) == nil)
-            #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
         } else {
             #expect(!interactions.switchDirectKeyboard())
         }
@@ -633,14 +644,10 @@ struct AgentDirectInputTests {
             AgentQuickKey.escape, .tab, .shiftTab, .backspace, .shiftEnter, .enter,
             .up, .down, .left, .right,
         ] {
-            if #available(iOS 27, *) {
-                try #require(
-                    Self.activateAccessibility(
-                        labeled: key.accessibilityLabel,
-                        in: controller.view))
-            } else {
-                try #require(interactions.sendQuickKey(key))
-            }
+            try #require(try await Self.activateControl(
+                labeled: key.accessibilityLabel,
+                in: controller.view,
+                probe: { interactions.sendQuickKey(key) }))
         }
 
         if #available(iOS 27, *) {
@@ -748,14 +755,10 @@ struct AgentDirectInputTests {
             Self.terminals(in: controller.view).first).frame.height
         #expect(interactions.directInputChromeMountCount == 1)
 
-        if #available(iOS 27, *) {
-            try #require(
-                Self.activateAccessibility(
-                    labeled: "Show tools keyboard",
-                    in: controller.view))
-        } else {
-            try #require(interactions.switchDirectKeyboard())
-        }
+        try #require(try await Self.activateControl(
+            labeled: "Show tools keyboard",
+            in: controller.view,
+            probe: { interactions.switchDirectKeyboard() }))
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         // Tools replaces the software keyboard without hiding the shortcut row.
@@ -767,14 +770,10 @@ struct AgentDirectInputTests {
         #expect(inset.height == 0)
         #expect(inset.lastPresentedHeight == 336)
 
-        if #available(iOS 27, *) {
-            try #require(
-                Self.activateAccessibility(
-                    labeled: "Show iOS keyboard",
-                    in: controller.view))
-        } else {
-            try #require(interactions.switchDirectKeyboard())
-        }
+        try #require(try await Self.activateControl(
+            labeled: "Show iOS keyboard",
+            in: controller.view,
+            probe: { interactions.switchDirectKeyboard() }))
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
@@ -1002,14 +1001,10 @@ struct AgentDirectInputTests {
                 && interactions.isConnected
         })
 
-        if #available(iOS 27, *) {
-            try #require(
-                Self.activateAccessibility(
-                    labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
-                    in: controller.view))
-        } else {
-            try #require(interactions.selectInputMode(.direct))
-        }
+        try #require(try await Self.activateControl(
+            labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
+            in: controller.view,
+            probe: { interactions.selectInputMode(.direct) }))
         try #require(await Self.eventually { inputMode.mode == AgentInputMode.direct })
         let first = try #require(Self.terminals(in: controller.view).first)
         try #require(await Self.eventually { first.isFirstResponder })
@@ -1074,14 +1069,10 @@ struct AgentDirectInputTests {
                 && interactions.isConnected
         })
 
-        if #available(iOS 27, *) {
-            try #require(
-                Self.activateAccessibility(
-                    labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
-                    in: controller.view))
-        } else {
-            try #require(interactions.selectInputMode(.direct))
-        }
+        try #require(try await Self.activateControl(
+            labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
+            in: controller.view,
+            probe: { interactions.selectInputMode(.direct) }))
         try #require(await Self.eventually { inputMode.mode == AgentInputMode.direct })
         let first = try #require(Self.terminals(in: controller.view).first)
         try #require(await Self.eventually { first.isFirstResponder })
@@ -1116,14 +1107,10 @@ struct AgentDirectInputTests {
             controller.view.layoutIfNeeded()
             return interactions.directInputChromeMountCount == 1
         })
-        if #available(iOS 27, *) {
-            try #require(
-                Self.activateAccessibility(
-                    labeled: "Dismiss keyboard",
-                    in: controller.view))
-        } else {
-            try #require(interactions.toggleDirectKeyboard())
-        }
+        try #require(try await Self.activateControl(
+            labeled: "Dismiss keyboard",
+            in: controller.view,
+            probe: { interactions.toggleDirectKeyboard() }))
         try #require(await Self.eventually { !afterFirst.isFirstResponder })
         #expect(!handoff.consume(agent.id))
 
@@ -1568,14 +1555,36 @@ struct AgentDirectInputTests {
         firstAccessible(in: root) { $0.accessibilityLabel == label }
     }
 
-    @discardableResult
-    private static func activateAccessibility(labeled label: String, in root: UIView) -> Bool {
-        guard let element = firstAccessible(labeled: label, in: root) else { return false }
+    private static func activateControl(
+        labeled label: String,
+        in root: UIView,
+        probe: () -> Bool
+    ) async throws -> Bool {
+        guard #available(iOS 27, *) else { return probe() }
+        guard let element = try await waitForAccessible(labeled: label, in: root) else {
+            return false
+        }
         if let control = element as? UIControl {
             control.sendActions(for: .touchUpInside)
             return true
         }
         return element.accessibilityActivate()
+    }
+
+    private static func waitForAccessible(
+        labeled label: String,
+        in root: UIView
+    ) async throws -> NSObject? {
+        for attempt in 0..<40 {
+            root.layoutIfNeeded()
+            if let element = firstAccessible(labeled: label, in: root) {
+                return element
+            }
+            if attempt < 39 {
+                try await Task.sleep(for: .milliseconds(50))
+            }
+        }
+        return nil
     }
 
     private static func firstAccessibleFrame(labeled label: String, in root: UIView) -> CGRect? {

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -70,6 +70,12 @@ struct AgentDirectInputTests {
                 "draft"))
     }
 
+    @Test func accessibilityTraversalFallsBackToIndexedContainerWhenElementsAreEmpty() {
+        let root = IndexedAccessibilityContainerView(label: "Indexed control")
+
+        #expect(Self.firstAccessible(labeled: "Indexed control", in: root) != nil)
+    }
+
     @Test func sharedActionMenuContractIsExhaustive() {
         #expect(
             AgentActionMenuPolicy.composerAddSections == [.addAttachments])
@@ -1513,15 +1519,21 @@ struct AgentDirectInputTests {
     private static func visitAccessible(
         in root: UIView, body: (NSObject) -> Void
     ) {
+        var visited = Set<ObjectIdentifier>()
+
         func visit(_ node: NSObject) {
+            guard visited.insert(ObjectIdentifier(node)).inserted else { return }
             body(node)
-            if let elements = node.accessibilityElements {
+            let elements = node.accessibilityElements
+            if let elements, !elements.isEmpty {
                 for element in elements {
                     if let object = element as? NSObject {
                         visit(object)
                     }
                 }
             } else {
+                // Some SwiftUI containers expose an empty array while their
+                // indexed accessibility API still owns the live controls.
                 let count = node.accessibilityElementCount()
                 if count > 0, count != NSNotFound {
                     for index in 0..<count {
@@ -1570,5 +1582,35 @@ struct AgentDirectInputTests {
             try await Task.sleep(for: .milliseconds(5))
         }
         return await condition()
+    }
+}
+
+private final class IndexedAccessibilityContainerView: UIView {
+    private let indexedLabel: String
+    private lazy var indexedElement: UIAccessibilityElement = {
+        let element = UIAccessibilityElement(accessibilityContainer: self)
+        element.accessibilityLabel = indexedLabel
+        return element
+    }()
+
+    init(label: String) {
+        indexedLabel = label
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var accessibilityElements: [Any]? {
+        get { [] }
+        set { }
+    }
+
+    override func accessibilityElementCount() -> Int { 1 }
+
+    override func accessibilityElement(at index: Int) -> Any? {
+        index == 0 ? indexedElement : nil
     }
 }

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -408,12 +408,13 @@ struct AgentDirectInputTests {
         keyboardTransitions.reset()
 
         if #available(iOS 27, *) {
-            #expect(
-                Self.firstAccessible(
+            try #require(
+                Self.activateAccessibility(
                     labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
-                    in: controller.view) != nil)
+                    in: controller.view))
+        } else {
+            try #require(interactions.selectInputMode(.direct))
         }
-        try #require(interactions.selectInputMode(.direct))
         // The measured keyboard stays in place while SwiftUI updates the
         // existing terminal and transfers first responder to it.
         #expect(inset.height == keyboardHeight)
@@ -423,7 +424,7 @@ struct AgentDirectInputTests {
             inputMode.mode == AgentInputMode.direct
                 && terminal.isLocalInputEnabled
                 && terminal.isFirstResponder
-                && interactions.isDirectInputChromeMounted
+                && interactions.directInputChromeMountCount == 1
                 && !inset.isHoldingHandoffHeight
                 && keyboardTransitions.observedHandoffWindow()
                 && keyboardTransitions.hasStableTail()
@@ -448,16 +449,18 @@ struct AgentDirectInputTests {
 
         keyboardTransitions.reset()
         if #available(iOS 27, *) {
-            #expect(
-                Self.firstAccessible(
+            try #require(
+                Self.activateAccessibility(
                     labeled: AgentDirectInputPresentation.showComposerAccessibilityLabel,
-                    in: controller.view) != nil)
+                    in: controller.view))
+        } else {
+            try #require(interactions.selectInputMode(.composer))
         }
-        try #require(interactions.selectInputMode(.composer))
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually {
             inputMode.mode == AgentInputMode.composer
+                && interactions.directInputChromeMountCount == 0
                 && !inset.isHoldingHandoffHeight
                 && keyboardTransitions.observedHandoffWindow()
                 && keyboardTransitions.hasStableTail()
@@ -512,7 +515,7 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
                 && interactions.isConnected
-                && interactions.isDirectInputChromeMounted
+                && interactions.directInputChromeMountCount == 1
         })
 
         let terminal = try #require(Self.terminals(in: controller.view).first)
@@ -595,7 +598,7 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
                 && interactions.isConnected
-                && interactions.isDirectInputChromeMounted
+                && interactions.directInputChromeMountCount == 1
         })
 
         let terminal = try #require(Self.terminals(in: controller.view).first)
@@ -625,7 +628,14 @@ struct AgentDirectInputTests {
             AgentQuickKey.escape, .tab, .shiftTab, .backspace, .shiftEnter, .enter,
             .up, .down, .left, .right,
         ] {
-            try #require(interactions.sendQuickKey(key))
+            if #available(iOS 27, *) {
+                try #require(
+                    Self.activateAccessibility(
+                        labeled: key.accessibilityLabel,
+                        in: controller.view))
+            } else {
+                try #require(interactions.sendQuickKey(key))
+            }
         }
 
         if #available(iOS 27, *) {
@@ -674,7 +684,7 @@ struct AgentDirectInputTests {
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
-        #expect(interactions.isDirectInputChromeMounted)
+        #expect(interactions.directInputChromeMountCount == 1)
         if #available(iOS 27, *) {
             #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
             #expect(Self.accessibleCount(labeled: "Dismiss keyboard", in: controller.view) == 1)
@@ -713,7 +723,7 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
                 && interactions.isConnected
-                && interactions.isDirectInputChromeMounted
+                && interactions.directInputChromeMountCount == 1
         })
 
         let terminal = try #require(Self.terminals(in: controller.view).first)
@@ -731,13 +741,20 @@ struct AgentDirectInputTests {
         await Task.yield()
         let heightWithSoftwareKeyboard = try #require(
             Self.terminals(in: controller.view).first).frame.height
-        #expect(interactions.isDirectInputChromeMounted)
+        #expect(interactions.directInputChromeMountCount == 1)
 
-        try #require(interactions.switchDirectKeyboard())
+        if #available(iOS 27, *) {
+            try #require(
+                Self.activateAccessibility(
+                    labeled: "Show tools keyboard",
+                    in: controller.view))
+        } else {
+            try #require(interactions.switchDirectKeyboard())
+        }
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         // Tools replaces the software keyboard without hiding the shortcut row.
-        #expect(interactions.isDirectInputChromeMounted)
+        #expect(interactions.directInputChromeMountCount == 1)
 
         // UIKit tears the software keyboard down while Tools stays first
         // responder — the production hold must keep `.system` once we leave Tools.
@@ -745,7 +762,14 @@ struct AgentDirectInputTests {
         #expect(inset.height == 0)
         #expect(inset.lastPresentedHeight == 336)
 
-        try #require(interactions.switchDirectKeyboard())
+        if #available(iOS 27, *) {
+            try #require(
+                Self.activateAccessibility(
+                    labeled: "Show iOS keyboard",
+                    in: controller.view))
+        } else {
+            try #require(interactions.switchDirectKeyboard())
+        }
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
@@ -754,7 +778,7 @@ struct AgentDirectInputTests {
         // switcher even while measured height is still zero. Two-sided bound:
         // wiring the modifier to the raw zero height expands the terminal by
         // ~lastPresentedHeight and still satisfies a one-sided upper bound.
-        #expect(interactions.isDirectInputChromeMounted)
+        #expect(interactions.directInputChromeMountCount == 1)
         let midSwapTerminal = try #require(Self.terminals(in: controller.view).first)
         #expect(midSwapTerminal.isFirstResponder)
         #expect(abs(heightWithSoftwareKeyboard - midSwapTerminal.frame.height) <= 1)
@@ -771,7 +795,7 @@ struct AgentDirectInputTests {
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
-        #expect(interactions.isDirectInputChromeMounted)
+        #expect(interactions.directInputChromeMountCount == 1)
         let afterShow = try #require(Self.terminals(in: controller.view).first)
         #expect(afterShow.isFirstResponder)
         #expect(abs(afterShow.frame.height - heightWithSoftwareKeyboard) < 1)
@@ -786,7 +810,7 @@ struct AgentDirectInputTests {
         await Task.yield()
         let afterHardwareHide = try #require(Self.terminals(in: controller.view).first)
         #expect(afterHardwareHide.isFirstResponder)
-        #expect(interactions.isDirectInputChromeMounted)
+        #expect(interactions.directInputChromeMountCount == 1)
         #expect(afterHardwareHide.frame.height - heightWithSoftwareKeyboard >= 336)
 
         await owner.leave().value
@@ -819,7 +843,7 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
                 && interactions.isConnected
-                && interactions.isDirectInputChromeMounted
+                && interactions.directInputChromeMountCount == 1
         })
 
         center.post(
@@ -961,6 +985,8 @@ struct AgentDirectInputTests {
                 composer: composer,
                 inputMode: inputMode,
                 interactionProbe: interactions))
+        // A scene-less hierarchy isolates Attach feed replacement from UIKit's
+        // active software-keyboard reload while retaining responder semantics.
         let window = Self.makeLocalTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
@@ -971,7 +997,14 @@ struct AgentDirectInputTests {
                 && interactions.isConnected
         })
 
-        try #require(interactions.selectInputMode(.direct))
+        if #available(iOS 27, *) {
+            try #require(
+                Self.activateAccessibility(
+                    labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
+                    in: controller.view))
+        } else {
+            try #require(interactions.selectInputMode(.direct))
+        }
         try #require(await Self.eventually { inputMode.mode == AgentInputMode.direct })
         let first = try #require(Self.terminals(in: controller.view).first)
         try #require(await Self.eventually { first.isFirstResponder })
@@ -1024,6 +1057,8 @@ struct AgentDirectInputTests {
                 inputMode: inputMode,
                 keyboardHandoff: handoff,
                 interactionProbe: interactions))
+        // A scene-less hierarchy isolates Attach feed replacement from UIKit's
+        // active software-keyboard reload while retaining responder semantics.
         let window = Self.makeLocalTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
@@ -1034,7 +1069,14 @@ struct AgentDirectInputTests {
                 && interactions.isConnected
         })
 
-        try #require(interactions.selectInputMode(.direct))
+        if #available(iOS 27, *) {
+            try #require(
+                Self.activateAccessibility(
+                    labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
+                    in: controller.view))
+        } else {
+            try #require(interactions.selectInputMode(.direct))
+        }
         try #require(await Self.eventually { inputMode.mode == AgentInputMode.direct })
         let first = try #require(Self.terminals(in: controller.view).first)
         try #require(await Self.eventually { first.isFirstResponder })
@@ -1067,9 +1109,16 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually {
             controller.view.setNeedsLayout()
             controller.view.layoutIfNeeded()
-            return interactions.isDirectInputChromeMounted
+            return interactions.directInputChromeMountCount == 1
         })
-        try #require(interactions.toggleDirectKeyboard())
+        if #available(iOS 27, *) {
+            try #require(
+                Self.activateAccessibility(
+                    labeled: "Dismiss keyboard",
+                    in: controller.view))
+        } else {
+            try #require(interactions.toggleDirectKeyboard())
+        }
         try #require(await Self.eventually { !afterFirst.isFirstResponder })
         #expect(!handoff.consume(agent.id))
 
@@ -1512,6 +1561,16 @@ struct AgentDirectInputTests {
 
     private static func firstAccessible(labeled label: String, in root: UIView) -> NSObject? {
         firstAccessible(in: root) { $0.accessibilityLabel == label }
+    }
+
+    @discardableResult
+    private static func activateAccessibility(labeled label: String, in root: UIView) -> Bool {
+        guard let element = firstAccessible(labeled: label, in: root) else { return false }
+        if let control = element as? UIControl {
+            control.sendActions(for: .touchUpInside)
+            return true
+        }
+        return element.accessibilityActivate()
     }
 
     private static func firstAccessibleFrame(labeled label: String, in root: UIView) -> CGRect? {

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -621,7 +621,6 @@ struct AgentDirectInputTests {
         let first = try #require(Self.terminals(in: controller.view).first)
         try #require(await Self.eventually { first.isFirstResponder })
         let firstID = owner.terminalID
-        let firstSurface = ObjectIdentifier(first)
 
         owner.transportGenerationDidChange(2)
         try #require(await Self.eventually {
@@ -636,19 +635,11 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
         })
-        // Hosted UI may still expose the predecessor surface briefly after the
-        // replacement Attach is live — wait for a distinct rendered terminal.
-        try #require(await Self.eventually {
-            Self.terminals(in: controller.view).contains {
-                ObjectIdentifier($0) != firstSurface
-            }
-        })
-
-        let replacement = try #require(
-            Self.terminals(in: controller.view).first {
-                ObjectIdentifier($0) != firstSurface
-            })
-        #expect(ObjectIdentifier(replacement) != firstSurface)
+        // Hosted SwiftUI may reuse/reconfigure the same UIView object across
+        // pipeline replacement — do not require ObjectIdentifier churn. Prove
+        // the rendered surface is bound to the replacement session instead.
+        let replacement = try #require(await Self.eventuallyTerminal(
+            in: controller.view, viewportContaining: "replaced"))
         #expect(replacement.isLocalInputEnabled)
         try #require(await Self.eventually { replacement.isFirstResponder })
         #expect(composer.draft == "keep")
@@ -703,14 +694,21 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
         })
-        let afterFirst = try #require(Self.terminals(in: controller.view).first)
+        // Bind to the replacement session before reading first-responder or
+        // chrome — `.first` can still be a predecessor briefly, and object
+        // identity is not a reliable replacement signal.
+        let afterFirst = try #require(await Self.eventuallyTerminal(
+            in: controller.view, viewportContaining: "first-replace"))
         try #require(await Self.eventually { afterFirst.isFirstResponder })
 
         // Production dismiss clears Direct Input raised intent. A leftover
         // TerminalKeyboardHandoff arm after the first replacement must not
-        // resurrect the keyboard on the next pipeline rebuild.
+        // resurrect the keyboard on the next pipeline rebuild. Wait on the
+        // observable chrome refresh after reclaim, not a stale surface.
         try #require(await Self.eventually {
-            Self.firstAccessible(labeled: "Dismiss keyboard", in: controller.view) != nil
+            controller.view.setNeedsLayout()
+            controller.view.layoutIfNeeded()
+            return Self.firstAccessible(labeled: "Dismiss keyboard", in: controller.view) != nil
         })
         try #require(
             Self.activateAccessibility(labeled: "Dismiss keyboard", in: controller.view))
@@ -729,7 +727,8 @@ struct AgentDirectInputTests {
             owner.terminalStatus == AttachTerminalStore.Status.live
         })
 
-        let afterSecond = try #require(Self.terminals(in: controller.view).first)
+        let afterSecond = try #require(await Self.eventuallyTerminal(
+            in: controller.view, viewportContaining: "second-replace"))
         #expect(afterSecond.isLocalInputEnabled)
         #expect(!afterSecond.isFirstResponder)
         #expect(!handoff.consume(agent.id))
@@ -911,6 +910,28 @@ struct AgentDirectInputTests {
         }
         walk(root)
         return found
+    }
+
+    /// Waits for a rendered terminal whose Ghostty session shows the
+    /// replacement output — the reliable binding signal when UIView object
+    /// identity may be reused across pipeline replacement.
+    private static func eventuallyTerminal(
+        in root: UIView,
+        viewportContaining needle: String,
+        timeout: Duration = .seconds(5)
+    ) async throws -> HeelerTerminalView? {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if let terminal = terminals(in: root).first(where: {
+                $0.terminalSession.readViewportText()?.contains(needle) == true
+            }) {
+                return terminal
+            }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        return terminals(in: root).first(where: {
+            $0.terminalSession.readViewportText()?.contains(needle) == true
+        })
     }
 
     private static func firstAccessible(labeled label: String, in root: UIView) -> NSObject? {

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -326,9 +326,13 @@ struct AgentDirectInputTests {
         await owner.leave().value
     }
 
-    @Test func hideComposerControlSelectsDirectAndRaisesKeyboard() async throws {
-        let center = NotificationCenter()
-        let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 336 }
+    @Test func composerAndDirectInputTransferVisibleKeyboardWithoutReloading() async throws {
+        let center = NotificationCenter.default
+        let inset = TerminalKeyboardInset(notificationCenter: center)
+        let keyboardTransitions = KeyboardTransitionProbe(
+            notificationCenter: center,
+            insetHeight: { inset.height })
+        defer { keyboardTransitions.stop() }
         let transport = ScriptedTransport()
         let composer = AgentComposerStore(target: "w1:p1") { params in
             try await transport.promptAgent(params)
@@ -344,10 +348,9 @@ struct AgentDirectInputTests {
                 composer: composer,
                 inputMode: inputMode,
                 keyboardInset: inset))
-        let window = Self.makeLocalTestWindow(
+        let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
-            rootViewController: controller,
-            attachesToScene: true)
+            rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually {
@@ -363,13 +366,20 @@ struct AgentDirectInputTests {
         composerInput.becomeFirstResponder()
         try #require(await Self.eventually { composerInput.isFirstResponder })
         try #require(await Self.eventually { composerInput.inputView == nil })
-        center.post(
-            name: UIResponder.keyboardWillShowNotification, object: nil,
-            userInfo: [
-                UIResponder.keyboardFrameEndUserInfoKey: CGRect(
-                    x: 0, y: 500, width: 402, height: 370)
-            ])
-        try #require(await Self.eventually { inset.height == 336 })
+        try #require(await Self.eventually {
+            inset.height > 0
+                && (keyboardTransitions.willShowCount > 0
+                    || keyboardTransitions.willChangeFrameCount > 0)
+        })
+        let keyboardHeight = inset.height
+        #expect(window.isKeyWindow)
+        #expect(composerInput.window === window)
+        keyboardTransitions.setChromeSample {
+            Self.keyboardChromeSample(in: controller.view, window: window, inset: inset)
+        }
+        keyboardTransitions.reset()
+        try #require(await Self.eventually { keyboardTransitions.hasStableTail() })
+        keyboardTransitions.reset()
 
         #expect(
             Self.firstAccessible(
@@ -382,15 +392,28 @@ struct AgentDirectInputTests {
                 in: controller.view))
         // The measured keyboard stays in place while SwiftUI updates the
         // existing terminal and transfers first responder to it.
-        #expect(inset.height == 336)
+        #expect(inset.height == keyboardHeight)
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
-        try #require(await Self.eventually { inputMode.mode == AgentInputMode.direct })
-
-        #expect(terminal.isLocalInputEnabled)
-        try #require(await Self.eventually { terminal.isFirstResponder })
+        try #require(await Self.eventually {
+            inputMode.mode == AgentInputMode.direct
+                && terminal.isLocalInputEnabled
+                && terminal.isFirstResponder
+                && !inset.isHoldingHandoffHeight
+                && keyboardTransitions.observedHandoffWindow()
+                && keyboardTransitions.hasStableTail()
+        })
+        keyboardTransitions.stopSampling()
         #expect(!composerInput.isFirstResponder)
-        #expect(inset.height == 336)
+        #expect(terminal.window === window)
+        #expect(inset.height == keyboardHeight)
+        #expect(
+            keyboardTransitions.observedInsetHeights.allSatisfy { $0 == keyboardHeight },
+            "Composer→Direct Input exposed transient insets: \(keyboardTransitions.observedInsetHeights)")
+        Self.expectStableKeyboardChrome(
+            keyboardTransitions.chromeSamples,
+            keyboardHeight: keyboardHeight,
+            direction: "Composer→Direct Input")
         #expect(composer.draft == "do not send")
         #expect(await transport.agentPromptParams.isEmpty)
         #expect(
@@ -398,16 +421,39 @@ struct AgentDirectInputTests {
                 if case .keystrokes = $0 { false } else { true }
             })
 
+        keyboardTransitions.reset()
         try #require(
             Self.activateAccessibility(
                 labeled: AgentDirectInputPresentation.showComposerAccessibilityLabel,
                 in: controller.view))
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
-        try #require(await Self.eventually { inputMode.mode == AgentInputMode.composer })
+        try #require(await Self.eventually {
+            inputMode.mode == AgentInputMode.composer
+                && !inset.isHoldingHandoffHeight
+                && keyboardTransitions.observedHandoffWindow()
+                && keyboardTransitions.hasStableTail()
+        })
+        keyboardTransitions.stopSampling()
 
         let restored = try #require(Self.terminals(in: controller.view).first)
+        let restoredComposerInput = try #require(
+            Self.firstView(in: controller.view) {
+                $0 is UITextView && $0.accessibilityLabel == "Message the Agent"
+            } as? UITextView)
         #expect(!restored.isLocalInputEnabled)
+        #expect(restoredComposerInput.isFirstResponder)
+        #expect(restoredComposerInput.autocorrectionType == terminal.autocorrectionType)
+        #expect(restoredComposerInput.autocapitalizationType == terminal.autocapitalizationType)
+        #expect(!terminal.isFirstResponder)
+        #expect(inset.height == keyboardHeight)
+        #expect(
+            keyboardTransitions.observedInsetHeights.allSatisfy { $0 == keyboardHeight },
+            "Direct Input→Composer exposed transient insets: \(keyboardTransitions.observedInsetHeights)")
+        Self.expectStableKeyboardChrome(
+            keyboardTransitions.chromeSamples,
+            keyboardHeight: keyboardHeight,
+            direction: "Direct Input→Composer")
         #expect(composer.draft == "do not send")
         #expect(await transport.agentPromptParams.isEmpty)
 
@@ -1175,6 +1221,207 @@ struct AgentDirectInputTests {
         return nil
     }
 
+    private struct KeyboardChromeSample {
+        let insetHeight: CGFloat
+        let switcherBottom: CGFloat?
+    }
+
+    @MainActor
+    private final class KeyboardTransitionProbe: NSObject {
+        // Hosted app tests cannot inspect the out-of-process keyboard surface:
+        // its layout guide remains empty even while Simulator renders it. This
+        // probe therefore samples the app-owned chrome on every display frame;
+        // Simulator acceptance separately verifies the keyboard surface itself.
+        private let notificationCenter: NotificationCenter
+        private var token: NSObjectProtocol?
+        private var showToken: NSObjectProtocol?
+        private var changeFrameToken: NSObjectProtocol?
+        private var displayLink: CADisplayLink?
+        private var samplingStartedAt: CFTimeInterval?
+        private let insetHeight: @MainActor () -> CGFloat
+        private var chromeSample: (@MainActor () -> KeyboardChromeSample)?
+        private(set) var willShowCount = 0
+        private(set) var willHideCount = 0
+        private(set) var willChangeFrameCount = 0
+        private(set) var observedInsetHeights: [CGFloat] = []
+        private(set) var chromeSamples: [KeyboardChromeSample] = []
+
+        init(
+            notificationCenter: NotificationCenter,
+            insetHeight: @escaping @MainActor () -> CGFloat
+        ) {
+            self.notificationCenter = notificationCenter
+            self.insetHeight = insetHeight
+            super.init()
+            showToken = notificationCenter.addObserver(
+                forName: UIResponder.keyboardWillShowNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.willShowCount += 1
+                    self?.recordInsetHeight()
+                }
+            }
+            token = notificationCenter.addObserver(
+                forName: UIResponder.keyboardWillHideNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.willHideCount += 1
+                    self?.recordInsetHeight()
+                }
+            }
+            changeFrameToken = notificationCenter.addObserver(
+                forName: UIResponder.keyboardWillChangeFrameNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.willChangeFrameCount += 1
+                    self?.recordInsetHeight()
+                }
+            }
+        }
+
+        func reset() {
+            stopSampling()
+            willShowCount = 0
+            willHideCount = 0
+            willChangeFrameCount = 0
+            observedInsetHeights = []
+            chromeSamples = []
+            captureChromeSample()
+            let displayLink = CADisplayLink(target: self, selector: #selector(sampleDisplayFrame))
+            displayLink.add(to: .main, forMode: .common)
+            self.displayLink = displayLink
+            samplingStartedAt = CACurrentMediaTime()
+        }
+
+        func setChromeSample(_ sample: @escaping @MainActor () -> KeyboardChromeSample) {
+            chromeSample = sample
+        }
+
+        func captureChromeSample() {
+            if let chromeSample {
+                chromeSamples.append(chromeSample())
+            }
+        }
+
+        @objc private func sampleDisplayFrame() {
+            captureChromeSample()
+        }
+
+        func hasStableTail(frameCount: Int = 4) -> Bool {
+            guard chromeSamples.count >= frameCount,
+                  let baseline = chromeSamples.last,
+                  baseline.switcherBottom != nil
+            else { return false }
+            return chromeSamples.suffix(frameCount).allSatisfy { sample in
+                abs(sample.insetHeight - baseline.insetHeight) <= 1
+                    && Self.close(sample.switcherBottom, baseline.switcherBottom)
+            }
+        }
+
+        func observedHandoffWindow(_ duration: TimeInterval = 0.65) -> Bool {
+            guard let samplingStartedAt else { return false }
+            return CACurrentMediaTime() - samplingStartedAt >= duration
+        }
+
+        private static func close(_ lhs: CGFloat?, _ rhs: CGFloat?) -> Bool {
+            guard let lhs, let rhs else { return lhs == nil && rhs == nil }
+            return abs(lhs - rhs) <= 1
+        }
+
+        func stopSampling() {
+            displayLink?.invalidate()
+            displayLink = nil
+            samplingStartedAt = nil
+        }
+
+        private func recordInsetHeight() {
+            observedInsetHeights.append(insetHeight())
+            captureChromeSample()
+        }
+
+        func stop() {
+            stopSampling()
+            if let showToken {
+                notificationCenter.removeObserver(showToken)
+            }
+            if let token {
+                notificationCenter.removeObserver(token)
+            }
+            if let changeFrameToken {
+                notificationCenter.removeObserver(changeFrameToken)
+            }
+            showToken = nil
+            self.token = nil
+            changeFrameToken = nil
+        }
+    }
+
+    @MainActor
+    private static func keyboardChromeSample(
+        in root: UIView,
+        window: UIWindow,
+        inset: TerminalKeyboardInset
+    ) -> KeyboardChromeSample {
+        let switcher = switchers(in: root)
+            .filter { $0.window === window }
+            .max { effectivePresentationOpacity(of: $0) < effectivePresentationOpacity(of: $1) }
+        let bottom = switcher.flatMap { switcher -> CGFloat? in
+            guard switcher.window === window, let superview = switcher.superview else { return nil }
+            let frame = switcher.layer.presentation()?.frame ?? switcher.frame
+            return superview.convert(frame, to: window).maxY
+        }
+        return KeyboardChromeSample(
+            insetHeight: inset.height,
+            switcherBottom: bottom)
+    }
+
+    private static func switchers(in root: UIView) -> [TerminalAgentSwitcherBar] {
+        var result: [TerminalAgentSwitcherBar] = []
+        if let switcher = root as? TerminalAgentSwitcherBar {
+            result.append(switcher)
+        }
+        for subview in root.subviews {
+            result.append(contentsOf: switchers(in: subview))
+        }
+        return result
+    }
+
+    private static func effectivePresentationOpacity(of view: UIView) -> Float {
+        var opacity: Float = 1
+        var current: UIView? = view
+        while let node = current {
+            if node.isHidden { return 0 }
+            opacity *= node.layer.presentation()?.opacity ?? node.layer.opacity
+            current = node.superview
+        }
+        return opacity
+    }
+
+    private static func expectStableKeyboardChrome(
+        _ samples: [KeyboardChromeSample],
+        keyboardHeight: CGFloat,
+        direction: String
+    ) {
+        #expect(!samples.isEmpty, "\(direction) produced no display-frame samples")
+        #expect(
+            samples.allSatisfy { abs($0.insetHeight - keyboardHeight) <= 1 },
+            "\(direction) moved the keyboard inset during a UIKit transition")
+        let bottoms = samples.compactMap(\.switcherBottom)
+        #expect(
+            bottoms.count == samples.count,
+            "\(direction) removed the Agent switcher during a UIKit transition")
+        guard let baseline = bottoms.first else { return }
+        #expect(
+            bottoms.allSatisfy { abs($0 - baseline) <= 1 },
+            "\(direction) moved the Agent switcher during a UIKit transition: \(bottoms)")
+    }
+
     /// Waits for the hosted terminal attached to the owner's current feed —
     /// the binding seam when UIView object identity may be reused and Ghostty
     /// viewport text is not a reliable harness signal.
@@ -1286,20 +1533,9 @@ struct AgentDirectInputTests {
 
     private static func makeLocalTestWindow(
         frame: CGRect,
-        rootViewController: UIViewController,
-        attachesToScene: Bool = false
+        rootViewController: UIViewController
     ) -> UIWindow {
-        let window: UIWindow
-        if attachesToScene,
-           let scene = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .first
-        {
-            window = UIWindow(windowScene: scene)
-            window.frame = frame
-        } else {
-            window = UIWindow(frame: frame)
-        }
+        let window = UIWindow(frame: frame)
         window.rootViewController = rootViewController
         window.makeKeyAndVisible()
         return window

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -82,6 +82,15 @@ struct AgentDirectInputTests {
             arrayLabel: "Array control")
 
         #expect(Self.firstAccessible(labeled: "Indexed control", in: root) != nil)
+        #expect(Self.firstAccessible(labeled: "Array control", in: root) != nil)
+    }
+
+    @Test func accessibilityTraversalDeduplicatesElementsAcrossContainerSources() {
+        let root = IndexedAccessibilityContainerView(
+            indexedLabel: "Shared control",
+            includesIndexedElementInArray: true)
+
+        #expect(Self.accessibleCount(labeled: "Shared control", in: root) == 1)
     }
 
     @Test func sharedActionMenuContractIsExhaustive() {
@@ -1591,6 +1600,7 @@ struct AgentDirectInputTests {
 private final class IndexedAccessibilityContainerView: UIView {
     private let indexedLabel: String
     private let arrayLabel: String?
+    private let includesIndexedElementInArray: Bool
     private lazy var indexedElement: UIAccessibilityElement = {
         let element = UIAccessibilityElement(accessibilityContainer: self)
         element.accessibilityLabel = indexedLabel
@@ -1602,9 +1612,14 @@ private final class IndexedAccessibilityContainerView: UIView {
         return element
     }()
 
-    init(indexedLabel: String, arrayLabel: String? = nil) {
+    init(
+        indexedLabel: String,
+        arrayLabel: String? = nil,
+        includesIndexedElementInArray: Bool = false
+    ) {
         self.indexedLabel = indexedLabel
         self.arrayLabel = arrayLabel
+        self.includesIndexedElementInArray = includesIndexedElementInArray
         super.init(frame: .zero)
     }
 
@@ -1614,7 +1629,12 @@ private final class IndexedAccessibilityContainerView: UIView {
     }
 
     override var accessibilityElements: [Any]? {
-        get { arrayLabel == nil ? [] : [arrayElement] }
+        get {
+            if includesIndexedElementInArray {
+                return [indexedElement]
+            }
+            return arrayLabel == nil ? [] : [arrayElement]
+        }
         set { }
     }
 

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -1171,45 +1171,22 @@ struct AgentDirectInputTests {
     }
 
     private static func firstAccessibleFrame(labeled label: String, in root: UIView) -> CGRect? {
-        // SwiftUI hosting nests accessibility containers arbitrarily deep —
-        // recurse through every container shape, not just UIViews.
-        func visit(_ node: NSObject) -> CGRect? {
+        // Reuse visitAccessible so frame probes share the same container walk as
+        // label lookups. Skip zero-size matches and keep searching — same rule
+        // TerminalAttachTests uses for hosted SwiftUI chrome.
+        var match: CGRect?
+        visitAccessible(in: root) { node in
+            guard match == nil, node.accessibilityLabel == label else { return }
             if let view = node as? UIView {
-                if view.accessibilityLabel == label, view.bounds.width > 0, view.bounds.height > 0 {
-                    return view.convert(view.bounds, to: root)
-                }
-            } else if node.accessibilityLabel == label {
-                let frame = node.accessibilityFrame
-                if frame.width > 0, frame.height > 0 {
-                    return root.convert(frame, from: nil)
-                }
-            }
-            if let elements = node.accessibilityElements {
-                for element in elements {
-                    if let object = element as? NSObject, let frame = visit(object) {
-                        return frame
-                    }
-                }
+                guard view.bounds.width > 0, view.bounds.height > 0 else { return }
+                match = view.convert(view.bounds, to: root)
             } else {
-                let count = node.accessibilityElementCount()
-                if count > 0, count != NSNotFound {
-                    for index in 0..<count {
-                        if let object = node.accessibilityElement(at: index) as? NSObject,
-                            let frame = visit(object)
-                        {
-                            return frame
-                        }
-                    }
-                }
+                let frame = node.accessibilityFrame
+                guard frame.width > 0, frame.height > 0 else { return }
+                match = root.convert(frame, from: nil)
             }
-            if let view = node as? UIView {
-                for subview in view.subviews {
-                    if let frame = visit(subview) { return frame }
-                }
-            }
-            return nil
         }
-        return visit(root)
+        return match
     }
 
     private static func accessibleCount(labeled label: String, in root: UIView) -> Int {

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -324,7 +324,7 @@ struct AgentDirectInputTests {
                 attachStore: owner,
                 composer: composer,
                 inputMode: inputMode))
-        let window = Self.makeLocalTestWindow(
+        let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
         defer { window.isHidden = true }
@@ -364,13 +364,15 @@ struct AgentDirectInputTests {
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
         let (inputMode, cleanup) = try Self.makeInputMode()
         defer { cleanup() }
+        let interactions = AgentTerminalInteractionProbe()
 
         let controller = UIHostingController(
             rootView: Self.makeDetailView(
                 attachStore: owner,
                 composer: composer,
                 inputMode: inputMode,
-                keyboardInset: inset))
+                keyboardInset: inset,
+                interactionProbe: interactions))
         let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
@@ -378,6 +380,7 @@ struct AgentDirectInputTests {
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
+                && interactions.isConnected
         })
 
         let terminal = try #require(Self.terminals(in: controller.view).first)
@@ -404,15 +407,13 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually { keyboardTransitions.hasStableTail() })
         keyboardTransitions.reset()
 
-        #expect(
-            Self.firstAccessible(
-                labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
-                in: controller.view) != nil)
-
-        try #require(
-            Self.activateAccessibility(
-                labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
-                in: controller.view))
+        if #available(iOS 27, *) {
+            #expect(
+                Self.firstAccessible(
+                    labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
+                    in: controller.view) != nil)
+        }
+        try #require(interactions.selectInputMode(.direct))
         // The measured keyboard stays in place while SwiftUI updates the
         // existing terminal and transfers first responder to it.
         #expect(inset.height == keyboardHeight)
@@ -422,6 +423,7 @@ struct AgentDirectInputTests {
             inputMode.mode == AgentInputMode.direct
                 && terminal.isLocalInputEnabled
                 && terminal.isFirstResponder
+                && interactions.isDirectInputChromeMounted
                 && !inset.isHoldingHandoffHeight
                 && keyboardTransitions.observedHandoffWindow()
                 && keyboardTransitions.hasStableTail()
@@ -445,10 +447,13 @@ struct AgentDirectInputTests {
             })
 
         keyboardTransitions.reset()
-        try #require(
-            Self.activateAccessibility(
-                labeled: AgentDirectInputPresentation.showComposerAccessibilityLabel,
-                in: controller.view))
+        if #available(iOS 27, *) {
+            #expect(
+                Self.firstAccessible(
+                    labeled: AgentDirectInputPresentation.showComposerAccessibilityLabel,
+                    in: controller.view) != nil)
+        }
+        try #require(interactions.selectInputMode(.composer))
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually {
@@ -491,25 +496,32 @@ struct AgentDirectInputTests {
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
         let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
         defer { cleanup() }
+        let interactions = AgentTerminalInteractionProbe()
 
         let controller = UIHostingController(
             rootView: Self.makeDetailView(
                 attachStore: owner,
                 composer: composer,
-                inputMode: inputMode))
-        let window = Self.makeLocalTestWindow(
+                inputMode: inputMode,
+                interactionProbe: interactions))
+        let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
+                && interactions.isConnected
+                && interactions.isDirectInputChromeMounted
         })
 
         let terminal = try #require(Self.terminals(in: controller.view).first)
         #expect(terminal.isLocalInputEnabled)
         #expect(!terminal.isFirstResponder)
-        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
+        #expect(!interactions.switchDirectKeyboard())
+        if #available(iOS 27, *) {
+            #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
+        }
 
         await owner.leave().value
     }
@@ -529,7 +541,7 @@ struct AgentDirectInputTests {
                 attachStore: owner,
                 composer: composer,
                 inputMode: inputMode))
-        let window = Self.makeLocalTestWindow(
+        let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
         defer { window.isHidden = true }
@@ -566,27 +578,33 @@ struct AgentDirectInputTests {
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
         let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
         defer { cleanup() }
+        let interactions = AgentTerminalInteractionProbe()
 
         let controller = UIHostingController(
             rootView: Self.makeDetailView(
                 attachStore: owner,
                 composer: composer,
                 inputMode: inputMode,
-                keyboardInset: inset))
-        let window = Self.makeLocalTestWindow(
+                keyboardInset: inset,
+                interactionProbe: interactions))
+        let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
+                && interactions.isConnected
+                && interactions.isDirectInputChromeMounted
         })
 
         let terminal = try #require(Self.terminals(in: controller.view).first)
         terminal.requestKeyboard()
         try #require(await Self.eventually { terminal.isFirstResponder })
 
-        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
+        if #available(iOS 27, *) {
+            #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
+        }
         controller.view.layoutIfNeeded()
         let heightBeforeKeyboard = terminal.frame.height
 
@@ -603,30 +621,32 @@ struct AgentDirectInputTests {
         let heightWithKeyboard = try #require(Self.terminals(in: controller.view).first)
             .frame.height
 
-        for label in [
-            "Escape", "Tab", "Shift Tab", "Backspace", "Shift Enter", "Enter",
-            "Up Arrow", "Down Arrow", "Left Arrow", "Right Arrow",
+        for key in [
+            AgentQuickKey.escape, .tab, .shiftTab, .backspace, .shiftEnter, .enter,
+            .up, .down, .left, .right,
         ] {
-            try #require(Self.activateAccessibility(labeled: label, in: controller.view))
+            try #require(interactions.sendQuickKey(key))
         }
 
-        // Shortcut row sits immediately above the Agent switcher strip.
-        // Keyboard dismiss lives only on the switcher — not on the row.
-        let escapeFrame = try #require(
-            Self.firstAccessibleFrame(labeled: "Escape", in: controller.view))
-        let dismissFrame = try #require(
-            Self.firstAccessibleFrame(labeled: "Dismiss keyboard", in: controller.view))
-        let enterFrame = try #require(
-            Self.firstAccessibleFrame(labeled: "Enter", in: controller.view))
-        let moreFrame = try #require(
-            Self.firstAccessibleFrame(labeled: "More", in: controller.view))
-        #expect(escapeFrame.maxY <= dismissFrame.minY + 1)
-        #expect(moreFrame.minX >= enterFrame.maxX)
-        #expect(Self.accessibleCount(labeled: "Dismiss keyboard", in: controller.view) == 1)
-        #expect(
-            Self.accessibleCount(
-                labeled: AgentDirectInputPresentation.showComposerAccessibilityLabel,
-                in: controller.view) == 1)
+        if #available(iOS 27, *) {
+            // Shortcut row sits immediately above the Agent switcher strip.
+            // Keyboard dismiss lives only on the switcher — not on the row.
+            let escapeFrame = try #require(
+                Self.firstAccessibleFrame(labeled: "Escape", in: controller.view))
+            let dismissFrame = try #require(
+                Self.firstAccessibleFrame(labeled: "Dismiss keyboard", in: controller.view))
+            let enterFrame = try #require(
+                Self.firstAccessibleFrame(labeled: "Enter", in: controller.view))
+            let moreFrame = try #require(
+                Self.firstAccessibleFrame(labeled: "More", in: controller.view))
+            #expect(escapeFrame.maxY <= dismissFrame.minY + 1)
+            #expect(moreFrame.minX >= enterFrame.maxX)
+            #expect(Self.accessibleCount(labeled: "Dismiss keyboard", in: controller.view) == 1)
+            #expect(
+                Self.accessibleCount(
+                    labeled: AgentDirectInputPresentation.showComposerAccessibilityLabel,
+                    in: controller.view) == 1)
+        }
 
         try #require(await Self.eventually {
             let inputs = await transport.attachInputs
@@ -654,8 +674,11 @@ struct AgentDirectInputTests {
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
-        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
-        #expect(Self.accessibleCount(labeled: "Dismiss keyboard", in: controller.view) == 1)
+        #expect(interactions.isDirectInputChromeMounted)
+        if #available(iOS 27, *) {
+            #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
+            #expect(Self.accessibleCount(labeled: "Dismiss keyboard", in: controller.view) == 1)
+        }
         let heightAfterHide = try #require(Self.terminals(in: controller.view).first)
             .frame.height
         #expect(abs(heightAfterHide - heightBeforeKeyboard) < 1)
@@ -673,20 +696,24 @@ struct AgentDirectInputTests {
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
         let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
         defer { cleanup() }
+        let interactions = AgentTerminalInteractionProbe()
 
         let controller = UIHostingController(
             rootView: Self.makeDetailView(
                 attachStore: owner,
                 composer: composer,
                 inputMode: inputMode,
-                keyboardInset: inset))
-        let window = Self.makeLocalTestWindow(
+                keyboardInset: inset,
+                interactionProbe: interactions))
+        let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
+                && interactions.isConnected
+                && interactions.isDirectInputChromeMounted
         })
 
         let terminal = try #require(Self.terminals(in: controller.view).first)
@@ -704,21 +731,13 @@ struct AgentDirectInputTests {
         await Task.yield()
         let heightWithSoftwareKeyboard = try #require(
             Self.terminals(in: controller.view).first).frame.height
-        // Show Composer lives only on the switcher; the shortcut row remains
-        // focused on terminal keys through every keyboard presentation.
-        let showComposer = AgentDirectInputPresentation.showComposerAccessibilityLabel
-        try #require(await Self.eventually {
-            Self.accessibleCount(labeled: showComposer, in: controller.view) == 1
-        })
+        #expect(interactions.isDirectInputChromeMounted)
 
-        try #require(
-            Self.activateAccessibility(labeled: "Show tools keyboard", in: controller.view))
+        try #require(interactions.switchDirectKeyboard())
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         // Tools replaces the software keyboard without hiding the shortcut row.
-        try #require(await Self.eventually {
-            Self.accessibleCount(labeled: showComposer, in: controller.view) == 1
-        })
+        #expect(interactions.isDirectInputChromeMounted)
 
         // UIKit tears the software keyboard down while Tools stays first
         // responder — the production hold must keep `.system` once we leave Tools.
@@ -726,8 +745,7 @@ struct AgentDirectInputTests {
         #expect(inset.height == 0)
         #expect(inset.lastPresentedHeight == 336)
 
-        try #require(
-            Self.activateAccessibility(labeled: "Show iOS keyboard", in: controller.view))
+        try #require(interactions.switchDirectKeyboard())
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
@@ -736,7 +754,7 @@ struct AgentDirectInputTests {
         // switcher even while measured height is still zero. Two-sided bound:
         // wiring the modifier to the raw zero height expands the terminal by
         // ~lastPresentedHeight and still satisfies a one-sided upper bound.
-        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 1)
+        #expect(interactions.isDirectInputChromeMounted)
         let midSwapTerminal = try #require(Self.terminals(in: controller.view).first)
         #expect(midSwapTerminal.isFirstResponder)
         #expect(abs(heightWithSoftwareKeyboard - midSwapTerminal.frame.height) <= 1)
@@ -753,7 +771,7 @@ struct AgentDirectInputTests {
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
-        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 1)
+        #expect(interactions.isDirectInputChromeMounted)
         let afterShow = try #require(Self.terminals(in: controller.view).first)
         #expect(afterShow.isFirstResponder)
         #expect(abs(afterShow.frame.height - heightWithSoftwareKeyboard) < 1)
@@ -768,7 +786,7 @@ struct AgentDirectInputTests {
         await Task.yield()
         let afterHardwareHide = try #require(Self.terminals(in: controller.view).first)
         #expect(afterHardwareHide.isFirstResponder)
-        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 1)
+        #expect(interactions.isDirectInputChromeMounted)
         #expect(afterHardwareHide.frame.height - heightWithSoftwareKeyboard >= 336)
 
         await owner.leave().value
@@ -784,20 +802,24 @@ struct AgentDirectInputTests {
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
         let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
         defer { cleanup() }
+        let interactions = AgentTerminalInteractionProbe()
 
         let controller = UIHostingController(
             rootView: Self.makeDetailView(
                 attachStore: owner,
                 composer: composer,
                 inputMode: inputMode,
-                keyboardInset: inset))
-        let window = Self.makeLocalTestWindow(
+                keyboardInset: inset,
+                interactionProbe: interactions))
+        let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
+                && interactions.isConnected
+                && interactions.isDirectInputChromeMounted
         })
 
         center.post(
@@ -827,7 +849,9 @@ struct AgentDirectInputTests {
 
         let hardwareTerminal = try #require(Self.terminals(in: controller.view).first)
         #expect(hardwareTerminal.isFirstResponder)
-        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
+        if #available(iOS 27, *) {
+            #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
+        }
         // No software keyboard: production inset must not reserve lastPresentedHeight.
         #expect(hardwareTerminal.frame.height - heightWithSoftwareKeyboard >= 336)
 
@@ -848,7 +872,7 @@ struct AgentDirectInputTests {
                 attachStore: owner,
                 composer: composer,
                 inputMode: inputMode))
-        let window = Self.makeLocalTestWindow(
+        let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
         defer { window.isHidden = true }
@@ -898,7 +922,7 @@ struct AgentDirectInputTests {
                 attachStore: owner,
                 composer: composer,
                 inputMode: inputMode))
-        let window = Self.makeLocalTestWindow(
+        let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
         defer { window.isHidden = true }
@@ -929,12 +953,14 @@ struct AgentDirectInputTests {
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
         let (inputMode, cleanup) = try Self.makeInputMode()
         defer { cleanup() }
+        let interactions = AgentTerminalInteractionProbe()
 
         let controller = UIHostingController(
             rootView: Self.makeDetailView(
                 attachStore: owner,
                 composer: composer,
-                inputMode: inputMode))
+                inputMode: inputMode,
+                interactionProbe: interactions))
         let window = Self.makeLocalTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
@@ -942,12 +968,10 @@ struct AgentDirectInputTests {
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
+                && interactions.isConnected
         })
 
-        try #require(
-            Self.activateAccessibility(
-                labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
-                in: controller.view))
+        try #require(interactions.selectInputMode(.direct))
         try #require(await Self.eventually { inputMode.mode == AgentInputMode.direct })
         let first = try #require(Self.terminals(in: controller.view).first)
         try #require(await Self.eventually { first.isFirstResponder })
@@ -990,6 +1014,7 @@ struct AgentDirectInputTests {
         defer { cleanup() }
         let handoff = TerminalKeyboardHandoff()
         let agent = Self.makeAgent(status: .idle)
+        let interactions = AgentTerminalInteractionProbe()
 
         let controller = UIHostingController(
             rootView: Self.makeDetailView(
@@ -997,7 +1022,8 @@ struct AgentDirectInputTests {
                 attachStore: owner,
                 composer: composer,
                 inputMode: inputMode,
-                keyboardHandoff: handoff))
+                keyboardHandoff: handoff,
+                interactionProbe: interactions))
         let window = Self.makeLocalTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
@@ -1005,12 +1031,10 @@ struct AgentDirectInputTests {
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
+                && interactions.isConnected
         })
 
-        try #require(
-            Self.activateAccessibility(
-                labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
-                in: controller.view))
+        try #require(interactions.selectInputMode(.direct))
         try #require(await Self.eventually { inputMode.mode == AgentInputMode.direct })
         let first = try #require(Self.terminals(in: controller.view).first)
         try #require(await Self.eventually { first.isFirstResponder })
@@ -1036,18 +1060,16 @@ struct AgentDirectInputTests {
         #expect(!firstFeed.isAttached(to: afterFirst))
         try #require(await Self.eventually { afterFirst.isFirstResponder })
 
-        // Production dismiss clears Direct Input raised intent via the
-        // switcher-owned keyboard toggle. A leftover TerminalKeyboardHandoff
-        // arm after the first replacement must not resurrect the keyboard on
-        // the next pipeline rebuild. Wait on the observable chrome refresh
-        // after reclaim, not a stale surface.
+        // Production dismiss clears Direct Input raised intent through the
+        // same action wired to the switcher keyboard toggle. A leftover
+        // TerminalKeyboardHandoff arm after the first replacement must not
+        // resurrect the keyboard on the next pipeline rebuild.
         try #require(await Self.eventually {
             controller.view.setNeedsLayout()
             controller.view.layoutIfNeeded()
-            return Self.firstAccessible(labeled: "Dismiss keyboard", in: controller.view) != nil
+            return interactions.isDirectInputChromeMounted
         })
-        try #require(
-            Self.activateAccessibility(labeled: "Dismiss keyboard", in: controller.view))
+        try #require(interactions.toggleDirectKeyboard())
         try #require(await Self.eventually { !afterFirst.isFirstResponder })
         #expect(!handoff.consume(agent.id))
 
@@ -1089,7 +1111,7 @@ struct AgentDirectInputTests {
                 attachStore: owner,
                 composer: composer,
                 inputMode: inputMode))
-        let window = Self.makeLocalTestWindow(
+        let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
         defer { window.isHidden = true }
@@ -1195,7 +1217,8 @@ struct AgentDirectInputTests {
         composer: AgentComposerStore,
         inputMode: AgentInputModeSettings,
         keyboardHandoff: TerminalKeyboardHandoff = TerminalKeyboardHandoff(),
-        keyboardInset: TerminalKeyboardInset = TerminalKeyboardInset()
+        keyboardInset: TerminalKeyboardInset = TerminalKeyboardInset(),
+        interactionProbe: AgentTerminalInteractionProbe? = nil
     ) -> AgentTerminalView {
         let defaults = UserDefaults(suiteName: "direct-detail-\(UUID())") ?? .standard
         let console = ConsoleStore(snapshotRetryDelay: .seconds(30)) { _, subscriptions in
@@ -1223,7 +1246,8 @@ struct AgentDirectInputTests {
             onSwitch: { _ in },
             onClosed: {},
             composer: composer,
-            attachStore: attachStore)
+            attachStore: attachStore,
+            interactionProbe: interactionProbe)
     }
 
     private static func makeAgent(status: AgentStatus) -> ConsoleAgent {
@@ -1562,16 +1586,6 @@ struct AgentDirectInputTests {
             }
         }
         visit(root)
-    }
-
-    @discardableResult
-    private static func activateAccessibility(labeled label: String, in root: UIView) -> Bool {
-        guard let element = firstAccessible(labeled: label, in: root) else { return false }
-        if let control = element as? UIControl {
-            control.sendActions(for: .touchUpInside)
-            return true
-        }
-        return element.accessibilityActivate()
     }
 
     private static func makeLocalTestWindow(

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -6,7 +6,7 @@ import UIKit
 @testable import Heeler
 
 @MainActor
-@Suite("Agent Direct Input")
+@Suite("Agent Direct Input", .serialized)
 struct AgentDirectInputTests {
     @Test func productionLayoutSeamTracksSoftwareKeyboardOnly() {
         let hardwareOnly = AgentDirectInputPresentation.resolve(
@@ -327,6 +327,8 @@ struct AgentDirectInputTests {
     }
 
     @Test func hideComposerControlSelectsDirectAndRaisesKeyboard() async throws {
+        let center = NotificationCenter()
+        let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 336 }
         let transport = ScriptedTransport()
         let composer = AgentComposerStore(target: "w1:p1") { params in
             try await transport.promptAgent(params)
@@ -340,15 +342,34 @@ struct AgentDirectInputTests {
             rootView: Self.makeDetailView(
                 attachStore: owner,
                 composer: composer,
-                inputMode: inputMode))
+                inputMode: inputMode,
+                keyboardInset: inset))
         let window = Self.makeLocalTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
-            rootViewController: controller)
+            rootViewController: controller,
+            attachesToScene: true)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
         })
+
+        let terminal = try #require(Self.terminals(in: controller.view).first)
+        #expect(!terminal.isLocalInputEnabled)
+        let composerInput = try #require(
+            Self.firstView(in: controller.view) {
+                $0 is UITextView && $0.accessibilityLabel == "Message the Agent"
+            } as? UITextView)
+        composerInput.becomeFirstResponder()
+        try #require(await Self.eventually { composerInput.isFirstResponder })
+        try #require(await Self.eventually { composerInput.inputView == nil })
+        center.post(
+            name: UIResponder.keyboardWillShowNotification, object: nil,
+            userInfo: [
+                UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                    x: 0, y: 500, width: 402, height: 370)
+            ])
+        try #require(await Self.eventually { inset.height == 336 })
 
         #expect(
             Self.firstAccessible(
@@ -359,13 +380,17 @@ struct AgentDirectInputTests {
             Self.activateAccessibility(
                 labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
                 in: controller.view))
+        // The measured keyboard stays in place while SwiftUI updates the
+        // existing terminal and transfers first responder to it.
+        #expect(inset.height == 336)
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually { inputMode.mode == AgentInputMode.direct })
 
-        let terminal = try #require(Self.terminals(in: controller.view).first)
         #expect(terminal.isLocalInputEnabled)
         try #require(await Self.eventually { terminal.isFirstResponder })
+        #expect(!composerInput.isFirstResponder)
+        #expect(inset.height == 336)
         #expect(composer.draft == "do not send")
         #expect(await transport.agentPromptParams.isEmpty)
         #expect(
@@ -1138,6 +1163,18 @@ struct AgentDirectInputTests {
         return found
     }
 
+    private static func firstView(
+        in root: UIView, matching: (UIView) -> Bool
+    ) -> UIView? {
+        if matching(root) { return root }
+        for subview in root.subviews {
+            if let match = firstView(in: subview, matching: matching) {
+                return match
+            }
+        }
+        return nil
+    }
+
     /// Waits for the hosted terminal attached to the owner's current feed —
     /// the binding seam when UIView object identity may be reused and Ghostty
     /// viewport text is not a reliable harness signal.
@@ -1249,9 +1286,20 @@ struct AgentDirectInputTests {
 
     private static func makeLocalTestWindow(
         frame: CGRect,
-        rootViewController: UIViewController
+        rootViewController: UIViewController,
+        attachesToScene: Bool = false
     ) -> UIWindow {
-        let window = UIWindow(frame: frame)
+        let window: UIWindow
+        if attachesToScene,
+           let scene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first
+        {
+            window = UIWindow(windowScene: scene)
+            window.frame = frame
+        } else {
+            window = UIWindow(frame: frame)
+        }
         window.rootViewController = rootViewController
         window.makeKeyAndVisible()
         return window

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -1493,11 +1493,8 @@ struct AgentDirectInputTests {
     }
 
     private static func accessibleCount(labeled label: String, in root: UIView) -> Int {
-        var seen = Set<ObjectIdentifier>()
         var count = 0
         visitAccessible(in: root) { node in
-            let id = ObjectIdentifier(node)
-            guard seen.insert(id).inserted else { return }
             if node.accessibilityLabel == label {
                 count += 1
             }

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -15,7 +15,6 @@ struct AgentDirectInputTests {
             currentHeight: 0,
             lastPresentedHeight: 336)
         #expect(hardwareOnly.keyboardPresentation == .hidden)
-        #expect(!hardwareOnly.showsShortcutRow)
         #expect(hardwareOnly.layout.contentInset == 0)
 
         let softwareUp = AgentDirectInputPresentation.resolve(
@@ -24,7 +23,6 @@ struct AgentDirectInputTests {
             currentHeight: 336,
             lastPresentedHeight: 336)
         #expect(softwareUp.keyboardPresentation == .system)
-        #expect(softwareUp.showsShortcutRow)
         #expect(softwareUp.layout.contentInset == 336)
 
         let tools = AgentDirectInputPresentation.resolve(
@@ -33,7 +31,6 @@ struct AgentDirectInputTests {
             currentHeight: 0,
             lastPresentedHeight: 336)
         #expect(tools.keyboardPresentation == .tools)
-        #expect(!tools.showsShortcutRow)
         #expect(tools.layout.contentInset == 336)
     }
 
@@ -46,7 +43,6 @@ struct AgentDirectInputTests {
             currentHeight: 0,
             lastPresentedHeight: 336)
         #expect(midSwap.keyboardPresentation == .system)
-        #expect(midSwap.showsShortcutRow)
         #expect(midSwap.layout.contentInset == 336)
         #expect(midSwap.layout.availableToolsHeight == 336)
 
@@ -419,8 +415,7 @@ struct AgentDirectInputTests {
         let terminal = try #require(Self.terminals(in: controller.view).first)
         #expect(terminal.isLocalInputEnabled)
         #expect(!terminal.isFirstResponder)
-        #expect(
-            Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
+        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
 
         await owner.leave().value
     }
@@ -467,7 +462,7 @@ struct AgentDirectInputTests {
         await owner.leave().value
     }
 
-    @Test func shortcutRowButtonsSendBytesWhileSoftwareKeyboardIsUp() async throws {
+    @Test func shortcutRowPersistsAndSendsBytesAcrossKeyboardVisibility() async throws {
         let center = NotificationCenter()
         let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 336 }
         let transport = ScriptedTransport()
@@ -497,7 +492,7 @@ struct AgentDirectInputTests {
         terminal.requestKeyboard()
         try #require(await Self.eventually { terminal.isFirstResponder })
 
-        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
+        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
         controller.view.layoutIfNeeded()
         let heightBeforeKeyboard = terminal.frame.height
 
@@ -546,7 +541,8 @@ struct AgentDirectInputTests {
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
-        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
+        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
+        #expect(Self.accessibleCount(labeled: "Dismiss keyboard", in: controller.view) == 1)
         let heightAfterHide = try #require(Self.terminals(in: controller.view).first)
             .frame.height
         #expect(abs(heightAfterHide - heightBeforeKeyboard) < 1)
@@ -595,9 +591,8 @@ struct AgentDirectInputTests {
         await Task.yield()
         let heightWithSoftwareKeyboard = try #require(
             Self.terminals(in: controller.view).first).frame.height
-        // Shortcut-row Show Composer is the row-owned control Tools lacks.
-        // The switcher also speaks the same label, so row presence is exactly
-        // two controls; row absence is exactly one (the switcher).
+        // Shortcut-row Show Composer and the switcher both speak the label.
+        // Direct Input keeps both controls through every keyboard presentation.
         let showComposer = AgentDirectInputPresentation.showComposerAccessibilityLabel
         try #require(await Self.eventually {
             Self.accessibleCount(labeled: showComposer, in: controller.view) == 2
@@ -607,11 +602,9 @@ struct AgentDirectInputTests {
             Self.activateAccessibility(labeled: "Show tools keyboard", in: controller.view))
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
-        // Tools presentation hides the software-keyboard shortcut row; wait for
-        // exactly the one switcher Show Composer rather than the shared Escape
-        // label the Tools keypad also speaks.
+        // Tools replaces the software keyboard without hiding the shortcut row.
         try #require(await Self.eventually {
-            Self.accessibleCount(labeled: showComposer, in: controller.view) == 1
+            Self.accessibleCount(labeled: showComposer, in: controller.view) == 2
         })
 
         // UIKit tears the software keyboard down while Tools stays first
@@ -653,7 +646,8 @@ struct AgentDirectInputTests {
         #expect(abs(afterShow.frame.height - heightWithSoftwareKeyboard) < 1)
 
         // Hardware keyboard hides the software keyboard while Ghostty remains
-        // first responder. Released hold must not keep a stale inset or row.
+        // first responder. Released hold must not keep a stale inset; the row
+        // remains because Direct Input still owns it.
         center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
         #expect(inset.height == 0)
         controller.view.setNeedsLayout()
@@ -661,7 +655,7 @@ struct AgentDirectInputTests {
         await Task.yield()
         let afterHardwareHide = try #require(Self.terminals(in: controller.view).first)
         #expect(afterHardwareHide.isFirstResponder)
-        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 1)
+        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 2)
         #expect(afterHardwareHide.frame.height - heightWithSoftwareKeyboard >= 336)
 
         await owner.leave().value
@@ -720,7 +714,7 @@ struct AgentDirectInputTests {
 
         let hardwareTerminal = try #require(Self.terminals(in: controller.view).first)
         #expect(hardwareTerminal.isFirstResponder)
-        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
+        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
         // No software keyboard: production inset must not reserve lastPresentedHeight.
         #expect(hardwareTerminal.frame.height - heightWithSoftwareKeyboard >= 336)
 

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -74,10 +74,9 @@ struct AgentDirectInputTests {
                 "draft"))
     }
 
-    @Test func sharedActionMenuSectionsMatchSurfaceContracts() {
+    @Test func sharedActionMenuContractIsExhaustive() {
         #expect(
-            AgentActionMenuPolicy.composerAddSections
-                == [.addAttachments])
+            AgentActionMenuPolicy.composerAddSections == [.addAttachments])
         #expect(
             AgentActionMenuPolicy.composerMoreSections
                 == [.sessionTools, .agentLifecycle])
@@ -85,79 +84,177 @@ struct AgentDirectInputTests {
             AgentActionMenuPolicy.directInputMoreSections
                 == [.addAttachments, .sessionTools, .agentLifecycle])
         #expect(
+            AgentActionMenuSection.addAttachments.items
+                == [.addImage, .addFile])
+        #expect(
             AgentActionMenuSection.sessionTools.items
                 == [.openTerminal, .newAgent, .skills, .snippets])
         #expect(
-            AgentActionMenuItem.addImage.isDraftOwned
-                && AgentActionMenuItem.addFile.isDraftOwned
-                && AgentActionMenuItem.skills.isDraftOwned
-                && AgentActionMenuItem.snippets.isDraftOwned)
+            AgentActionMenuSection.agentLifecycle.items
+                == [.worktreeDetails, .renameAgent, .renameWorkspace, .closeAgent])
         #expect(
-            !AgentActionMenuItem.openTerminal.isDraftOwned
-                && !AgentActionMenuItem.newAgent.isDraftOwned
-                && !AgentActionMenuItem.renameAgent.isDraftOwned
-                && !AgentActionMenuItem.closeAgent.isDraftOwned)
-        #expect(AgentActionMenuItem.closeAgent.role == .destructive)
+            AgentActionMenuItem.allCases
+                == AgentActionMenuSection.allCases.flatMap(\.items))
+
+        let metadata: [(AgentActionMenuItem, String, String, Bool, Bool)] = [
+            (.addImage, "Add Image", "photo", false, true),
+            (.addFile, "Add File", "doc", false, true),
+            (.openTerminal, "Open Terminal", "apple.terminal", false, false),
+            (.newAgent, "New Agent", "plus", false, false),
+            (.skills, "Skills", "sparkles", false, true),
+            (.snippets, "Snippets", "quote.bubble", false, true),
+            (.worktreeDetails, "Worktree Details", "arrow.triangle.branch", false, false),
+            (.renameAgent, "Rename Agent", "pencil", false, false),
+            (.renameWorkspace, "Rename Workspace", "pencil.line", false, false),
+            (.closeAgent, "Close Agent", "trash", true, false),
+        ]
+        for (item, title, systemImage, isDestructive, isDraftOwned) in metadata {
+            #expect(item.title == title)
+            #expect(item.systemImage == systemImage)
+            #expect((item.role == .destructive) == isDestructive)
+            #expect(item.isDraftOwned == isDraftOwned)
+        }
     }
 
-    @Test func sharedActionMenuAvailabilityFollowsComposerActions() {
-        var openedTerminal = false
-        var startedAgent = false
-        var showedSkills = false
-        var managedSnippets = false
-        var addedImage = false
-        let actions = AgentComposerActions(
+    @Test func sharedActionMenuAvailabilityAndDispatchCoverAllGates() {
+        enum Event: Equatable {
+            case addImage, addFile, openTerminal, startAgent, skills, snippets
+            case worktree, renameAgent, renameWorkspace, closeAgent
+        }
+        var events: [Event] = []
+        let gated = AgentComposerActions(
             canBegin: false,
             attachLinkCount: 0,
-            addImage: { addedImage = true },
-            addFile: {},
+            addImage: { events.append(.addImage) },
+            addFile: { events.append(.addFile) },
             showAttachLinks: {},
-            openTerminal: { openedTerminal = true },
-            isOpeningTerminal: true,
-            startAgent: { startedAgent = true },
-            manageSnippets: { managedSnippets = true },
-            showSkills: { showedSkills = true },
+            openTerminal: nil,
+            isOpeningTerminal: false,
+            startAgent: { events.append(.startAgent) },
+            manageSnippets: { events.append(.snippets) },
+            showSkills: nil,
             showWorktreeDetails: nil,
-            renameAgent: {},
-            renameWorkspace: {},
-            closeAgent: {})
-
-        #expect(!AgentActionMenuPolicy.isEnabled(.addImage, actions: actions))
-        #expect(!AgentActionMenuPolicy.isEnabled(.addFile, actions: actions))
-        #expect(!AgentActionMenuPolicy.isEnabled(.openTerminal, actions: actions))
-        #expect(AgentActionMenuPolicy.isVisible(.skills, actions: actions))
-        #expect(!AgentActionMenuPolicy.isVisible(.worktreeDetails, actions: actions))
-
+            renameAgent: { events.append(.renameAgent) },
+            renameWorkspace: { events.append(.renameWorkspace) },
+            closeAgent: { events.append(.closeAgent) })
+        let busy = AgentComposerActions(
+            canBegin: true,
+            attachLinkCount: 0,
+            addImage: { events.append(.addImage) },
+            addFile: { events.append(.addFile) },
+            showAttachLinks: {},
+            openTerminal: { events.append(.openTerminal) },
+            isOpeningTerminal: true,
+            startAgent: { events.append(.startAgent) },
+            manageSnippets: { events.append(.snippets) },
+            showSkills: { events.append(.skills) },
+            showWorktreeDetails: { events.append(.worktree) },
+            renameAgent: { events.append(.renameAgent) },
+            renameWorkspace: { events.append(.renameWorkspace) },
+            closeAgent: { events.append(.closeAgent) })
         let ready = AgentComposerActions(
             canBegin: true,
             attachLinkCount: 0,
-            addImage: { addedImage = true },
-            addFile: {},
+            addImage: { events.append(.addImage) },
+            addFile: { events.append(.addFile) },
             showAttachLinks: {},
-            openTerminal: { openedTerminal = true },
+            openTerminal: { events.append(.openTerminal) },
             isOpeningTerminal: false,
-            startAgent: { startedAgent = true },
-            manageSnippets: { managedSnippets = true },
-            showSkills: nil,
-            showWorktreeDetails: {},
-            renameAgent: {},
-            renameWorkspace: {},
-            closeAgent: {})
-        #expect(AgentActionMenuPolicy.isEnabled(.addImage, actions: ready))
-        #expect(AgentActionMenuPolicy.isEnabled(.openTerminal, actions: ready))
-        #expect(!AgentActionMenuPolicy.isVisible(.skills, actions: ready))
-        #expect(AgentActionMenuPolicy.isVisible(.worktreeDetails, actions: ready))
+            startAgent: { events.append(.startAgent) },
+            manageSnippets: { events.append(.snippets) },
+            showSkills: { events.append(.skills) },
+            showWorktreeDetails: { events.append(.worktree) },
+            renameAgent: { events.append(.renameAgent) },
+            renameWorkspace: { events.append(.renameWorkspace) },
+            closeAgent: { events.append(.closeAgent) })
 
-        AgentActionMenuPolicy.perform(.addImage, actions: actions)
-        AgentActionMenuPolicy.perform(.openTerminal, actions: ready)
-        AgentActionMenuPolicy.perform(.newAgent, actions: actions)
-        AgentActionMenuPolicy.perform(.skills, actions: actions)
-        AgentActionMenuPolicy.perform(.snippets, actions: actions)
-        #expect(addedImage)
-        #expect(openedTerminal)
-        #expect(startedAgent)
-        #expect(showedSkills)
-        #expect(managedSnippets)
+        let availability: [(AgentActionMenuItem, AgentComposerActions, Bool, Bool)] = [
+            (.addImage, gated, true, false),
+            (.addFile, gated, true, false),
+            (.openTerminal, gated, true, false),
+            (.openTerminal, busy, true, false),
+            (.openTerminal, ready, true, true),
+            (.newAgent, ready, true, true),
+            (.skills, gated, false, true),
+            (.skills, ready, true, true),
+            (.snippets, ready, true, true),
+            (.worktreeDetails, gated, false, true),
+            (.worktreeDetails, ready, true, true),
+            (.renameAgent, ready, true, true),
+            (.renameWorkspace, ready, true, true),
+            (.closeAgent, ready, true, true),
+        ]
+        for (item, actions, visible, enabled) in availability {
+            #expect(AgentActionMenuPolicy.isVisible(item, actions: actions) == visible)
+            #expect(AgentActionMenuPolicy.isEnabled(item, actions: actions) == enabled)
+        }
+
+        for item in AgentActionMenuItem.allCases {
+            AgentActionMenuPolicy.perform(item, actions: ready)
+        }
+        #expect(
+            events == [
+                .addImage, .addFile, .openTerminal, .startAgent, .skills, .snippets,
+                .worktree, .renameAgent, .renameWorkspace, .closeAgent,
+            ])
+    }
+
+    @Test func directInputRestoreComposerThenRunsBeforeDraftOwnedActions() {
+        enum Step: Equatable {
+            case restore
+            case action(AgentActionMenuItem)
+        }
+        var steps: [Step] = []
+        let actions = AgentComposerActions(
+            canBegin: true,
+            attachLinkCount: 0,
+            addImage: { steps.append(.action(.addImage)) },
+            addFile: { steps.append(.action(.addFile)) },
+            showAttachLinks: {},
+            openTerminal: { steps.append(.action(.openTerminal)) },
+            isOpeningTerminal: false,
+            startAgent: { steps.append(.action(.newAgent)) },
+            manageSnippets: { steps.append(.action(.snippets)) },
+            showSkills: { steps.append(.action(.skills)) },
+            showWorktreeDetails: { steps.append(.action(.worktreeDetails)) },
+            renameAgent: { steps.append(.action(.renameAgent)) },
+            renameWorkspace: { steps.append(.action(.renameWorkspace)) },
+            closeAgent: { steps.append(.action(.closeAgent)) })
+        let restoreComposerThen: (@escaping () -> Void) -> Void = { action in
+            steps.append(.restore)
+            action()
+        }
+
+        for item in AgentActionMenuItem.allCases {
+            AgentActionMenuPolicy.dispatch(
+                item,
+                actions: actions,
+                restoreComposerThen: restoreComposerThen)
+        }
+
+        #expect(
+            steps == [
+                .restore, .action(.addImage),
+                .restore, .action(.addFile),
+                .action(.openTerminal),
+                .action(.newAgent),
+                .restore, .action(.skills),
+                .restore, .action(.snippets),
+                .action(.worktreeDetails),
+                .action(.renameAgent),
+                .action(.renameWorkspace),
+                .action(.closeAgent),
+            ])
+
+        steps.removeAll()
+        for item in AgentActionMenuItem.allCases where item.isDraftOwned {
+            AgentActionMenuPolicy.dispatch(item, actions: actions)
+        }
+        #expect(
+            steps == [
+                .action(.addImage), .action(.addFile),
+                .action(.skills), .action(.snippets),
+            ])
     }
 
     @Test func keyboardClaimPolicyUnifiesReplacementAndAgentSwitchGates() {

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -581,7 +581,7 @@ struct AgentDirectInputTests {
             .frame.height
 
         for label in [
-            "Escape", "Tab", "Shift Tab", "Enter",
+            "Escape", "Tab", "Shift Tab", "Backspace", "Shift Enter", "Enter",
             "Up Arrow", "Down Arrow", "Left Arrow", "Right Arrow",
         ] {
             try #require(Self.activateAccessibility(labeled: label, in: controller.view))
@@ -611,7 +611,10 @@ struct AgentDirectInputTests {
                 && inputs.contains(TerminalAttachInput.keystrokes(Data([0x09])))
                 && inputs.contains(
                     TerminalAttachInput.keystrokes(Data([0x1B, 0x5B, 0x5A])))
+                && inputs.contains(
+                    TerminalAttachInput.keystrokes(Data([0x0A])))
                 && inputs.contains(TerminalAttachInput.keystrokes(Data([0x0D])))
+                && inputs.contains(TerminalAttachInput.keystrokes(Data([0x7F])))
                 && inputs.contains(TerminalAttachInput.keystrokes(Data([0x1B, 0x5B, 0x41])))
                 && inputs.contains(TerminalAttachInput.keystrokes(Data([0x1B, 0x5B, 0x42])))
                 && inputs.contains(TerminalAttachInput.keystrokes(Data([0x1B, 0x5B, 0x44])))

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -375,8 +375,11 @@ struct AgentDirectInputTests {
             Self.activateAccessibility(labeled: "Show tools keyboard", in: controller.view))
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
-        await Task.yield()
-        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
+        // Tools presentation hides the software-keyboard shortcut row; wait for
+        // that chrome transition rather than assuming one yield rebuilt a11y.
+        try #require(await Self.eventually {
+            Self.firstAccessible(labeled: "Escape", in: controller.view) == nil
+        })
 
         // UIKit tears the software keyboard down while Tools stays first
         // responder — the production hold must keep `.system` once we leave Tools.
@@ -615,6 +618,11 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually {
             owner.terminalID != firstID
         })
+        // Replacement pipeline is a fresh Attach waiting for its first size.
+        owner.viewDidResize(cols: 80, rows: 24)
+        try #require(await Self.eventually {
+            await transport.attachRequests.count == 2
+        })
         #expect(await transport.emitAttachOutput(Data("replaced".utf8)))
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
@@ -668,6 +676,10 @@ struct AgentDirectInputTests {
         // Replacement while keyboard up — intent reclaim, not a leftover handoff.
         owner.transportGenerationDidChange(2)
         try #require(await Self.eventually { owner.terminalID != firstID })
+        owner.viewDidResize(cols: 80, rows: 24)
+        try #require(await Self.eventually {
+            await transport.attachRequests.count == 2
+        })
         #expect(await transport.emitAttachOutput(Data("first-replace".utf8)))
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
@@ -686,6 +698,10 @@ struct AgentDirectInputTests {
         let secondID = owner.terminalID
         owner.transportGenerationDidChange(3)
         try #require(await Self.eventually { owner.terminalID != secondID })
+        owner.viewDidResize(cols: 80, rows: 24)
+        try #require(await Self.eventually {
+            await transport.attachRequests.count == 3
+        })
         #expect(await transport.emitAttachOutput(Data("second-replace".utf8)))
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
@@ -728,6 +744,10 @@ struct AgentDirectInputTests {
 
         owner.transportGenerationDidChange(2)
         try #require(await Self.eventually { owner.terminalID != firstID })
+        owner.viewDidResize(cols: 80, rows: 24)
+        try #require(await Self.eventually {
+            await transport.attachRequests.count == 2
+        })
         #expect(await transport.emitAttachOutput(Data("still-down".utf8)))
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -8,33 +8,45 @@ import UIKit
 @MainActor
 @Suite("Agent Direct Input")
 struct AgentDirectInputTests {
-    @Test func shortcutRowTracksSystemKeyboardPresentationOnly() {
-        #expect(AgentDirectInputChrome.showsShortcutRow(presentation: .system))
-        #expect(!AgentDirectInputChrome.showsShortcutRow(presentation: .hidden))
-        #expect(!AgentDirectInputChrome.showsShortcutRow(presentation: .tools))
+    @Test func softwareKeyboardPresentationIgnoresFirstResponderAlone() {
+        let hardwareOnly = AgentDirectInputPresentation.resolve(
+            usesToolsKeyboard: false,
+            currentHeight: 0,
+            lastPresentedHeight: 336)
+        #expect(hardwareOnly.keyboardPresentation == .hidden)
+        #expect(!hardwareOnly.showsShortcutRow)
+        #expect(hardwareOnly.contentInset == 0)
+
+        let softwareUp = AgentDirectInputPresentation.resolve(
+            usesToolsKeyboard: false,
+            currentHeight: 336,
+            lastPresentedHeight: 336)
+        #expect(softwareUp.keyboardPresentation == .system)
+        #expect(softwareUp.showsShortcutRow)
+        #expect(softwareUp.contentInset == 336)
+
+        let tools = AgentDirectInputPresentation.resolve(
+            usesToolsKeyboard: true,
+            currentHeight: 0,
+            lastPresentedHeight: 336)
+        #expect(tools.keyboardPresentation == .tools)
+        #expect(!tools.showsShortcutRow)
+        #expect(tools.contentInset == 336)
     }
 
-    @Test func directKeyboardPresentationMatchesShellArithmetic() {
+    @Test func hideAndShowComposerAccessibilityCopyIsProductionFacing() {
         #expect(
-            AgentDirectInputChrome.keyboardPresentation(
-                usesToolsKeyboard: false,
-                insetHeight: 0,
-                keyboardIsUp: true) == .system)
+            AgentDirectInputPresentation.hideComposerAccessibilityLabel
+                == "Hide Composer")
         #expect(
-            AgentDirectInputChrome.keyboardPresentation(
-                usesToolsKeyboard: false,
-                insetHeight: 0,
-                keyboardIsUp: false) == .hidden)
+            AgentDirectInputPresentation.showComposerAccessibilityLabel
+                == "Show Composer")
         #expect(
-            AgentDirectInputChrome.keyboardPresentation(
-                usesToolsKeyboard: true,
-                insetHeight: 0,
-                keyboardIsUp: true) == .tools)
+            AgentDirectInputPresentation.hideComposerAccessibilityHint.contains(
+                "iOS keyboard"))
         #expect(
-            AgentDirectInputChrome.keyboardPresentation(
-                usesToolsKeyboard: false,
-                insetHeight: 336,
-                keyboardIsUp: false) == .system)
+            AgentDirectInputPresentation.showComposerAccessibilityHint.contains(
+                "draft"))
     }
 
     @Test func composerModeStillRejectsLocalGhosttyInput() async throws {
@@ -75,44 +87,7 @@ struct AgentDirectInputTests {
         await owner.leave().value
     }
 
-    @Test func directInputEnablesLocalInputAndSendsPtyBytes() async throws {
-        let transport = ScriptedTransport()
-        let composer = AgentComposerStore(target: "w1:p1") { params in
-            try await transport.promptAgent(params)
-        }
-        composer.replaceDraft(with: "waiting draft")
-        let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
-        let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
-        defer { cleanup() }
-
-        let controller = UIHostingController(
-            rootView: Self.makeDetailView(
-                attachStore: owner,
-                composer: composer,
-                inputMode: inputMode))
-        let window = Self.makeLocalTestWindow(
-            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
-            rootViewController: controller)
-        defer { window.isHidden = true }
-        controller.view.layoutIfNeeded()
-        try #require(await Self.eventually { owner.terminalStatus == .live })
-
-        let terminal = try #require(Self.terminals(in: controller.view).first)
-        #expect(terminal.isLocalInputEnabled)
-        terminal.requestKeyboard()
-        #expect(terminal.isFirstResponder)
-
-        terminal.sendControlKey(.enter)
-        try #require(await Self.eventually {
-            await transport.attachInputs.contains(.keystrokes(Data([0x0D])))
-        })
-        #expect(composer.draft == "waiting draft")
-        #expect(await transport.agentPromptParams.isEmpty)
-
-        await owner.leave().value
-    }
-
-    @Test func modeSwitchPreservesDraftAndSendsNothing() async throws {
+    @Test func hideComposerControlSelectsDirectAndRaisesKeyboard() async throws {
         let transport = ScriptedTransport()
         let composer = AgentComposerStore(target: "w1:p1") { params in
             try await transport.promptAgent(params)
@@ -134,13 +109,22 @@ struct AgentDirectInputTests {
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually { owner.terminalStatus == .live })
 
-        inputMode.select(.direct)
+        #expect(
+            Self.firstAccessible(
+                labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
+                in: controller.view) != nil)
+
+        try #require(
+            Self.activateAccessibility(
+                labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
+                in: controller.view))
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
-        await Task.yield()
+        try #require(await Self.eventually { inputMode.mode == .direct })
 
         let terminal = try #require(Self.terminals(in: controller.view).first)
         #expect(terminal.isLocalInputEnabled)
+        try #require(await Self.eventually { terminal.isFirstResponder })
         #expect(composer.draft == "do not send")
         #expect(await transport.agentPromptParams.isEmpty)
         #expect(
@@ -148,10 +132,13 @@ struct AgentDirectInputTests {
                 if case .keystrokes = $0 { false } else { true }
             })
 
-        inputMode.select(.composer)
+        try #require(
+            Self.activateAccessibility(
+                labeled: AgentDirectInputPresentation.showComposerAccessibilityLabel,
+                in: controller.view))
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
-        await Task.yield()
+        try #require(await Self.eventually { inputMode.mode == .composer })
 
         let restored = try #require(Self.terminals(in: controller.view).first)
         #expect(!restored.isLocalInputEnabled)
@@ -161,7 +148,7 @@ struct AgentDirectInputTests {
         await owner.leave().value
     }
 
-    @Test func shortcutKeysWriteAgentQuickKeyBytes() async throws {
+    @Test func coldPersistedDirectDoesNotRaiseKeyboard() async throws {
         let transport = ScriptedTransport()
         let composer = AgentComposerStore(target: "w1:p1") { _ in }
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
@@ -181,10 +168,56 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually { owner.terminalStatus == .live })
 
         let terminal = try #require(Self.terminals(in: controller.view).first)
-        terminal.sendQuickKey(.escape)
-        terminal.sendQuickKey(.tab)
-        terminal.sendQuickKey(.shiftTab)
-        terminal.sendQuickKey(.enter)
+        #expect(terminal.isLocalInputEnabled)
+        #expect(!terminal.isFirstResponder)
+        #expect(
+            Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
+
+        await owner.leave().value
+    }
+
+    @Test func shortcutRowButtonsSendBytesWhileSoftwareKeyboardIsUp() async throws {
+        let center = NotificationCenter()
+        let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 336 }
+        let transport = ScriptedTransport()
+        let composer = AgentComposerStore(target: "w1:p1") { _ in }
+        let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
+        let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
+        defer { cleanup() }
+
+        let controller = UIHostingController(
+            rootView: Self.makeDetailView(
+                attachStore: owner,
+                composer: composer,
+                inputMode: inputMode,
+                keyboardInset: inset))
+        let window = Self.makeLocalTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
+            rootViewController: controller)
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+        try #require(await Self.eventually { owner.terminalStatus == .live })
+
+        let terminal = try #require(Self.terminals(in: controller.view).first)
+        terminal.requestKeyboard()
+        try #require(await Self.eventually { terminal.isFirstResponder })
+
+        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
+
+        center.post(
+            name: UIResponder.keyboardWillShowNotification, object: nil,
+            userInfo: [
+                UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                    x: 0, y: 500, width: 402, height: 370)
+            ])
+        try #require(await Self.eventually { inset.height == 336 })
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+        await Task.yield()
+
+        for label in ["Escape", "Tab", "Shift Tab", "Enter"] {
+            try #require(Self.activateAccessibility(labeled: label, in: controller.view))
+        }
 
         try #require(await Self.eventually {
             let inputs = await transport.attachInputs
@@ -194,6 +227,116 @@ struct AgentDirectInputTests {
                 && inputs.contains(.keystrokes(Data([0x0D])))
         })
         #expect(await transport.agentPromptParams.isEmpty)
+
+        center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
+        #expect(inset.height == 0)
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+        await Task.yield()
+        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
+        #expect(
+            AgentDirectInputPresentation.resolve(
+                usesToolsKeyboard: false,
+                currentHeight: inset.height,
+                lastPresentedHeight: inset.lastPresentedHeight).contentInset == 0)
+
+        await owner.leave().value
+    }
+
+    @Test func hardwareFirstResponderDoesNotReserveSoftwareKeyboardGap() async throws {
+        let center = NotificationCenter()
+        let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 336 }
+        let transport = ScriptedTransport()
+        let composer = AgentComposerStore(target: "w1:p1") { _ in }
+        let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
+        let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
+        defer { cleanup() }
+
+        let controller = UIHostingController(
+            rootView: Self.makeDetailView(
+                attachStore: owner,
+                composer: composer,
+                inputMode: inputMode,
+                keyboardInset: inset))
+        let window = Self.makeLocalTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
+            rootViewController: controller)
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+        try #require(await Self.eventually { owner.terminalStatus == .live })
+
+        center.post(
+            name: UIResponder.keyboardWillShowNotification, object: nil,
+            userInfo: [
+                UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                    x: 0, y: 500, width: 402, height: 370)
+            ])
+        try #require(await Self.eventually { inset.height == 336 })
+        #expect(inset.lastPresentedHeight == 336)
+
+        center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
+        #expect(inset.height == 0)
+        #expect(inset.lastPresentedHeight == 336)
+
+        let terminal = try #require(Self.terminals(in: controller.view).first)
+        terminal.requestKeyboard()
+        try #require(await Self.eventually { terminal.isFirstResponder })
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+        await Task.yield()
+
+        let presentation = AgentDirectInputPresentation.resolve(
+            usesToolsKeyboard: false,
+            currentHeight: inset.height,
+            lastPresentedHeight: inset.lastPresentedHeight)
+        #expect(terminal.isFirstResponder)
+        #expect(presentation.keyboardPresentation == .hidden)
+        #expect(!presentation.showsShortcutRow)
+        #expect(presentation.contentInset == 0)
+        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
+
+        await owner.leave().value
+    }
+
+    @Test func directPasteRoutesThroughAttachReview() async throws {
+        let transport = ScriptedTransport()
+        let composer = AgentComposerStore(target: "w1:p1") { _ in }
+        let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
+        let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
+        defer { cleanup() }
+
+        let controller = UIHostingController(
+            rootView: Self.makeDetailView(
+                attachStore: owner,
+                composer: composer,
+                inputMode: inputMode))
+        let window = Self.makeLocalTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
+            rootViewController: controller)
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+        try #require(await Self.eventually { owner.terminalStatus == .live })
+
+        let terminal = try #require(Self.terminals(in: controller.view).first)
+        #expect(terminal.isLocalInputEnabled)
+        terminal.requestPaste("git status\ngit diff")
+        let pending = try #require(owner.pendingPaste)
+        #expect(pending.text == "git status\ngit diff")
+        #expect(
+            await transport.attachInputs.allSatisfy {
+                if case .keystrokes = $0 { false } else { true }
+            })
+
+        owner.confirmPaste()
+        try #require(await Self.eventually {
+            await transport.attachInputs.contains {
+                if case .keystrokes(let data) = $0 {
+                    return String(data: data, encoding: .utf8)?.contains("git status") == true
+                }
+                return false
+            }
+        })
+        #expect(owner.pendingPaste == nil)
 
         await owner.leave().value
     }
@@ -230,11 +373,56 @@ struct AgentDirectInputTests {
         await owner.leave().value
     }
 
-    @Test func directHandoffClaimsGhosttyKeyboard() async throws {
-        let handoff = TerminalKeyboardHandoff()
-        let agent = Self.makeAgent(status: .idle)
-        handoff.arm(for: agent.id)
+    @Test func terminalReplacementWhileDirectOwnsKeyboardClaimsIntent() async throws {
+        let transport = ScriptedTransport()
+        let composer = AgentComposerStore(target: "w1:p1") { _ in }
+        composer.replaceDraft(with: "keep")
+        let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
+        let (inputMode, cleanup) = try Self.makeInputMode()
+        defer { cleanup() }
 
+        let controller = UIHostingController(
+            rootView: Self.makeDetailView(
+                attachStore: owner,
+                composer: composer,
+                inputMode: inputMode))
+        let window = Self.makeLocalTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
+            rootViewController: controller)
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+        try #require(await Self.eventually { owner.terminalStatus == .live })
+
+        try #require(
+            Self.activateAccessibility(
+                labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
+                in: controller.view))
+        try #require(await Self.eventually { inputMode.mode == .direct })
+        let first = try #require(Self.terminals(in: controller.view).first)
+        try #require(await Self.eventually { first.isFirstResponder })
+        let firstID = owner.terminalID
+        let firstSurface = ObjectIdentifier(first)
+
+        // Same-screen pipeline replacement (reconnect). Intent is owned by
+        // Direct Input's presentation state, so the new surface claims without
+        // raising a keyboard that was down.
+        owner.transportGenerationDidChange(2)
+        try #require(await Self.eventually {
+            owner.terminalID != firstID
+        })
+        #expect(await transport.emitAttachOutput(Data("replaced".utf8)))
+        try #require(await Self.eventually { owner.terminalStatus == .live })
+
+        let replacement = try #require(Self.terminals(in: controller.view).first)
+        #expect(ObjectIdentifier(replacement) != firstSurface)
+        #expect(replacement.isLocalInputEnabled)
+        try #require(await Self.eventually { replacement.isFirstResponder })
+        #expect(composer.draft == "keep")
+
+        await owner.leave().value
+    }
+
+    @Test func terminalReplacementWhileDirectKeyboardDownStaysDown() async throws {
         let transport = ScriptedTransport()
         let composer = AgentComposerStore(target: "w1:p1") { _ in }
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
@@ -243,11 +431,9 @@ struct AgentDirectInputTests {
 
         let controller = UIHostingController(
             rootView: Self.makeDetailView(
-                agent: agent,
                 attachStore: owner,
                 composer: composer,
-                inputMode: inputMode,
-                keyboardHandoff: handoff))
+                inputMode: inputMode))
         let window = Self.makeLocalTestWindow(
             frame: CGRect(x: 0, y: 0, width: 402, height: 874),
             rootViewController: controller)
@@ -255,10 +441,18 @@ struct AgentDirectInputTests {
         controller.view.layoutIfNeeded()
         try #require(await Self.eventually { owner.terminalStatus == .live })
 
-        let terminal = try #require(Self.terminals(in: controller.view).first)
-        #expect(terminal.isLocalInputEnabled)
-        #expect(terminal.isFirstResponder)
-        #expect(!handoff.consume(agent.id))
+        let first = try #require(Self.terminals(in: controller.view).first)
+        #expect(!first.isFirstResponder)
+        let firstID = owner.terminalID
+
+        owner.transportGenerationDidChange(2)
+        try #require(await Self.eventually { owner.terminalID != firstID })
+        #expect(await transport.emitAttachOutput(Data("still-down".utf8)))
+        try #require(await Self.eventually { owner.terminalStatus == .live })
+
+        let replacement = try #require(Self.terminals(in: controller.view).first)
+        #expect(replacement.isLocalInputEnabled)
+        #expect(!replacement.isFirstResponder)
 
         await owner.leave().value
     }
@@ -287,15 +481,6 @@ struct AgentDirectInputTests {
             includesDraftTools: true,
             manageSnippets: {})
         #expect(composer.tabs == [.controls, .skills, .snippets, .appearance])
-    }
-
-    @Test func hideAndShowComposerAccessibilityCopy() {
-        #expect(AgentInputMode.composer.segmentTitle == "Composer")
-        #expect(AgentInputMode.direct.segmentTitle == "Keyboard")
-        #expect(AgentQuickKey.escape.accessibilityLabel == "Escape")
-        #expect(AgentQuickKey.tab.accessibilityLabel == "Tab")
-        #expect(AgentQuickKey.shiftTab.accessibilityLabel == "Shift Tab")
-        #expect(AgentQuickKey.enter.accessibilityLabel == "Enter")
     }
 
     private static func makeInputMode(
@@ -341,7 +526,8 @@ struct AgentDirectInputTests {
         attachStore: AgentAttachStore,
         composer: AgentComposerStore,
         inputMode: AgentInputModeSettings,
-        keyboardHandoff: TerminalKeyboardHandoff = TerminalKeyboardHandoff()
+        keyboardHandoff: TerminalKeyboardHandoff = TerminalKeyboardHandoff(),
+        keyboardInset: TerminalKeyboardInset = TerminalKeyboardInset()
     ) -> AgentTerminalView {
         let defaults = UserDefaults(suiteName: "direct-detail-\(UUID())") ?? .standard
         let console = ConsoleStore(snapshotRetryDelay: .seconds(30)) { _, subscriptions in
@@ -364,7 +550,7 @@ struct AgentDirectInputTests {
             hosts: [],
             activity: AppActivityCoordinator(),
             keyboardHandoff: keyboardHandoff,
-            keyboardInset: TerminalKeyboardInset(),
+            keyboardInset: keyboardInset,
             isOnStage: { true },
             onSwitch: { _ in },
             onClosed: {},
@@ -395,6 +581,49 @@ struct AgentDirectInputTests {
         }
         walk(root)
         return found
+    }
+
+    private static func firstAccessible(labeled label: String, in root: UIView) -> NSObject? {
+        func visit(_ node: NSObject) -> NSObject? {
+            if node.accessibilityLabel == label {
+                return node
+            }
+            if let elements = node.accessibilityElements {
+                for element in elements {
+                    if let object = element as? NSObject, let match = visit(object) {
+                        return match
+                    }
+                }
+            } else {
+                let count = node.accessibilityElementCount()
+                if count > 0, count != NSNotFound {
+                    for index in 0..<count {
+                        if let object = node.accessibilityElement(at: index) as? NSObject,
+                            let match = visit(object)
+                        {
+                            return match
+                        }
+                    }
+                }
+            }
+            if let view = node as? UIView {
+                for subview in view.subviews {
+                    if let match = visit(subview) { return match }
+                }
+            }
+            return nil
+        }
+        return visit(root)
+    }
+
+    @discardableResult
+    private static func activateAccessibility(labeled label: String, in root: UIView) -> Bool {
+        guard let element = firstAccessible(labeled: label, in: root) else { return false }
+        if let control = element as? UIControl {
+            control.sendActions(for: .touchUpInside)
+            return true
+        }
+        return element.accessibilityActivate()
     }
 
     private static func makeLocalTestWindow(

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -518,6 +518,15 @@ struct AgentDirectInputTests {
             try #require(Self.activateAccessibility(labeled: label, in: controller.view))
         }
 
+        // Shortcut row sits immediately above the Agent switcher strip.
+        // Keyboard dismiss lives only on the switcher — not on the row.
+        let escapeFrame = try #require(
+            Self.firstAccessibleFrame(labeled: "Escape", in: controller.view))
+        let dismissFrame = try #require(
+            Self.firstAccessibleFrame(labeled: "Dismiss keyboard", in: controller.view))
+        #expect(escapeFrame.maxY <= dismissFrame.minY + 1)
+        #expect(Self.accessibleCount(labeled: "Dismiss keyboard", in: controller.view) == 1)
+
         try #require(await Self.eventually {
             let inputs = await transport.attachInputs
             return inputs.contains(TerminalAttachInput.keystrokes(Data([0x1B])))
@@ -617,8 +626,8 @@ struct AgentDirectInputTests {
         controller.view.layoutIfNeeded()
         await Task.yield()
 
-        // Pre-show `.system` hold: shortcut row stays adjacent to the keyboard
-        // footprint even while measured height is still zero. Two-sided bound:
+        // Pre-show `.system` hold: shortcut row stays visible above the
+        // switcher even while measured height is still zero. Two-sided bound:
         // wiring the modifier to the raw zero height expands the terminal by
         // ~lastPresentedHeight and still satisfies a one-sided upper bound.
         #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 2)
@@ -920,10 +929,11 @@ struct AgentDirectInputTests {
         #expect(!firstFeed.isAttached(to: afterFirst))
         try #require(await Self.eventually { afterFirst.isFirstResponder })
 
-        // Production dismiss clears Direct Input raised intent. A leftover
-        // TerminalKeyboardHandoff arm after the first replacement must not
-        // resurrect the keyboard on the next pipeline rebuild. Wait on the
-        // observable chrome refresh after reclaim, not a stale surface.
+        // Production dismiss clears Direct Input raised intent via the
+        // switcher-owned keyboard toggle. A leftover TerminalKeyboardHandoff
+        // arm after the first replacement must not resurrect the keyboard on
+        // the next pipeline rebuild. Wait on the observable chrome refresh
+        // after reclaim, not a stale surface.
         try #require(await Self.eventually {
             controller.view.setNeedsLayout()
             controller.view.layoutIfNeeded()
@@ -1158,6 +1168,48 @@ struct AgentDirectInputTests {
 
     private static func firstAccessible(labeled label: String, in root: UIView) -> NSObject? {
         firstAccessible(in: root) { $0.accessibilityLabel == label }
+    }
+
+    private static func firstAccessibleFrame(labeled label: String, in root: UIView) -> CGRect? {
+        // SwiftUI hosting nests accessibility containers arbitrarily deep —
+        // recurse through every container shape, not just UIViews.
+        func visit(_ node: NSObject) -> CGRect? {
+            if let view = node as? UIView {
+                if view.accessibilityLabel == label, view.bounds.width > 0, view.bounds.height > 0 {
+                    return view.convert(view.bounds, to: root)
+                }
+            } else if node.accessibilityLabel == label {
+                let frame = node.accessibilityFrame
+                if frame.width > 0, frame.height > 0 {
+                    return root.convert(frame, from: nil)
+                }
+            }
+            if let elements = node.accessibilityElements {
+                for element in elements {
+                    if let object = element as? NSObject, let frame = visit(object) {
+                        return frame
+                    }
+                }
+            } else {
+                let count = node.accessibilityElementCount()
+                if count > 0, count != NSNotFound {
+                    for index in 0..<count {
+                        if let object = node.accessibilityElement(at: index) as? NSObject,
+                            let frame = visit(object)
+                        {
+                            return frame
+                        }
+                    }
+                }
+            }
+            if let view = node as? UIView {
+                for subview in view.subviews {
+                    if let frame = visit(subview) { return frame }
+                }
+            }
+            return nil
+        }
+        return visit(root)
     }
 
     private static func accessibleCount(labeled label: String, in root: UIView) -> Int {

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -580,7 +580,10 @@ struct AgentDirectInputTests {
         let heightWithKeyboard = try #require(Self.terminals(in: controller.view).first)
             .frame.height
 
-        for label in ["Escape", "Tab", "Shift Tab", "Enter"] {
+        for label in [
+            "Escape", "Tab", "Shift Tab", "Enter",
+            "Up Arrow", "Down Arrow", "Left Arrow", "Right Arrow",
+        ] {
             try #require(Self.activateAccessibility(labeled: label, in: controller.view))
         }
 
@@ -590,8 +593,17 @@ struct AgentDirectInputTests {
             Self.firstAccessibleFrame(labeled: "Escape", in: controller.view))
         let dismissFrame = try #require(
             Self.firstAccessibleFrame(labeled: "Dismiss keyboard", in: controller.view))
+        let enterFrame = try #require(
+            Self.firstAccessibleFrame(labeled: "Enter", in: controller.view))
+        let moreFrame = try #require(
+            Self.firstAccessibleFrame(labeled: "More", in: controller.view))
         #expect(escapeFrame.maxY <= dismissFrame.minY + 1)
+        #expect(moreFrame.minX >= enterFrame.maxX)
         #expect(Self.accessibleCount(labeled: "Dismiss keyboard", in: controller.view) == 1)
+        #expect(
+            Self.accessibleCount(
+                labeled: AgentDirectInputPresentation.showComposerAccessibilityLabel,
+                in: controller.view) == 1)
 
         try #require(await Self.eventually {
             let inputs = await transport.attachInputs
@@ -600,6 +612,10 @@ struct AgentDirectInputTests {
                 && inputs.contains(
                     TerminalAttachInput.keystrokes(Data([0x1B, 0x5B, 0x5A])))
                 && inputs.contains(TerminalAttachInput.keystrokes(Data([0x0D])))
+                && inputs.contains(TerminalAttachInput.keystrokes(Data([0x1B, 0x5B, 0x41])))
+                && inputs.contains(TerminalAttachInput.keystrokes(Data([0x1B, 0x5B, 0x42])))
+                && inputs.contains(TerminalAttachInput.keystrokes(Data([0x1B, 0x5B, 0x44])))
+                && inputs.contains(TerminalAttachInput.keystrokes(Data([0x1B, 0x5B, 0x43])))
         })
         #expect(await transport.agentPromptParams.isEmpty)
 
@@ -662,11 +678,11 @@ struct AgentDirectInputTests {
         await Task.yield()
         let heightWithSoftwareKeyboard = try #require(
             Self.terminals(in: controller.view).first).frame.height
-        // Shortcut-row Show Composer and the switcher both speak the label.
-        // Direct Input keeps both controls through every keyboard presentation.
+        // Show Composer lives only on the switcher; the shortcut row remains
+        // focused on terminal keys through every keyboard presentation.
         let showComposer = AgentDirectInputPresentation.showComposerAccessibilityLabel
         try #require(await Self.eventually {
-            Self.accessibleCount(labeled: showComposer, in: controller.view) == 2
+            Self.accessibleCount(labeled: showComposer, in: controller.view) == 1
         })
 
         try #require(
@@ -675,7 +691,7 @@ struct AgentDirectInputTests {
         controller.view.layoutIfNeeded()
         // Tools replaces the software keyboard without hiding the shortcut row.
         try #require(await Self.eventually {
-            Self.accessibleCount(labeled: showComposer, in: controller.view) == 2
+            Self.accessibleCount(labeled: showComposer, in: controller.view) == 1
         })
 
         // UIKit tears the software keyboard down while Tools stays first
@@ -694,7 +710,7 @@ struct AgentDirectInputTests {
         // switcher even while measured height is still zero. Two-sided bound:
         // wiring the modifier to the raw zero height expands the terminal by
         // ~lastPresentedHeight and still satisfies a one-sided upper bound.
-        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 2)
+        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 1)
         let midSwapTerminal = try #require(Self.terminals(in: controller.view).first)
         #expect(midSwapTerminal.isFirstResponder)
         #expect(abs(heightWithSoftwareKeyboard - midSwapTerminal.frame.height) <= 1)
@@ -711,7 +727,7 @@ struct AgentDirectInputTests {
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
-        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 2)
+        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 1)
         let afterShow = try #require(Self.terminals(in: controller.view).first)
         #expect(afterShow.isFirstResponder)
         #expect(abs(afterShow.frame.height - heightWithSoftwareKeyboard) < 1)
@@ -726,7 +742,7 @@ struct AgentDirectInputTests {
         await Task.yield()
         let afterHardwareHide = try #require(Self.terminals(in: controller.view).first)
         #expect(afterHardwareHide.isFirstResponder)
-        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 2)
+        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 1)
         #expect(afterHardwareHide.frame.height - heightWithSoftwareKeyboard >= 336)
 
         await owner.leave().value

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -391,11 +391,13 @@ struct AgentDirectInputTests {
         await Task.yield()
 
         // Pre-show `.system` hold: shortcut row stays adjacent to the keyboard
-        // footprint even while measured height is still zero.
+        // footprint even while measured height is still zero. Two-sided bound:
+        // wiring the modifier to the raw zero height expands the terminal by
+        // ~lastPresentedHeight and still satisfies a one-sided upper bound.
         #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
         let midSwapTerminal = try #require(Self.terminals(in: controller.view).first)
         #expect(midSwapTerminal.isFirstResponder)
-        #expect(heightWithSoftwareKeyboard - midSwapTerminal.frame.height <= 1)
+        #expect(abs(heightWithSoftwareKeyboard - midSwapTerminal.frame.height) <= 1)
 
         // Software keyboard actually appears — hold must release without a
         // transient `.hidden` dip (row and inset stay).
@@ -793,7 +795,10 @@ struct AgentDirectInputTests {
             stageFile: { _, _ in throw TransportError.cancelled },
             composer: composer,
             closePane: {})
-        owner.rejoin()
+        // Fresh stores start `.active` with `.waitingForSize`. `rejoin()` is a
+        // no-op until leave/rejoinRequired, so open the channel the same way
+        // production does: the first positive size report.
+        owner.viewDidResize(cols: 80, rows: 24)
         try #require(await Self.eventually {
             await transport.attachRequests.count == 1
         })

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -370,10 +370,12 @@ struct AgentDirectInputTests {
         await Task.yield()
         let heightWithSoftwareKeyboard = try #require(
             Self.terminals(in: controller.view).first).frame.height
-        let shortcutRowID =
-            AgentDirectInputPresentation.shortcutRowAccessibilityIdentifier
+        // Shortcut-row Show Composer is the row-owned control Tools lacks.
+        // The switcher also speaks the same label, so row presence is the
+        // second copy — not a shared Escape / identifier walk.
+        let showComposer = AgentDirectInputPresentation.showComposerAccessibilityLabel
         try #require(await Self.eventually {
-            Self.firstAccessible(identifier: shortcutRowID, in: controller.view) != nil
+            Self.accessibleCount(labeled: showComposer, in: controller.view) >= 2
         })
 
         try #require(
@@ -381,10 +383,10 @@ struct AgentDirectInputTests {
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         // Tools presentation hides the software-keyboard shortcut row; wait for
-        // that source-specific identity rather than the shared Escape label the
-        // Tools keypad also speaks.
+        // that row-owned Show Composer to leave rather than the shared Escape
+        // label the Tools keypad also speaks.
         try #require(await Self.eventually {
-            Self.firstAccessible(identifier: shortcutRowID, in: controller.view) == nil
+            Self.accessibleCount(labeled: showComposer, in: controller.view) < 2
         })
 
         // UIKit tears the software keyboard down while Tools stays first
@@ -403,8 +405,7 @@ struct AgentDirectInputTests {
         // footprint even while measured height is still zero. Two-sided bound:
         // wiring the modifier to the raw zero height expands the terminal by
         // ~lastPresentedHeight and still satisfies a one-sided upper bound.
-        #expect(
-            Self.firstAccessible(identifier: shortcutRowID, in: controller.view) != nil)
+        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) >= 2)
         let midSwapTerminal = try #require(Self.terminals(in: controller.view).first)
         #expect(midSwapTerminal.isFirstResponder)
         #expect(abs(heightWithSoftwareKeyboard - midSwapTerminal.frame.height) <= 1)
@@ -421,8 +422,7 @@ struct AgentDirectInputTests {
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
-        #expect(
-            Self.firstAccessible(identifier: shortcutRowID, in: controller.view) != nil)
+        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) >= 2)
         let afterShow = try #require(Self.terminals(in: controller.view).first)
         #expect(afterShow.isFirstResponder)
         #expect(abs(afterShow.frame.height - heightWithSoftwareKeyboard) < 1)
@@ -436,8 +436,7 @@ struct AgentDirectInputTests {
         await Task.yield()
         let afterHardwareHide = try #require(Self.terminals(in: controller.view).first)
         #expect(afterHardwareHide.isFirstResponder)
-        #expect(
-            Self.firstAccessible(identifier: shortcutRowID, in: controller.view) == nil)
+        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) < 2)
         #expect(afterHardwareHide.frame.height - heightWithSoftwareKeyboard >= 336)
 
         await owner.leave().value
@@ -621,6 +620,7 @@ struct AgentDirectInputTests {
         let first = try #require(Self.terminals(in: controller.view).first)
         try #require(await Self.eventually { first.isFirstResponder })
         let firstID = owner.terminalID
+        let firstFeed = owner.terminalFeed
 
         owner.transportGenerationDidChange(2)
         try #require(await Self.eventually {
@@ -635,11 +635,12 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
         })
-        // Hosted SwiftUI may reuse/reconfigure the same UIView object across
-        // pipeline replacement — do not require ObjectIdentifier churn. Prove
-        // the rendered surface is bound to the replacement session instead.
+        // Hosted SwiftUI may reuse the UIView address; prove the rendered
+        // terminal is attached to the replacement feed, not the predecessor.
+        #expect(owner.terminalFeed !== firstFeed)
         let replacement = try #require(await Self.eventuallyTerminal(
-            in: controller.view, viewportContaining: "replaced"))
+            boundTo: owner.terminalFeed, in: controller.view))
+        #expect(!firstFeed.isAttached(to: replacement))
         #expect(replacement.isLocalInputEnabled)
         try #require(await Self.eventually { replacement.isFirstResponder })
         #expect(composer.draft == "keep")
@@ -682,6 +683,7 @@ struct AgentDirectInputTests {
         let first = try #require(Self.terminals(in: controller.view).first)
         try #require(await Self.eventually { first.isFirstResponder })
         let firstID = owner.terminalID
+        let firstFeed = owner.terminalFeed
 
         // Replacement while keyboard up — intent reclaim, not a leftover handoff.
         owner.transportGenerationDidChange(2)
@@ -694,11 +696,12 @@ struct AgentDirectInputTests {
         try #require(await Self.eventually {
             owner.terminalStatus == AttachTerminalStore.Status.live
         })
-        // Bind to the replacement session before reading first-responder or
-        // chrome — `.first` can still be a predecessor briefly, and object
-        // identity is not a reliable replacement signal.
+        // Bind to the replacement feed before reading first-responder or
+        // chrome — `.first` can still be a predecessor briefly.
+        #expect(owner.terminalFeed !== firstFeed)
         let afterFirst = try #require(await Self.eventuallyTerminal(
-            in: controller.view, viewportContaining: "first-replace"))
+            boundTo: owner.terminalFeed, in: controller.view))
+        #expect(!firstFeed.isAttached(to: afterFirst))
         try #require(await Self.eventually { afterFirst.isFirstResponder })
 
         // Production dismiss clears Direct Input raised intent. A leftover
@@ -716,6 +719,7 @@ struct AgentDirectInputTests {
         #expect(!handoff.consume(agent.id))
 
         let secondID = owner.terminalID
+        let secondFeed = owner.terminalFeed
         owner.transportGenerationDidChange(3)
         try #require(await Self.eventually { owner.terminalID != secondID })
         owner.viewDidResize(cols: 80, rows: 24)
@@ -727,8 +731,10 @@ struct AgentDirectInputTests {
             owner.terminalStatus == AttachTerminalStore.Status.live
         })
 
+        #expect(owner.terminalFeed !== secondFeed)
         let afterSecond = try #require(await Self.eventuallyTerminal(
-            in: controller.view, viewportContaining: "second-replace"))
+            boundTo: owner.terminalFeed, in: controller.view))
+        #expect(!secondFeed.isAttached(to: afterSecond))
         #expect(afterSecond.isLocalInputEnabled)
         #expect(!afterSecond.isFirstResponder)
         #expect(!handoff.consume(agent.id))
@@ -912,73 +918,84 @@ struct AgentDirectInputTests {
         return found
     }
 
-    /// Waits for a rendered terminal whose Ghostty session shows the
-    /// replacement output — the reliable binding signal when UIView object
-    /// identity may be reused across pipeline replacement.
+    /// Waits for the hosted terminal attached to the owner's current feed —
+    /// the binding seam when UIView object identity may be reused and Ghostty
+    /// viewport text is not a reliable harness signal.
     private static func eventuallyTerminal(
+        boundTo feed: TerminalByteFeed,
         in root: UIView,
-        viewportContaining needle: String,
         timeout: Duration = .seconds(5)
     ) async throws -> HeelerTerminalView? {
         let deadline = ContinuousClock.now + timeout
         while ContinuousClock.now < deadline {
-            if let terminal = terminals(in: root).first(where: {
-                $0.terminalSession.readViewportText()?.contains(needle) == true
-            }) {
+            root.setNeedsLayout()
+            root.layoutIfNeeded()
+            if let terminal = terminals(in: root).first(where: { feed.isAttached(to: $0) }) {
                 return terminal
             }
             try await Task.sleep(for: .milliseconds(5))
         }
-        return terminals(in: root).first(where: {
-            $0.terminalSession.readViewportText()?.contains(needle) == true
-        })
+        root.setNeedsLayout()
+        root.layoutIfNeeded()
+        return terminals(in: root).first(where: { feed.isAttached(to: $0) })
     }
 
     private static func firstAccessible(labeled label: String, in root: UIView) -> NSObject? {
         firstAccessible(in: root) { $0.accessibilityLabel == label }
     }
 
-    private static func firstAccessible(
-        identifier: String, in root: UIView
-    ) -> NSObject? {
-        firstAccessible(in: root) {
-            ($0 as? UIAccessibilityIdentification)?.accessibilityIdentifier == identifier
+    private static func accessibleCount(labeled label: String, in root: UIView) -> Int {
+        var seen = Set<ObjectIdentifier>()
+        var count = 0
+        visitAccessible(in: root) { node in
+            let id = ObjectIdentifier(node)
+            guard seen.insert(id).inserted else { return }
+            if node.accessibilityLabel == label {
+                count += 1
+            }
         }
+        return count
     }
 
     private static func firstAccessible(
         in root: UIView, matching: (NSObject) -> Bool
     ) -> NSObject? {
-        func visit(_ node: NSObject) -> NSObject? {
-            if matching(node) {
-                return node
-            }
+        var match: NSObject?
+        visitAccessible(in: root) { node in
+            guard match == nil, matching(node) else { return }
+            match = node
+        }
+        return match
+    }
+
+    private static func visitAccessible(
+        in root: UIView, body: (NSObject) -> Void
+    ) {
+        func visit(_ node: NSObject) {
+            body(node)
             if let elements = node.accessibilityElements {
                 for element in elements {
-                    if let object = element as? NSObject, let match = visit(object) {
-                        return match
+                    if let object = element as? NSObject {
+                        visit(object)
                     }
                 }
             } else {
                 let count = node.accessibilityElementCount()
                 if count > 0, count != NSNotFound {
                     for index in 0..<count {
-                        if let object = node.accessibilityElement(at: index) as? NSObject,
-                            let match = visit(object)
-                        {
-                            return match
+                        if let object = node.accessibilityElement(at: index) as? NSObject {
+                            visit(object)
                         }
                     }
                 }
             }
             if let view = node as? UIView {
                 for subview in view.subviews {
-                    if let match = visit(subview) { return match }
+                    visit(subview)
                 }
             }
-            return nil
         }
-        return visit(root)
+        visit(root)
     }
 
     @discardableResult

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -521,9 +521,14 @@ struct AgentDirectInputTests {
         let terminal = try #require(Self.terminals(in: controller.view).first)
         #expect(terminal.isLocalInputEnabled)
         #expect(!terminal.isFirstResponder)
-        #expect(!interactions.switchDirectKeyboard())
         if #available(iOS 27, *) {
+            #expect(
+                Self.firstAccessible(
+                    labeled: "Show tools keyboard",
+                    in: controller.view) == nil)
             #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
+        } else {
+            #expect(!interactions.switchDirectKeyboard())
         }
 
         await owner.leave().value

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -920,7 +920,9 @@ struct AgentDirectInputTests {
     private static func firstAccessible(
         identifier: String, in root: UIView
     ) -> NSObject? {
-        firstAccessible(in: root) { $0.accessibilityIdentifier == identifier }
+        firstAccessible(in: root) {
+            ($0 as? UIAccessibilityIdentification)?.accessibilityIdentifier == identifier
+        }
     }
 
     private static func firstAccessible(

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -74,6 +74,125 @@ struct AgentDirectInputTests {
                 "draft"))
     }
 
+    @Test func sharedActionMenuSectionsMatchSurfaceContracts() {
+        #expect(
+            AgentActionMenuPolicy.composerAddSections
+                == [.addAttachments])
+        #expect(
+            AgentActionMenuPolicy.composerMoreSections
+                == [.sessionTools, .agentLifecycle])
+        #expect(
+            AgentActionMenuPolicy.directInputMoreSections
+                == [.addAttachments, .sessionTools, .agentLifecycle])
+        #expect(
+            AgentActionMenuSection.sessionTools.items
+                == [.openTerminal, .newAgent, .skills, .snippets])
+        #expect(
+            AgentActionMenuItem.addImage.isDraftOwned
+                && AgentActionMenuItem.addFile.isDraftOwned
+                && AgentActionMenuItem.skills.isDraftOwned
+                && AgentActionMenuItem.snippets.isDraftOwned)
+        #expect(
+            !AgentActionMenuItem.openTerminal.isDraftOwned
+                && !AgentActionMenuItem.newAgent.isDraftOwned
+                && !AgentActionMenuItem.renameAgent.isDraftOwned
+                && !AgentActionMenuItem.closeAgent.isDraftOwned)
+        #expect(AgentActionMenuItem.closeAgent.role == .destructive)
+    }
+
+    @Test func sharedActionMenuAvailabilityFollowsComposerActions() {
+        var openedTerminal = false
+        var startedAgent = false
+        var showedSkills = false
+        var managedSnippets = false
+        var addedImage = false
+        let actions = AgentComposerActions(
+            canBegin: false,
+            attachLinkCount: 0,
+            addImage: { addedImage = true },
+            addFile: {},
+            showAttachLinks: {},
+            openTerminal: { openedTerminal = true },
+            isOpeningTerminal: true,
+            startAgent: { startedAgent = true },
+            manageSnippets: { managedSnippets = true },
+            showSkills: { showedSkills = true },
+            showWorktreeDetails: nil,
+            renameAgent: {},
+            renameWorkspace: {},
+            closeAgent: {})
+
+        #expect(!AgentActionMenuPolicy.isEnabled(.addImage, actions: actions))
+        #expect(!AgentActionMenuPolicy.isEnabled(.addFile, actions: actions))
+        #expect(!AgentActionMenuPolicy.isEnabled(.openTerminal, actions: actions))
+        #expect(AgentActionMenuPolicy.isVisible(.skills, actions: actions))
+        #expect(!AgentActionMenuPolicy.isVisible(.worktreeDetails, actions: actions))
+
+        let ready = AgentComposerActions(
+            canBegin: true,
+            attachLinkCount: 0,
+            addImage: { addedImage = true },
+            addFile: {},
+            showAttachLinks: {},
+            openTerminal: { openedTerminal = true },
+            isOpeningTerminal: false,
+            startAgent: { startedAgent = true },
+            manageSnippets: { managedSnippets = true },
+            showSkills: nil,
+            showWorktreeDetails: {},
+            renameAgent: {},
+            renameWorkspace: {},
+            closeAgent: {})
+        #expect(AgentActionMenuPolicy.isEnabled(.addImage, actions: ready))
+        #expect(AgentActionMenuPolicy.isEnabled(.openTerminal, actions: ready))
+        #expect(!AgentActionMenuPolicy.isVisible(.skills, actions: ready))
+        #expect(AgentActionMenuPolicy.isVisible(.worktreeDetails, actions: ready))
+
+        AgentActionMenuPolicy.perform(.addImage, actions: actions)
+        AgentActionMenuPolicy.perform(.openTerminal, actions: ready)
+        AgentActionMenuPolicy.perform(.newAgent, actions: actions)
+        AgentActionMenuPolicy.perform(.skills, actions: actions)
+        AgentActionMenuPolicy.perform(.snippets, actions: actions)
+        #expect(addedImage)
+        #expect(openedTerminal)
+        #expect(startedAgent)
+        #expect(showedSkills)
+        #expect(managedSnippets)
+    }
+
+    @Test func keyboardClaimPolicyUnifiesReplacementAndAgentSwitchGates() {
+        #expect(
+            !AgentDirectInputPresentation.shouldClaimKeyboard(
+                wantsKeyboard: false,
+                isKeyboardUp: false,
+                usesToolsKeyboard: false,
+                softwareKeyboardHeight: 0))
+        #expect(
+            AgentDirectInputPresentation.shouldClaimKeyboard(
+                wantsKeyboard: true,
+                isKeyboardUp: false,
+                usesToolsKeyboard: false,
+                softwareKeyboardHeight: 0))
+        #expect(
+            AgentDirectInputPresentation.shouldClaimKeyboard(
+                wantsKeyboard: false,
+                isKeyboardUp: true,
+                usesToolsKeyboard: false,
+                softwareKeyboardHeight: 0))
+        #expect(
+            AgentDirectInputPresentation.shouldClaimKeyboard(
+                wantsKeyboard: false,
+                isKeyboardUp: false,
+                usesToolsKeyboard: true,
+                softwareKeyboardHeight: 0))
+        #expect(
+            AgentDirectInputPresentation.shouldClaimKeyboard(
+                wantsKeyboard: false,
+                isKeyboardUp: false,
+                usesToolsKeyboard: false,
+                softwareKeyboardHeight: 336))
+    }
+
     @Test func composerModeStillRejectsLocalGhosttyInput() async throws {
         let transport = ScriptedTransport()
         let composer = AgentComposerStore(target: "w1:p1") { params in

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -371,11 +371,11 @@ struct AgentDirectInputTests {
         let heightWithSoftwareKeyboard = try #require(
             Self.terminals(in: controller.view).first).frame.height
         // Shortcut-row Show Composer is the row-owned control Tools lacks.
-        // The switcher also speaks the same label, so row presence is the
-        // second copy — not a shared Escape / identifier walk.
+        // The switcher also speaks the same label, so row presence is exactly
+        // two controls; row absence is exactly one (the switcher).
         let showComposer = AgentDirectInputPresentation.showComposerAccessibilityLabel
         try #require(await Self.eventually {
-            Self.accessibleCount(labeled: showComposer, in: controller.view) >= 2
+            Self.accessibleCount(labeled: showComposer, in: controller.view) == 2
         })
 
         try #require(
@@ -383,10 +383,10 @@ struct AgentDirectInputTests {
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         // Tools presentation hides the software-keyboard shortcut row; wait for
-        // that row-owned Show Composer to leave rather than the shared Escape
+        // exactly the one switcher Show Composer rather than the shared Escape
         // label the Tools keypad also speaks.
         try #require(await Self.eventually {
-            Self.accessibleCount(labeled: showComposer, in: controller.view) < 2
+            Self.accessibleCount(labeled: showComposer, in: controller.view) == 1
         })
 
         // UIKit tears the software keyboard down while Tools stays first
@@ -405,7 +405,7 @@ struct AgentDirectInputTests {
         // footprint even while measured height is still zero. Two-sided bound:
         // wiring the modifier to the raw zero height expands the terminal by
         // ~lastPresentedHeight and still satisfies a one-sided upper bound.
-        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) >= 2)
+        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 2)
         let midSwapTerminal = try #require(Self.terminals(in: controller.view).first)
         #expect(midSwapTerminal.isFirstResponder)
         #expect(abs(heightWithSoftwareKeyboard - midSwapTerminal.frame.height) <= 1)
@@ -422,7 +422,7 @@ struct AgentDirectInputTests {
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
         await Task.yield()
-        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) >= 2)
+        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 2)
         let afterShow = try #require(Self.terminals(in: controller.view).first)
         #expect(afterShow.isFirstResponder)
         #expect(abs(afterShow.frame.height - heightWithSoftwareKeyboard) < 1)
@@ -436,7 +436,7 @@ struct AgentDirectInputTests {
         await Task.yield()
         let afterHardwareHide = try #require(Self.terminals(in: controller.view).first)
         #expect(afterHardwareHide.isFirstResponder)
-        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) < 2)
+        #expect(Self.accessibleCount(labeled: showComposer, in: controller.view) == 1)
         #expect(afterHardwareHide.frame.height - heightWithSoftwareKeyboard >= 336)
 
         await owner.leave().value

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -8,30 +8,55 @@ import UIKit
 @MainActor
 @Suite("Agent Direct Input")
 struct AgentDirectInputTests {
-    @Test func softwareKeyboardPresentationIgnoresFirstResponderAlone() {
+    @Test func productionLayoutSeamTracksSoftwareKeyboardOnly() {
         let hardwareOnly = AgentDirectInputPresentation.resolve(
             usesToolsKeyboard: false,
+            expectsSystemKeyboard: false,
             currentHeight: 0,
             lastPresentedHeight: 336)
         #expect(hardwareOnly.keyboardPresentation == .hidden)
         #expect(!hardwareOnly.showsShortcutRow)
-        #expect(hardwareOnly.contentInset == 0)
+        #expect(hardwareOnly.layout.contentInset == 0)
 
         let softwareUp = AgentDirectInputPresentation.resolve(
             usesToolsKeyboard: false,
+            expectsSystemKeyboard: false,
             currentHeight: 336,
             lastPresentedHeight: 336)
         #expect(softwareUp.keyboardPresentation == .system)
         #expect(softwareUp.showsShortcutRow)
-        #expect(softwareUp.contentInset == 336)
+        #expect(softwareUp.layout.contentInset == 336)
 
         let tools = AgentDirectInputPresentation.resolve(
             usesToolsKeyboard: true,
+            expectsSystemKeyboard: false,
             currentHeight: 0,
             lastPresentedHeight: 336)
         #expect(tools.keyboardPresentation == .tools)
         #expect(!tools.showsShortcutRow)
-        #expect(tools.contentInset == 336)
+        #expect(tools.layout.contentInset == 336)
+    }
+
+    @Test func toolsToSystemPreShowKeepsStableInset() {
+        // Shared TerminalAttachTests contract: `.system` with currentHeight 0
+        // still reserves lastPresentedHeight during the Tools→iOS swap.
+        let midSwap = AgentDirectInputPresentation.resolve(
+            usesToolsKeyboard: false,
+            expectsSystemKeyboard: true,
+            currentHeight: 0,
+            lastPresentedHeight: 336)
+        #expect(midSwap.keyboardPresentation == .system)
+        #expect(midSwap.showsShortcutRow)
+        #expect(midSwap.layout.contentInset == 336)
+        #expect(midSwap.layout.availableToolsHeight == 336)
+
+        let withoutHold = AgentDirectInputPresentation.resolve(
+            usesToolsKeyboard: false,
+            expectsSystemKeyboard: false,
+            currentHeight: 0,
+            lastPresentedHeight: 336)
+        #expect(withoutHold.keyboardPresentation == .hidden)
+        #expect(withoutHold.layout.contentInset == 0)
     }
 
     @Test func hideAndShowComposerAccessibilityCopyIsProductionFacing() {
@@ -69,12 +94,14 @@ struct AgentDirectInputTests {
             rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
-        try #require(await Self.eventually { owner.terminalStatus == .live })
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
 
         let terminal = try #require(Self.terminals(in: controller.view).first)
         #expect(!terminal.isLocalInputEnabled)
         terminal.requestKeyboard()
-        terminal.sendControlKey(.enter)
+        terminal.sendControlKey(TerminalControlKey.enter)
         await Task.yield()
         #expect(!terminal.isFirstResponder)
         #expect(
@@ -107,7 +134,9 @@ struct AgentDirectInputTests {
             rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
-        try #require(await Self.eventually { owner.terminalStatus == .live })
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
 
         #expect(
             Self.firstAccessible(
@@ -120,7 +149,7 @@ struct AgentDirectInputTests {
                 in: controller.view))
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
-        try #require(await Self.eventually { inputMode.mode == .direct })
+        try #require(await Self.eventually { inputMode.mode == AgentInputMode.direct })
 
         let terminal = try #require(Self.terminals(in: controller.view).first)
         #expect(terminal.isLocalInputEnabled)
@@ -138,7 +167,7 @@ struct AgentDirectInputTests {
                 in: controller.view))
         controller.view.setNeedsLayout()
         controller.view.layoutIfNeeded()
-        try #require(await Self.eventually { inputMode.mode == .composer })
+        try #require(await Self.eventually { inputMode.mode == AgentInputMode.composer })
 
         let restored = try #require(Self.terminals(in: controller.view).first)
         #expect(!restored.isLocalInputEnabled)
@@ -150,7 +179,9 @@ struct AgentDirectInputTests {
 
     @Test func coldPersistedDirectDoesNotRaiseKeyboard() async throws {
         let transport = ScriptedTransport()
-        let composer = AgentComposerStore(target: "w1:p1") { _ in }
+        let composer = AgentComposerStore(target: "w1:p1") { _ in
+            Agent(.fixture(paneID: "w1:p1"))
+        }
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
         let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
         defer { cleanup() }
@@ -165,7 +196,9 @@ struct AgentDirectInputTests {
             rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
-        try #require(await Self.eventually { owner.terminalStatus == .live })
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
 
         let terminal = try #require(Self.terminals(in: controller.view).first)
         #expect(terminal.isLocalInputEnabled)
@@ -176,11 +209,54 @@ struct AgentDirectInputTests {
         await owner.leave().value
     }
 
+    @Test func ghosttyReturnSendsPtyCRWithoutComposerPrompt() async throws {
+        let transport = ScriptedTransport()
+        let composer = AgentComposerStore(target: "w1:p1") { _ in
+            Agent(.fixture(paneID: "w1:p1"))
+        }
+        composer.replaceDraft(with: "waiting draft")
+        let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
+        let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
+        defer { cleanup() }
+
+        let controller = UIHostingController(
+            rootView: Self.makeDetailView(
+                attachStore: owner,
+                composer: composer,
+                inputMode: inputMode))
+        let window = Self.makeLocalTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
+            rootViewController: controller)
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
+
+        let terminal = try #require(Self.terminals(in: controller.view).first)
+        #expect(terminal.isLocalInputEnabled)
+        terminal.requestKeyboard()
+        try #require(await Self.eventually { terminal.isFirstResponder })
+
+        // System Return / Ghostty local-input path — not the app shortcut row.
+        terminal.sendControlKey(TerminalControlKey.enter)
+        try #require(await Self.eventually {
+            await transport.attachInputs.contains(
+                TerminalAttachInput.keystrokes(Data([0x0D])))
+        })
+        #expect(composer.draft == "waiting draft")
+        #expect(await transport.agentPromptParams.isEmpty)
+
+        await owner.leave().value
+    }
+
     @Test func shortcutRowButtonsSendBytesWhileSoftwareKeyboardIsUp() async throws {
         let center = NotificationCenter()
         let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 336 }
         let transport = ScriptedTransport()
-        let composer = AgentComposerStore(target: "w1:p1") { _ in }
+        let composer = AgentComposerStore(target: "w1:p1") { _ in
+            Agent(.fixture(paneID: "w1:p1"))
+        }
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
         let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
         defer { cleanup() }
@@ -196,7 +272,9 @@ struct AgentDirectInputTests {
             rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
-        try #require(await Self.eventually { owner.terminalStatus == .live })
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
 
         let terminal = try #require(Self.terminals(in: controller.view).first)
         terminal.requestKeyboard()
@@ -221,10 +299,11 @@ struct AgentDirectInputTests {
 
         try #require(await Self.eventually {
             let inputs = await transport.attachInputs
-            return inputs.contains(.keystrokes(Data([0x1B])))
-                && inputs.contains(.keystrokes(Data([0x09])))
-                && inputs.contains(.keystrokes(Data([0x1B, 0x5B, 0x5A])))
-                && inputs.contains(.keystrokes(Data([0x0D])))
+            return inputs.contains(TerminalAttachInput.keystrokes(Data([0x1B])))
+                && inputs.contains(TerminalAttachInput.keystrokes(Data([0x09])))
+                && inputs.contains(
+                    TerminalAttachInput.keystrokes(Data([0x1B, 0x5B, 0x5A])))
+                && inputs.contains(TerminalAttachInput.keystrokes(Data([0x0D])))
         })
         #expect(await transport.agentPromptParams.isEmpty)
 
@@ -234,20 +313,25 @@ struct AgentDirectInputTests {
         controller.view.layoutIfNeeded()
         await Task.yield()
         #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
-        #expect(
-            AgentDirectInputPresentation.resolve(
-                usesToolsKeyboard: false,
-                currentHeight: inset.height,
-                lastPresentedHeight: inset.lastPresentedHeight).contentInset == 0)
+        // Production consumes presentation.layout — zero height must not keep
+        // lastPresentedHeight as the bottom inset.
+        let dismissed = AgentDirectInputPresentation.resolve(
+            usesToolsKeyboard: false,
+            expectsSystemKeyboard: false,
+            currentHeight: inset.height,
+            lastPresentedHeight: inset.lastPresentedHeight)
+        #expect(dismissed.layout.contentInset == 0)
 
         await owner.leave().value
     }
 
-    @Test func hardwareFirstResponderDoesNotReserveSoftwareKeyboardGap() async throws {
+    @Test func toolsToSystemSwapKeepsShortcutRowThroughCoalesce() async throws {
         let center = NotificationCenter()
         let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 336 }
         let transport = ScriptedTransport()
-        let composer = AgentComposerStore(target: "w1:p1") { _ in }
+        let composer = AgentComposerStore(target: "w1:p1") { _ in
+            Agent(.fixture(paneID: "w1:p1"))
+        }
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
         let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
         defer { cleanup() }
@@ -263,7 +347,81 @@ struct AgentDirectInputTests {
             rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
-        try #require(await Self.eventually { owner.terminalStatus == .live })
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
+
+        let terminal = try #require(Self.terminals(in: controller.view).first)
+        terminal.requestKeyboard()
+        try #require(await Self.eventually { terminal.isFirstResponder })
+        center.post(
+            name: UIResponder.keyboardWillShowNotification, object: nil,
+            userInfo: [
+                UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                    x: 0, y: 500, width: 402, height: 370)
+            ])
+        try #require(await Self.eventually { inset.height == 336 })
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+        await Task.yield()
+
+        try #require(
+            Self.activateAccessibility(labeled: "Show tools keyboard", in: controller.view))
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+        await Task.yield()
+        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
+
+        // UIKit tears the software keyboard down while Tools stays first
+        // responder — the production hold must keep `.system` once we leave Tools.
+        center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
+        #expect(inset.height == 0)
+        #expect(inset.lastPresentedHeight == 336)
+
+        try #require(
+            Self.activateAccessibility(labeled: "Show iOS keyboard", in: controller.view))
+        controller.view.setNeedsLayout()
+        controller.view.layoutIfNeeded()
+        await Task.yield()
+
+        // Pre-show `.system` hold: shortcut row stays adjacent to the keyboard
+        // footprint even while measured height is still zero.
+        #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) != nil)
+        let midSwap = AgentDirectInputPresentation.resolve(
+            usesToolsKeyboard: false,
+            expectsSystemKeyboard: true,
+            currentHeight: inset.height,
+            lastPresentedHeight: inset.lastPresentedHeight)
+        #expect(midSwap.layout.contentInset == 336)
+
+        await owner.leave().value
+    }
+
+    @Test func hardwareFirstResponderDoesNotReserveSoftwareKeyboardGap() async throws {
+        let center = NotificationCenter()
+        let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 336 }
+        let transport = ScriptedTransport()
+        let composer = AgentComposerStore(target: "w1:p1") { _ in
+            Agent(.fixture(paneID: "w1:p1"))
+        }
+        let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
+        let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
+        defer { cleanup() }
+
+        let controller = UIHostingController(
+            rootView: Self.makeDetailView(
+                attachStore: owner,
+                composer: composer,
+                inputMode: inputMode,
+                keyboardInset: inset))
+        let window = Self.makeLocalTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
+            rootViewController: controller)
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
 
         center.post(
             name: UIResponder.keyboardWillShowNotification, object: nil,
@@ -287,12 +445,13 @@ struct AgentDirectInputTests {
 
         let presentation = AgentDirectInputPresentation.resolve(
             usesToolsKeyboard: false,
+            expectsSystemKeyboard: false,
             currentHeight: inset.height,
             lastPresentedHeight: inset.lastPresentedHeight)
         #expect(terminal.isFirstResponder)
         #expect(presentation.keyboardPresentation == .hidden)
         #expect(!presentation.showsShortcutRow)
-        #expect(presentation.contentInset == 0)
+        #expect(presentation.layout.contentInset == 0)
         #expect(Self.firstAccessible(labeled: "Escape", in: controller.view) == nil)
 
         await owner.leave().value
@@ -300,7 +459,9 @@ struct AgentDirectInputTests {
 
     @Test func directPasteRoutesThroughAttachReview() async throws {
         let transport = ScriptedTransport()
-        let composer = AgentComposerStore(target: "w1:p1") { _ in }
+        let composer = AgentComposerStore(target: "w1:p1") { _ in
+            Agent(.fixture(paneID: "w1:p1"))
+        }
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
         let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
         defer { cleanup() }
@@ -315,7 +476,9 @@ struct AgentDirectInputTests {
             rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
-        try #require(await Self.eventually { owner.terminalStatus == .live })
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
 
         let terminal = try #require(Self.terminals(in: controller.view).first)
         #expect(terminal.isLocalInputEnabled)
@@ -343,7 +506,9 @@ struct AgentDirectInputTests {
 
     @Test func blockedStatusStaysInDirectInput() async throws {
         let transport = ScriptedTransport()
-        let composer = AgentComposerStore(target: "w1:p1", initialStatus: .blocked) { _ in }
+        let composer = AgentComposerStore(target: "w1:p1", initialStatus: .blocked) { _ in
+            Agent(.fixture(paneID: "w1:p1"))
+        }
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
         let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
         defer { cleanup() }
@@ -359,14 +524,17 @@ struct AgentDirectInputTests {
             rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
-        try #require(await Self.eventually { owner.terminalStatus == .live })
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
 
-        #expect(inputMode.mode == .direct)
+        #expect(inputMode.mode == AgentInputMode.direct)
         let terminal = try #require(Self.terminals(in: controller.view).first)
         #expect(terminal.isLocalInputEnabled)
-        terminal.sendQuickKey(.enter)
+        terminal.sendQuickKey(AgentQuickKey.enter)
         try #require(await Self.eventually {
-            await transport.attachInputs.contains(.keystrokes(Data([0x0D])))
+            await transport.attachInputs.contains(
+                TerminalAttachInput.keystrokes(Data([0x0D])))
         })
         #expect(await transport.agentPromptParams.isEmpty)
 
@@ -375,7 +543,9 @@ struct AgentDirectInputTests {
 
     @Test func terminalReplacementWhileDirectOwnsKeyboardClaimsIntent() async throws {
         let transport = ScriptedTransport()
-        let composer = AgentComposerStore(target: "w1:p1") { _ in }
+        let composer = AgentComposerStore(target: "w1:p1") { _ in
+            Agent(.fixture(paneID: "w1:p1"))
+        }
         composer.replaceDraft(with: "keep")
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
         let (inputMode, cleanup) = try Self.makeInputMode()
@@ -391,27 +561,28 @@ struct AgentDirectInputTests {
             rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
-        try #require(await Self.eventually { owner.terminalStatus == .live })
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
 
         try #require(
             Self.activateAccessibility(
                 labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
                 in: controller.view))
-        try #require(await Self.eventually { inputMode.mode == .direct })
+        try #require(await Self.eventually { inputMode.mode == AgentInputMode.direct })
         let first = try #require(Self.terminals(in: controller.view).first)
         try #require(await Self.eventually { first.isFirstResponder })
         let firstID = owner.terminalID
         let firstSurface = ObjectIdentifier(first)
 
-        // Same-screen pipeline replacement (reconnect). Intent is owned by
-        // Direct Input's presentation state, so the new surface claims without
-        // raising a keyboard that was down.
         owner.transportGenerationDidChange(2)
         try #require(await Self.eventually {
             owner.terminalID != firstID
         })
         #expect(await transport.emitAttachOutput(Data("replaced".utf8)))
-        try #require(await Self.eventually { owner.terminalStatus == .live })
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
 
         let replacement = try #require(Self.terminals(in: controller.view).first)
         #expect(ObjectIdentifier(replacement) != firstSurface)
@@ -422,9 +593,81 @@ struct AgentDirectInputTests {
         await owner.leave().value
     }
 
+    @Test func dismissAfterReplacementDoesNotRaiseOnSecondReplacement() async throws {
+        let transport = ScriptedTransport()
+        let composer = AgentComposerStore(target: "w1:p1") { _ in
+            Agent(.fixture(paneID: "w1:p1"))
+        }
+        let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
+        let (inputMode, cleanup) = try Self.makeInputMode()
+        defer { cleanup() }
+        let handoff = TerminalKeyboardHandoff()
+        let agent = Self.makeAgent(status: .idle)
+
+        let controller = UIHostingController(
+            rootView: Self.makeDetailView(
+                agent: agent,
+                attachStore: owner,
+                composer: composer,
+                inputMode: inputMode,
+                keyboardHandoff: handoff))
+        let window = Self.makeLocalTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
+            rootViewController: controller)
+        defer { window.isHidden = true }
+        controller.view.layoutIfNeeded()
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
+
+        try #require(
+            Self.activateAccessibility(
+                labeled: AgentDirectInputPresentation.hideComposerAccessibilityLabel,
+                in: controller.view))
+        try #require(await Self.eventually { inputMode.mode == AgentInputMode.direct })
+        let first = try #require(Self.terminals(in: controller.view).first)
+        try #require(await Self.eventually { first.isFirstResponder })
+        let firstID = owner.terminalID
+
+        // Replacement while keyboard up — intent reclaim, not a leftover handoff.
+        owner.transportGenerationDidChange(2)
+        try #require(await Self.eventually { owner.terminalID != firstID })
+        #expect(await transport.emitAttachOutput(Data("first-replace".utf8)))
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
+        let afterFirst = try #require(Self.terminals(in: controller.view).first)
+        try #require(await Self.eventually { afterFirst.isFirstResponder })
+
+        // Production dismiss clears Direct Input raised intent. A leftover
+        // TerminalKeyboardHandoff arm after the first replacement must not
+        // resurrect the keyboard on the next pipeline rebuild.
+        try #require(
+            Self.activateAccessibility(labeled: "Dismiss keyboard", in: controller.view))
+        try #require(await Self.eventually { !afterFirst.isFirstResponder })
+        #expect(!handoff.consume(agent.id))
+
+        let secondID = owner.terminalID
+        owner.transportGenerationDidChange(3)
+        try #require(await Self.eventually { owner.terminalID != secondID })
+        #expect(await transport.emitAttachOutput(Data("second-replace".utf8)))
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
+
+        let afterSecond = try #require(Self.terminals(in: controller.view).first)
+        #expect(afterSecond.isLocalInputEnabled)
+        #expect(!afterSecond.isFirstResponder)
+        #expect(!handoff.consume(agent.id))
+
+        await owner.leave().value
+    }
+
     @Test func terminalReplacementWhileDirectKeyboardDownStaysDown() async throws {
         let transport = ScriptedTransport()
-        let composer = AgentComposerStore(target: "w1:p1") { _ in }
+        let composer = AgentComposerStore(target: "w1:p1") { _ in
+            Agent(.fixture(paneID: "w1:p1"))
+        }
         let owner = try await Self.makeLiveAttach(transport: transport, composer: composer)
         let (inputMode, cleanup) = try Self.makeInputMode(initial: .direct)
         defer { cleanup() }
@@ -439,7 +682,9 @@ struct AgentDirectInputTests {
             rootViewController: controller)
         defer { window.isHidden = true }
         controller.view.layoutIfNeeded()
-        try #require(await Self.eventually { owner.terminalStatus == .live })
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
 
         let first = try #require(Self.terminals(in: controller.view).first)
         #expect(!first.isFirstResponder)
@@ -448,7 +693,9 @@ struct AgentDirectInputTests {
         owner.transportGenerationDidChange(2)
         try #require(await Self.eventually { owner.terminalID != firstID })
         #expect(await transport.emitAttachOutput(Data("still-down".utf8)))
-        try #require(await Self.eventually { owner.terminalStatus == .live })
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
 
         let replacement = try #require(Self.terminals(in: controller.view).first)
         #expect(replacement.isLocalInputEnabled)
@@ -517,7 +764,9 @@ struct AgentDirectInputTests {
             await transport.attachRequests.count == 1
         })
         #expect(await transport.emitAttachOutput(Data("live".utf8)))
-        try #require(await Self.eventually { owner.terminalStatus == .live })
+        try #require(await Self.eventually {
+            owner.terminalStatus == AttachTerminalStore.Status.live
+        })
         return owner
     }
 

--- a/Tests/HeelerTests/AgentDirectInputTests.swift
+++ b/Tests/HeelerTests/AgentDirectInputTests.swift
@@ -71,7 +71,15 @@ struct AgentDirectInputTests {
     }
 
     @Test func accessibilityTraversalFallsBackToIndexedContainerWhenElementsAreEmpty() {
-        let root = IndexedAccessibilityContainerView(label: "Indexed control")
+        let root = IndexedAccessibilityContainerView(indexedLabel: "Indexed control")
+
+        #expect(Self.firstAccessible(labeled: "Indexed control", in: root) != nil)
+    }
+
+    @Test func accessibilityTraversalIncludesIndexedElementsWhenArrayIsIncomplete() {
+        let root = IndexedAccessibilityContainerView(
+            indexedLabel: "Indexed control",
+            arrayLabel: "Array control")
 
         #expect(Self.firstAccessible(labeled: "Indexed control", in: root) != nil)
     }
@@ -1521,22 +1529,20 @@ struct AgentDirectInputTests {
         func visit(_ node: NSObject) {
             guard visited.insert(ObjectIdentifier(node)).inserted else { return }
             body(node)
-            let elements = node.accessibilityElements
-            if let elements, !elements.isEmpty {
+            if let elements = node.accessibilityElements {
                 for element in elements {
                     if let object = element as? NSObject {
                         visit(object)
                     }
                 }
-            } else {
-                // Some SwiftUI containers expose an empty array while their
-                // indexed accessibility API still owns the live controls.
-                let count = node.accessibilityElementCount()
-                if count > 0, count != NSNotFound {
-                    for index in 0..<count {
-                        if let object = node.accessibilityElement(at: index) as? NSObject {
-                            visit(object)
-                        }
+            }
+            // SwiftUI containers can expose an empty or incomplete array while
+            // their indexed accessibility API still owns the live controls.
+            let count = node.accessibilityElementCount()
+            if count > 0, count != NSNotFound {
+                for index in 0..<count {
+                    if let object = node.accessibilityElement(at: index) as? NSObject {
+                        visit(object)
                     }
                 }
             }
@@ -1584,14 +1590,21 @@ struct AgentDirectInputTests {
 
 private final class IndexedAccessibilityContainerView: UIView {
     private let indexedLabel: String
+    private let arrayLabel: String?
     private lazy var indexedElement: UIAccessibilityElement = {
         let element = UIAccessibilityElement(accessibilityContainer: self)
         element.accessibilityLabel = indexedLabel
         return element
     }()
+    private lazy var arrayElement: UIAccessibilityElement = {
+        let element = UIAccessibilityElement(accessibilityContainer: self)
+        element.accessibilityLabel = arrayLabel
+        return element
+    }()
 
-    init(label: String) {
-        indexedLabel = label
+    init(indexedLabel: String, arrayLabel: String? = nil) {
+        self.indexedLabel = indexedLabel
+        self.arrayLabel = arrayLabel
         super.init(frame: .zero)
     }
 
@@ -1601,7 +1614,7 @@ private final class IndexedAccessibilityContainerView: UIView {
     }
 
     override var accessibilityElements: [Any]? {
-        get { [] }
+        get { arrayLabel == nil ? [] : [arrayElement] }
         set { }
     }
 

--- a/Tests/HeelerTests/AgentInputModeSettingsTests.swift
+++ b/Tests/HeelerTests/AgentInputModeSettingsTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@MainActor
+@Suite("Agent input mode settings")
+struct AgentInputModeSettingsTests {
+    private func makeDefaults() throws -> (UserDefaults, cleanup: () -> Void) {
+        let suiteName = "hm-agent-input-mode-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        return (defaults, { defaults.removePersistentDomain(forName: suiteName) })
+    }
+
+    @Test func defaultsToComposer() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+
+        let settings = AgentInputModeSettings(defaults: defaults)
+
+        #expect(settings.mode == .composer)
+        #expect(!settings.isDirect)
+    }
+
+    @Test func selectionPersistsAcrossStoreInstances() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let settings = AgentInputModeSettings(defaults: defaults)
+
+        settings.select(.direct)
+
+        #expect(AgentInputModeSettings(defaults: defaults).mode == .direct)
+        #expect(AgentInputModeSettings(defaults: defaults).isDirect)
+    }
+
+    @Test func unknownStoredOptionFallsBackToComposer() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        defaults.set("keys-mode", forKey: "agent-input-mode")
+
+        #expect(AgentInputModeSettings(defaults: defaults).mode == .composer)
+    }
+
+    @Test func everyModeIsOfferedInAStableOrder() {
+        #expect(AgentInputMode.allCases == [.composer, .direct])
+        #expect(AgentInputMode.allCases.map(\.segmentTitle) == ["Composer", "Keyboard"])
+    }
+}

--- a/Tests/HeelerTests/AgentSurfaceReplacementTests.swift
+++ b/Tests/HeelerTests/AgentSurfaceReplacementTests.swift
@@ -692,6 +692,7 @@ struct AgentSurfaceReplacementTests {
                 agent: agent,
                 console: console,
                 terminal: terminal,
+                inputMode: AgentInputModeSettings(defaults: defaults),
                 hosts: [],
                 activity: activity,
                 keyboardHandoff: handoff,
@@ -707,7 +708,8 @@ struct AgentSurfaceReplacementTests {
         agent: ConsoleAgent,
         activity: AppActivityCoordinator,
         attachStore: AgentAttachStore,
-        composer: AgentComposerStore
+        composer: AgentComposerStore,
+        inputMode: AgentInputModeSettings? = nil
     ) -> AgentTerminalView {
         let defaults = UserDefaults(suiteName: "attach-recovery-\(UUID())") ?? .standard
         let console = ConsoleStore(snapshotRetryDelay: .seconds(30)) { _, subscriptions in
@@ -726,6 +728,7 @@ struct AgentSurfaceReplacementTests {
             agent: agent,
             console: console,
             terminal: terminal,
+            inputMode: inputMode ?? AgentInputModeSettings(defaults: defaults),
             hosts: [],
             activity: activity,
             keyboardHandoff: TerminalKeyboardHandoff(),

--- a/Tests/HeelerTests/AgentSurfaceReplacementTests.swift
+++ b/Tests/HeelerTests/AgentSurfaceReplacementTests.swift
@@ -112,7 +112,8 @@ struct AgentSurfaceReplacementTests {
 
         // Deliberately not retained: the predecessor has to be free to go away,
         // or a stale sink would still look live.
-        weak var predecessor = Self.terminals(in: controller.view).first
+        weak var predecessor: HeelerTerminalView?
+        predecessor = Self.terminals(in: controller.view).first
         #expect(predecessor != nil, "the first surface should exist")
         feed.write(Data("first".utf8))
 

--- a/Tests/HeelerTests/ContentViewActivityDriverTests.swift
+++ b/Tests/HeelerTests/ContentViewActivityDriverTests.swift
@@ -46,12 +46,11 @@ struct ContentViewActivityDriverTests {
                 hostStore: HostStore(volatileHosts: [host]),
                 console: console,
                 activity: activity))
-        // A plain UIKit hierarchy is enough: the window needs no connected
-        // scene for SwiftUI to fire appearance, and with it the `.task`
-        // modifiers under test.
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: 874))
-        window.rootViewController = controller
-        window.makeKeyAndVisible()
+        // Bind the hosted view to the test app's connected scene so SwiftUI
+        // owns a valid lifecycle for the `.task` modifiers under test.
+        let window = try await makeTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 402, height: 874),
+            rootViewController: controller)
         defer { window.isHidden = true }
 
         // The view's own first `.task` aligns the injected Console with the

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -688,6 +688,21 @@ struct TerminalAgentSwitcherTests {
         #expect(!handoff.consume(second))
     }
 
+    @MainActor
+    @Test func keyboardHandoffCancellationOnlyClearsTheMatchingAgent() {
+        let handoff = TerminalKeyboardHandoff()
+        let first = ConsoleAgent.ID(hostID: UUID(), paneID: "w1:p1")
+        let second = ConsoleAgent.ID(hostID: UUID(), paneID: "w2:p2")
+
+        handoff.arm(for: first)
+        handoff.cancel(for: second)
+        #expect(handoff.consume(first))
+
+        handoff.arm(for: second)
+        handoff.cancel(for: second)
+        #expect(!handoff.consume(second))
+    }
+
     /// The keyboard may not dip between the two terminals: it carries the
     /// switcher, so a dip flashes the row away mid-switch. The replacement
     /// takes first responder in the same pass it reaches the window.
@@ -760,10 +775,14 @@ struct TerminalAgentSwitcherTests {
         // fallback must stay out of it: the sleeps inside the handoff window
         // can stretch past its 500ms on a loaded runner (#225).
         terminal.keyboardTransitionFallbackDelay = 60
+        let localKeyboardFrame = CGRect(x: 0, y: 400, width: 390, height: 300)
+        terminal.keyboardLayoutFrameProvider = { _ in localKeyboardFrame }
         terminal.raisesKeyboardWhenReady = true
         terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 600)
         host.view.addSubview(terminal)
         window.layoutIfNeeded()
+        let ownKeyboardEndFrame = window.convert(
+            localKeyboardFrame, to: window.screen.coordinateSpace)
 
         // A foreign settle, posted to the process-wide center inside the
         // handoff window. Before the isolation above, exactly this thawed the
@@ -787,8 +806,7 @@ struct TerminalAgentSwitcherTests {
         // the terminal's own center, the only one it observes.
         center.post(
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
-            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
-                x: 0, y: 400, width: 390, height: 300)])
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
         try await waitForGridReportsToSettle { reportedGrids.count }
         let escaped = reportedGrids
         #expect(!escaped.isEmpty, "the settled grid never made it past the freeze")
@@ -891,6 +909,8 @@ struct TerminalAgentSwitcherTests {
                 reportedGrids.append(TerminalGrid(columns: columns, rows: rows))
             },
             notificationCenter: center)
+        let localKeyboardFrame = CGRect(x: 0, y: 400, width: 390, height: 300)
+        terminal.keyboardLayoutFrameProvider = { _ in localKeyboardFrame }
         let foreignHost = UIViewController()
         let foreignWindow = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 390, height: 700),
@@ -916,6 +936,8 @@ struct TerminalAgentSwitcherTests {
         host.view.addSubview(terminal)
         window.layoutIfNeeded()
         #expect(terminal.isFirstResponder)
+        let ownKeyboardEndFrame = window.convert(
+            localKeyboardFrame, to: window.screen.coordinateSpace)
 
         // The other window's keyboard notifications provide no usable scene
         // identity. Its end frame leaves nothing covering this terminal's
@@ -936,6 +958,12 @@ struct TerminalAgentSwitcherTests {
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
                 x: 0, y: 700, width: 390, height: 300)])
+        // Same top edge as this window's keyboard, but a different floating
+        // footprint. Comparing only minY would incorrectly thaw the handoff.
+        center.post(
+            name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                x: 50, y: 400, width: 290, height: 300)])
         #expect(terminal.inputViewRebuildCount == rebuildsBeforeForeignEvent)
 
         for height: CGFloat in [520, 440, 360] {
@@ -950,12 +978,12 @@ struct TerminalAgentSwitcherTests {
         // the terminal's window, and the freeze thaws.
         center.post(
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
-            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
-                x: 0, y: 400, width: 390, height: 300)])
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
         #expect(terminal.inputViewRebuildCount > rebuildsBeforeForeignEvent)
         try await waitForGridReportsToSettle { reportedGrids.count }
         #expect(
             !reportedGrids.isEmpty,
             "the terminal's own settle never made it past the freeze")
     }
+
 }

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -44,6 +44,13 @@ struct TerminalAgentSwitcherTests {
             status: status ?? agent.agent.status, isPinned: isPinned)
     }
 
+    @MainActor
+    private static func waitForMainQueueTurn() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.main.async { continuation.resume() }
+        }
+    }
+
     /// The project is what tells a console full of `claude` apart, so it
     /// leads; the agent's own name is the fallback when nothing named the
     /// workspace.
@@ -54,6 +61,7 @@ struct TerminalAgentSwitcherTests {
         #expect(Self.makeAgent(pane: "p4").switcherLabel == "claude")
     }
 
+    @MainActor
     private static func firstStrip(in view: UIView) -> TerminalAgentSwitcherBar? {
         if let strip = view as? TerminalAgentSwitcherBar { return strip }
         for subview in view.subviews {
@@ -808,6 +816,7 @@ struct TerminalAgentSwitcherTests {
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
         #expect(reportedGrids.isEmpty)
+        await Self.waitForMainQueueTurn()
 
         // The rebuilt input views republish the settled destination frame.
         center.post(
@@ -838,6 +847,187 @@ struct TerminalAgentSwitcherTests {
         #expect(
             Set(escaped) == [settled],
             "the freeze let a grid other than the settled \(settled) out: \(escaped)")
+    }
+
+    /// `becomeFirstResponder()` and `reloadInputViews()` may synchronously
+    /// publish keyboard frames. An explicit Composer-to-terminal handoff must
+    /// return to its owner before rebuilding input views, or the terminal can
+    /// report settlement before the owner has entered its settling state and
+    /// that one-shot callback is lost.
+    @MainActor
+    @Test func anExplicitHandoffCannotSettleBeforeItsOwnerAcceptsIt() async throws {
+        let center = NotificationCenter()
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            notificationCenter: center)
+        let host = UIViewController()
+        let window = try await makeTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 390, height: 700),
+            rootViewController: host)
+        defer {
+            terminal.removeFromSuperview()
+            window.isHidden = true
+        }
+
+        terminal.keyboardTransitionFallbackDelay = 60
+        let localKeyboardFrame = CGRect(x: 0, y: 400, width: 390, height: 300)
+        terminal.keyboardLayoutFrameProvider = { _ in localKeyboardFrame }
+        terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 400)
+        host.view.addSubview(terminal)
+        window.layoutIfNeeded()
+
+        let handoffID = UUID()
+        var ownerAccepted = false
+        var settledOwnerStates: [Bool] = []
+        terminal.onKeyboardHandoffEnded = { settledID, outcome in
+            guard settledID == handoffID else { return }
+            guard outcome == .settled else { return }
+            settledOwnerStates.append(ownerAccepted)
+        }
+        #expect(terminal.requestKeyboardHandoff(id: handoffID))
+        terminal.requestKeyboard()
+        #expect(
+            settledOwnerStates.isEmpty,
+            "a duplicate request must not cancel the accepted handoff")
+
+        let rebuildsBeforeOwnedFrame = terminal.inputViewRebuildCount
+        let ownKeyboardEndFrame = window.convert(
+            localKeyboardFrame, to: window.screen.coordinateSpace)
+        center.post(
+            name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
+
+        #expect(
+            terminal.inputViewRebuildCount == rebuildsBeforeOwnedFrame,
+            "the destination rebuilt input views before its owner accepted the handoff")
+        #expect(settledOwnerStates.isEmpty)
+
+        ownerAccepted = true
+        await Self.waitForMainQueueTurn()
+        #expect(terminal.inputViewRebuildCount > rebuildsBeforeOwnedFrame)
+        #expect(settledOwnerStates.isEmpty)
+
+        center.post(
+            name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
+        #expect(settledOwnerStates == [true])
+    }
+
+    /// The terminal owns the only safety leash for Composer-to-Direct. If no
+    /// destination frame ever arrives, timing out must release the hold
+    /// without treating a transient hide as proof that the keyboard left.
+    @MainActor
+    @Test func aTerminalTimeoutPreservesItsDestinationOwnedInset() async throws {
+        let center = NotificationCenter()
+        let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 402 }
+        center.post(
+            name: UIResponder.keyboardWillShowNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                x: 0, y: 554, width: 440, height: 436)])
+        try await Task.sleep(for: .milliseconds(120))
+        #expect(inset.height == 402)
+
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            notificationCenter: center)
+        let host = UIViewController()
+        let window = try await makeTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 390, height: 700),
+            rootViewController: host)
+        defer {
+            terminal.removeFromSuperview()
+            window.isHidden = true
+        }
+        terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 400)
+        terminal.keyboardTransitionFallbackDelay = 0.05
+        host.view.addSubview(terminal)
+        window.layoutIfNeeded()
+
+        let handoffID = inset.beginDestinationOwnedResponderHandoff()
+        var endedOutcome: TerminalKeyboardHandoffOutcome?
+        terminal.onKeyboardHandoffEnded = { endedID, outcome in
+            guard endedID == handoffID else { return }
+            endedOutcome = outcome
+            switch outcome {
+            case .settled, .timedOut:
+                inset.endResponderHandoff(endedID)
+            case .cancelled:
+                inset.cancelResponderHandoff(endedID, currentHeight: { 0 })
+            }
+        }
+        #expect(terminal.requestKeyboardHandoff(id: handoffID))
+        center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
+        try await Task.sleep(for: .milliseconds(80))
+
+        #expect(endedOutcome == .timedOut)
+        #expect(!inset.isHoldingHandoffHeight)
+        #expect(inset.height == 402)
+    }
+
+    /// SwiftUI can temporarily detach a live terminal while presenting new
+    /// chrome. That must not cancel a handoff which the same terminal resumes
+    /// after reattachment.
+    @MainActor
+    @Test func aTemporaryDetachKeepsItsDestinationOwnedHandoff() async throws {
+        let center = NotificationCenter()
+        let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 402 }
+        center.post(
+            name: UIResponder.keyboardWillShowNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                x: 0, y: 554, width: 440, height: 436)])
+        try await Task.sleep(for: .milliseconds(120))
+        #expect(inset.height == 402)
+
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            notificationCenter: center)
+        let host = UIViewController()
+        let window = try await makeTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 390, height: 700),
+            rootViewController: host)
+        defer {
+            terminal.removeFromSuperview()
+            window.isHidden = true
+        }
+        terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 400)
+        terminal.keyboardTransitionFallbackDelay = 60
+        let localKeyboardFrame = CGRect(x: 0, y: 400, width: 390, height: 300)
+        terminal.keyboardLayoutFrameProvider = { _ in localKeyboardFrame }
+        host.view.addSubview(terminal)
+        window.layoutIfNeeded()
+
+        let handoffID = inset.beginDestinationOwnedResponderHandoff()
+        var endedOutcome: TerminalKeyboardHandoffOutcome?
+        terminal.onKeyboardHandoffEnded = { endedID, outcome in
+            guard endedID == handoffID else { return }
+            endedOutcome = outcome
+            switch outcome {
+            case .settled, .timedOut:
+                inset.endResponderHandoff(endedID)
+            case .cancelled:
+                inset.cancelResponderHandoff(endedID, currentHeight: { nil })
+            }
+        }
+        #expect(terminal.requestKeyboardHandoff(id: handoffID))
+        center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
+        terminal.removeFromSuperview()
+        await Task.yield()
+
+        #expect(endedOutcome == nil)
+        #expect(inset.isHoldingHandoffHeight)
+
+        host.view.addSubview(terminal)
+        terminal.requestKeyboard()
+        let ownKeyboardEndFrame = window.convert(
+            localKeyboardFrame, to: window.screen.coordinateSpace)
+        center.post(
+            name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
+        await Self.waitForMainQueueTurn()
+        center.post(
+            name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
+
+        #expect(endedOutcome == .settled)
+        #expect(!inset.isHoldingHandoffHeight)
+        #expect(inset.height == 402)
     }
 
     /// Both terminals' accessories ride the keyboard while it changes hands,
@@ -985,6 +1175,7 @@ struct TerminalAgentSwitcherTests {
         center.post(
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
+        await Self.waitForMainQueueTurn()
         #expect(terminal.inputViewRebuildCount > rebuildsBeforeForeignEvent)
         #expect(reportedGrids.isEmpty)
         center.post(

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -801,9 +801,15 @@ struct TerminalAgentSwitcherTests {
         }
         #expect(reportedGrids.isEmpty)
 
-        // The keyboard settled. A keyboard that never left reports no
-        // did-show, so its end frame is what thaws the grid — delivered on
-        // the terminal's own center, the only one it observes.
+        // The first owned frame still includes both responders' accessories.
+        // It rebuilds the input views but must leave the grid frozen until
+        // UIKit republishes the destination-only frame.
+        center.post(
+            name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
+        #expect(reportedGrids.isEmpty)
+
+        // The rebuilt input views republish the settled destination frame.
         center.post(
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
@@ -974,12 +980,16 @@ struct TerminalAgentSwitcherTests {
         #expect(terminal.inputViewRebuildCount == rebuildsBeforeForeignEvent)
         #expect(reportedGrids.isEmpty)
 
-        // This terminal's own settle: the keyboard ends its move covering
-        // the terminal's window, and the freeze thaws.
+        // The first owned frame rebuilds the destination input views while
+        // retaining the freeze; their republished frame then thaws it.
         center.post(
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
         #expect(terminal.inputViewRebuildCount > rebuildsBeforeForeignEvent)
+        #expect(reportedGrids.isEmpty)
+        center.post(
+            name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
         try await waitForGridReportsToSettle { reportedGrids.count }
         #expect(
             !reportedGrids.isEmpty,

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -1021,7 +1021,11 @@ struct TerminalAttachTests {
         #expect(terminal.bounds.contains(region))
         // Reaches the visible prompt above the parked caret (#90), or the
         // single entry point is unhittable in practice.
-        #expect(region.height >= TerminalKeyboardTapTarget.alternateScreenMinimumHeight)
+        // CGRect intersection can round an exact-height band down by one ULP
+        // when Ghostty reports fractional caret metrics.
+        #expect(
+            region.height
+                >= TerminalKeyboardTapTarget.alternateScreenMinimumHeight.nextDown)
         // Full width: the row is the target, not the glyph the cursor sits on.
         #expect(region.width == terminal.bounds.width)
     }

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -1693,18 +1693,20 @@ struct TerminalAttachTests {
     @Test func agentQuickKeysEncodeExpectedBytes() {
         #expect(
             AgentQuickKey.allCases == [
-                .escape, .tab, .shiftTab, .left, .up, .down, .right, .enter,
-                .backspace,
+                .escape, .tab, .shiftTab, .shiftEnter, .left, .up, .down, .right,
+                .enter, .backspace,
             ])
         #expect(AgentQuickKey.escape.bytes(applicationCursor: false) == [0x1B])
         #expect(AgentQuickKey.tab.bytes(applicationCursor: false) == [0x09])
         #expect(AgentQuickKey.shiftTab.bytes(applicationCursor: false) == [0x1B, 0x5B, 0x5A])
+        #expect(AgentQuickKey.shiftEnter.bytes(applicationCursor: false) == [0x0A])
         #expect(AgentQuickKey.left.bytes(applicationCursor: false) == [0x1B, 0x5B, 0x44])
         #expect(AgentQuickKey.up.bytes(applicationCursor: true) == [0x1B, 0x4F, 0x41])
         #expect(AgentQuickKey.down.bytes(applicationCursor: false) == [0x1B, 0x5B, 0x42])
         #expect(AgentQuickKey.right.bytes(applicationCursor: false) == [0x1B, 0x5B, 0x43])
         #expect(AgentQuickKey.enter.bytes(applicationCursor: false) == [0x0D])
         #expect(AgentQuickKey.backspace.bytes(applicationCursor: false) == [0x7F])
+        #expect(AgentQuickKey.shiftEnter.title == "⇧Enter")
         #expect(AgentQuickKey.enter.title == "Enter")
         #expect(AgentQuickKey.backspace.title == "Backspace")
         #expect(AgentQuickKey.enter.systemImageName == nil)

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -1353,6 +1353,121 @@ struct TerminalAttachTests {
         #expect(inset.height == 402)
     }
 
+    /// Moving a visible system keyboard between Composer and Direct Input can
+    /// emit a transient hide followed by a smaller frame. Neither may move the
+    /// app-owned chrome before the destination responder settles.
+    @MainActor
+    @Test func responderHandoffKeepsTheKeyboardInsetAtItsSettledHeight() async throws {
+        let center = NotificationCenter()
+        let inset = TerminalKeyboardInset(notificationCenter: center) { frame in
+            frame.height == 436 ? 402 : 365
+        }
+        let completeFrame = CGRect(x: 0, y: 554, width: 440, height: 436)
+        let transientFrame = CGRect(x: 0, y: 591, width: 440, height: 399)
+
+        center.post(
+            name: UIResponder.keyboardWillShowNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: completeFrame])
+        try await Task.sleep(for: .milliseconds(120))
+        #expect(inset.height == 402)
+
+        let handoffID = inset.beginResponderHandoff()
+        center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
+        center.post(
+            name: UIResponder.keyboardWillChangeFrameNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: transientFrame])
+
+        #expect(inset.height == 402)
+        #expect(inset.lastPresentedHeight == 402)
+
+        inset.endResponderHandoff(UUID())
+        #expect(inset.isHoldingHandoffHeight)
+        #expect(inset.height == 402)
+
+        inset.endResponderHandoff(handoffID)
+        #expect(!inset.isHoldingHandoffHeight)
+        #expect(inset.height == 402)
+        #expect(inset.lastPresentedHeight == 402)
+    }
+
+    /// A scene transition can emit will-hide without a matching did-frame.
+    /// The safety leash must release the hold, notify its owner, and reconcile
+    /// a hide that never received a destination frame.
+    @MainActor
+    @Test func responderHandoffFallbackReleasesAnUnsettledFreeze() async throws {
+        let center = NotificationCenter()
+        let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 402 }
+        inset.responderHandoffFallbackDelay = .milliseconds(50)
+
+        center.post(
+            name: UIResponder.keyboardWillShowNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                x: 0, y: 554, width: 440, height: 436)])
+        try await Task.sleep(for: .milliseconds(120))
+        #expect(inset.height == 402)
+
+        var ownerHandoffID: UUID?
+        var expiredHandoffID: UUID?
+        let handoffID = inset.beginResponderHandoff(onFallback: { expiredID in
+            expiredHandoffID = expiredID
+            if ownerHandoffID == expiredID {
+                ownerHandoffID = nil
+            }
+        })
+        ownerHandoffID = handoffID
+        center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
+        try await Task.sleep(for: .milliseconds(80))
+
+        #expect(!inset.isHoldingHandoffHeight)
+        #expect(expiredHandoffID == handoffID)
+        #expect(ownerHandoffID == nil)
+        #expect(inset.height == 0)
+        #expect(inset.lastPresentedHeight == 402)
+    }
+
+    /// Keyboard notifications are process-wide on iPad. A hide from another
+    /// scene must not clear this scene's still-visible keyboard footprint.
+    @MainActor
+    @Test func responderHandoffFallbackUsesTheOwningWindowHeight() async throws {
+        let center = NotificationCenter()
+        let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 402 }
+        inset.responderHandoffFallbackDelay = .milliseconds(50)
+
+        center.post(
+            name: UIResponder.keyboardWillShowNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                x: 0, y: 554, width: 440, height: 436)])
+        try await Task.sleep(for: .milliseconds(120))
+        #expect(inset.height == 402)
+
+        _ = inset.beginResponderHandoff(currentHeight: { 402 })
+        center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
+        try await Task.sleep(for: .milliseconds(80))
+
+        #expect(!inset.isHoldingHandoffHeight)
+        #expect(inset.height == 402)
+        #expect(inset.lastPresentedHeight == 402)
+    }
+
+    @MainActor
+    @Test func responderHandoffCancellationUsesTheOwningWindowHeight() async throws {
+        let center = NotificationCenter()
+        let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 402 }
+        center.post(
+            name: UIResponder.keyboardWillShowNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                x: 0, y: 554, width: 440, height: 436)])
+        try await Task.sleep(for: .milliseconds(120))
+
+        let handoffID = inset.beginResponderHandoff()
+        center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
+        inset.cancelResponderHandoff(handoffID, currentHeight: { 402 })
+
+        #expect(!inset.isHoldingHandoffHeight)
+        #expect(inset.height == 402)
+        #expect(inset.lastPresentedHeight == 402)
+    }
+
     @Test func agentKeyboardReplacementKeepsTheTerminalInsetStable() {
         let system = AgentComposerKeyboardLayout(
             currentHeight: 402, lastPresentedHeight: 402,

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -1449,6 +1449,63 @@ struct TerminalAttachTests {
         #expect(inset.lastPresentedHeight == 402)
     }
 
+    /// Composer-to-Direct already has the destination terminal's bounded
+    /// fallback. A second inset-owned timer starts earlier and can commit a
+    /// transient hide before the terminal gets its final frame.
+    @MainActor
+    @Test func destinationOwnedFallbackKeepsTheInsetFrozen() async throws {
+        let center = NotificationCenter()
+        let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 402 }
+        inset.responderHandoffFallbackDelay = .milliseconds(50)
+        inset.destinationResponderHandoffFallbackDelay = .milliseconds(200)
+
+        center.post(
+            name: UIResponder.keyboardWillShowNotification, object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                x: 0, y: 554, width: 440, height: 436)])
+        try await Task.sleep(for: .milliseconds(120))
+        #expect(inset.height == 402)
+
+        let handoffID = inset.beginDestinationOwnedResponderHandoff()
+        center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
+        try await Task.sleep(for: .milliseconds(80))
+
+        #expect(inset.isHoldingHandoffHeight)
+        #expect(inset.height == 402)
+        inset.endResponderHandoff(handoffID)
+        #expect(!inset.isHoldingHandoffHeight)
+        #expect(inset.height == 402)
+    }
+
+    /// A destination can disappear before its weakly captured terminal timer
+    /// fires. The inset owner has a later watchdog so that loss cannot leave
+    /// the shared handoff token frozen forever.
+    @MainActor
+    @Test func destinationLossFallsBackThroughTheInsetOwner() async throws {
+        let center = NotificationCenter()
+        let inset = TerminalKeyboardInset(notificationCenter: center) { _ in 402 }
+        inset.destinationResponderHandoffFallbackDelay = .milliseconds(50)
+
+        center.post(
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil,
+            userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect(
+                x: 0, y: 554, width: 440, height: 436)])
+        try await Task.sleep(for: .milliseconds(120))
+        #expect(inset.height == 402)
+
+        var expiredID: UUID?
+        let handoffID = inset.beginDestinationOwnedResponderHandoff(
+            currentHeight: { nil }
+        ) { expiredID = $0 }
+        center.post(name: UIResponder.keyboardWillHideNotification, object: nil)
+        try await Task.sleep(for: .milliseconds(80))
+
+        #expect(expiredID == handoffID)
+        #expect(!inset.isHoldingHandoffHeight)
+        #expect(inset.height == 402)
+    }
+
     @MainActor
     @Test func responderHandoffCancellationUsesTheOwningWindowHeight() async throws {
         let center = NotificationCenter()

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GhosttyTerminal
 import SwiftUI
 import Synchronization
 import Testing
@@ -19,6 +20,93 @@ struct TerminalAttachTests {
 
     private enum FakeAttachChannelError: Error {
         case rejectedWrite
+    }
+
+    private struct ReportedGrid: Equatable {
+        let columns: Int
+        let rows: Int
+    }
+
+    /// A pre-handoff resize can still be inside Ghostty's IO pipeline when the
+    /// keyboard freeze begins, then arrive as if it belonged to the handoff.
+    /// The settled surface grid must replace that stale deferred value.
+    @MainActor
+    @Test func aSettledSurfaceGridOverridesAStaleDeferredResize() async throws {
+        var reportedGrids: [ReportedGrid] = []
+        let bridge = TerminalSessionCallbackBridge(
+            onSizeChanged: { columns, rows in
+                reportedGrids.append(ReportedGrid(columns: columns, rows: rows))
+            },
+            onViewportTextChanged: nil,
+            onSend: nil,
+            onScroll: nil,
+            onPaste: nil)
+        let stale = InMemoryTerminalViewport(columns: 33, rows: 20)
+
+        bridge.beginSizeReportDeferral()
+        await withCheckedContinuation { continuation in
+            bridge.onViewport = { _ in continuation.resume() }
+            bridge.resize(stale)
+        }
+        bridge.onViewport = nil
+        bridge.provideAuthoritativeDeferredSize(columns: 33, rows: 14)
+        bridge.finishSizeReportDeferral()
+        try await waitForGridReportsToSettle { reportedGrids.count }
+        #expect(reportedGrids == [ReportedGrid(columns: 33, rows: 14)])
+    }
+
+    /// Ghostty can publish the engine resize after the surface delegate has
+    /// already supplied the settled fallback. A stale grid is rejected
+    /// against the live surface, and its matching final callback is consumed
+    /// as the fallback's duplicate rather than resizing the Host twice.
+    @MainActor
+    @Test func aSettledFallbackRejectsLateStaleAndDuplicateResizes() async throws {
+        var reportedGrids: [ReportedGrid] = []
+        let bridge = TerminalSessionCallbackBridge(
+            onSizeChanged: { columns, rows in
+                reportedGrids.append(ReportedGrid(columns: columns, rows: rows))
+            },
+            onViewportTextChanged: nil,
+            onSend: nil,
+            onScroll: nil,
+            onPaste: nil)
+        bridge.isSizeReportCurrent = { columns, rows in
+            columns == 33 && rows == 14
+        }
+
+        bridge.beginSizeReportDeferral()
+        bridge.provideAuthoritativeDeferredSize(columns: 33, rows: 14)
+        bridge.finishSizeReportDeferral()
+        try await waitForGridReportsToSettle { reportedGrids.count }
+
+        await withCheckedContinuation { continuation in
+            bridge.onViewport = { _ in continuation.resume() }
+            bridge.resize(InMemoryTerminalViewport(columns: 33, rows: 20))
+            bridge.resize(InMemoryTerminalViewport(columns: 33, rows: 14))
+        }
+        #expect(reportedGrids == [ReportedGrid(columns: 33, rows: 14)])
+    }
+
+    /// Thawing cannot overtake a post-freeze resize whose main-actor delivery
+    /// is still queued, or the deferred final grid is silently lost.
+    @MainActor
+    @Test func aHandoffThawWaitsForItsQueuedResize() async throws {
+        var reportedGrids: [ReportedGrid] = []
+        let bridge = TerminalSessionCallbackBridge(
+            onSizeChanged: { columns, rows in
+                reportedGrids.append(ReportedGrid(columns: columns, rows: rows))
+            },
+            onViewportTextChanged: nil,
+            onSend: nil,
+            onScroll: nil,
+            onPaste: nil)
+        let settled = InMemoryTerminalViewport(columns: 33, rows: 14)
+
+        bridge.beginSizeReportDeferral()
+        bridge.resize(settled)
+        bridge.finishSizeReportDeferral()
+        try await waitForGridReportsToSettle { reportedGrids.count }
+        #expect(reportedGrids == [ReportedGrid(columns: 33, rows: 14)])
     }
 
     @Test func attachOutputPumpWithholdsStartupChatterUntilTheHandshake() async throws {

--- a/Tests/HeelerTests/TerminalZoomSettingsTests.swift
+++ b/Tests/HeelerTests/TerminalZoomSettingsTests.swift
@@ -13,11 +13,11 @@ struct TerminalZoomSettingsTests {
         return (defaults, { defaults.removePersistentDomain(forName: suiteName) })
     }
 
-    @Test func defaultsToFourteenPoints() throws {
+    @Test func defaultsToNinePoints() throws {
         let (defaults, cleanup) = try makeDefaults()
         defer { cleanup() }
 
-        #expect(TerminalZoomSettings(defaults: defaults).fontSize == 14)
+        #expect(TerminalZoomSettings(defaults: defaults).fontSize == 9)
     }
 
     @Test func fontSizePersistsAcrossStoreInstances() throws {
@@ -39,7 +39,7 @@ struct TerminalZoomSettingsTests {
         settings.adjust(by: 1)
         settings.adjust(by: -1)
 
-        #expect(settings.fontSize == 15)
+        #expect(settings.fontSize == 10)
     }
 
     @Test func fractionalZoomLandsOnWholePoints() throws {

--- a/docs/adr/0016-direct-input-on-agent-attach.md
+++ b/docs/adr/0016-direct-input-on-agent-attach.md
@@ -9,10 +9,11 @@ default off. Composer remains the default authored-input path from ADR 0013.
 When Direct Input is on, Agent detail hides the Composer card, preserves the
 `AgentComposerStore` draft unchanged, enables Ghostty local input, and routes
 the system keyboard into the live Agent Attach PTY. A compact app-owned
-shortcut row (Esc, Tab, Shift-Tab, Enter) sits above the Agent switcher strip
-as ordinary content — never as `inputAccessoryView`. Show Composer restores the
-card immediately. Mode changes disable animation, never Send, insert, or clear
-the draft, and do not force Composer when Agent Status is Blocked.
+shortcut row (Esc, Tab, Shift-Tab, Enter) remains above the Agent switcher strip
+as ordinary content in every keyboard state — never as `inputAccessoryView`.
+Show Composer restores the card immediately. Mode changes disable animation,
+never Send, insert, or clear the draft, and do not force Composer when Agent
+Status is Blocked.
 
 ## Rationale
 

--- a/docs/adr/0016-direct-input-on-agent-attach.md
+++ b/docs/adr/0016-direct-input-on-agent-attach.md
@@ -9,8 +9,8 @@ default off. Composer remains the default authored-input path from ADR 0013.
 When Direct Input is on, Agent detail hides the Composer card, preserves the
 `AgentComposerStore` draft unchanged, enables Ghostty local input, and routes
 the system keyboard into the live Agent Attach PTY. A compact app-owned
-shortcut row (Esc, Tab, Shift-Tab, Enter) sits above the system keyboard as
-ordinary content — never as `inputAccessoryView`. Show Composer restores the
+shortcut row (Esc, Tab, Shift-Tab, Enter) sits above the Agent switcher strip
+as ordinary content — never as `inputAccessoryView`. Show Composer restores the
 card immediately. Mode changes disable animation, never Send, insert, or clear
 the draft, and do not force Composer when Agent Status is Blocked.
 

--- a/docs/adr/0016-direct-input-on-agent-attach.md
+++ b/docs/adr/0016-direct-input-on-agent-attach.md
@@ -1,0 +1,51 @@
+---
+status: accepted
+---
+
+# Direct Input: opt-in system keyboard on Agent Attach
+
+Agent detail gains an explicit, app-wide **Direct Input** preference (#251),
+default off. Composer remains the default authored-input path from ADR 0013.
+When Direct Input is on, Agent detail hides the Composer card, preserves the
+`AgentComposerStore` draft unchanged, enables Ghostty local input, and routes
+the system keyboard into the live Agent Attach PTY. A compact app-owned
+shortcut row (Esc, Tab, Shift-Tab, Enter) sits above the system keyboard as
+ordinary content — never as `inputAccessoryView`. Show Composer restores the
+card immediately. Mode changes disable animation, never Send, insert, or clear
+the draft, and do not force Composer when Agent Status is Blocked.
+
+## Rationale
+
+ADR 0013 keeps Attach display-only because the Agent TUI draws its own input
+box and because drafting locally avoids remote-echo latency for prompt-sized
+text. On a compact phone that Composer card plus the tools keyboard still
+occludes most of the TUI, and the tools pad only offers Esc/Tab/Enter by
+*replacing* the Apple keyboard. Issue 251 asks for the opposite arrangement:
+Apple keyboard as terminal input, with those shortcuts available at the same
+time.
+
+ADR 0015 already scoped direct keyboard input to ordinary shells (Shell
+Terminal). Reusing Shell Terminal for an Agent would attach a different herdr
+tab, drop Agent switcher and notification semantics, and leave the Agent TUI.
+Direct Input is therefore a second, Agent-detail-scoped exception: same Attach
+PTY, same Agent chrome, optional presentation mode.
+
+Composer stays default because Direct Input reintroduces the dual-prompt
+collision ADR 0012/0013 rejected and uses PTY CR for Return rather than
+`agent.prompt`. Making it opt-in keeps that surprise behind an explicit Hide
+Composer / Keyboard control.
+
+## Consequences
+
+- ADR 0013 remains the accepted default architecture. This ADR records the
+  intentional exception; it does not rewrite 0013's Composer-default story.
+- Mode preference is app-wide `UserDefaults`, never auto-enabled by size class.
+- Skills, Snippets, and Add remain Composer-owned: reaching them from Direct
+  Input restores Composer before inserting into the draft.
+- Paste review rides the existing Attach path once local input is enabled.
+- Keyboard handoff across Agent switch and terminal pipeline replacement
+  claims Ghostty in Direct Input the way Composer claims the draft field.
+- Blocked status does not force Composer; Esc/Enter operate the Agent TUI.
+- Glossary gains **Direct Input**. Attach is display-only in Composer mode;
+  Direct Input is the named exception. Avoid Keys mode, terminal mode, and
+  unqualified Attach for this surface.

--- a/docs/adr/0016-direct-input-on-agent-attach.md
+++ b/docs/adr/0016-direct-input-on-agent-attach.md
@@ -13,7 +13,9 @@ shortcut row (Esc, Tab, Shift-Tab, Enter) remains above the Agent switcher strip
 as ordinary content in every keyboard state — never as `inputAccessoryView`.
 Show Composer restores the card immediately. Mode changes disable animation,
 never Send, insert, or clear the draft, and do not force Composer when Agent
-Status is Blocked.
+Status is Blocked. Hiding a focused Composer transfers first responder to the
+terminal before removing the Composer, so the visible system keyboard does not
+dismiss and present again.
 
 ## Rationale
 


### PR DESCRIPTION
## Summary

- add an app-wide, opt-in Direct Input mode for Agent detail while keeping Composer as the default
- route the iOS keyboard into the live Attach PTY and keep a compact shortcut row visible above the Agent switcher
- provide Esc, Tab, Shift-Tab, arrow keys, Backspace, Shift-Enter, Enter, and Agent actions without replacing the system keyboard
- preserve Composer drafts and keep the keyboard resident across Composer/Direct Input handoffs and terminal replacement
- polish the fixed Enter/More controls and align the Agent switcher action icons

## Design

- Direct Input is an explicit exception to the Composer-owned input model and is documented in ADR 0016
- switching modes never sends, inserts, or clears the Composer draft
- the shortcut row is app content rather than an input accessory, so it remains available when the keyboard is hidden
- keyboard ownership is transferred before replacing the visible surface to avoid dismiss/re-present jumps

## Validation

- make test: 1286 tests in 127 app suites passed
- HeelerSSH package runner: 12 tests passed, 31 fixture-gated tests skipped
- targeted Agent Direct Input and Agent switcher suites: 45 tests passed
- iPhone 17 Simulator acceptance via Computer Use, including keyboard-visible and keyboard-hidden Direct Input states
- physical-device build, install, and launch via make install

Closes #251
