### PR TITLE
Unify Agent identity across notifications and Live Activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Entries reference the issue that motivated them.
 
 ### Changed
 
+- Agent cards consistently lead with the herdr workspace or Agent identity,
+  followed by the launch directory and a shared Agent-type and Host line;
+  terminal-generated titles and TUI metadata no longer compete with that
+  hierarchy. (#259)
+
 - When no size has been saved, Terminal Text Size now defaults to 8 pt instead
   of 14 pt. Existing saved sizes do not change. (#256; PR #257)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Entries reference the issue that motivated them.
 
 ### Changed
 
+- Agent alerts consistently identify Agents by workspace plus friendly kind.
+  Live Activities use compact aligned rows with a colored status dot beside the
+  workspace and the friendly kind underneath, without terminal-title,
+  custom-name, workdir, or special Blocked-row background noise. (#260)
+
 - Agent cards consistently lead with the herdr workspace or Agent identity,
   followed by the launch directory and a shared Agent-type and Host line;
   terminal-generated titles and TUI metadata no longer compete with that

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		5C68C3082AD5958A28843055 /* TerminalTitleGlyphs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651D511E8A282C4CB0214098 /* TerminalTitleGlyphs.swift */; };
 		5C79B0EEF08521BF5907D3F2 /* NotificationKeyMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91F0473741A92D7EFA40CBA /* NotificationKeyMirror.swift */; };
 		5DBC04E1863A4740B3C84F3B /* DemoScreenshotMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0A5D6A13F3F940E50EDCFD /* DemoScreenshotMode.swift */; };
+		5E04052A267C18A7415B4930 /* AgentNotificationIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401F5B396F9F00568A4FFF88 /* AgentNotificationIdentity.swift */; };
 		5F19761A75CECE4A6FC80543 /* NotificationKeyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB05396E5E55060B5A23621C /* NotificationKeyStoreTests.swift */; };
 		5FCC5971328F9D7C5FB80DD5 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCDD3A343C4D08ED707188AF /* NotificationService.swift */; };
 		600145C630EB5F0AC8F11CC2 /* SettingsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13F076778BEA3359D447E78D /* SettingsViewTests.swift */; };
@@ -174,6 +175,7 @@
 		80E28FB88E27A5A8FA516BAA /* IBMPlexMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 48F025CF6E2C3068BF911290 /* IBMPlexMono-Regular.ttf */; };
 		81E0207D8AA28513FEA755B0 /* SkillsPaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9156B9BB51E7A5AD1792D9 /* SkillsPaneStore.swift */; };
 		81F92E9FF8783F2B473DAE5A /* HostTelemetryPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2FDB99BA76C2379B0590B3B /* HostTelemetryPresentationTests.swift */; };
+		8254C70BCD2334725D5F3ED2 /* AgentNotificationIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401F5B396F9F00568A4FFF88 /* AgentNotificationIdentity.swift */; };
 		82600FB64A99ADAD1C60D451 /* PairingCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D419158B027AF5F38B73AD8B /* PairingCodeTests.swift */; };
 		836C6CE781A0FE57FBA87727 /* JSONValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F261A0911D08819AFC013F1E /* JSONValueTests.swift */; };
 		83AAFC996DF32402681F38AB /* HostDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A63EFEB7D00E59949CF331 /* HostDraft.swift */; };
@@ -183,6 +185,7 @@
 		8668C3C60FB9539A7DD1A4EC /* Base64URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32413805C1AA874DBEE37547 /* Base64URL.swift */; };
 		86EA13918F2EE2103B2DEFB3 /* AgentLiveActivityWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A9489C21BDCFA7616782BF /* AgentLiveActivityWidget.swift */; };
 		88C55182255106627222F533 /* HostKeyFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4EA32065B4A00D219B301CF /* HostKeyFingerprint.swift */; };
+		8911EB7CDDCA09EDE76C721E /* AgentNotificationIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401F5B396F9F00568A4FFF88 /* AgentNotificationIdentity.swift */; };
 		8985893366A5DA338007D1A0 /* AgentActivityEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69EBBC2C99AA84420FDF600A /* AgentActivityEnvelope.swift */; };
 		89A6F9928DC45E4A92CBB1E2 /* AgentNotificationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB37CBDC9DE0CE539FC476A0 /* AgentNotificationRenderer.swift */; };
 		8B171AB6CB0C087D059631C4 /* ContentViewActivityDriverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7374E36C37E07625B05361AE /* ContentViewActivityDriverTests.swift */; };
