### PR TITLE
Default terminal font size to 8 pt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Entries reference the issue that motivated them.
 ### Changed
 
 - Fresh installations use an 8 pt terminal font by default, fitting more of an
-  Agent's TUI on a mobile display while preserving existing saved sizes. (#256)
+  Agent's TUI on a mobile display while preserving existing saved sizes.
+  (#256; PR #257)
 
 ## [0.1.3] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Changed
+
+- Fresh installations use an 8 pt terminal font by default, fitting more of an
+  Agent's TUI on a mobile display while preserving existing saved sizes. (#256)
+
 ## [0.1.3] - 2026-08-28
 
 ### Changed

--- a/Sources/Heeler/Settings/TerminalZoomSettings.swift
+++ b/Sources/Heeler/Settings/TerminalZoomSettings.swift
@@ -7,7 +7,7 @@ import Observation
 @MainActor
 @Observable
 final class TerminalZoomSettings {
-    static let defaultFontSize: Float = 14
+    static let defaultFontSize: Float = 8
     /// Whole points only. The low end goes all the way down to libghostty's
     /// own minimum: 4 pt is unreadable, but it fits a wide TUI on screen, and
     /// zooming out for the shape of a layout is a real thing people do.

--- a/Sources/Heeler/Terminal/TerminalTouchScroll.swift
+++ b/Sources/Heeler/Terminal/TerminalTouchScroll.swift
@@ -42,13 +42,16 @@ enum TerminalKeyboardTapTarget {
         minimumHeight: CGFloat = TerminalKeyboardTapTarget.minimumHeight
     ) -> CGRect {
         guard caretRect.height > 0, !bounds.isEmpty else { return .null }
-        let height = max(caretRect.height, minimumHeight)
-        let region = CGRect(
+        let height = min(max(caretRect.height, minimumHeight), bounds.height)
+        let centeredY = caretRect.midY - height / 2
+        let originY = min(
+            max(centeredY, bounds.minY),
+            bounds.maxY - height)
+        return CGRect(
             x: bounds.minX,
-            y: caretRect.midY - height / 2,
+            y: originY,
             width: bounds.width,
             height: height)
-        return region.intersection(bounds)
     }
 }
 

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -845,6 +845,16 @@ struct TerminalAttachTests {
         #expect(region == CGRect(x: 0, y: 344, width: 390, height: 132))
     }
 
+    @Test func keyboardTapTargetKeepsItsMinimumHeightAtTheViewportEdge() {
+        let bounds = CGRect(x: 0, y: 0, width: 390, height: 720)
+        let region = TerminalKeyboardTapTarget.region(
+            caretRect: CGRect(x: 72, y: 700, width: 9, height: 20),
+            in: bounds,
+            minimumHeight: TerminalKeyboardTapTarget.alternateScreenMinimumHeight)
+
+        #expect(region == CGRect(x: 0, y: 588, width: 390, height: 132))
+    }
+
     /// Every chat-style agent TUI pins its input box to the bottom rows, but
     /// each parks the caret somewhere of its own, so the bottom quarter is
     /// the tool-agnostic floor the caret band cannot be.

--- a/Tests/HeelerTests/TerminalZoomSettingsTests.swift
+++ b/Tests/HeelerTests/TerminalZoomSettingsTests.swift
@@ -39,7 +39,7 @@ struct TerminalZoomSettingsTests {
         settings.adjust(by: 1)
         settings.adjust(by: -1)
 
-        #expect(settings.fontSize == 15)
+        #expect(settings.fontSize == 9)
     }
 
     @Test func fractionalZoomLandsOnWholePoints() throws {

--- a/Tests/HeelerTests/TerminalZoomSettingsTests.swift
+++ b/Tests/HeelerTests/TerminalZoomSettingsTests.swift
@@ -13,11 +13,11 @@ struct TerminalZoomSettingsTests {
         return (defaults, { defaults.removePersistentDomain(forName: suiteName) })
     }
 
-    @Test func defaultsToFourteenPoints() throws {
+    @Test func defaultsToEightPoints() throws {
         let (defaults, cleanup) = try makeDefaults()
         defer { cleanup() }
 
-        #expect(TerminalZoomSettings(defaults: defaults).fontSize == 14)
+        #expect(TerminalZoomSettings(defaults: defaults).fontSize == 8)
     }
 
     @Test func fontSizePersistsAcrossStoreInstances() throws {


### PR DESCRIPTION
## Summary

- start terminals at 8 pt when no font-size preference has been saved
- preserve every existing persisted font-size choice
- keep the keyboard activation band at its documented minimum when the smaller grid places the caret near a viewport edge
- update regression coverage and Unreleased notes

Closes #256

## Testing

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make test`
- `git diff --check`
