### PR TITLE
fix(transport): expose agent CLIs to SSH discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Fixed
+
+- New Agent now detects supported Agent CLIs from the Host's standard
+  user-local, Bun, Cargo, Homebrew, and Linuxbrew install paths over SSH.
+  (#254)
+
 ## [0.1.4] - 2026-09-01
 
 ### Changed

--- a/Sources/Heeler/Transport/HerdrHostPath.swift
+++ b/Sources/Heeler/Transport/HerdrHostPath.swift
@@ -10,23 +10,23 @@ import Foundation
 /// while the PTY Attach dies (#206).
 ///
 /// Extra prefixes are appended after the session `PATH` so an existing
-/// `herdr` keeps priority. There is no separate discovery probe: those
-/// prefixes already cover the same directories, and a probe would add a
-/// round trip inside attach/wake/session-list deadlines.
+/// `herdr` keeps priority. There is no separate probe to discover the
+/// `herdr` path; the agent-availability probe reuses this export in its
+/// shell body instead of adding another SSH round trip.
 ///
 /// Two ways the prefixes get onto a command, pick by how `herdr` is spelled:
 /// - ``wrappingBareHerdr(_:)`` at the exec site when the command *word* is
 ///   still an unpathed `herdr` (session list, plugin list, and those
 ///   overrides).
-/// - Bake ``pathExport`` into an existing `/bin/sh -c` body when `herdr`
-///   lives inside that body (the default plugin config-dir probe uses
-///   command substitution). Wrapping looks only at the command word, so it
-///   cannot see that inner `herdr`.
+/// - Bake ``pathExport`` into an existing `/bin/sh -c` body when a bare
+///   `herdr` or an agent probe lives inside that body. The default plugin
+///   config-dir and agent-discovery commands use this form. Wrapping looks
+///   only at the command word, so it cannot see an inner `herdr`.
 enum HerdrHostPath: Sendable {
-    /// Directories appended to `PATH` on herdr CLI execs. `$HOME` is
-    /// expanded by the remote `/bin/sh`, not by Swift.
+    /// Directories appended to `PATH` on herdr CLI and Agent discovery
+    /// execs. `$HOME` is expanded by the remote `/bin/sh`, not by Swift.
     static let extraPATH =
-        "$HOME/.local/bin:$HOME/.linuxbrew/bin:$HOME/.cargo/bin:"
+        "$HOME/.local/bin:$HOME/.linuxbrew/bin:$HOME/.cargo/bin:$HOME/.bun/bin:"
         + "/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin"
 
     static var pathAssignment: String {

--- a/Sources/Heeler/Transport/SSHTransportSettings.swift
+++ b/Sources/Heeler/Transport/SSHTransportSettings.swift
@@ -43,7 +43,8 @@ struct SSHTransportSettings: Sendable {
             "command -v \(kind.executable) >/dev/null 2>&1"
                 + " && printf \"\(agentAvailabilityMarker)%s\\n\" \"\(kind.rawValue)\""
         }
-        return "/bin/sh -c '\(checks.joined(separator: "; ")); exit 0'"
+        return "/bin/sh -c '\(HerdrHostPath.pathExport); "
+            + "\(checks.joined(separator: "; ")); exit 0'"
     }
 
     /// Kinds reported by a Host `command -v` probe. Only marker-prefixed lines

--- a/Tests/HeelerTests/HerdrHostPathTests.swift
+++ b/Tests/HeelerTests/HerdrHostPathTests.swift
@@ -11,9 +11,15 @@ struct HerdrHostPathTests {
         #expect(HerdrHostPath.extraPATH.contains("/home/linuxbrew/.linuxbrew/bin"))
         #expect(HerdrHostPath.extraPATH.contains("$HOME/.linuxbrew/bin"))
         #expect(HerdrHostPath.extraPATH.contains("$HOME/.cargo/bin"))
+        #expect(HerdrHostPath.extraPATH.contains("$HOME/.bun/bin"))
         #expect(HerdrHostPath.extraPATH.contains("/usr/local/bin"))
         // Existing PATH entries keep priority over the extra prefixes.
         #expect(HerdrHostPath.pathExport.hasPrefix("export PATH=\"$PATH:"))
+    }
+
+    @Test func agentDiscoveryExportsExtraPATHBeforeProbing() {
+        let command = SSHTransportSettings.defaultAgentDiscoveryCommand
+        #expect(command.hasPrefix("/bin/sh -c '\(HerdrHostPath.pathExport); "))
     }
 
     @Test func bareHerdrIsOnlyTheCommandWord() {


### PR DESCRIPTION
## Why

Heeler's New Agent form can show `No Agents Found` when supported CLIs exist on the Host outside the SSH server's non-interactive `PATH`.

`SSHTransportSettings.defaultAgentDiscoveryCommand` runs a `/bin/sh -c` probe. `HerdrHostPath.wrappingBareHerdr` does not wrap it because the command word is `/bin/sh`, so `command -v` cannot see user-local, Bun, or Homebrew installs.

Fixes #254.

## Scope

- Add `HerdrHostPath.pathExport` to the default agent discovery command before its `command -v` checks.
- Add `$HOME/.bun/bin` to `HerdrHostPath.extraPATH` so the supported `omp` executable is visible for standard Bun installs.
- Add a regression test that requires the discovery command to export the shared PATH before probing.
- Record the user-visible fix in `CHANGELOG.md`.

The Heeler plugin and relay are unchanged. They do not participate in agent discovery.

## Tradeoffs

The probe keeps the Host's existing `PATH` entries first and appends the known install prefixes. Custom `agentDiscoveryCommand` overrides keep their existing behavior.

## Blast Radius

The change affects only the default SSH probe that feeds the New Agent picker. It does not change the herdr API, wire types, agent kind catalog, plugin protocol, or launch requests.

Hosts with CLIs in the existing SSH `PATH` behave the same. Hosts with CLIs in the shared prefixes now report those kinds to the app.

## Verification

- An SSH probe without the extra prefixes found no `claude`, `codex`, `omp`, `agent`, or `gemini` commands on the affected Host.
- The same probe with the fixed PATH export emitted markers for all five commands.
- `swiftc -parse Sources/Heeler/Transport/SSHTransportSettings.swift Sources/Heeler/Transport/HerdrHostPath.swift Tests/HeelerTests/HerdrHostPathTests.swift` passed.
- `npm test` in `plugin` passed with 221 tests.
- `npm test` in `relay` passed with 88 tests.
- `scripts/generate-wire-types.py --check --schema scripts/herdr-schema.json` passed.
- `scripts/test-vps-ssh-access-scripts.sh` passed.
- `scripts/test-run-with-timeout.sh` passed.
- `make verify-ssh-artifacts` passed.
- The focused iOS test and `make test` were attempted but could not run because this Mac has CommandLineTools without Xcode or `xcodegen`. CI remains required for the iOS test target.