@@ -442,6 +445,7 @@
 		3A84F06EC2D4448E5DF72D76 /* TerminalTitleGlyphsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTitleGlyphsTests.swift; sourceTree = "<group>"; };
 		3CB3A0C20671F436B322D0F3 /* SkillFrontmatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillFrontmatter.swift; sourceTree = "<group>"; };
 		3F4858DA258C7032AC64AD52 /* RelayContentStateDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayContentStateDecodeTests.swift; sourceTree = "<group>"; };
+		401F5B396F9F00568A4FFF88 /* AgentNotificationIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationIdentity.swift; sourceTree = "<group>"; };
 		414B652A16576BEDEE9AE000 /* ClosePaneStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosePaneStoreTests.swift; sourceTree = "<group>"; };
 		4273AC6F39EB1E015820E614 /* TerminalAppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAppearanceSettingsView.swift; sourceTree = "<group>"; };
 		427512344847A84699F819A0 /* TerminalFontSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalFontSettingsTests.swift; sourceTree = "<group>"; };
@@ -1195,6 +1199,7 @@
 		D0614D2FA211CC05C8E69C17 /* HeelerNotificationCore */ = {
 			isa = PBXGroup;
 			children = (
+				401F5B396F9F00568A4FFF88 /* AgentNotificationIdentity.swift */,
 				FB37CBDC9DE0CE539FC476A0 /* AgentNotificationRenderer.swift */,
 				F61A04DBA56C56925B594FF1 /* NotificationEnvelope.swift */,
 				C91F0473741A92D7EFA40CBA /* NotificationKeyMirror.swift */,
@@ -1436,6 +1441,7 @@
 				FCCE1492C64201FF221B64A3 /* AgentActivityEnvelope.swift in Sources */,
 				4AF54D36B8F0639880713FD1 /* AgentActivityLink.swift in Sources */,
 				33046B4CC05A07D26F088082 /* AgentLiveActivityWidget.swift in Sources */,
+				8911EB7CDDCA09EDE76C721E /* AgentNotificationIdentity.swift in Sources */,
 				554C1ECECE17B440C8B37A3D /* AgentNotificationRenderer.swift in Sources */,
 				10324EE6A79714E5D12220B6 /* AgentStatusPalette.swift in Sources */,
 				8668C3C60FB9539A7DD1A4EC /* Base64URL.swift in Sources */,
@@ -1477,6 +1483,7 @@
 				72448624659DCDD94EF81DE8 /* AgentNotificationBannerStore.swift in Sources */,
 				143A46DB20266BCCDF1206F6 /* AgentNotificationBannerView.swift in Sources */,
 				0FCA9A08E011A847F31A4B85 /* AgentNotificationCenterDelegate.swift in Sources */,
+				8254C70BCD2334725D5F3ED2 /* AgentNotificationIdentity.swift in Sources */,
 				3286D6FBB12157F2A19A82CE /* AgentNotificationRenderer.swift in Sources */,
 				5B137E763FFACD1AFE5C7E30 /* AgentNotificationRouter.swift in Sources */,
 				541F71DBCA922E84DCA98D5E /* AgentNotificationRouting.swift in Sources */,
@@ -1617,6 +1624,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5E04052A267C18A7415B4930 /* AgentNotificationIdentity.swift in Sources */,
 				89A6F9928DC45E4A92CBB1E2 /* AgentNotificationRenderer.swift in Sources */,
 				A22BF5A22115749857055CED /* Base64URL.swift in Sources */,
 				950179DD8580B71A6BBAF0C2 /* HerdrAPITypes.swift in Sources */,

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -1393,8 +1393,8 @@
 			targets = (
 				081A3B29EFF2C7B2FCAA3248 /* Heeler */,
 				DFFB82C74B73FA5CBCE6D5D2 /* HeelerNotificationService */,
-				9806EA6C63028F1217417282 /* HeelerTests */,
 				134E6CD1AC1396155DAB93E2 /* HeelerWidgets */,
+				9806EA6C63028F1217417282 /* HeelerTests */,
 			);
 		};
 /* End PBXProject section */

--- a/Sources/Heeler/Console/AgentCardView.swift
+++ b/Sources/Heeler/Console/AgentCardView.swift
@@ -1,18 +1,22 @@
 import SwiftUI
 import UIKit
 
-/// One Console card (#8): the project and status up front, Host, agent kind,
-/// and pane address as context, plus the last-output snippet. The project
-/// leads because a console full of agents is usually a console full of
-/// `claude` — the workspace is what tells the rows apart.
+/// One Console card (#8): the same workspace label and Agent kind herdr uses,
+/// plus launch directory, Host, and status. Terminal titles, trailing TUI
+/// output, and opaque pane ids are deliberately absent: none identifies the
+/// Agent in herdr's own Agents pane.
 struct AgentCardView: View {
     let agent: ConsoleAgent
     var isPinned: Bool = false
 
+    private var presentation: AgentCardPresentation {
+        AgentCardPresentation(agent: agent)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .firstTextBaseline) {
-                Text(headline)
+                Text(presentation.headline)
                     .font(.headline)
                     .lineLimit(1)
                 if isPinned {
@@ -25,66 +29,70 @@ struct AgentCardView: View {
                 Spacer(minLength: 8)
                 AgentStatusBadge(status: agent.agent.status)
             }
-            if !agent.agent.title.isEmpty {
-                Text(agent.agent.title)
-                    .font(.subheadline)
-                    .lineLimit(1)
-            }
-            if let snippet = agent.lastOutputSnippet {
-                Text(snippet)
+            if let context = presentation.context {
+                Text(context)
                     .font(.caption.monospaced())
                     .foregroundStyle(.secondary)
-                    .lineLimit(2)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
             }
-            HStack(spacing: 6) {
-                if agent.isLinkedWorktree {
-                    HStack(spacing: 3) {
-                        Image(systemName: "arrow.triangle.branch")
-                        Text("Worktree")
-                    }
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(.quaternary, in: Capsule())
-                    .accessibilityElement(children: .ignore)
-                    .accessibilityLabel("Linked worktree")
+            HStack {
+                if let agentType = presentation.agentType {
+                    Text(agentType)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
                 }
-                if let kind = agentKindTag {
-                    Text(kind)
-                        .font(.caption2)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(.quaternary, in: Capsule())
-                }
-                Text(agent.agent.paneID)
-                    .font(.caption2.monospaced())
-                    .foregroundStyle(.tertiary)
                 Spacer(minLength: 8)
                 Text(agent.hostName)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
         }
         .padding(.vertical, 4)
     }
+}
 
-    /// The card's lead line: the project the agent works in, falling back to
-    /// the agent's own name when the snapshot carried no workspace.
-    private var headline: String {
-        workspaceContext ?? agent.agent.displayName
+struct AgentCardPresentation: Equatable {
+    let headline: String
+    let context: String?
+    let agentType: String?
+
+    init(agent: ConsoleAgent) {
+        headline = agent.switcherLabel
+        context = Self.nonEmpty(agent.agent.cwd).map {
+            Self.abbreviatingStandardHome(in: $0, username: agent.hostUsername)
+        }
+
+        let kind = switch SupportedAgentKind(rawValue: agent.agent.kind) {
+        case .some(.claude): "Claude"
+        case let supported?: supported.displayName
+        case nil: agent.agent.kind
+        }
+        agentType = headline.caseInsensitiveCompare(kind) == .orderedSame
+            ? nil
+            : kind
     }
 
-    /// The agent name, tagged at the foot of the card — dropped when the
-    /// headline already fell back to it.
-    private var agentKindTag: String? {
-        workspaceContext == nil ? nil : agent.agent.displayName
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
     }
 
-    /// The workspace context: label, with the worktree repo when it adds
-    /// information the label does not already carry.
-    private var workspaceContext: String? {
-        agent.workspaceContext
+    /// The snapshot carries an expanded remote path but not `$HOME`. Standard
+    /// macOS/Linux SSH-account homes can still be shortened without guessing
+    /// that an arbitrary path prefix is a home directory.
+    private static func abbreviatingStandardHome(
+        in path: String, username: String?
+    ) -> String {
+        guard let username, !username.isEmpty else { return path }
+        let homes = username == "root"
+            ? ["/root"]
+            : ["/Users/\(username)", "/home/\(username)"]
+        guard let home = homes.first(where: { path == $0 || path.hasPrefix("\($0)/") })
+        else { return path }
+        return path == home ? "~" : "~\(path.dropFirst(home.count))"
     }
 }
 
@@ -129,8 +137,7 @@ struct AgentStatusBadge: View {
                     checkoutPath: "/work/proj-wt",
                     isLinkedWorktree: true),
                 lastOutputSnippet: "Allow Claude to run rm -rf? 1. Yes 2. No"))
-        // No workspace in the snapshot: the agent name takes the lead line
-        // and the foot tag drops.
+        // No workspace in the snapshot: the Agent's own name takes the lead.
         AgentCardView(
             agent: ConsoleAgent(
                 hostID: UUID(),

--- a/Sources/Heeler/Console/ConsoleAgent.swift
+++ b/Sources/Heeler/Console/ConsoleAgent.swift
@@ -13,6 +13,9 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
 
     let hostID: Host.ID
     let hostName: String
+    /// SSH account name, used only for conservative presentation of standard
+    /// macOS/Linux home paths as `~`. The actual remote path stays unchanged.
+    let hostUsername: String?
     var agent: Agent
     /// Workspace label from the session snapshot; nil when the snapshot did
     /// not carry the workspace.
@@ -33,10 +36,12 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
         agent: Agent,
         workspaceLabel: String?,
         repositoryCheckout: RepositoryCheckout?,
-        lastOutputSnippet: String? = nil
+        lastOutputSnippet: String? = nil,
+        hostUsername: String? = nil
     ) {
         self.hostID = hostID
         self.hostName = hostName
+        self.hostUsername = hostUsername
         self.agent = agent
         self.workspaceLabel = workspaceLabel
         self.repositoryCheckout = repositoryCheckout

--- a/Sources/Heeler/Console/HostConsoleProjection.swift
+++ b/Sources/Heeler/Console/HostConsoleProjection.swift
@@ -629,7 +629,8 @@ final class HostConsoleProjection {
                 agent: agent,
                 workspaceLabel: workspace?.label,
                 repositoryCheckout: workspace?.worktree.map(RepositoryCheckout.init),
-                lastOutputSnippet: agentsByPane[agent.paneID]?.lastOutputSnippet)
+                lastOutputSnippet: agentsByPane[agent.paneID]?.lastOutputSnippet,
+                hostUsername: host.username)
         }
         for (paneID, change) in latestStatusChanges
         where change.revision > snapshotStartRevision {

--- a/Sources/Heeler/LiveActivities/AgentActivityContentBuilder.swift
+++ b/Sources/Heeler/LiveActivities/AgentActivityContentBuilder.swift
@@ -132,10 +132,14 @@ enum AgentActivityContentBuilder {
         let kind = agent.agent.kind.isEmpty ? "unknown" : agent.agent.kind
         let trimmed = prefixGraphemes(agent.agent.title, max: maxTitleGraphemes)
         let name = agent.agent.name.map { prefixGraphemes($0, max: maxTitleGraphemes) }
+        let workspace = agent.workspaceLabel.map {
+            prefixGraphemes($0, max: maxTitleGraphemes)
+        }
         return AgentActivityDetails.AgentDetail(
             paneID: agent.agent.paneID,
             kind: kind,
             name: name?.isEmpty == false ? name : nil,
+            workspace: workspace?.isEmpty == false ? workspace : nil,
             status: agent.agent.status.rawValue,
             title: trimmed.isEmpty ? nil : trimmed)
     }

--- a/Sources/Heeler/Notifications/AgentNotificationBannerStore.swift
+++ b/Sources/Heeler/Notifications/AgentNotificationBannerStore.swift
@@ -116,8 +116,7 @@ final class AgentNotificationBannerStore {
         banner = AgentNotificationBanner(
             target: target,
             alert: AgentNotificationRenderer.alert(
-                project: agent.workspaceLabel ?? agent.repoName, agentKind: agent.agent.kind,
-                task: agent.agent.title, status: status))
+                workspace: agent.workspaceLabel, agentKind: agent.agent.kind, status: status))
         playSound()
         armDismissal()
     }

--- a/Sources/HeelerActivityCore/AgentActivityEnvelope.swift
+++ b/Sources/HeelerActivityCore/AgentActivityEnvelope.swift
@@ -12,18 +12,25 @@ struct AgentActivityDetails: Sendable, Equatable {
         var kind: String
         /// The herdr agent name (`display_agent ?? name`); nil when unnamed.
         var name: String? = nil
+        /// The herdr workspace label; nil when an older producer did not
+        /// include one or the workspace is unavailable.
+        var workspace: String? = nil
         var status: String
         var title: String?
 
-        /// The identity a row leads with: the herdr name, else the kind.
-        var displayName: String { name ?? kind }
+        /// Notification surfaces intentionally use one identity everywhere,
+        /// independent of terminal titles and custom Agent names.
+        var displayIdentity: String {
+            AgentNotificationIdentity.title(workspace: workspace, kind: kind)
+        }
 
-        /// The title as rendered: leading agent status glyphs stripped
-        /// (the wire keeps them); nil when nothing remains.
-        var displayTitle: String? {
-            guard let title else { return nil }
-            let stripped = TerminalTitleGlyphs.strip(title)
-            return stripped.isEmpty ? nil : stripped
+        /// The Live Activity's primary label. Older producers may omit it;
+        /// the row then promotes the friendly Agent kind instead.
+        var displayWorkspace: String? { Self.nonEmpty(workspace) }
+
+        private static func nonEmpty(_ text: String?) -> String? {
+            guard let text, !text.isEmpty else { return nil }
+            return text
         }
     }
 }
@@ -140,7 +147,8 @@ enum AgentActivityEnvelope {
             }
             agents.append(
                 AgentActivityDetails.AgentDetail(
-                    paneID: pane, kind: kind, name: nonEmpty(item.name), status: status,
+                    paneID: pane, kind: kind, name: nonEmpty(item.name),
+                    workspace: nonEmpty(item.workspace), status: status,
                     title: nonEmpty(item.title)))
         }
         return AgentActivityDetails(hostName: host, agents: agents)
@@ -154,7 +162,8 @@ enum AgentActivityEnvelope {
         let agents = Array(details.agents.prefix(5)).map { agent in
             OutgoingAgent(
                 kind: agent.kind, name: nonEmpty(agent.name), pane: agent.paneID,
-                status: agent.status, title: nonEmpty(agent.title))
+                status: agent.status, title: nonEmpty(agent.title),
+                workspace: nonEmpty(agent.workspace))
         }
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
@@ -181,6 +190,7 @@ enum AgentActivityEnvelope {
         var name: String?
         var status: String?
         var title: String?
+        var workspace: String?
     }
 
     private struct OutgoingPlaintext: Encodable {
@@ -195,5 +205,6 @@ enum AgentActivityEnvelope {
         var pane: String
         var status: String
         var title: String?
+        var workspace: String?
     }
 }

--- a/Sources/HeelerNotificationCore/AgentNotificationIdentity.swift
+++ b/Sources/HeelerNotificationCore/AgentNotificationIdentity.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// The compact Agent identity shared by alert notifications and Live
+/// Activities. Workspace labels distinguish parallel Agents; the friendly
+/// kind remains useful context without exposing terminal titles or custom
+/// Agent names.
+enum AgentNotificationIdentity {
+    static func title(workspace: String?, kind: String) -> String {
+        let kind = kindLabel(kind)
+        guard let workspace = nonEmpty(workspace) else { return kind }
+        return "\(workspace) · \(kind)"
+    }
+
+    static func kindLabel(_ rawValue: String) -> String {
+        let rawValue = nonEmpty(rawValue) ?? "unknown"
+        return switch rawValue.lowercased() {
+        case "pi": "Pi"
+        case "claude": "Claude"
+        case "codex": "Codex"
+        case "gemini": "Gemini CLI"
+        case "cursor": "Cursor Agent"
+        case "devin": "Devin CLI"
+        case "agy": "Antigravity"
+        case "cline": "Cline"
+        case "omp": "OMP"
+        case "mastracode": "Mastra Code"
+        case "opencode": "OpenCode"
+        case "copilot": "GitHub Copilot CLI"
+        case "kimi": "Kimi CLI"
+        case "kiro": "Kiro CLI"
+        case "droid": "Droid"
+        case "amp": "Amp"
+        case "grok": "Grok Build"
+        case "hermes": "Hermes Agent"
+        case "kilo": "Kilo Code"
+        case "qodercli": "Qoder CLI"
+        case "maki": "Maki"
+        case "qwen": "Qwen Code"
+        case "unknown": "Unknown"
+        default: rawValue
+        }
+    }
+
+    private static func nonEmpty(_ text: String?) -> String? {
+        guard let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !trimmed.isEmpty
+        else { return nil }
+        return trimmed
+    }
+}

--- a/Sources/HeelerNotificationCore/AgentNotificationRenderer.swift
+++ b/Sources/HeelerNotificationCore/AgentNotificationRenderer.swift
@@ -9,7 +9,7 @@ struct AgentNotificationAlert: Sendable, Equatable {
 
 /// The service extension's logic as a pure function (#71): take the push's
 /// `userInfo` and the registered Notification Keys, select the key by the
-/// envelope's kid, decrypt, and phrase the alert as project, agent task, and
+/// envelope's kid, decrypt, and phrase the alert as workspace, Agent kind, and
 /// status. Anything undecryptable — missing or non-string envelope, unknown
 /// kid, any `NotificationEnvelopeError` — degrades to `fallback`, which the
 /// extension applies unconditionally so a forged push can never render
@@ -18,76 +18,39 @@ enum AgentNotificationRenderer {
     /// Mirrors the relay's generic wrap copy; deliberately unalarming.
     static let fallback = AgentNotificationAlert(title: "Heeler", body: "Agent update")
 
-    /// Terminal titles are whole task descriptions ("排查修复 split 按钮 UI
-    /// 结构问题") and can run to a full line of prose. iOS truncates the banner
-    /// itself, but only after the notification has spent its payload budget on
-    /// text nobody reads, so the phrasing cuts first.
-    static let taskLimit = 80
-
     static func alert(
         userInfo: [AnyHashable: Any], keys: [NotificationKeyRecord]
     ) -> AgentNotificationAlert {
         guard let (_, payload) = NotificationEnvelope.open(userInfo: userInfo, keys: keys)
         else { return fallback }
         return alert(
-            project: payload.project, agentKind: payload.agentKind, task: payload.title,
-            status: payload.status)
+            workspace: payload.project, agentKind: payload.agentKind, status: payload.status)
     }
 
     /// The one phrasing of an Agent Notification, shared by the push path
     /// above and the in-app foreground banner (#77) so the wording cannot
     /// drift between them.
     ///
-    /// The project leads: with several agents running, it is what tells one
+    /// The workspace leads: with several agents running, it is what tells one
     /// notification from another — the agent kind rarely differs. The Host is
     /// deliberately absent: it is the same machine every time and spends the
-    /// whole line on an address nobody reads. `project` and `task` are
-    /// best-effort (an older plugin sends neither), and the copy degrades one
-    /// step at a time rather than all at once.
+    /// whole line on an address nobody reads. The encrypted wire still calls
+    /// this value `project` for backward compatibility with older plugins.
     static func alert(
-        project: String?, agentKind: String, task: String?, status: AgentStatus
+        workspace: String?, agentKind: String, status: AgentStatus
     ) -> AgentNotificationAlert {
-        let project = trimmedNonEmpty(project)
-        let task = trimmedNonEmpty(task)
         return AgentNotificationAlert(
-            title: project.map { "\($0) · \(agentKind)" } ?? agentKind,
-            body: body(for: status, task: task))
+            title: AgentNotificationIdentity.title(workspace: workspace, kind: agentKind),
+            body: body(for: status))
     }
 
-    private static func body(for status: AgentStatus, task: String?) -> String {
-        guard let task else { return statusOnlyBody(for: status) }
-        return "\(word(for: status)) · \(truncated(task))"
-    }
-
-    private static func statusOnlyBody(for status: AgentStatus) -> String {
+    private static func body(for status: AgentStatus) -> String {
         switch status {
-        case .blocked: "Blocked: waiting for your input"
-        case .done: "Done: the agent finished"
+        case .blocked: "Blocked — waiting for input"
+        case .done: "Done"
         // The status set is open on the wire; render unrecognized values
         // factually instead of guessing at their meaning.
         default: "Status: \(status.rawValue)"
         }
-    }
-
-    private static func word(for status: AgentStatus) -> String {
-        switch status {
-        case .blocked: "Blocked"
-        case .done: "Done"
-        default: status.rawValue
-        }
-    }
-
-    private static func truncated(_ text: String) -> String {
-        guard text.count > taskLimit else { return text }
-        let head = text.prefix(taskLimit - 1)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return head + "…"
-    }
-
-    private static func trimmedNonEmpty(_ text: String?) -> String? {
-        guard let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines),
-            !trimmed.isEmpty
-        else { return nil }
-        return trimmed
     }
 }

--- a/Sources/HeelerWidgets/AgentActivityDecryptor.swift
+++ b/Sources/HeelerWidgets/AgentActivityDecryptor.swift
@@ -13,14 +13,13 @@ enum AgentActivityPresentation: Equatable, Sendable {
         }
     }
 
-    /// Headline: the first envelope row's task title (its kind when the
-    /// title is missing), or the generic app name when details are
-    /// unavailable. Host identity is never rendered.
+    /// Fallback headline when a row cannot be drawn. Host identity is never
+    /// rendered.
     var headerTitle: String {
         switch self {
         case .detailed:
             guard let primary = primaryAgent else { return AgentActivityCopy.genericAppName }
-            return primary.title ?? primary.kind
+            return primary.displayIdentity
         case .countsOnly:
             return AgentActivityCopy.genericAppName
         }
@@ -35,8 +34,7 @@ enum AgentActivityPresentation: Equatable, Sendable {
         }
     }
 
-    /// The agent whose task title is the headline: rows arrive in envelope
-    /// order (pinned eligible first, then status rank).
+    /// First Agent in envelope order (pinned eligible first, then status rank).
     var primaryAgent: AgentActivityDetails.AgentDetail? {
         agents.first
     }

--- a/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
+++ b/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
@@ -3,11 +3,11 @@ import SwiftUI
 import UIKit
 import WidgetKit
 
-/// Live Activity for one Host. The lock-screen banner gives the leading
-/// agent a full two-line row and packs up to three more agents into compact
-/// rows. Rows arrive in the sender's pin-aware order and are rendered as
-/// given; Host identity is never rendered. Agent rows deep-link to their
-/// detail while the surrounding chrome opens the Console.
+/// Live Activity for one Host. The lock-screen banner gives each visible
+/// Agent the same compact workspace-and-kind row, up to four rows. Rows
+/// arrive in the sender's pin-aware order and are rendered as given; Host
+/// identity is never rendered. Agent rows deep-link to their detail while
+/// the surrounding chrome opens the Console.
 struct AgentLiveActivityWidget: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: AgentActivityAttributes.self) { context in
@@ -130,14 +130,13 @@ struct AgentActivityLockScreenView: View {
             Color(uiColor: AgentActivityLockScreenChrome.backgroundColor)
                 .ignoresSafeArea()
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 0) {
                 header
                 ForEach(visibleAgents.dropFirst(), id: \.paneID) { agent in
                     AgentActivityLinkedRow(
                         hostID: hostID,
                         agent: agent,
                         surface: .lockScreen,
-                        density: .compact,
                         minimumHeight: rowMinimumHeight)
                 }
                 if let caption = presentation.lockScreenTrailingCaption(isStale: isStale) {
@@ -167,7 +166,7 @@ struct AgentActivityLockScreenView: View {
     }
 
     private var header: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
+        HStack(alignment: .top, spacing: 8) {
             headline
             Spacer(minLength: 8)
             AgentActivityCountChips(counts: presentation.counts, surface: .lockScreen)
@@ -202,14 +201,12 @@ enum AgentActivityIsland {
         DynamicIsland {
             DynamicIslandExpandedRegion(.center) {
                 if let primary = presentation.primaryAgent {
-                    AgentActivityLinked(
+                    AgentActivityLinkedRow(
                         hostID: hostID,
                         agent: primary,
                         surface: .island,
                         minimumHeight: AgentActivityRowMetrics.denseMinimumHeight
-                    ) {
-                        AgentActivityHeadlineView(agent: primary, surface: .island)
-                    }
+                    )
                 } else {
                     Text(presentation.headerTitle)
                         .font(.headline)
@@ -298,11 +295,9 @@ private struct AgentActivityCompactLeading: View {
 
 enum AgentActivityNarration {
     static func rowLabel(for agent: AgentActivityDetails.AgentDetail) -> String {
-        var row = "\(agent.displayName), \(agent.status)"
-        if let title = agent.displayTitle {
-            row += ", \(title)"
-        }
-        return row
+        [agent.displayWorkspace, AgentNotificationIdentity.kindLabel(agent.kind), agent.status]
+            .compactMap { $0 }
+            .joined(separator: ", ")
     }
 }
 
@@ -350,7 +345,6 @@ private struct AgentActivityLinkedRow: View {
     let hostID: String
     let agent: AgentActivityDetails.AgentDetail
     let surface: AgentActivitySurface
-    var density: AgentActivityRowDensity = .full
     let minimumHeight: CGFloat
 
     var body: some View {
@@ -360,14 +354,9 @@ private struct AgentActivityLinkedRow: View {
             surface: surface,
             minimumHeight: minimumHeight
         ) {
-            AgentActivityRowView(agent: agent, surface: surface, density: density)
+            AgentActivityRowView(agent: agent, surface: surface)
         }
     }
-}
-
-private enum AgentActivityRowDensity: Equatable {
-    case full
-    case compact
 }
 
 private struct AgentActivityCountChips: View {
@@ -398,70 +387,17 @@ private struct AgentActivityCountChips: View {
     }
 }
 
-/// The headline: two lines mirroring the herdr sidebar's hierarchy —
-/// status dot plus the task title on top, the agent's identity (its herdr
-/// name, kind when unnamed, exactly like the TUI) indented beneath. A
-/// missing title promotes the identity to the top line alone.
-private struct AgentActivityHeadlineView: View {
-    let agent: AgentActivityDetails.AgentDetail
-    let surface: AgentActivitySurface
-
-    private var ink: Color { AgentActivityStatusStyle.ink(for: agent.status, on: surface) }
-    private var isBlocked: Bool { agent.status == "blocked" }
-
-    var body: some View {
-        let content = VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 7) {
-                Circle()
-                    .fill(ink)
-                    .frame(width: 8, height: 8)
-                    .accessibilityHidden(true)
-                Text(agent.displayTitle ?? agent.displayName)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(
-                        isBlocked ? ink : AgentActivitySemanticStyle.primary(on: surface))
-                    .lineLimit(1)
-            }
-            if agent.displayTitle != nil {
-                Text(agent.displayName)
-                    .font(.footnote)
-                    .foregroundStyle(AgentActivitySemanticStyle.secondary(on: surface))
-                    .lineLimit(1)
-                    .padding(.leading, 15)
-            }
-        }
-        switch surface {
-        case .island:
-            content.accessibilityLabel(AgentActivityNarration.rowLabel(for: agent))
-        case .lockScreen:
-            content
-        }
-    }
-}
-
-/// One agent row. Full density mirrors the headline hierarchy at smaller
-/// type; compact density keeps the title and identity on one line. Status
-/// is painted, not narrated as an event — a done row is the current state,
-/// not "just finished".
+/// One uniform row: a status dot beside the workspace, then the friendly Agent
+/// kind underneath. Every row owns identical geometry; status is color only,
+/// never extra text, inset, or a background that shifts one row from another.
 private struct AgentActivityRowView: View {
     let agent: AgentActivityDetails.AgentDetail
     let surface: AgentActivitySurface
-    var density: AgentActivityRowDensity = .full
 
-    private var isBlocked: Bool { agent.status == "blocked" }
     private var ink: Color { AgentActivityStatusStyle.ink(for: agent.status, on: surface) }
-    private var wash: Color { AgentActivityStatusStyle.wash(for: agent.status, on: surface) }
 
     var body: some View {
         let content = rowContent
-            .padding(.vertical, isBlocked ? blockedVerticalPadding : 0)
-            .padding(.horizontal, isBlocked ? 6 : 0)
-            .background {
-                if isBlocked {
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(wash.opacity(0.15))
-                }
-            }
         switch surface {
         case .island:
             content.accessibilityLabel(AgentActivityNarration.rowLabel(for: agent))
@@ -470,57 +406,27 @@ private struct AgentActivityRowView: View {
         }
     }
 
-    @ViewBuilder
     private var rowContent: some View {
-        switch density {
-        case .full:
-            VStack(alignment: .leading, spacing: 1) {
-                HStack(spacing: 7) {
-                    statusDot
-                    title
-                    Spacer(minLength: 0)
-                }
-                if agent.displayTitle != nil {
-                    Text(agent.displayName)
-                        .font(.caption)
-                        .foregroundStyle(AgentActivitySemanticStyle.secondary(on: surface))
-                        .lineLimit(1)
-                        .padding(.leading, 14)
-                }
-            }
-        case .compact:
+        VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 7) {
-                statusDot
-                title
-                    .layoutPriority(1)
-                if agent.displayTitle != nil {
-                    Text("· \(agent.displayName)")
-                        .font(.caption2)
-                        .foregroundStyle(AgentActivitySemanticStyle.secondary(on: surface))
-                        .lineLimit(1)
-                }
-                Spacer(minLength: 0)
+                Circle()
+                    .fill(ink)
+                    .frame(width: 7, height: 7)
+                    .accessibilityHidden(true)
+                Text(agent.displayWorkspace ?? AgentNotificationIdentity.kindLabel(agent.kind))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(AgentActivitySemanticStyle.primary(on: surface))
+                    .lineLimit(1)
+            }
+            if agent.displayWorkspace != nil {
+                Text(AgentNotificationIdentity.kindLabel(agent.kind))
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(AgentActivitySemanticStyle.secondary(on: surface))
+                    .lineLimit(1)
+                    .padding(.leading, 14)
             }
         }
-    }
-
-    private var statusDot: some View {
-        Circle()
-            .fill(ink)
-            .frame(width: 7, height: 7)
-            .accessibilityHidden(true)
-    }
-
-    private var title: some View {
-        Text(agent.displayTitle ?? agent.displayName)
-            .font(.caption.weight(isBlocked ? .semibold : .regular))
-            .foregroundStyle(
-                isBlocked ? ink : AgentActivitySemanticStyle.primary(on: surface))
-            .lineLimit(1)
-    }
-
-    private var blockedVerticalPadding: CGFloat {
-        density == .compact ? 2 : 3
+        .layoutPriority(1)
     }
 }
 
@@ -530,10 +436,12 @@ private struct AgentActivityRowView: View {
 /// live agent. Open this file's canvas in Xcode to review the banner.
 #if DEBUG
     private func previewAgent(
-        _ status: String, kind: String, name: String? = nil, pane: String, title: String? = nil
+        _ status: String, kind: String, workspace: String? = "Heeler", name: String? = nil,
+        pane: String, title: String? = nil
     ) -> AgentActivityDetails.AgentDetail {
         AgentActivityDetails.AgentDetail(
-            paneID: pane, kind: kind, name: name, status: status, title: title)
+            paneID: pane, kind: kind, name: name, workspace: workspace, status: status,
+            title: title)
     }
 
     private enum AgentActivityPreviewFixtures {
@@ -721,7 +629,7 @@ private struct AgentActivityRowView: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             if let primary = presentation.primaryAgent {
-                AgentActivityHeadlineView(agent: primary, surface: .island)
+                AgentActivityRowView(agent: primary, surface: .island)
             }
             ForEach(presentation.secondaryAgents, id: \.paneID) { agent in
                 AgentActivityRowView(agent: agent, surface: .island)

--- a/Tests/HeelerTests/AgentActivityContentBuilderTests.swift
+++ b/Tests/HeelerTests/AgentActivityContentBuilderTests.swift
@@ -126,6 +126,16 @@ struct AgentActivityContentBuilderTests {
         #expect(byPane["w:p2"]?.name == nil)
     }
 
+    @Test func carriesTheWorkspaceLabelAndTrimsItToTheDisplayLimit() throws {
+        let workspace = String(repeating: "锁", count: 81)
+        let desire = try #require(
+            AgentActivityContentBuilder.desire(
+                from: [agent("w:p1", .working, workspace: workspace)], hostName: "mbp"))
+
+        #expect(desire.agents.first?.workspace == String(repeating: "锁", count: 80))
+        #expect(desire.agents.first?.displayIdentity.hasSuffix(" · Claude") == true)
+    }
+
     @Test func omitsEmptyTitlesAndFallsBackToUnknownKind() throws {
         let blankKind = Agent(
             terminalID: "t", kind: "", title: "", status: .done,
@@ -289,12 +299,13 @@ struct AgentActivityContentBuilderTests {
 
     private func agent(
         _ paneID: String, _ status: AgentStatus,
-        kind: String = "claude", title: String = "Task", name: String? = nil
+        kind: String = "claude", title: String = "Task", name: String? = nil,
+        workspace: String? = nil
     ) -> ConsoleAgent {
         ConsoleAgent(
             hostID: hostID, hostName: "mbp",
             agent: Agent(
                 .fixture(paneID: paneID, status: status, kind: kind, title: title, name: name)),
-            workspaceLabel: nil, repositoryCheckout: nil)
+            workspaceLabel: workspace, repositoryCheckout: nil)
     }
 }

--- a/Tests/HeelerTests/AgentActivityEnvelopeTests.swift
+++ b/Tests/HeelerTests/AgentActivityEnvelopeTests.swift
@@ -36,6 +36,7 @@ struct AgentActivityEnvelopeTests {
             #expect(got.name == expected.name)
             #expect(got.status == expected.status)
             #expect(got.title == expected.title)
+            #expect(got.workspace == expected.workspace)
         }
     }
 
@@ -53,7 +54,8 @@ struct AgentActivityEnvelopeTests {
             hostName: vector.payload.host,
             agents: vector.payload.agents.map {
                 AgentActivityDetails.AgentDetail(
-                    paneID: $0.pane, kind: $0.kind, name: $0.name, status: $0.status,
+                    paneID: $0.pane, kind: $0.kind, name: $0.name,
+                    workspace: $0.workspace, status: $0.status,
                     title: $0.title)
             })
 

--- a/Tests/HeelerTests/AgentActivityPresentationTests.swift
+++ b/Tests/HeelerTests/AgentActivityPresentationTests.swift
@@ -17,7 +17,7 @@ struct AgentActivityPresentationTests {
         paneID: String, status: String = "working"
     ) -> AgentActivityDetails.AgentDetail {
         AgentActivityDetails.AgentDetail(
-            paneID: paneID, kind: "claude", name: nil, status: status,
+            paneID: paneID, kind: "claude", name: nil, workspace: "Heeler", status: status,
             title: "Task \(paneID)")
     }
 
@@ -113,7 +113,27 @@ struct AgentActivityPresentationTests {
 
     @Test func narrationIncludesStatusForIslandAccessibility() {
         let agent = agentDetail(paneID: "w1:p1", status: "blocked")
-        #expect(AgentActivityNarration.rowLabel(for: agent) == "claude, blocked, Task w1:p1")
+        #expect(AgentActivityNarration.rowLabel(for: agent) == "Heeler, Claude, blocked")
+    }
+
+    @Test func identityIgnoresCustomAgentNameAndTerminalTitle() {
+        let agent = AgentActivityDetails.AgentDetail(
+            paneID: "w1:p1", kind: "codex", name: "identityprobe", workspace: "Heeler",
+            status: "working", title: "Developer · identityprobe")
+
+        #expect(agent.displayIdentity == "Heeler · Codex")
+        #expect(agent.displayWorkspace == "Heeler")
+    }
+
+    @Test func liveActivityRowsNarrateWorkspaceKindAndStatusWithoutTaskNoise() {
+        let agent = AgentActivityDetails.AgentDetail(
+            paneID: "w1:p1", kind: "claude", workspace: "Checkout",
+            status: "blocked", title: nil)
+
+        #expect(agent.displayWorkspace == "Checkout")
+        #expect(
+            AgentActivityNarration.rowLabel(for: agent)
+                == "Checkout, Claude, blocked")
     }
 
     @Test func lockScreenRowsUseComfortableAndDenseAppleTargetHeights() {

--- a/Tests/HeelerTests/AgentNotificationBannerStoreTests.swift
+++ b/Tests/HeelerTests/AgentNotificationBannerStoreTests.swift
@@ -87,7 +87,8 @@ struct AgentNotificationBannerStoreTests {
             store.banner
                 == AgentNotificationBanner(
                     target: AgentNotificationTarget(hostID: hostID, paneID: "wV:p1"),
-                    alert: AgentNotificationAlert(title: "claude", body: "Blocked · Task")))
+                    alert: AgentNotificationAlert(
+                        title: "Claude", body: "Blocked — waiting for input")))
         #expect(world.soundCount == 1)
     }
 
@@ -104,7 +105,7 @@ struct AgentNotificationBannerStoreTests {
         #expect(
             store.banner?.alert
                 == AgentNotificationAlert(
-                    title: "Caterm · claude", body: "Blocked · Task"))
+                    title: "Caterm · Claude", body: "Blocked — waiting for input"))
     }
 
     @Test func doneTransitionBannersWithTheDoneCopy() async throws {
@@ -117,7 +118,7 @@ struct AgentNotificationBannerStoreTests {
         try await waitUntil("the Done banner should show") { store.banner != nil }
         #expect(
             store.banner?.alert
-                == AgentNotificationAlert(title: "codex", body: "Done · Task"))
+                == AgentNotificationAlert(title: "Codex", body: "Done"))
     }
 
     /// The first sight of a pane is baseline, not a transition: a killed-state

--- a/Tests/HeelerTests/AgentNotificationRendererTests.swift
+++ b/Tests/HeelerTests/AgentNotificationRendererTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 /// The service extension's whole job as a pure function: pick the right
 /// Notification Key by the envelope's kid, decrypt, and rewrite the alert to
-/// Host, agent kind, and status — or degrade to the generic fallback banner
+/// workspace, Agent kind, and status — or degrade to the generic fallback banner
 /// on any undecryptable push (#71). Envelopes come from the shared vectors,
 /// so this stays in lockstep with the plugin's encrypt direction.
 @Suite("Agent notification renderer")
@@ -24,7 +24,7 @@ struct AgentNotificationRendererTests {
     }
 
     /// A payload from a plugin that predates the display fields: the copy
-    /// degrades to the agent kind and a status sentence rather than falling
+    /// degrades to the friendly Agent kind and status rather than falling
     /// back to the generic banner.
     @Test func rewritesABlockedPushWithoutDisplayFields() throws {
         let vector = try Self.vector(named: "blocked claude agent")
@@ -33,21 +33,21 @@ struct AgentNotificationRendererTests {
         let alert = AgentNotificationRenderer.alert(
             userInfo: ["envelope": vector.envelope], keys: [record])
 
-        #expect(alert.title == "claude")
-        #expect(alert.body == "Blocked: waiting for your input")
+        #expect(alert.title == "Claude")
+        #expect(alert.body == "Blocked — waiting for input")
     }
 
-    /// The shape the current plugin sends: the project leads, the agent kind
-    /// trails it, and the body says what the agent was doing.
-    @Test func leadsWithTheProjectAndTheAgentsTask() throws {
+    /// The shape the current plugin sends: the workspace leads, the friendly
+    /// Agent kind trails it, and the body carries status only.
+    @Test func leadsWithTheWorkspaceAndFriendlyAgentKind() throws {
         let vector = try Self.vector(named: "blocked agent with a project and a task title")
         let record = try Self.record(forVector: vector, named: "mac-studio")
 
         let alert = AgentNotificationRenderer.alert(
             userInfo: ["envelope": vector.envelope], keys: [record])
 
-        #expect(alert.title == "Caterm · claude")
-        #expect(alert.body == "Blocked · 排查修复 split 按钮 UI 结构问题")
+        #expect(alert.title == "Caterm · Claude")
+        #expect(alert.body == "Blocked — waiting for input")
     }
 
     /// The Host is the same machine on every notification and would spend the
@@ -63,36 +63,29 @@ struct AgentNotificationRendererTests {
         #expect(!alert.body.contains("zingerbee"))
     }
 
-    @Test func trimsATaskTitleThatWouldOverrunTheBanner() {
-        let long = String(repeating: "重构传输层", count: 40)
-
+    @Test func doesNotRenderTheTerminalTask() {
         let alert = AgentNotificationRenderer.alert(
-            project: "heeler", agentKind: "claude", task: long, status: .done)
+            workspace: "Heeler", agentKind: "codex", status: .done)
 
-        let task = alert.body.dropFirst("Done · ".count)
-        #expect(task.count == AgentNotificationRenderer.taskLimit)
-        #expect(task.hasSuffix("…"))
-        #expect(long.hasPrefix(task.dropLast()))
+        #expect(alert == AgentNotificationAlert(title: "Heeler · Codex", body: "Done"))
     }
 
     /// Best-effort fields: whitespace-only is the same as absent, so a Host
     /// that resolved a blank never renders a dangling separator.
     @Test func treatsBlankDisplayFieldsAsAbsent() {
         let alert = AgentNotificationRenderer.alert(
-            project: "  ", agentKind: "claude", task: "\n", status: .blocked)
+            workspace: "  ", agentKind: "claude", status: .blocked)
 
-        #expect(alert.title == "claude")
-        #expect(alert.body == "Blocked: waiting for your input")
+        #expect(alert.title == "Claude")
+        #expect(alert.body == "Blocked — waiting for input")
     }
 
-    /// An unrecognized status still names itself in the short form when there
-    /// is a task to pair it with.
-    @Test func pairsAnUnrecognizedStatusWithTheTask() {
+    /// An unrecognized status still names itself factually.
+    @Test func rendersAnUnrecognizedStatusFactually() {
         let alert = AgentNotificationRenderer.alert(
-            project: "heeler", agentKind: "claude", task: "Fix the flaky test",
-            status: AgentStatus(rawValue: "exited"))
+            workspace: "heeler", agentKind: "claude", status: AgentStatus(rawValue: "exited"))
 
-        #expect(alert.body == "exited · Fix the flaky test")
+        #expect(alert.body == "Status: exited")
     }
 
     @Test func rewritesADonePush() throws {
@@ -102,8 +95,8 @@ struct AgentNotificationRendererTests {
         let alert = AgentNotificationRenderer.alert(
             userInfo: ["envelope": vector.envelope], keys: [record])
 
-        #expect(alert.title == "codex")
-        #expect(alert.body == "Done: the agent finished")
+        #expect(alert.title == "Codex")
+        #expect(alert.body == "Done")
     }
 
     /// The status set is open on the wire; an unrecognized value must still
@@ -135,10 +128,10 @@ struct AgentNotificationRendererTests {
         let doneAlert = AgentNotificationRenderer.alert(
             userInfo: ["envelope": done.envelope], keys: records)
 
-        #expect(blockedAlert.title == "claude")
-        #expect(blockedAlert.body == "Blocked: waiting for your input")
-        #expect(doneAlert.title == "codex")
-        #expect(doneAlert.body == "Done: the agent finished")
+        #expect(blockedAlert.title == "Claude")
+        #expect(blockedAlert.body == "Blocked — waiting for input")
+        #expect(doneAlert.title == "Codex")
+        #expect(doneAlert.body == "Done")
     }
 
     @Test func unknownKidFallsBackToTheGenericBanner() throws {

--- a/Tests/HeelerTests/ConsoleListPresentationStoreTests.swift
+++ b/Tests/HeelerTests/ConsoleListPresentationStoreTests.swift
@@ -169,3 +169,89 @@ struct ConsoleListPresentationStoreTests {
         #expect(section.statusCounts.items.map(\.status) == [.blocked, .working, .done])
     }
 }
+
+@Suite("Agent card presentation")
+struct AgentCardPresentationTests {
+    @Test func everyAgentKindMatchesHerdrNameThenTypeAndDirectory() {
+        let claude = presentation(
+            kind: "claude",
+            title: "Profile photo ethnicity scoring review",
+            cwd: "/Users/developer/swype",
+            workspaceLabel: "swype")
+        let codex = presentation(
+            kind: "codex",
+            title: "Developer",
+            cwd: "/Users/developer/Developer",
+            workspaceLabel: "cw-userscript")
+
+        #expect(claude.headline == "swype")
+        #expect(claude.agentType == "Claude")
+        #expect(claude.context == "~/swype")
+        #expect(codex.headline == "cw-userscript")
+        #expect(codex.agentType == "Codex")
+        #expect(codex.context == "~/Developer")
+    }
+
+    @Test func theAgentNameLeadsWhenNoWorkspaceContextExists() {
+        let presentation = presentation(
+            kind: "claude",
+            name: "reviewer",
+            title: "A terminal-generated title",
+            cwd: "/work/project",
+            workspaceLabel: nil)
+
+        #expect(presentation.headline == "reviewer")
+        #expect(presentation.context == "/work/project")
+        #expect(presentation.agentType == "Claude")
+    }
+
+    @Test func anUnnamedAgentDoesNotRepeatItsKind() {
+        let presentation = presentation(
+            kind: "codex",
+            title: "A terminal-generated title",
+            cwd: "/work/project",
+            workspaceLabel: nil)
+
+        #expect(presentation.headline == "codex")
+        #expect(presentation.agentType == nil)
+    }
+
+    @Test func onlyStandardHomesForTheSSHAccountUseTilde() {
+        #expect(presentation(
+            kind: "codex", title: "", cwd: "/home/developer/project",
+            workspaceLabel: "project").context == "~/project")
+        #expect(presentation(
+            kind: "codex", title: "", cwd: "/Users/someone-else/project",
+            workspaceLabel: "project").context == "/Users/someone-else/project")
+        #expect(presentation(
+            kind: "codex", title: "", cwd: "/Users/developer-other/project",
+            workspaceLabel: "project").context == "/Users/developer-other/project")
+    }
+
+    private func presentation(
+        kind: String,
+        name: String? = nil,
+        title: String,
+        cwd: String,
+        workspaceLabel: String?
+    ) -> AgentCardPresentation {
+        AgentCardPresentation(
+            agent: ConsoleAgent(
+                hostID: UUID(),
+                hostName: "devbox",
+                agent: Agent(
+                    terminalID: "terminal",
+                    kind: kind,
+                    title: title,
+                    status: .idle,
+                    workspaceID: "workspace",
+                    tabID: "tab",
+                    paneID: "pane",
+                    cwd: cwd,
+                    revision: 1,
+                    name: name),
+                workspaceLabel: workspaceLabel,
+                repositoryCheckout: nil,
+                hostUsername: "developer"))
+    }
+}

