### PR TITLE
Align Agent cards with herdr identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Entries reference the issue that motivated them.
 
 ### Changed
 
+- Agent cards consistently lead with the herdr workspace or Agent identity,
+  followed by the launch directory and a shared Agent-type and Host line;
+  terminal-generated titles and TUI metadata no longer compete with that
+  hierarchy. (#259)
+
 - When no size has been saved, Terminal Text Size now defaults to 8 pt instead
   of 14 pt. Existing saved sizes do not change. (#256; PR #257)
 

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -1393,8 +1393,8 @@
 			targets = (
 				081A3B29EFF2C7B2FCAA3248 /* Heeler */,
 				DFFB82C74B73FA5CBCE6D5D2 /* HeelerNotificationService */,
-				9806EA6C63028F1217417282 /* HeelerTests */,
 				134E6CD1AC1396155DAB93E2 /* HeelerWidgets */,
+				9806EA6C63028F1217417282 /* HeelerTests */,
 			);
 		};
 /* End PBXProject section */

--- a/Sources/Heeler/Console/AgentCardView.swift
+++ b/Sources/Heeler/Console/AgentCardView.swift
@@ -1,18 +1,22 @@
 import SwiftUI
 import UIKit
 
-/// One Console card (#8): the project and status up front, Host, agent kind,
-/// and pane address as context, plus the last-output snippet. The project
-/// leads because a console full of agents is usually a console full of
-/// `claude` — the workspace is what tells the rows apart.
+/// One Console card (#8): the same workspace label and Agent kind herdr uses,
+/// plus launch directory, Host, and status. Terminal titles, trailing TUI
+/// output, and opaque pane ids are deliberately absent: none identifies the
+/// Agent in herdr's own Agents pane.
 struct AgentCardView: View {
     let agent: ConsoleAgent
     var isPinned: Bool = false
 
+    private var presentation: AgentCardPresentation {
+        AgentCardPresentation(agent: agent)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .firstTextBaseline) {
-                Text(headline)
+                Text(presentation.headline)
                     .font(.headline)
                     .lineLimit(1)
                 if isPinned {
@@ -25,66 +29,70 @@ struct AgentCardView: View {
                 Spacer(minLength: 8)
                 AgentStatusBadge(status: agent.agent.status)
             }
-            if !agent.agent.title.isEmpty {
-                Text(agent.agent.title)
-                    .font(.subheadline)
-                    .lineLimit(1)
-            }
-            if let snippet = agent.lastOutputSnippet {
-                Text(snippet)
+            if let context = presentation.context {
+                Text(context)
                     .font(.caption.monospaced())
                     .foregroundStyle(.secondary)
-                    .lineLimit(2)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
             }
-            HStack(spacing: 6) {
-                if agent.isLinkedWorktree {
-                    HStack(spacing: 3) {
-                        Image(systemName: "arrow.triangle.branch")
-                        Text("Worktree")
-                    }
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(.quaternary, in: Capsule())
-                    .accessibilityElement(children: .ignore)
-                    .accessibilityLabel("Linked worktree")
+            HStack {
+                if let agentType = presentation.agentType {
+                    Text(agentType)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
                 }
-                if let kind = agentKindTag {
-                    Text(kind)
-                        .font(.caption2)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(.quaternary, in: Capsule())
-                }
-                Text(agent.agent.paneID)
-                    .font(.caption2.monospaced())
-                    .foregroundStyle(.tertiary)
                 Spacer(minLength: 8)
                 Text(agent.hostName)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
         }
         .padding(.vertical, 4)
     }
+}
 
-    /// The card's lead line: the project the agent works in, falling back to
-    /// the agent's own name when the snapshot carried no workspace.
-    private var headline: String {
-        workspaceContext ?? agent.agent.displayName
+struct AgentCardPresentation: Equatable {
+    let headline: String
+    let context: String?
+    let agentType: String?
+
+    init(agent: ConsoleAgent) {
+        headline = agent.switcherLabel
+        context = Self.nonEmpty(agent.agent.cwd).map {
+            Self.abbreviatingStandardHome(in: $0, username: agent.hostUsername)
+        }
+
+        let kind = switch SupportedAgentKind(rawValue: agent.agent.kind) {
+        case .some(.claude): "Claude"
+        case let supported?: supported.displayName
+        case nil: agent.agent.kind
+        }
+        agentType = headline.caseInsensitiveCompare(kind) == .orderedSame
+            ? nil
+            : kind
     }
 
-    /// The agent name, tagged at the foot of the card — dropped when the
-    /// headline already fell back to it.
-    private var agentKindTag: String? {
-        workspaceContext == nil ? nil : agent.agent.displayName
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
     }
 
-    /// The workspace context: label, with the worktree repo when it adds
-    /// information the label does not already carry.
-    private var workspaceContext: String? {
-        agent.workspaceContext
+    /// The snapshot carries an expanded remote path but not `$HOME`. Standard
+    /// macOS/Linux SSH-account homes can still be shortened without guessing
+    /// that an arbitrary path prefix is a home directory.
+    private static func abbreviatingStandardHome(
+        in path: String, username: String?
+    ) -> String {
+        guard let username, !username.isEmpty else { return path }
+        let homes = username == "root"
+            ? ["/root"]
+            : ["/Users/\(username)", "/home/\(username)"]
+        guard let home = homes.first(where: { path == $0 || path.hasPrefix("\($0)/") })
+        else { return path }
+        return path == home ? "~" : "~\(path.dropFirst(home.count))"
     }
 }
 
@@ -129,8 +137,7 @@ struct AgentStatusBadge: View {
                     checkoutPath: "/work/proj-wt",
                     isLinkedWorktree: true),
                 lastOutputSnippet: "Allow Claude to run rm -rf? 1. Yes 2. No"))
-        // No workspace in the snapshot: the agent name takes the lead line
-        // and the foot tag drops.
+        // No workspace in the snapshot: the Agent's own name takes the lead.
         AgentCardView(
             agent: ConsoleAgent(
                 hostID: UUID(),

--- a/Sources/Heeler/Console/ConsoleAgent.swift
+++ b/Sources/Heeler/Console/ConsoleAgent.swift
@@ -13,6 +13,9 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
 
     let hostID: Host.ID
     let hostName: String
+    /// SSH account name, used only for conservative presentation of standard
+    /// macOS/Linux home paths as `~`. The actual remote path stays unchanged.
+    let hostUsername: String?
     var agent: Agent
     /// Workspace label from the session snapshot; nil when the snapshot did
     /// not carry the workspace.
@@ -33,10 +36,12 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
         agent: Agent,
         workspaceLabel: String?,
         repositoryCheckout: RepositoryCheckout?,
-        lastOutputSnippet: String? = nil
+        lastOutputSnippet: String? = nil,
+        hostUsername: String? = nil
     ) {
         self.hostID = hostID
         self.hostName = hostName
+        self.hostUsername = hostUsername
         self.agent = agent
         self.workspaceLabel = workspaceLabel
         self.repositoryCheckout = repositoryCheckout

--- a/Sources/Heeler/Console/HostConsoleProjection.swift
+++ b/Sources/Heeler/Console/HostConsoleProjection.swift
@@ -629,7 +629,8 @@ final class HostConsoleProjection {
                 agent: agent,
                 workspaceLabel: workspace?.label,
                 repositoryCheckout: workspace?.worktree.map(RepositoryCheckout.init),
-                lastOutputSnippet: agentsByPane[agent.paneID]?.lastOutputSnippet)
+                lastOutputSnippet: agentsByPane[agent.paneID]?.lastOutputSnippet,
+                hostUsername: host.username)
         }
         for (paneID, change) in latestStatusChanges
         where change.revision > snapshotStartRevision {

--- a/Tests/HeelerTests/ConsoleListPresentationStoreTests.swift
+++ b/Tests/HeelerTests/ConsoleListPresentationStoreTests.swift
@@ -169,3 +169,89 @@ struct ConsoleListPresentationStoreTests {
         #expect(section.statusCounts.items.map(\.status) == [.blocked, .working, .done])
     }
 }
+
+@Suite("Agent card presentation")
+struct AgentCardPresentationTests {
+    @Test func everyAgentKindMatchesHerdrNameThenTypeAndDirectory() {
+        let claude = presentation(
+            kind: "claude",
+            title: "Profile photo ethnicity scoring review",
+            cwd: "/Users/developer/swype",
+            workspaceLabel: "swype")
+        let codex = presentation(
+            kind: "codex",
+            title: "Developer",
+            cwd: "/Users/developer/Developer",
+            workspaceLabel: "cw-userscript")
+
+        #expect(claude.headline == "swype")
+        #expect(claude.agentType == "Claude")
+        #expect(claude.context == "~/swype")
+        #expect(codex.headline == "cw-userscript")
+        #expect(codex.agentType == "Codex")
+        #expect(codex.context == "~/Developer")
+    }
+
+    @Test func theAgentNameLeadsWhenNoWorkspaceContextExists() {
+        let presentation = presentation(
+            kind: "claude",
+            name: "reviewer",
+            title: "A terminal-generated title",
+            cwd: "/work/project",
+            workspaceLabel: nil)
+
+        #expect(presentation.headline == "reviewer")
+        #expect(presentation.context == "/work/project")
+        #expect(presentation.agentType == "Claude")
+    }
+
+    @Test func anUnnamedAgentDoesNotRepeatItsKind() {
+        let presentation = presentation(
+            kind: "codex",
+            title: "A terminal-generated title",
+            cwd: "/work/project",
+            workspaceLabel: nil)
+
+        #expect(presentation.headline == "codex")
+        #expect(presentation.agentType == nil)
+    }
+
+    @Test func onlyStandardHomesForTheSSHAccountUseTilde() {
+        #expect(presentation(
+            kind: "codex", title: "", cwd: "/home/developer/project",
+            workspaceLabel: "project").context == "~/project")
+        #expect(presentation(
+            kind: "codex", title: "", cwd: "/Users/someone-else/project",
+            workspaceLabel: "project").context == "/Users/someone-else/project")
+        #expect(presentation(
+            kind: "codex", title: "", cwd: "/Users/developer-other/project",
+            workspaceLabel: "project").context == "/Users/developer-other/project")
+    }
+
+    private func presentation(
+        kind: String,
+        name: String? = nil,
+        title: String,
+        cwd: String,
+        workspaceLabel: String?
+    ) -> AgentCardPresentation {
+        AgentCardPresentation(
+            agent: ConsoleAgent(
+                hostID: UUID(),
+                hostName: "devbox",
+                agent: Agent(
+                    terminalID: "terminal",
+                    kind: kind,
+                    title: title,
+                    status: .idle,
+                    workspaceID: "workspace",
+                    tabID: "tab",
+                    paneID: "pane",
+                    cwd: cwd,
+                    revision: 1,
+                    name: name),
+                workspaceLabel: workspaceLabel,
+                repositoryCheckout: nil,
+                hostUsername: "developer"))
+    }
+}


### PR DESCRIPTION
## Summary

- lead every Agent card with the stable workspace/Agent identity used by herdr
- show the launch directory on its own line, conservatively abbreviating standard SSH-account homes with `~`
- use one consistent Agent-type and Host line for Claude and Codex, including the shorter `Claude` label
- remove terminal-generated titles, TUI snippets, pane ids, and worktree badges from the list hierarchy

## Testing

- `xcodebuild test -project Heeler.xcodeproj -scheme Heeler -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:HeelerTests/AgentCardPresentationTests`
- built, installed, and visually verified with `make sim`

Closes #258