--- a/Tests/HeelerTests/Support/LiveActivityVectorFile.swift
+++ b/Tests/HeelerTests/Support/LiveActivityVectorFile.swift
@@ -84,6 +84,7 @@ struct LiveActivityVectorFile: Decodable, Sendable {
         let name: String?
         let status: String
         let title: String?
+        let workspace: String?
     }
 
     struct Invalid: Decodable, Sendable, CustomStringConvertible {

--- a/docs/agents/live-activity-contract.md
+++ b/docs/agents/live-activity-contract.md
@@ -43,7 +43,7 @@ opened as an activity envelope, and vice versa.
 Decrypted plaintext (canonical form):
 
 ```json
-{"agents": [{"kind": "claude", "name": "reviewer", "pane": "wV:p1", "status": "blocked", "title": "..."}],
+{"agents": [{"kind": "claude", "name": "reviewer", "pane": "wV:p1", "status": "blocked", "title": "...", "workspace": "Heeler"}],
  "host": "mbp", "v": 1}
 ```
 
@@ -63,8 +63,11 @@ Decrypted plaintext (canonical form):
   graphemes; omitted (not empty) when unavailable. `kind` falls back to
   `"unknown"`.
 - `name` is the herdr agent name (`display_agent ?? name`), trimmed to ≤80
-  graphemes; omitted (not empty) when the agent is unnamed. Agent entry key
-  order stays alphabetical: `kind` < `name` < `pane` < `status` < `title`.
+  graphemes; omitted (not empty) when the agent is unnamed.
+- `workspace` is the herdr workspace label resolved by `workspace_id`, trimmed
+  to ≤80 graphemes and omitted when unavailable. It is additive v1 metadata,
+  so older senders remain readable with a kind-only identity. Agent entry key
+  order is `kind` < `name` < `pane` < `status` < `title` < `workspace`.
 - `host` is the Host machine's short hostname (first DNS label), ≤80
   graphemes.
 - Unknown fields in plaintext or envelope frame are ignored (additive v1
@@ -73,15 +76,15 @@ Decrypted plaintext (canonical form):
   APNs payload stays under 4096. Producers degrade in order: drop all
   `title` fields, then send `agents: []`; counts always fit.
 
-The widget renders no Host identity: an agent renders as two lines
-mirroring the herdr sidebar's hierarchy — the task `title` on top with
-the identity (`name`, falling back to `kind` when unnamed, exactly like
-the TUI) indented beneath; a missing title promotes the identity to the
-top line alone. The lock screen draws a uniform list in envelope order
-(pinned eligible first, then status rank): all four rows when the
-inventory fits, otherwise three rows plus "+N more" (the ~160pt banner
-budget). The `host` field stays in the wire for producers but is not
-displayed.
+The widget renders no Host identity. Every Agent uses identical, leading-aligned
+geometry: a colored status dot beside `workspace`, then the friendly Agent kind
+(for example `Claude`) underneath. There is no status word, status-specific row
+inset, or background. Terminal titles and custom Agent names remain backward-compatible
+encrypted metadata but are not notification identity. The lock screen draws
+the uniform list in envelope order (pinned eligible first, then status rank):
+all four rows when the inventory fits, otherwise four rows plus "+N more"
+within the ~160pt banner budget. The `host` field stays in the wire for
+producers but is not displayed.
 
 ## Relay request (plugin → relay)
 

--- a/docs/design/issue-247-live-activity-redesign.md
+++ b/docs/design/issue-247-live-activity-redesign.md
@@ -1,9 +1,16 @@
 # Issue #247 Live Activity redesign
 
-Status: Implementation-ready
+Status: Implemented; identity decisions superseded by #260
 Date: 2026-08-27
 Issue: [#247](https://github.com/zingerbee/Heeler/issues/247)
 Scope: widget UI in `Sources/HeelerWidgets/AgentLiveActivityWidget.swift`, Lock Screen row-cap helpers in `Sources/HeelerWidgets/AgentActivityDecryptor.swift`, compiling the existing `Sources/Heeler/Console/AgentStatusPalette.swift` into the widget target, and the `project.yml` / `Heeler.xcodeproj` regeneration that target change requires. Wire contract, encryption, start/update/end, envelope row ordering, and chip enumeration order are unchanged (ADR 0014, `docs/agents/live-activity-contract.md`).
+
+> Issue #260 later superseded this document's row identity, hierarchy, spacing,
+> and Blocked-background decisions. Current Live Activity rows render
+> a colored status dot beside `workspace`, with `friendly kind` underneath,
+> identical leading alignment, and no row background. ADR 0014 and
+> `docs/agents/live-activity-contract.md` are authoritative; the system-color,
+> link, lifecycle, and row-budget decisions below still apply.
 
 This is not a one-line color swap. Light Mode is broken because the banner is a branded dark slab that ignores the system appearance, and the status inks were authored only for that slab. The redesign keeps Heeler's herdr-aligned status language and the existing aggregate list, and makes the Lock Screen presentation native, calm, information-dense, and legible in both appearances.
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -362,8 +362,9 @@ this command and `src/notify-hook.js` for the same event (verified on
 notify hook: `notify` flags do not gate it, and a Host with no
 `live_activity` registration sends nothing.
 
-The hook lists the Host's agents through `HERDR_BIN_PATH` (`herdr agent list`)
-and drives one Live Activity per Host. Eligible statuses are **Working**,
+The hook lists the Host's agents through `HERDR_BIN_PATH` (`herdr agent list`),
+resolves workspace labels best-effort through `herdr workspace list`, and drives
+one Live Activity per Host. Eligible statuses are **Working**,
 **Blocked**, and **Done**; idle and unknown panes are hidden. The encrypted
 details envelope uses the same Notification Key as alerts, sealed under AAD
 `HERDR-ACTIVITY:1` (see `docs/agents/live-activity-contract.md` and
@@ -392,9 +393,10 @@ activity token, and the sealed envelope. Transient failures (network errors,
 429, 5xx) are retried up to 3 attempts. A `410 Unregistered` verdict deletes
 only that entry's `live_activity` field, preserving the alert `token`, `key`,
 `notify` flags, and any field this plugin does not understand. A relay-origin
-`413` degrades the envelope once per step (drop every `title`, then send
-`agents: []`) and retries; the hook also pre-degrades when the projected
-ciphertext would exceed the Live Activity size budget.
+`413` degrades the envelope once per step (drop every `title` while retaining
+the displayed workspace/kind/status, then send `agents: []`) and retries;
+the hook also pre-degrades when the projected ciphertext would exceed the Live
+Activity size budget.
 
 Last-state (`activity/last-state.json`: `sent_at_ms`, `statuses`, `ended`) is
 written only after at least one successful delivery. All state writes are

--- a/plugin/src/activity-envelope.js
+++ b/plugin/src/activity-envelope.js
@@ -50,7 +50,8 @@ export function canonicalActivityPlaintext(plaintext) {
   const agents = Array.isArray(plaintext?.agents) ? plaintext.agents : [];
   return JSON.stringify({
     agents: agents.map((agent) => {
-      const entry = { kind: agent.kind };
+      const entry = {};
+      entry.kind = agent.kind;
       if (typeof agent.name === "string" && agent.name.length > 0) {
         entry.name = agent.name;
       }
@@ -58,6 +59,9 @@ export function canonicalActivityPlaintext(plaintext) {
       entry.status = agent.status;
       if (typeof agent.title === "string" && agent.title.length > 0) {
         entry.title = agent.title;
+      }
+      if (typeof agent.workspace === "string" && agent.workspace.length > 0) {
+        entry.workspace = agent.workspace;
       }
       return entry;
     }),

--- a/plugin/src/activity-hook.js
+++ b/plugin/src/activity-hook.js
@@ -200,10 +200,38 @@ async function listAgents(binPath) {
   return agents;
 }
 
+/**
+ * Resolve all workspace labels once per update. Labels are presentation-only,
+ * so a Host that cannot answer still sends kind-only identities.
+ */
+async function listWorkspaceLabels(binPath) {
+  try {
+    const result = await runHerdr(binPath, ["workspace", "list"]);
+    if (result.code !== 0) return new Map();
+    const workspaces = JSON.parse(result.stdout)?.result?.workspaces;
+    if (!Array.isArray(workspaces)) return new Map();
+    const labels = new Map();
+    for (const workspace of workspaces) {
+      const id = optionalText(workspace?.workspace_id);
+      const label = optionalText(workspace?.label);
+      if (id !== null && label !== null) labels.set(id, label);
+    }
+    return labels;
+  } catch {
+    return new Map();
+  }
+}
+
 function dropTitles(plaintextObject) {
   return {
     agents: plaintextObject.agents.map((agent) => {
-      const entry = { kind: agent.kind, pane: agent.pane, status: agent.status };
+      const entry = {};
+      entry.kind = agent.kind;
+      entry.pane = agent.pane;
+      entry.status = agent.status;
+      if (typeof agent.workspace === "string" && agent.workspace.length > 0) {
+        entry.workspace = agent.workspace;
+      }
       return entry;
     }),
     host: plaintextObject.host,
@@ -372,6 +400,7 @@ async function main() {
   const empty = Object.keys(statuses).length === 0;
   if (empty && lastState?.ended === true) return;
 
+  const workspaceLabels = empty ? new Map() : await listWorkspaceLabels(binPath);
   const pushEvent = empty ? "end" : "update";
   const priority = hasNewlyBlocked(statuses, previous) ? 10 : 5;
   const timestamp = Math.floor(Date.now() / 1000);
@@ -385,6 +414,7 @@ async function main() {
       agents,
       hostName,
       pinnedPaneIds: device.pinnedPaneIds,
+      workspaceLabels,
     });
     const content =
       pushEvent === "end"

--- a/plugin/src/activity-state.js
+++ b/plugin/src/activity-state.js
@@ -78,10 +78,15 @@ export function parsePinnedPaneIds(value) {
 }
 
 /**
- * @param {{agents: object[], hostName: string, pinnedPaneIds?: unknown}} input
+ * @param {{agents: object[], hostName: string, pinnedPaneIds?: unknown, workspaceLabels?: Map<string, string>}} input
  * @returns {{counts: {working: number, blocked: number, done: number}, plaintextObject: object}}
  */
-export function buildActivityState({ agents, hostName, pinnedPaneIds }) {
+export function buildActivityState({
+  agents,
+  hostName,
+  pinnedPaneIds,
+  workspaceLabels = new Map(),
+}) {
   const counts = { working: 0, blocked: 0, done: 0 };
   const eligible = [];
   for (const agent of Array.isArray(agents) ? agents : []) {
@@ -115,11 +120,15 @@ export function buildActivityState({ agents, hostName, pinnedPaneIds }) {
     const name = forDisplay(
       optionalText(entry.agent.display_agent) ?? optionalText(entry.agent.name),
     );
-    const wire = { kind: optionalText(entry.agent.agent) ?? "unknown" };
+    const wire = {};
+    wire.kind = optionalText(entry.agent.agent) ?? "unknown";
     if (name !== null) wire.name = name;
     wire.pane = entry.pane;
     wire.status = entry.status;
     if (title !== null) wire.title = title;
+    const workspaceId = optionalText(entry.agent.workspace_id);
+    const workspace = forDisplay(workspaceId === null ? null : workspaceLabels.get(workspaceId));
+    if (workspace !== null) wire.workspace = workspace;
     return wire;
   });
   return {

--- a/plugin/test-vectors/live-activity-content-v1.json
+++ b/plugin/test-vectors/live-activity-content-v1.json
@@ -1,18 +1,19 @@
 {
-  "description": "Shared Live Activity content envelope v1 test vectors (docs/agents/live-activity-contract.md). Single source of truth for the encrypted per-Host agent details carried inside a Live Activity content-state, consumed by both the Node plugin tests (seal direction) and the Swift app tests (open direction, plus seal for app-local updates). Envelopes were generated with raw AES-256-GCM calls, independent of all implementations. AAD is HERDR-ACTIVITY:1 (domain-separated from HERDR-NOTIFY:1; see the cross-AAD invalid vector). Canonical plaintext encoding: compact JSON, object keys in ascending alphabetical order at every level; agents ordered pinned-eligible first by pinned_pane_ids index (most recently pinned first), then blocked > done > working with ties by pane ascending, capped at 5 entries after that sort; name (the herdr agent name) and title are each omitted when absent, <=80 graphemes otherwise; agent entry key order kind < name < pane < status < title. Vectors that carry `inventory` (herdr agent-list shape) and `pinned_pane_ids` pin the sort rule: producers must build `payload` from that input. Producers keep the base64url ct <= ~2800 bytes by dropping titles first, then sending empty agents. `key` is the 32-byte Notification Key and `keyId` its derived id, both unpadded base64url. Non-`decodeOnly` valid vectors must be reproduced byte-for-byte by the seal side; `decodeOnly: true` envelopes must open to `payload` but are not canonical encodings. Invalid vectors must fail with the given typed error.",
+  "description": "Shared Live Activity content envelope v1 test vectors (docs/agents/live-activity-contract.md). Single source of truth for the encrypted per-Host agent details carried inside a Live Activity content-state, consumed by both the Node plugin tests (seal direction) and the Swift app tests (open direction, plus seal for app-local updates). Envelopes were generated with raw AES-256-GCM calls, independent of all implementations. AAD is HERDR-ACTIVITY:1 (domain-separated from HERDR-NOTIFY:1; see the cross-AAD invalid vector). Canonical plaintext encoding: compact JSON, object keys in ascending alphabetical order at every level; agents ordered pinned-eligible first by pinned_pane_ids index (most recently pinned first), then blocked > done > working with ties by pane ascending, capped at 5 entries after that sort; name, title, and workspace are omitted when absent and <=80 graphemes otherwise; agent entry key order kind < name < pane < status < title < workspace. Vectors that carry `inventory` (herdr agent-list shape) and `pinned_pane_ids` pin the sort rule: producers must build `payload` from that input. Producers keep the base64url ct <= ~2800 bytes by dropping titles first, then sending empty agents. `key` is the 32-byte Notification Key and `keyId` its derived id, both unpadded base64url. Non-`decodeOnly` valid vectors must be reproduced byte-for-byte by the seal side; `decodeOnly: true` envelopes must open to `payload` but are not canonical encodings. Invalid vectors must fail with the given typed error.",
   "valid": [
     {
       "name": "single working agent",
       "key": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
       "keyId": "Yw3NKWbEM2Y",
-      "envelope": "{\"v\":1,\"kid\":\"Yw3NKWbEM2Y\",\"n\":\"AAECAwQFBgcICQoL\",\"ct\":\"PCC3fKCLtmive8zwk4IRA-f0vRaTFz4JXALHqT8ZYdxkMpTe2Jco6EWGU8_780lMmypCt3ihzKhU_kR-Os_XmplIqh_x6wSEsspN4F9mmmndO0aE7t20zEfd_6sdns2tLk_8AhndL5Ao-r4zagh8U5gPDdiX5x-4IJ0n767EGCyBY33V7DKnHtte7AAmCqPqwb7W\"}",
+      "envelope": "{\"v\":1,\"kid\":\"Yw3NKWbEM2Y\",\"n\":\"AAECAwQFBgcICQoL\",\"ct\":\"PCC3fKCLtmive8zwk4IRA-f0vRaTFz4JXALHqT8ZYdxkMpTe2Jco6EWGU8_780lMmypCt3ihzKhU_kR-Os_XmplIqh_x6wSEsspN4F9mmmndO0aE7t20zEfd_6sdns2tLk_8AhndL5Ao-r4zalkDCNUVCdiTpEb_b8V1heeDAmvJcH2bmPWjPHuVapsfty6yFNjBQxcrojcNZwS5VIpvnN0kJjgYmmMb\"}",
       "payload": {
         "agents": [
           {
             "kind": "claude",
             "pane": "wV:p1",
             "status": "working",
-            "title": "实现锁屏显示 agent 工作状态"
+            "title": "实现锁屏显示 agent 工作状态",
+            "workspace": "Heeler"
           }
         ],
         "host": "mbp",

--- a/plugin/test/activity-envelope.test.js
+++ b/plugin/test/activity-envelope.test.js
@@ -25,6 +25,9 @@ function openedFields(payload) {
       const entry = { kind: agent.kind, pane: agent.pane, status: agent.status };
       if (typeof agent.name === "string" && agent.name.length > 0) entry.name = agent.name;
       if (typeof agent.title === "string" && agent.title.length > 0) entry.title = agent.title;
+      if (typeof agent.workspace === "string" && agent.workspace.length > 0) {
+        entry.workspace = agent.workspace;
+      }
       return entry;
     }),
   };

--- a/plugin/test/activity-hook.test.js
+++ b/plugin/test/activity-hook.test.js
@@ -81,9 +81,12 @@ async function startFakeRelay(respond = () => ({ status: 200, body: { apnsId: "x
   });
 }
 
-function writeHerdrStub(agents) {
+function writeHerdrStub(
+  agents,
+  workspaces = [{ workspace_id: "w1", label: "Heeler" }],
+) {
   const binPath = join(stubDir, "herdr");
-  writeFileSync(join(stubDir, "response.json"), JSON.stringify({ agents }));
+  writeFileSync(join(stubDir, "response.json"), JSON.stringify({ agents, workspaces }));
   writeFileSync(
     binPath,
     [
@@ -96,15 +99,15 @@ function writeHerdrStub(agents) {
       '  path.join(dir, "invocations.log"),',
       '  JSON.stringify({ args, at: Date.now() }) + "\\n",',
       ");",
-      'if (args[0] !== "agent" || args[1] !== "list") {',
+      'const response = JSON.parse(fs.readFileSync(path.join(dir, "response.json"), "utf8"));',
+      'if (args[0] === "agent" && args[1] === "list") {',
+      '  process.stdout.write(JSON.stringify({ id: "cli:agent:list", result: { agents: response.agents, type: "agent_list" } }));',
+      '} else if (args[0] === "workspace" && args[1] === "list") {',
+      '  process.stdout.write(JSON.stringify({ id: "cli:workspace:list", result: { workspaces: response.workspaces, type: "workspace_list" } }));',
+      '} else {',
       '  process.stderr.write(`stub: unexpected subcommand ${args.join(" ")}`);',
       "  process.exit(64);",
       "}",
-      'const response = JSON.parse(fs.readFileSync(path.join(dir, "response.json"), "utf8"));',
-      "process.stdout.write(JSON.stringify({",
-      '  id: "cli:agent:list",',
-      "  result: { agents: response.agents, type: \"agent_list\" },",
-      "}));",
       "process.exit(0);",
     ].join("\n"),
     { mode: 0o755 },
@@ -299,8 +302,12 @@ suite("activity-hook: update and end", () => {
     assert.equal(opened.payload.agents[0].pane, PANE_ID);
     assert.equal(opened.payload.agents[0].status, "working");
     assert.equal(opened.payload.agents[0].title, "实现锁屏显示 agent 工作状态");
+    assert.equal(opened.payload.agents[0].workspace, "Heeler");
     decryptEnvelope(byToken.get(ACTIVITY_TOKEN_B).envelope, KEY_B);
-    assert.deepEqual(stubInvocations()[0].args, ["agent", "list"]);
+    assert.deepEqual(stubInvocations().map((entry) => entry.args), [
+      ["agent", "list"],
+      ["workspace", "list"],
+    ]);
   });
 
   test("pinned_pane_ids from each device reorder that device's envelope only", async () => {
@@ -461,6 +468,7 @@ suite("activity-hook: relay failures", () => {
     const second = decryptEnvelope(relay.requests[1].body.envelope, KEY_A);
     assert.equal(first.payload.agents[0].title, "a long enough title to drop");
     assert.equal("title" in second.payload.agents[0], false);
+    assert.equal(second.payload.agents[0].workspace, "Heeler");
     assert.equal(second.payload.agents[0].pane, PANE_ID);
     assert.equal(second.payload.agents[0].status, "working");
   });

--- a/plugin/test/activity-state.test.js
+++ b/plugin/test/activity-state.test.js
@@ -99,6 +99,21 @@ suite("buildActivityState", () => {
     assert.deepEqual(Object.keys(byPane["w1:p1"]), ["kind", "name", "pane", "status"]);
   });
 
+  test("carries the workspace label by workspace id and omits unavailable labels", () => {
+    const { plaintextObject } = buildActivityState({
+      agents: [
+        agent("w1:p1", "working", { agent: "codex", workspace_id: "w1" }),
+        agent("w2:p1", "blocked", { agent: "claude", workspace_id: "missing" }),
+      ],
+      hostName: "mbp",
+      workspaceLabels: new Map([["w1", "Heeler"]]),
+    });
+    const byPane = Object.fromEntries(plaintextObject.agents.map((entry) => [entry.pane, entry]));
+    assert.equal(byPane["w1:p1"].workspace, "Heeler");
+    assert.equal("workspace" in byPane["w2:p1"], false);
+    assert.deepEqual(Object.keys(byPane["w1:p1"]), ["kind", "pane", "status", "workspace"]);
+  });
+
   test("prefers the stripped title, falls kind back to unknown, and trims host", () => {
     const longHost = "h".repeat(DISPLAY_LIMIT + 5);
     const { plaintextObject } = buildActivityState({


### PR DESCRIPTION
## Summary

- use one notification identity everywhere: herdr workspace plus a friendly Agent kind, with kind-only fallback
- resolve workspace labels best-effort in the plugin and carry them as additive v1 Live Activity envelope metadata
- render every Live Activity row with identical compact geometry: status dot and workspace, then Agent kind underneath
- render foreground and APNs notifications as `Workspace · Agent` with status-only body copy
- remove terminal titles, custom Agent names, cwd, and status-specific row backgrounds from notification presentation
- preserve the existing Live Activity lifecycle, status chips, delivery rules, and deep links

## Relationship to #259

This is stacked on #259. The notification implementation is the final commit (`7d412fe`); after #259 merges, its Agent-card commit will drop out of this PR's diff automatically.

## Testing

- `cd plugin && npm test` — 222/222 passed
- `scripts/run-heelerssh-package-tests.sh 'platform=iOS Simulator,name=iPhone 17'` — passed (12 executed, 31 fixture-gated)
- `make test` — 1,304/1,305 app tests passed; the sole failure is the newly upstream `AgentDirectInputTests.composerAndDirectInputTransferVisibleKeyboardWithoutReloading()` keyboard-notification timing assertion
- the complete `AgentDirectInputTests` suite in a disposable, detached `origin/main` worktree reproduces that exact same failure and assertion on the same iOS 26.5 Simulator, confirming it is independent of this stack
- built and installed with `make sim`
- visually verified and approved on an isolated iPhone 17 Simulator using genuine ActivityKit Live Activity and notification surfaces

Closes #260
