### PR TITLE
fix: restore Attach with the ready transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Entries reference the issue that motivated them.
 ### Fixed
 
 - Attach terminals begin restoring as soon as a reconnected Host's Transport
-  is ready, without waiting for event subscription and snapshot recovery. (#264)
+  is ready, without waiting for event subscription and snapshot recovery. (#264; PR #265)
 
 ## [0.1.3] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Entries reference the issue that motivated them.
   Composer remains the default. Switching modes preserves the draft and keeps
   a visible iOS keyboard in place. (#251; PR #253)
 
+### Fixed
+
+- Attach terminals begin restoring as soon as a reconnected Host's Transport
+  is ready, without waiting for event subscription and snapshot recovery. (#264)
+
 ## [0.1.3] - 2026-08-28
 
 ### Changed

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		3662BE3559CB08401960176C /* AgentNotificationRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B02412C186BA855DFD9379A /* AgentNotificationRoutingTests.swift */; };
 		3684BDED2C234F399A6758C9 /* GhosttyTheme in Frameworks */ = {isa = PBXBuildFile; productRef = E086C559FC229264CF662993 /* GhosttyTheme */; };
 		36FB81E449F98DC68A366C2E /* HerdrAPITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F7065C3BE109D2F52AE3BC2 /* HerdrAPITypes.swift */; };
+		3776558F9FD16419AC405116 /* AttachRestorationTraceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BD5F61844F525B628AB358 /* AttachRestorationTraceTests.swift */; };
 		388498BDF8F2848EA515819B /* HostOnboardingPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D6865847B4D827038D1AF0 /* HostOnboardingPresentationTests.swift */; };
 		390E9313FFE9AA540C6B6113 /* AgentInputModeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F641C391CC59D30055B5F85F /* AgentInputModeSettings.swift */; };
 		3ABBA2BF9C6B51EF1E0C7314 /* TerminalKeysKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC019B4A164A7B01F1D46344 /* TerminalKeysKeyboard.swift */; };
@@ -218,6 +219,7 @@
 		A20CC86A7DC41BD651647882 /* KnownHostsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89A4121CF3A5722FE9B3C1E8 /* KnownHostsStore.swift */; };
 		A22BF5A22115749857055CED /* Base64URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32413805C1AA874DBEE37547 /* Base64URL.swift */; };
 		A236FAB25CBCB58BDDDBA00C /* TerminalMouseReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4997A79DA8D98F7BA97E60F6 /* TerminalMouseReporting.swift */; };
+		A25418700A3D7FCCC08026BF /* AttachRestorationTrace.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE2F11B705B68BB1FBE993D /* AttachRestorationTrace.swift */; };
 		A2DE15E21439EDC3B04F5DFA /* HostListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79662827F6A91D8EFBF112F7 /* HostListView.swift */; };
 		A32FEE6CB03586CB5117A3C5 /* TerminalZoomSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2CED0240EA91B680CF3A758 /* TerminalZoomSettings.swift */; };
 		A4693B8221D4D110809D1175 /* SnippetsKeyboardPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EE6515A20AFA09762788C5 /* SnippetsKeyboardPane.swift */; };
@@ -632,6 +634,7 @@
 		D4CA687285B470E3968D1DB6 /* PairingCeremony.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCeremony.swift; sourceTree = "<group>"; };
 		D588CA22544907E638437FEA /* AgentInputModeSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInputModeSettingsTests.swift; sourceTree = "<group>"; };
 		D5C058D102046A707547A0FD /* GeneratedWireTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedWireTypesTests.swift; sourceTree = "<group>"; };
+		D6BD5F61844F525B628AB358 /* AttachRestorationTraceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachRestorationTraceTests.swift; sourceTree = "<group>"; };
 		D6EA52B6C673891A3ABBA27E /* AgentNotificationBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationBannerView.swift; sourceTree = "<group>"; };
 		D6F4E5BC2440CFE0FEB3591B /* HeelerSSHHostKeyVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHHostKeyVerifier.swift; sourceTree = "<group>"; };
 		D6F5C337F9BC29D46E48E35E /* HeelerSSHJumpHostGateE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHJumpHostGateE2ETests.swift; sourceTree = "<group>"; };
@@ -675,6 +678,7 @@
 		FB37CBDC9DE0CE539FC476A0 /* AgentNotificationRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationRenderer.swift; sourceTree = "<group>"; };
 		FB43ADC71539AC324F155DD0 /* HeelerWidgetsBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerWidgetsBundle.swift; sourceTree = "<group>"; };
 		FBA937EDF831047EA33892F9 /* HeelerTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HeelerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FBE2F11B705B68BB1FBE993D /* AttachRestorationTrace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachRestorationTrace.swift; sourceTree = "<group>"; };
 		FDC98A5038CD109556BE903F /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
 		FE0B6961E10487A3AC3547E9 /* Preflight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preflight.swift; sourceTree = "<group>"; };
 		FE302F516B139F4BADCEC6CB /* EventsSessionBufferingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionBufferingTests.swift; sourceTree = "<group>"; };
@@ -738,6 +742,7 @@
 				12CB6AC68294D97226EBF857 /* AppAppearanceSettingsTests.swift */,
 				0B248F9372687FDBE3AD24A1 /* AppForegroundRecoveryTests.swift */,
 				93417EFE29FA2DC3DD3FAF9F /* AsyncDeadlineTests.swift */,
+				D6BD5F61844F525B628AB358 /* AttachRestorationTraceTests.swift */,
 				8C5A562F5A01AE08691B8479 /* AttachTerminalStoreTests.swift */,
 				414B652A16576BEDEE9AE000 /* ClosePaneStoreTests.swift */,
 				F4616CECA2722086A6B8B490 /* ComposerAttachmentTests.swift */,
@@ -976,6 +981,7 @@
 				9A430D16838A39772ED0AA73 /* AgentStatusPalette.swift */,
 				F234ED041A4A2835A59A7510 /* AgentTerminalView.swift */,
 				5870640477FDEB252DEE80B7 /* AttachLinkIndex.swift */,
+				FBE2F11B705B68BB1FBE993D /* AttachRestorationTrace.swift */,
 				F07A0F64626D74A8EC9A1FE2 /* AttachTerminalStore.swift */,
 				1D46328CE795C513FE11AD04 /* ClosePaneStore.swift */,
 				6D83F0739372AE699009E238 /* ConsoleAgent.swift */,
@@ -1487,6 +1493,7 @@
 				8D9ED28E1DB5A72B471CBD45 /* AppAppearanceSettings.swift in Sources */,
 				76EAFFA9DAD45987F02DC536 /* AsyncDeadline.swift in Sources */,
 				3C5AFE8D3844A13198DDBEEA /* AttachLinkIndex.swift in Sources */,
+				A25418700A3D7FCCC08026BF /* AttachRestorationTrace.swift in Sources */,
 				052916002C06699B9F2F1A4B /* AttachTerminalStore.swift in Sources */,
 				B787DA8CB25A81E3914F8638 /* AttachmentStaging.swift in Sources */,
 				35205050C9CB8E473D8A28C0 /* Base64URL.swift in Sources */,
@@ -1653,6 +1660,7 @@
 				F2EDACBD031E425D1B629920 /* AppAppearanceSettingsTests.swift in Sources */,
 				DF1D75FBECE8FABC8E3A093D /* AppForegroundRecoveryTests.swift in Sources */,
 				969C4D0D24CCCE445C85D0AC /* AsyncDeadlineTests.swift in Sources */,
+				3776558F9FD16419AC405116 /* AttachRestorationTraceTests.swift in Sources */,
 				E40D1C6F825ABCD68AA5F196 /* AttachTerminalStoreTests.swift in Sources */,
 				5150B659FACE9AFD9ECF9F6D /* AuthorizedKeysTestLock.swift in Sources */,
 				61F58007C6B81F14D2F6B58B /* ClosePaneStoreTests.swift in Sources */,

--- a/Sources/Heeler/Console/AgentAttachStore.swift
+++ b/Sources/Heeler/Console/AgentAttachStore.swift
@@ -102,9 +102,9 @@ final class AgentAttachStore {
     /// ordinary replacement and rejoin transitions keep their existing teardown
     /// semantics.
     private var activationRecoveryOwnsOnStageLifecycle = false
-    /// A foreground replacement already waits at the terminal-ready seam. The
-    /// matching generation publication acknowledges that same pipeline; it
-    /// must not enqueue a second writer behind it.
+    /// A foreground replacement already waits at the terminal-ready seam. Its
+    /// exact acquired generation may acknowledge that same pipeline; a newer
+    /// generation must still enqueue the replacement that owns it.
     private var activationRecoveryAwaitsTransport = false
 
     init(
@@ -294,7 +294,8 @@ final class AgentAttachStore {
         guard let generation, lifecycleState == .active else { return }
         if activationRecoveryAwaitsTransport,
             terminalRecoveryOwner != nil || terminal.status == .waitingForSize
-                || terminal.status == .connecting
+                || terminal.status == .connecting,
+            terminal.acquiredTransportGeneration == generation
         {
             transportGeneration = generation
             activationRecoveryAwaitsTransport = false

--- a/Sources/Heeler/Console/AgentAttachStore.swift
+++ b/Sources/Heeler/Console/AgentAttachStore.swift
@@ -269,10 +269,8 @@ final class AgentAttachStore {
             }
             if terminalRecoveryOwner != nil {
                 activationRecoveryOwnsOnStageLifecycle = true
-                activationRecovery.begin()
-                if let transportGeneration {
-                    _ = activationRecovery.recordProjection(transportGeneration)
-                }
+                activationRecovery.begin(
+                    projectedGeneration: transportGeneration)
                 return
             }
             if terminal.transportGeneration == transportGeneration,
@@ -281,7 +279,8 @@ final class AgentAttachStore {
                 return
             }
             input.detachSessionForReplacement()
-            activationRecovery.begin()
+            activationRecovery.begin(
+                projectedGeneration: transportGeneration)
             replaceTerminal(ownsOnStageLifecycle: true) { [weak self] in
                 guard let self else { return false }
                 return self.lifecycleState == .active && self.isOnStage()

--- a/Sources/Heeler/Console/AgentAttachStore.swift
+++ b/Sources/Heeler/Console/AgentAttachStore.swift
@@ -102,6 +102,10 @@ final class AgentAttachStore {
     /// ordinary replacement and rejoin transitions keep their existing teardown
     /// semantics.
     private var activationRecoveryOwnsOnStageLifecycle = false
+    /// A foreground replacement already waits at the terminal-ready seam. The
+    /// matching generation publication acknowledges that same pipeline; it
+    /// must not enqueue a second writer behind it.
+    private var activationRecoveryAwaitsTransport = false
 
     init(
         target: String,
@@ -123,7 +127,8 @@ final class AgentAttachStore {
         let linkIndex = AttachLinkIndex()
         self.linkIndex = linkIndex
         terminal = Self.makeTerminal(
-            target: target, input: input, runTerminal: runTerminal, linkIndex: linkIndex)
+            target: target, input: input, transportGeneration: transportGeneration,
+            runTerminal: runTerminal, linkIndex: linkIndex)
         staging = ComposerStagingStore(
             stageImage: stageImage,
             stageFile: stageFile,
@@ -259,7 +264,18 @@ final class AgentAttachStore {
     func didBecomeActive(afterPossibleSuspension: Bool = false) {
         guard lifecycleState == .active, isOnStage() else { return }
         guard !afterPossibleSuspension else {
+            if terminalRecoveryOwner != nil {
+                activationRecoveryOwnsOnStageLifecycle = true
+                activationRecoveryAwaitsTransport = true
+                return
+            }
+            if terminal.transportGeneration == transportGeneration,
+                terminal.status == .waitingForSize || terminal.status == .connecting
+            {
+                return
+            }
             input.detachSessionForReplacement()
+            activationRecoveryAwaitsTransport = true
             replaceTerminal(ownsOnStageLifecycle: true) { [weak self] in
                 guard let self else { return false }
                 return self.lifecycleState == .active && self.isOnStage()
@@ -275,9 +291,21 @@ final class AgentAttachStore {
     /// stager resolves the live Transport per call, so a retryable or
     /// completed upload stays actionable across the reconnect.
     func transportGenerationDidChange(_ generation: UInt64?) {
-        guard let generation, generation != transportGeneration,
-            lifecycleState == .active
-        else { return }
+        guard let generation, lifecycleState == .active else { return }
+        if activationRecoveryAwaitsTransport,
+            terminalRecoveryOwner != nil || terminal.status == .waitingForSize
+                || terminal.status == .connecting
+        {
+            transportGeneration = generation
+            activationRecoveryAwaitsTransport = false
+            return
+        }
+        activationRecoveryAwaitsTransport = false
+        if terminal.transportGeneration == generation {
+            transportGeneration = generation
+            return
+        }
+        guard generation != transportGeneration else { return }
         transportGeneration = generation
         replaceTerminal { [weak self] in
             guard let self else { return false }
@@ -328,6 +356,7 @@ final class AgentAttachStore {
             self.terminal = Self.makeTerminal(
                 target: self.target,
                 input: self.input,
+                transportGeneration: self.transportGeneration,
                 runTerminal: self.runTerminal,
                 linkIndex: self.linkIndex)
             self.finishTerminalRecovery(ownedBy: recoveryOwner)
@@ -407,6 +436,7 @@ final class AgentAttachStore {
             self.terminal = Self.makeTerminal(
                 target: self.target,
                 input: self.input,
+                transportGeneration: self.transportGeneration,
                 runTerminal: self.runTerminal,
                 linkIndex: self.linkIndex)
             self.finishTerminalRecovery(ownedBy: recoveryOwner)
@@ -425,6 +455,7 @@ final class AgentAttachStore {
             !isOnStage()
         else { return }
         lifecycleState = .rejoinRequired
+        activationRecoveryAwaitsTransport = false
         finishTerminalRecovery(ownedBy: owner)
     }
 
@@ -468,6 +499,7 @@ final class AgentAttachStore {
         lifecycleState = .left
         terminalRecoveryOwner = nil
         activationRecoveryOwnsOnStageLifecycle = false
+        activationRecoveryAwaitsTransport = false
         invalidateAttachLinkOpen()
         attachLinkOpenFailure = nil
         linkIndex.clear()
@@ -515,6 +547,7 @@ final class AgentAttachStore {
     private static func makeTerminal(
         target: String,
         input: TerminalInputController,
+        transportGeneration: UInt64?,
         runTerminal: @escaping TerminalSessionRunner,
         linkIndex: AttachLinkIndex
     ) -> AttachTerminalStore {
@@ -522,6 +555,7 @@ final class AgentAttachStore {
             target: target,
             takeover: true,
             input: input,
+            transportGeneration: transportGeneration,
             observeOutput: { data in linkIndex.receive(data) },
             finishOutput: { linkIndex.finishOutput() },
             runTerminal: runTerminal)

--- a/Sources/Heeler/Console/AgentAttachStore.swift
+++ b/Sources/Heeler/Console/AgentAttachStore.swift
@@ -161,6 +161,22 @@ final class AgentAttachStore {
         terminal.feed
     }
 
+    #if DEBUG
+    func terminalDidBecomeVisible() {
+        terminal.restorationTrace.emit(.agentDetailVisible, generation: terminal.transportGeneration)
+    }
+
+    func agentSnapshotSwitcherDidBecomeAvailable() {
+        terminal.restorationTrace.emit(
+            .agentSnapshotSwitcherAvailable,
+            generation: terminal.transportGeneration)
+    }
+
+    func terminalSurfaceDidAttach() {
+        terminal.restorationTrace.emit(.terminalSurfaceAttached, generation: terminal.transportGeneration)
+    }
+    #endif
+
     var attachLinks: [AttachLink] {
         linkIndex.links
     }

--- a/Sources/Heeler/Console/AgentAttachStore.swift
+++ b/Sources/Heeler/Console/AgentAttachStore.swift
@@ -102,10 +102,9 @@ final class AgentAttachStore {
     /// ordinary replacement and rejoin transitions keep their existing teardown
     /// semantics.
     private var activationRecoveryOwnsOnStageLifecycle = false
-    /// A foreground replacement already waits at the terminal-ready seam. Its
-    /// exact acquired generation may acknowledge that same pipeline; a newer
-    /// generation must still enqueue the replacement that owns it.
-    private var activationRecoveryAwaitsTransport = false
+    /// Joins the independently scheduled readiness projection and terminal
+    /// waiter for the exact foreground-recovery pipeline.
+    private var activationRecovery = TerminalRecoveryGenerationLatch()
 
     init(
         target: String,
@@ -264,9 +263,16 @@ final class AgentAttachStore {
     func didBecomeActive(afterPossibleSuspension: Bool = false) {
         guard lifecycleState == .active, isOnStage() else { return }
         guard !afterPossibleSuspension else {
+            if activationRecovery.isActive {
+                activationRecoveryOwnsOnStageLifecycle = true
+                return
+            }
             if terminalRecoveryOwner != nil {
                 activationRecoveryOwnsOnStageLifecycle = true
-                activationRecoveryAwaitsTransport = true
+                activationRecovery.begin()
+                if let transportGeneration {
+                    _ = activationRecovery.recordProjection(transportGeneration)
+                }
                 return
             }
             if terminal.transportGeneration == transportGeneration,
@@ -275,7 +281,7 @@ final class AgentAttachStore {
                 return
             }
             input.detachSessionForReplacement()
-            activationRecoveryAwaitsTransport = true
+            activationRecovery.begin()
             replaceTerminal(ownsOnStageLifecycle: true) { [weak self] in
                 guard let self else { return false }
                 return self.lifecycleState == .active && self.isOnStage()
@@ -292,16 +298,11 @@ final class AgentAttachStore {
     /// completed upload stays actionable across the reconnect.
     func transportGenerationDidChange(_ generation: UInt64?) {
         guard let generation, lifecycleState == .active else { return }
-        if activationRecoveryAwaitsTransport,
-            terminalRecoveryOwner != nil || terminal.status == .waitingForSize
-                || terminal.status == .connecting,
-            terminal.acquiredTransportGeneration == generation
-        {
-            transportGeneration = generation
-            activationRecoveryAwaitsTransport = false
+        if let decision = activationRecovery.recordProjection(generation) {
+            advanceTransportGeneration(to: generation)
+            applyActivationRecovery(decision)
             return
         }
-        activationRecoveryAwaitsTransport = false
         if terminal.transportGeneration == generation {
             transportGeneration = generation
             return
@@ -312,6 +313,40 @@ final class AgentAttachStore {
             guard let self else { return false }
             return self.lifecycleState == .active && self.transportGeneration == generation
         }
+    }
+
+    private func terminalTransportDidBecomeReady(
+        pipelineID: TerminalSurfaceID,
+        generation: UInt64
+    ) {
+        guard
+            let decision = activationRecovery.recordAcquisition(
+                generation, by: pipelineID)
+        else { return }
+        applyActivationRecovery(decision)
+    }
+
+    private func applyActivationRecovery(
+        _ decision: TerminalRecoveryGenerationLatch.Decision
+    ) {
+        switch decision {
+        case .pending:
+            return
+        case .acknowledge(let generation), .retain(let generation):
+            advanceTransportGeneration(to: generation)
+        case .replace(let generation):
+            advanceTransportGeneration(to: generation)
+            replaceTerminal { [weak self] in
+                guard let self else { return false }
+                return self.lifecycleState == .active
+                    && self.transportGeneration == generation
+            }
+        }
+    }
+
+    private func advanceTransportGeneration(to generation: UInt64) {
+        guard transportGeneration.map({ generation > $0 }) ?? true else { return }
+        transportGeneration = generation
     }
 
     /// Tears the terminal pipeline down and builds a fresh one, serialized
@@ -354,12 +389,21 @@ final class AgentAttachStore {
                 return
             }
             guard self.terminalRecoveryOwner == recoveryOwner else { return }
-            self.terminal = Self.makeTerminal(
+            let replacement = Self.makeTerminal(
                 target: self.target,
                 input: self.input,
                 transportGeneration: self.transportGeneration,
                 runTerminal: self.runTerminal,
-                linkIndex: self.linkIndex)
+                linkIndex: self.linkIndex,
+                transportReady: { [weak self] pipelineID, generation in
+                    self?.terminalTransportDidBecomeReady(
+                        pipelineID: pipelineID, generation: generation)
+                },
+                runDidFinish: { [weak self] pipelineID in
+                    self?.activationRecovery.clear(boundTo: pipelineID)
+                })
+            self.terminal = replacement
+            self.activationRecovery.bind(to: replacement.surfaceID)
             self.finishTerminalRecovery(ownedBy: recoveryOwner)
         }
     }
@@ -399,6 +443,7 @@ final class AgentAttachStore {
     /// is actually looking at queued behind it on "Connecting…" forever.
     func rejoin() {
         guard lifecycleState != .active, isOnStage() else { return }
+        activationRecovery.clear()
         let requiresFullReplacement = lifecycleState == .rejoinRequired
         lifecycleState = .active
         // A rejoin is the latest terminal transition even when it is queued
@@ -434,12 +479,21 @@ final class AgentAttachStore {
                 return
             }
             guard self.terminalRecoveryOwner == recoveryOwner else { return }
-            self.terminal = Self.makeTerminal(
+            let replacement = Self.makeTerminal(
                 target: self.target,
                 input: self.input,
                 transportGeneration: self.transportGeneration,
                 runTerminal: self.runTerminal,
-                linkIndex: self.linkIndex)
+                linkIndex: self.linkIndex,
+                transportReady: { [weak self] pipelineID, generation in
+                    self?.terminalTransportDidBecomeReady(
+                        pipelineID: pipelineID, generation: generation)
+                },
+                runDidFinish: { [weak self] pipelineID in
+                    self?.activationRecovery.clear(boundTo: pipelineID)
+                })
+            self.terminal = replacement
+            self.activationRecovery.bind(to: replacement.surfaceID)
             self.finishTerminalRecovery(ownedBy: recoveryOwner)
         }
     }
@@ -456,7 +510,7 @@ final class AgentAttachStore {
             !isOnStage()
         else { return }
         lifecycleState = .rejoinRequired
-        activationRecoveryAwaitsTransport = false
+        activationRecovery.clear()
         finishTerminalRecovery(ownedBy: owner)
     }
 
@@ -500,7 +554,7 @@ final class AgentAttachStore {
         lifecycleState = .left
         terminalRecoveryOwner = nil
         activationRecoveryOwnsOnStageLifecycle = false
-        activationRecoveryAwaitsTransport = false
+        activationRecovery.clear()
         invalidateAttachLinkOpen()
         attachLinkOpenFailure = nil
         linkIndex.clear()
@@ -550,7 +604,11 @@ final class AgentAttachStore {
         input: TerminalInputController,
         transportGeneration: UInt64?,
         runTerminal: @escaping TerminalSessionRunner,
-        linkIndex: AttachLinkIndex
+        linkIndex: AttachLinkIndex,
+        transportReady: @escaping @MainActor @Sendable (TerminalSurfaceID, UInt64) -> Void = {
+            _, _ in
+        },
+        runDidFinish: @escaping @MainActor @Sendable (TerminalSurfaceID) -> Void = { _ in }
     ) -> AttachTerminalStore {
         AttachTerminalStore(
             target: target,
@@ -559,6 +617,8 @@ final class AgentAttachStore {
             transportGeneration: transportGeneration,
             observeOutput: { data in linkIndex.receive(data) },
             finishOutput: { linkIndex.finishOutput() },
+            transportReady: transportReady,
+            runDidFinish: runDidFinish,
             runTerminal: runTerminal)
     }
 }

--- a/Sources/Heeler/Console/AgentAttachStore.swift
+++ b/Sources/Heeler/Console/AgentAttachStore.swift
@@ -273,11 +273,6 @@ final class AgentAttachStore {
                     projectedGeneration: transportGeneration)
                 return
             }
-            if terminal.transportGeneration == transportGeneration,
-                terminal.status == .waitingForSize || terminal.status == .connecting
-            {
-                return
-            }
             input.detachSessionForReplacement()
             activationRecovery.begin(
                 projectedGeneration: transportGeneration)

--- a/Sources/Heeler/Console/AgentAttachStore.swift
+++ b/Sources/Heeler/Console/AgentAttachStore.swift
@@ -105,6 +105,12 @@ final class AgentAttachStore {
     /// Joins the independently scheduled readiness projection and terminal
     /// waiter for the exact foreground-recovery pipeline.
     private var activationRecovery = TerminalRecoveryGenerationLatch()
+    #if DEBUG
+    /// Created at the possible-suspension activation edge and retained until
+    /// the replacement that actually publishes adopts it, or recovery is
+    /// definitively abandoned off stage.
+    private(set) var pendingForegroundRecoveryTrace: AttachRestorationTrace?
+    #endif
 
     init(
         target: String,
@@ -279,6 +285,11 @@ final class AgentAttachStore {
     func didBecomeActive(afterPossibleSuspension: Bool = false) {
         guard lifecycleState == .active, isOnStage() else { return }
         guard !afterPossibleSuspension else {
+            #if DEBUG
+            if !activationRecovery.isActive {
+                beginPendingForegroundRecoveryTrace()
+            }
+            #endif
             if activationRecovery.isActive {
                 activationRecoveryOwnsOnStageLifecycle = true
                 return
@@ -398,6 +409,12 @@ final class AgentAttachStore {
                 }
                 return
             }
+            #if DEBUG
+            if !self.isOnStage(), self.pendingForegroundRecoveryTrace != nil {
+                self.abortTerminalRecoveryOffStage(ownedBy: recoveryOwner)
+                return
+            }
+            #endif
             guard self.terminalRecoveryOwner == recoveryOwner else { return }
             let replacement = Self.makeTerminal(
                 target: self.target,
@@ -412,7 +429,11 @@ final class AgentAttachStore {
                 runDidFinish: { [weak self] pipelineID in
                     self?.activationRecovery.clear(boundTo: pipelineID)
                 })
+            #if DEBUG
+            self.publishReplacement(replacement)
+            #else
             self.terminal = replacement
+            #endif
             self.activationRecovery.bind(to: replacement.surfaceID)
             self.finishTerminalRecovery(ownedBy: recoveryOwner)
         }
@@ -423,6 +444,29 @@ final class AgentAttachStore {
         terminalRecoveryOwner = nil
         activationRecoveryOwnsOnStageLifecycle = false
     }
+
+    #if DEBUG
+    private func beginPendingForegroundRecoveryTrace() {
+        guard pendingForegroundRecoveryTrace == nil else { return }
+        let trace = AttachRestorationTrace()
+        trace.emit(.foregroundRecoveryStarted, generation: transportGeneration)
+        pendingForegroundRecoveryTrace = trace
+    }
+
+    private func publishReplacement(_ replacement: AttachTerminalStore) {
+        if let trace = pendingForegroundRecoveryTrace {
+            replacement.adoptRestorationTrace(trace)
+            pendingForegroundRecoveryTrace = nil
+        }
+        terminal = replacement
+    }
+
+    private func abortPendingForegroundRecoveryTrace() {
+        guard let trace = pendingForegroundRecoveryTrace else { return }
+        trace.emit(.foregroundRecoveryAborted, generation: transportGeneration)
+        pendingForegroundRecoveryTrace = nil
+    }
+    #endif
 
     func retryTerminal() {
         terminal.retry()
@@ -485,6 +529,9 @@ final class AgentAttachStore {
                 }
             }
             guard self.terminal.status == .stopped else {
+                #if DEBUG
+                self.abortPendingForegroundRecoveryTrace()
+                #endif
                 self.finishTerminalRecovery(ownedBy: recoveryOwner)
                 return
             }
@@ -502,7 +549,11 @@ final class AgentAttachStore {
                 runDidFinish: { [weak self] pipelineID in
                     self?.activationRecovery.clear(boundTo: pipelineID)
                 })
+            #if DEBUG
+            self.publishReplacement(replacement)
+            #else
             self.terminal = replacement
+            #endif
             self.activationRecovery.bind(to: replacement.surfaceID)
             self.finishTerminalRecovery(ownedBy: recoveryOwner)
         }
@@ -520,6 +571,9 @@ final class AgentAttachStore {
             !isOnStage()
         else { return }
         lifecycleState = .rejoinRequired
+        #if DEBUG
+        abortPendingForegroundRecoveryTrace()
+        #endif
         activationRecovery.clear()
         finishTerminalRecovery(ownedBy: owner)
     }
@@ -561,6 +615,9 @@ final class AgentAttachStore {
         {
             return lifecycleTask ?? Task {}
         }
+        #if DEBUG
+        abortPendingForegroundRecoveryTrace()
+        #endif
         lifecycleState = .left
         terminalRecoveryOwner = nil
         activationRecoveryOwnsOnStageLifecycle = false

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -263,6 +263,11 @@ struct AgentTerminalView: View {
 
     private var terminalScreen: TerminalScreenView {
         var screen = TerminalScreenView(feed: attach.terminalFeed)
+        #if DEBUG
+        screen.onSurfaceAttached = {
+            attach.terminalSurfaceDidAttach()
+        }
+        #endif
         screen.onSizeChanged = { cols, rows in
             attach.viewDidResize(cols: cols, rows: rows)
         }
@@ -562,6 +567,21 @@ struct AgentTerminalView: View {
             // Arming again leaves a stale one-shot that can raise a dismissed
             // keyboard on a later replacement.
         }
+        #if DEBUG
+        // A fresh terminal ID means a new Attach pipeline, including a
+        // foreground recovery. Mark its visible detail edge separately from
+        // outer SwiftUI appearance, which does not run for that replacement.
+        .onChange(of: attach.terminalID, initial: true) { _, _ in
+            attach.terminalDidBecomeVisible()
+            recordSwitcherAvailabilityIfPossible()
+        }
+        // The switcher consumes this snapshot-derived input. Waiting until the
+        // selected Agent is present avoids treating an empty/stale projection
+        // as availability.
+        .onChange(of: console.agents) { _, _ in
+            recordSwitcherAvailabilityIfPossible()
+        }
+        #endif
         .onChange(of: keyboardControl.isFirstResponder) { _, isUp in
             // Tools→iOS keeps first responder across the coalesce window; a
             // real dismiss resigns and must drop the pre-show `.system` hold.
@@ -590,6 +610,13 @@ struct AgentTerminalView: View {
                 console.togglePin(hostID: id.hostID, paneID: id.paneID)
             })
     }
+
+    #if DEBUG
+    private func recordSwitcherAvailabilityIfPossible() {
+        guard console.agents.contains(where: { $0.id == agent.id }) else { return }
+        attach.agentSnapshotSwitcherDidBecomeAvailable()
+    }
+    #endif
 
     private var terminalKeysContext: TerminalKeysContext {
         TerminalKeysContext(

--- a/Sources/Heeler/Console/AttachRestorationTrace.swift
+++ b/Sources/Heeler/Console/AttachRestorationTrace.swift
@@ -1,0 +1,107 @@
+#if DEBUG
+import Foundation
+import os
+
+/// Debug-only timing markers for one Agent Detail Attach pipeline.
+///
+/// The trace intentionally contains no Host, pane, command, or terminal data.
+/// A replacement pipeline receives a new identifier, making initial entry and
+/// every foreground recovery independently searchable in Instruments.
+@MainActor
+final class AttachRestorationTrace {
+    enum Phase: Hashable {
+        case agentDetailVisible
+        case agentSnapshotSwitcherAvailable
+        case transportAcquired
+        case attachRequestStarted
+        case attachPTYOpened
+        case terminalSurfaceAttached
+        case initialResize
+        case firstOutputBytes
+    }
+
+    private static let log = OSLog(
+        subsystem: "dev.bybee.heeler",
+        category: "attach-restoration")
+
+    private let traceID: String
+    private let signpostID: OSSignpostID
+    private var state = AttachRestorationTraceState()
+
+    init(traceID: UUID = UUID()) {
+        let identifier = traceID.uuidString.lowercased()
+        self.traceID = identifier
+        signpostID = OSSignpostID(log: Self.log)
+    }
+
+    func emit(_ phase: Phase, generation: UInt64? = nil) {
+        guard state.record(phase) else { return }
+        let generation = generation.map { String($0) } ?? "none"
+        switch phase {
+        case .agentDetailVisible:
+            os_signpost(.event, log: Self.log, name: "agent_detail_visible", signpostID: signpostID,
+                "trace_id=%{public}s generation=%{public}s", traceID, generation)
+        case .agentSnapshotSwitcherAvailable:
+            os_signpost(.event, log: Self.log, name: "agent_snapshot_switcher_available", signpostID: signpostID,
+                "trace_id=%{public}s generation=%{public}s", traceID, generation)
+        case .transportAcquired:
+            os_signpost(.event, log: Self.log, name: "transport_acquired", signpostID: signpostID,
+                "trace_id=%{public}s generation=%{public}s", traceID, generation)
+        case .attachRequestStarted:
+            // `attachTerminal` owns remote target resolution and PTY open as
+            // one operation. This marks only the app-observable request edge.
+            os_signpost(.event, log: Self.log, name: "attach_request_started", signpostID: signpostID,
+                "trace_id=%{public}s generation=%{public}s", traceID, generation)
+        case .attachPTYOpened:
+            // This is the app-observable completion: `attachTerminal` returned.
+            os_signpost(.event, log: Self.log, name: "attach_pty_opened", signpostID: signpostID,
+                "trace_id=%{public}s generation=%{public}s", traceID, generation)
+        case .terminalSurfaceAttached:
+            os_signpost(.event, log: Self.log, name: "terminal_surface_attached", signpostID: signpostID,
+                "trace_id=%{public}s generation=%{public}s", traceID, generation)
+        case .initialResize:
+            os_signpost(.event, log: Self.log, name: "initial_resize", signpostID: signpostID,
+                "trace_id=%{public}s generation=%{public}s", traceID, generation)
+        case .firstOutputBytes:
+            // Feed receipt, not a Ghostty renderer-presented frame.
+            os_signpost(.event, log: Self.log, name: "first_output_bytes", signpostID: signpostID,
+                "trace_id=%{public}s generation=%{public}s", traceID, generation)
+        }
+    }
+}
+
+/// Debug-only bridge across the Attach runner boundary. It deliberately owns
+/// only app-observable edges, not remote herdr implementation details.
+struct AttachRestorationTraceEvents: Sendable {
+    private let trace: AttachRestorationTrace
+    private let generation: @MainActor @Sendable () -> UInt64?
+
+    init(
+        trace: AttachRestorationTrace,
+        generation: @escaping @MainActor @Sendable () -> UInt64?
+    ) {
+        self.trace = trace
+        self.generation = generation
+    }
+
+    @MainActor
+    func attachRequestDidStart() {
+        trace.emit(.attachRequestStarted, generation: generation())
+    }
+
+    @MainActor
+    func attachChannelDidOpen() {
+        trace.emit(.attachPTYOpened, generation: generation())
+    }
+}
+
+/// The once-only phase gate keeps SwiftUI's repeated body and appearance work
+/// from making one Attach pipeline look like several recovery attempts.
+struct AttachRestorationTraceState {
+    private(set) var emittedPhases: Set<AttachRestorationTrace.Phase> = []
+
+    mutating func record(_ phase: AttachRestorationTrace.Phase) -> Bool {
+        emittedPhases.insert(phase).inserted
+    }
+}
+#endif

--- a/Sources/Heeler/Console/AttachRestorationTrace.swift
+++ b/Sources/Heeler/Console/AttachRestorationTrace.swift
@@ -10,6 +10,8 @@ import os
 @MainActor
 final class AttachRestorationTrace {
     enum Phase: Hashable {
+        case foregroundRecoveryStarted
+        case foregroundRecoveryAborted
         case agentDetailVisible
         case agentSnapshotSwitcherAvailable
         case transportAcquired
@@ -38,6 +40,12 @@ final class AttachRestorationTrace {
         guard state.record(phase) else { return }
         let generation = generation.map { String($0) } ?? "none"
         switch phase {
+        case .foregroundRecoveryStarted:
+            os_signpost(.event, log: Self.log, name: "foreground_recovery_started", signpostID: signpostID,
+                "trace_id=%{public}s generation=%{public}s", traceID, generation)
+        case .foregroundRecoveryAborted:
+            os_signpost(.event, log: Self.log, name: "foreground_recovery_aborted", signpostID: signpostID,
+                "trace_id=%{public}s generation=%{public}s", traceID, generation)
         case .agentDetailVisible:
             os_signpost(.event, log: Self.log, name: "agent_detail_visible", signpostID: signpostID,
                 "trace_id=%{public}s generation=%{public}s", traceID, generation)
@@ -68,6 +76,8 @@ final class AttachRestorationTrace {
                 "trace_id=%{public}s generation=%{public}s", traceID, generation)
         }
     }
+
+    var recordedPhases: Set<Phase> { state.emittedPhases }
 }
 
 /// Debug-only bridge across the Attach runner boundary. It deliberately owns

--- a/Sources/Heeler/Console/AttachTerminalStore.swift
+++ b/Sources/Heeler/Console/AttachTerminalStore.swift
@@ -8,9 +8,19 @@ typealias TerminalSessionRunner =
 
 struct TerminalSessionHandler: Sendable {
     private let operation: TerminalSessionOperation
+    private let transportReady: @MainActor @Sendable (UInt64) -> Void
 
-    init(_ operation: @escaping TerminalSessionOperation) {
+    init(
+        transportReady: @escaping @MainActor @Sendable (UInt64) -> Void = { _ in },
+        _ operation: @escaping TerminalSessionOperation
+    ) {
+        self.transportReady = transportReady
         self.operation = operation
+    }
+
+    @MainActor
+    func transportDidBecomeReady(_ generation: UInt64) {
+        transportReady(generation)
     }
 
     @MainActor
@@ -106,6 +116,7 @@ final class AttachTerminalStore {
 
     private var cols: Int?
     private var rows: Int?
+    private(set) var transportGeneration: UInt64?
     private var stopRequested = false
     private var preservesPendingPasteOnStop = false
     private var session: TerminalAttachSession?
@@ -115,6 +126,7 @@ final class AttachTerminalStore {
     init(
         target: TerminalAttachTarget, takeover: Bool = false,
         input: TerminalInputController = TerminalInputController(),
+        transportGeneration: UInt64? = nil,
         observeOutput: @escaping @MainActor @Sendable (Data) -> Void = { _ in },
         finishOutput: @escaping @MainActor @Sendable () -> Void = {},
         runTerminal: @escaping TerminalSessionRunner
@@ -122,6 +134,7 @@ final class AttachTerminalStore {
         self.target = target
         self.takeover = takeover
         self.input = input
+        self.transportGeneration = transportGeneration
         self.observeOutput = observeOutput
         self.finishOutput = finishOutput
         self.runTerminal = runTerminal
@@ -130,6 +143,7 @@ final class AttachTerminalStore {
     convenience init(
         target: String, takeover: Bool = false,
         input: TerminalInputController = TerminalInputController(),
+        transportGeneration: UInt64? = nil,
         observeOutput: @escaping @MainActor @Sendable (Data) -> Void = { _ in },
         finishOutput: @escaping @MainActor @Sendable () -> Void = {},
         runTerminal: @escaping TerminalSessionRunner
@@ -138,6 +152,7 @@ final class AttachTerminalStore {
             target: .agentPane(target),
             takeover: takeover,
             input: input,
+            transportGeneration: transportGeneration,
             observeOutput: observeOutput,
             finishOutput: finishOutput,
             runTerminal: runTerminal)
@@ -225,7 +240,11 @@ final class AttachTerminalStore {
             try await runTerminal(
                 TerminalAttachRequest(
                     target: target, takeover: takeover, cols: cols, rows: rows),
-                TerminalSessionHandler { [weak self] session in
+                TerminalSessionHandler(
+                    transportReady: { [weak self] generation in
+                        self?.transportGeneration = generation
+                    }
+                ) { [weak self] session in
                     guard let self else {
                         await session.end()
                         return

--- a/Sources/Heeler/Console/AttachTerminalStore.swift
+++ b/Sources/Heeler/Console/AttachTerminalStore.swift
@@ -9,6 +9,9 @@ typealias TerminalSessionRunner =
 struct TerminalSessionHandler: Sendable {
     private let operation: TerminalSessionOperation
     private let transportReady: @MainActor @Sendable (UInt64) -> Void
+    #if DEBUG
+    private let traceEvents: AttachRestorationTraceEvents?
+    #endif
 
     init(
         transportReady: @escaping @MainActor @Sendable (UInt64) -> Void = { _ in },
@@ -16,12 +19,39 @@ struct TerminalSessionHandler: Sendable {
     ) {
         self.transportReady = transportReady
         self.operation = operation
+        #if DEBUG
+        traceEvents = nil
+        #endif
     }
+
+    #if DEBUG
+    init(
+        transportReady: @escaping @MainActor @Sendable (UInt64) -> Void = { _ in },
+        traceEvents: AttachRestorationTraceEvents,
+        _ operation: @escaping TerminalSessionOperation
+    ) {
+        self.transportReady = transportReady
+        self.traceEvents = traceEvents
+        self.operation = operation
+    }
+    #endif
 
     @MainActor
     func transportDidBecomeReady(_ generation: UInt64) {
         transportReady(generation)
     }
+
+    #if DEBUG
+    @MainActor
+    func attachRequestDidStart() {
+        traceEvents?.attachRequestDidStart()
+    }
+
+    @MainActor
+    func attachChannelDidOpen() {
+        traceEvents?.attachChannelDidOpen()
+    }
+    #endif
 
     @MainActor
     func run(_ session: TerminalAttachSession) async throws {
@@ -201,6 +231,9 @@ final class AttachTerminalStore {
     private var session: TerminalAttachSession?
     private var inputGeneration: TerminalInputController.SessionGeneration?
     private var runTask: Task<Void, Never>?
+    #if DEBUG
+    let restorationTrace = AttachRestorationTrace()
+    #endif
 
     init(
         target: TerminalAttachTarget, takeover: Bool = false,
@@ -258,6 +291,9 @@ final class AttachTerminalStore {
         self.rows = rows
         if runTask == nil {
             if status == .waitingForSize {
+                #if DEBUG
+                restorationTrace.emit(.initialResize, generation: transportGeneration)
+                #endif
                 start()
             }
             // .ended waits for retry(); .stopped is terminal.
@@ -330,25 +366,36 @@ final class AttachTerminalStore {
             runDidFinish(surfaceID)
         }
         guard let cols, let rows else { return }
+        let request = TerminalAttachRequest(
+            target: target, takeover: takeover, cols: cols, rows: rows)
+        let operation: TerminalSessionOperation = { [weak self] session in
+            guard let self else {
+                await session.end()
+                return
+            }
+            try await self.consume(session, initialCols: cols, initialRows: rows)
+        }
+        let transportReady: @MainActor @Sendable (UInt64) -> Void = { [weak self] generation in
+            guard let self else { return }
+            self.transportGeneration = generation
+            self.acquiredTransportGeneration = generation
+            self.transportReady(self.surfaceID, generation)
+            #if DEBUG
+            self.restorationTrace.emit(.transportAcquired, generation: generation)
+            #endif
+        }
+        #if DEBUG
+        let handler = TerminalSessionHandler(
+            transportReady: transportReady,
+            traceEvents: AttachRestorationTraceEvents(
+                trace: restorationTrace,
+                generation: { [weak self] in self?.acquiredTransportGeneration }),
+            operation)
+        #else
+        let handler = TerminalSessionHandler(transportReady: transportReady, operation)
+        #endif
         do {
-            try await runTerminal(
-                TerminalAttachRequest(
-                    target: target, takeover: takeover, cols: cols, rows: rows),
-                TerminalSessionHandler(
-                    transportReady: { [weak self] generation in
-                        guard let self else { return }
-                        self.transportGeneration = generation
-                        self.acquiredTransportGeneration = generation
-                        self.transportReady(self.surfaceID, generation)
-                    }
-                ) { [weak self] session in
-                    guard let self else {
-                        await session.end()
-                        return
-                    }
-                    try await self.consume(
-                        session, initialCols: cols, initialRows: rows)
-                })
+            try await runTerminal(request, handler)
         } catch {
             guard !stopRequested else { return }
             status = .ended(Self.message(for: error))
@@ -393,6 +440,9 @@ final class AttachTerminalStore {
                 if status == .connecting {
                     status = .live
                 }
+                #if DEBUG
+                restorationTrace.emit(.firstOutputBytes, generation: acquiredTransportGeneration)
+                #endif
                 observeOutput(bytes)
                 feed.write(bytes)
             }

--- a/Sources/Heeler/Console/AttachTerminalStore.swift
+++ b/Sources/Heeler/Console/AttachTerminalStore.swift
@@ -117,6 +117,10 @@ final class AttachTerminalStore {
     private var cols: Int?
     private var rows: Int?
     private(set) var transportGeneration: UInt64?
+    /// The Transport generation this pipeline actually acquired from its
+    /// runner. Unlike `transportGeneration`, this is never seeded from a
+    /// projection value before the terminal-ready seam has been crossed.
+    private(set) var acquiredTransportGeneration: UInt64?
     private var stopRequested = false
     private var preservesPendingPasteOnStop = false
     private var session: TerminalAttachSession?
@@ -243,6 +247,7 @@ final class AttachTerminalStore {
                 TerminalSessionHandler(
                     transportReady: { [weak self] generation in
                         self?.transportGeneration = generation
+                        self?.acquiredTransportGeneration = generation
                     }
                 ) { [weak self] session in
                     guard let self else {

--- a/Sources/Heeler/Console/AttachTerminalStore.swift
+++ b/Sources/Heeler/Console/AttachTerminalStore.swift
@@ -86,12 +86,12 @@ struct TerminalRecoveryGenerationLatch {
     private var acquiredGeneration: UInt64?
     private var projectedGeneration: UInt64?
 
-    mutating func begin() {
+    mutating func begin(projectedGeneration: UInt64?) {
         guard !isActive else { return }
         isActive = true
         pipelineID = nil
         acquiredGeneration = nil
-        projectedGeneration = nil
+        self.projectedGeneration = projectedGeneration
     }
 
     mutating func bind(to pipelineID: TerminalSurfaceID) {

--- a/Sources/Heeler/Console/AttachTerminalStore.swift
+++ b/Sources/Heeler/Console/AttachTerminalStore.swift
@@ -232,7 +232,11 @@ final class AttachTerminalStore {
     private var inputGeneration: TerminalInputController.SessionGeneration?
     private var runTask: Task<Void, Never>?
     #if DEBUG
-    let restorationTrace = AttachRestorationTrace()
+    private(set) var restorationTrace = AttachRestorationTrace()
+
+    func adoptRestorationTrace(_ trace: AttachRestorationTrace) {
+        restorationTrace = trace
+    }
     #endif
 
     init(

--- a/Sources/Heeler/Console/AttachTerminalStore.swift
+++ b/Sources/Heeler/Console/AttachTerminalStore.swift
@@ -69,6 +69,79 @@ struct TerminalSurfaceID: Hashable, Sendable {
     init() {}
 }
 
+/// Reconciles the two independently scheduled signals that identify a
+/// foreground recovery's Transport. Readiness is projected before terminal
+/// waiters resume, so either signal may arrive first. A decision is made only
+/// after both belong to the same terminal pipeline.
+struct TerminalRecoveryGenerationLatch {
+    enum Decision: Equatable {
+        case pending
+        case acknowledge(UInt64)
+        case replace(UInt64)
+        case retain(UInt64)
+    }
+
+    private(set) var isActive = false
+    private var pipelineID: TerminalSurfaceID?
+    private var acquiredGeneration: UInt64?
+    private var projectedGeneration: UInt64?
+
+    mutating func begin() {
+        guard !isActive else { return }
+        isActive = true
+        pipelineID = nil
+        acquiredGeneration = nil
+        projectedGeneration = nil
+    }
+
+    mutating func bind(to pipelineID: TerminalSurfaceID) {
+        guard isActive else { return }
+        self.pipelineID = pipelineID
+        acquiredGeneration = nil
+    }
+
+    mutating func recordProjection(_ generation: UInt64) -> Decision? {
+        guard isActive else { return nil }
+        projectedGeneration = max(projectedGeneration ?? generation, generation)
+        return reconcile()
+    }
+
+    mutating func recordAcquisition(
+        _ generation: UInt64,
+        by pipelineID: TerminalSurfaceID
+    ) -> Decision? {
+        guard isActive, self.pipelineID == pipelineID else { return nil }
+        acquiredGeneration = generation
+        return reconcile()
+    }
+
+    mutating func clear(boundTo pipelineID: TerminalSurfaceID) {
+        guard self.pipelineID == pipelineID else { return }
+        clear()
+    }
+
+    mutating func clear() {
+        isActive = false
+        pipelineID = nil
+        acquiredGeneration = nil
+        projectedGeneration = nil
+    }
+
+    private mutating func reconcile() -> Decision {
+        guard let acquiredGeneration, let projectedGeneration else {
+            return .pending
+        }
+        defer { clear() }
+        if projectedGeneration == acquiredGeneration {
+            return .acknowledge(acquiredGeneration)
+        }
+        if projectedGeneration > acquiredGeneration {
+            return .replace(projectedGeneration)
+        }
+        return .retain(acquiredGeneration)
+    }
+}
+
 /// The Agent detail screen's session pipeline: a full interactive terminal
 /// over the Host's terminal channel — raw PTY bytes into the view through a
 /// `TerminalByteFeed`, keystrokes back out, geometry changes as SSH
@@ -110,6 +183,8 @@ final class AttachTerminalStore {
     private let input: TerminalInputController
     private let observeOutput: @MainActor @Sendable (Data) -> Void
     private let finishOutput: @MainActor @Sendable () -> Void
+    private let transportReady: @MainActor @Sendable (TerminalSurfaceID, UInt64) -> Void
+    private let runDidFinish: @MainActor @Sendable (TerminalSurfaceID) -> Void
     /// Opens and owns exclusive Host terminal access for one complete run,
     /// including explicit channel teardown.
     private let runTerminal: TerminalSessionRunner
@@ -133,6 +208,10 @@ final class AttachTerminalStore {
         transportGeneration: UInt64? = nil,
         observeOutput: @escaping @MainActor @Sendable (Data) -> Void = { _ in },
         finishOutput: @escaping @MainActor @Sendable () -> Void = {},
+        transportReady: @escaping @MainActor @Sendable (TerminalSurfaceID, UInt64) -> Void = {
+            _, _ in
+        },
+        runDidFinish: @escaping @MainActor @Sendable (TerminalSurfaceID) -> Void = { _ in },
         runTerminal: @escaping TerminalSessionRunner
     ) {
         self.target = target
@@ -141,6 +220,8 @@ final class AttachTerminalStore {
         self.transportGeneration = transportGeneration
         self.observeOutput = observeOutput
         self.finishOutput = finishOutput
+        self.transportReady = transportReady
+        self.runDidFinish = runDidFinish
         self.runTerminal = runTerminal
     }
 
@@ -150,6 +231,10 @@ final class AttachTerminalStore {
         transportGeneration: UInt64? = nil,
         observeOutput: @escaping @MainActor @Sendable (Data) -> Void = { _ in },
         finishOutput: @escaping @MainActor @Sendable () -> Void = {},
+        transportReady: @escaping @MainActor @Sendable (TerminalSurfaceID, UInt64) -> Void = {
+            _, _ in
+        },
+        runDidFinish: @escaping @MainActor @Sendable (TerminalSurfaceID) -> Void = { _ in },
         runTerminal: @escaping TerminalSessionRunner
     ) {
         self.init(
@@ -159,6 +244,8 @@ final class AttachTerminalStore {
             transportGeneration: transportGeneration,
             observeOutput: observeOutput,
             finishOutput: finishOutput,
+            transportReady: transportReady,
+            runDidFinish: runDidFinish,
             runTerminal: runTerminal)
     }
 
@@ -238,7 +325,10 @@ final class AttachTerminalStore {
     /// One session lifetime: open at the current geometry, pump output until
     /// the stream ends, surface how it ended.
     private func run() async {
-        defer { runTask = nil }
+        defer {
+            runTask = nil
+            runDidFinish(surfaceID)
+        }
         guard let cols, let rows else { return }
         do {
             try await runTerminal(
@@ -246,8 +336,10 @@ final class AttachTerminalStore {
                     target: target, takeover: takeover, cols: cols, rows: rows),
                 TerminalSessionHandler(
                     transportReady: { [weak self] generation in
-                        self?.transportGeneration = generation
-                        self?.acquiredTransportGeneration = generation
+                        guard let self else { return }
+                        self.transportGeneration = generation
+                        self.acquiredTransportGeneration = generation
+                        self.transportReady(self.surfaceID, generation)
                     }
                 ) { [weak self] session in
                     guard let self else {

--- a/Sources/Heeler/Console/HostConsoleProjection.swift
+++ b/Sources/Heeler/Console/HostConsoleProjection.swift
@@ -213,7 +213,13 @@ final class HostConsoleProjection {
         return { request, handler in
             try await session.withTerminalTransport { transport, generation in
                 await handler.transportDidBecomeReady(generation)
+                #if DEBUG
+                await handler.attachRequestDidStart()
+                #endif
                 let terminal = try await transport.attachTerminal(request)
+                #if DEBUG
+                await handler.attachChannelDidOpen()
+                #endif
                 try await handler.runEndingSession(terminal)
             }
         }

--- a/Sources/Heeler/Console/HostConsoleProjection.swift
+++ b/Sources/Heeler/Console/HostConsoleProjection.swift
@@ -53,6 +53,7 @@ final class HostConsoleProjection {
     private let onChange: @MainActor @Sendable () -> Void
     private var consumeTask: Task<Void, Never>?
     private var latencyTask: Task<Void, Never>?
+    private var terminalTransportTask: Task<Void, Never>?
     private var resyncTask: Task<Void, Never>?
     private var resyncRetryTask: Task<Void, Never>?
     private var resyncPending = false
@@ -107,6 +108,16 @@ final class HostConsoleProjection {
                 guard !Task.isCancelled else { return }
                 self.latency = session.currentLatency
                 self.publish()
+            }
+        }
+        terminalTransportTask = Task { [weak self] in
+            guard let self else { return }
+            for await generation in session.terminalTransportGenerations {
+                guard !Task.isCancelled else { return }
+                // Transport installation is the terminal readiness edge. It
+                // intentionally precedes events subscription and snapshot work.
+                transportGeneration = max(transportGeneration, generation)
+                publish()
             }
         }
         if isActive {
@@ -188,17 +199,20 @@ final class HostConsoleProjection {
         resyncRetryTask?.cancel()
         consumeTask?.cancel()
         latencyTask?.cancel()
+        terminalTransportTask?.cancel()
         resyncTask = nil
         resyncRetryTask = nil
         consumeTask = nil
         latencyTask = nil
+        terminalTransportTask = nil
         Task { await session.end() }
     }
 
     func terminalRunner() -> TerminalSessionRunner {
         let session = session
         return { request, handler in
-            try await session.withTerminalTransport { transport in
+            try await session.withTerminalTransport { transport, generation in
+                await handler.transportDidBecomeReady(generation)
                 let terminal = try await transport.attachTerminal(request)
                 try await handler.runEndingSession(terminal)
             }
@@ -496,18 +510,6 @@ final class HostConsoleProjection {
             }
             if status == .connected {
                 publish()
-                Task { [weak self] in
-                    guard let self else { return }
-                    let generation = await session.transportGeneration
-                    guard !hasEnded else { return }
-                    // These reads race across quick `.connected` bursts and
-                    // can land out of order; generations only grow, so the
-                    // newest write must win regardless of arrival order — a
-                    // regression here would spuriously replace a healthy
-                    // terminal downstream.
-                    transportGeneration = max(transportGeneration, generation)
-                    publish()
-                }
                 scheduleResync()
             } else {
                 invalidateSnapshot()

--- a/Sources/Heeler/Console/ShellTerminalStore.swift
+++ b/Sources/Heeler/Console/ShellTerminalStore.swift
@@ -350,10 +350,8 @@ final class ShellTerminalStore {
         if afterPossibleSuspension {
             if activationRecovery.isActive { return }
             if isReplacing {
-                activationRecovery.begin()
-                if let transportGeneration {
-                    _ = activationRecovery.recordProjection(transportGeneration)
-                }
+                activationRecovery.begin(
+                    projectedGeneration: transportGeneration)
                 return
             }
             if terminal.transportGeneration == transportGeneration,
@@ -362,7 +360,8 @@ final class ShellTerminalStore {
                 return
             }
             input.detachSessionForReplacement()
-            activationRecovery.begin()
+            activationRecovery.begin(
+                projectedGeneration: transportGeneration)
             replaceTerminal()
         } else {
             terminal.didBecomeActive()

--- a/Sources/Heeler/Console/ShellTerminalStore.swift
+++ b/Sources/Heeler/Console/ShellTerminalStore.swift
@@ -283,7 +283,7 @@ final class ShellTerminalStore {
     @ObservationIgnored private var lifecycleID: UInt64 = 0
     @ObservationIgnored private var isReplacing = false
     @ObservationIgnored private var replacementID: UInt64 = 0
-    @ObservationIgnored private var activationRecoveryAwaitsTransport = false
+    @ObservationIgnored private var activationRecovery = TerminalRecoveryGenerationLatch()
 
     init(
         identity: ShellTerminalIdentity,
@@ -348,8 +348,12 @@ final class ShellTerminalStore {
         }
         guard lifecycleState == .active else { return }
         if afterPossibleSuspension {
+            if activationRecovery.isActive { return }
             if isReplacing {
-                activationRecoveryAwaitsTransport = true
+                activationRecovery.begin()
+                if let transportGeneration {
+                    _ = activationRecovery.recordProjection(transportGeneration)
+                }
                 return
             }
             if terminal.transportGeneration == transportGeneration,
@@ -358,7 +362,7 @@ final class ShellTerminalStore {
                 return
             }
             input.detachSessionForReplacement()
-            activationRecoveryAwaitsTransport = true
+            activationRecovery.begin()
             replaceTerminal()
         } else {
             terminal.didBecomeActive()
@@ -367,15 +371,11 @@ final class ShellTerminalStore {
 
     func transportGenerationDidChange(_ generation: UInt64?) {
         guard let generation, lifecycleState == .active else { return }
-        if activationRecoveryAwaitsTransport,
-            isReplacing || terminal.status == .waitingForSize || terminal.status == .connecting,
-            terminal.acquiredTransportGeneration == generation
-        {
-            transportGeneration = generation
-            activationRecoveryAwaitsTransport = false
+        if let decision = activationRecovery.recordProjection(generation) {
+            advanceTransportGeneration(to: generation)
+            applyActivationRecovery(decision)
             return
         }
-        activationRecoveryAwaitsTransport = false
         if terminal.transportGeneration == generation {
             transportGeneration = generation
             return
@@ -383,6 +383,36 @@ final class ShellTerminalStore {
         guard generation != transportGeneration else { return }
         transportGeneration = generation
         replaceTerminal()
+    }
+
+    private func terminalTransportDidBecomeReady(
+        pipelineID: TerminalSurfaceID,
+        generation: UInt64
+    ) {
+        guard
+            let decision = activationRecovery.recordAcquisition(
+                generation, by: pipelineID)
+        else { return }
+        applyActivationRecovery(decision)
+    }
+
+    private func applyActivationRecovery(
+        _ decision: TerminalRecoveryGenerationLatch.Decision
+    ) {
+        switch decision {
+        case .pending:
+            return
+        case .acknowledge(let generation), .retain(let generation):
+            advanceTransportGeneration(to: generation)
+        case .replace(let generation):
+            advanceTransportGeneration(to: generation)
+            replaceTerminal()
+        }
+    }
+
+    private func advanceTransportGeneration(to generation: UInt64) {
+        guard transportGeneration.map({ generation > $0 }) ?? true else { return }
+        transportGeneration = generation
     }
 
     private func replaceTerminal() {
@@ -402,17 +432,27 @@ final class ShellTerminalStore {
                 self.abortReplacementOffStage(replacementID: replacementID)
                 return
             }
-            self.terminal = Self.makeTerminal(
+            let replacement = Self.makeTerminal(
                 terminalID: self.identity.terminalID,
                 input: self.input,
                 transportGeneration: self.transportGeneration,
-                runTerminal: self.runTerminal)
+                runTerminal: self.runTerminal,
+                transportReady: { [weak self] pipelineID, generation in
+                    self?.terminalTransportDidBecomeReady(
+                        pipelineID: pipelineID, generation: generation)
+                },
+                runDidFinish: { [weak self] pipelineID in
+                    self?.activationRecovery.clear(boundTo: pipelineID)
+                })
+            self.terminal = replacement
+            self.activationRecovery.bind(to: replacement.surfaceID)
             self.isReplacing = false
         }
     }
 
     func rejoin() {
         guard lifecycleState != .active, isOnStage() else { return }
+        activationRecovery.clear()
         lifecycleState = .active
         replacementID &+= 1
         let replacementID = replacementID
@@ -436,11 +476,20 @@ final class ShellTerminalStore {
                 self.abortReplacementOffStage(replacementID: replacementID)
                 return
             }
-            self.terminal = Self.makeTerminal(
+            let replacement = Self.makeTerminal(
                 terminalID: self.identity.terminalID,
                 input: self.input,
                 transportGeneration: self.transportGeneration,
-                runTerminal: self.runTerminal)
+                runTerminal: self.runTerminal,
+                transportReady: { [weak self] pipelineID, generation in
+                    self?.terminalTransportDidBecomeReady(
+                        pipelineID: pipelineID, generation: generation)
+                },
+                runDidFinish: { [weak self] pipelineID in
+                    self?.activationRecovery.clear(boundTo: pipelineID)
+                })
+            self.terminal = replacement
+            self.activationRecovery.bind(to: replacement.surfaceID)
             self.isReplacing = false
         }
     }
@@ -452,6 +501,7 @@ final class ShellTerminalStore {
     private func abortReplacementOffStage(replacementID: UInt64) {
         guard self.replacementID == replacementID else { return }
         isReplacing = false
+        activationRecovery.clear()
         guard lifecycleState == .active, !isOnStage() else { return }
         lifecycleState = .rejoinRequired
     }
@@ -464,7 +514,7 @@ final class ShellTerminalStore {
         lifecycleState = .left
         replacementID &+= 1
         isReplacing = false
-        activationRecoveryAwaitsTransport = false
+        activationRecovery.clear()
         input.cancelPaste()
         // The view may disappear immediately after scheduling this work. A
         // temporary strong capture guarantees the PTY and terminal lease are
@@ -498,13 +548,19 @@ final class ShellTerminalStore {
         terminalID: String,
         input: TerminalInputController,
         transportGeneration: UInt64?,
-        runTerminal: @escaping TerminalSessionRunner
+        runTerminal: @escaping TerminalSessionRunner,
+        transportReady: @escaping @MainActor @Sendable (TerminalSurfaceID, UInt64) -> Void = {
+            _, _ in
+        },
+        runDidFinish: @escaping @MainActor @Sendable (TerminalSurfaceID) -> Void = { _ in }
     ) -> AttachTerminalStore {
         AttachTerminalStore(
             target: .terminal(terminalID),
             takeover: true,
             input: input,
             transportGeneration: transportGeneration,
+            transportReady: transportReady,
+            runDidFinish: runDidFinish,
             runTerminal: runTerminal)
     }
 }

--- a/Sources/Heeler/Console/ShellTerminalStore.swift
+++ b/Sources/Heeler/Console/ShellTerminalStore.swift
@@ -368,7 +368,8 @@ final class ShellTerminalStore {
     func transportGenerationDidChange(_ generation: UInt64?) {
         guard let generation, lifecycleState == .active else { return }
         if activationRecoveryAwaitsTransport,
-            isReplacing || terminal.status == .waitingForSize || terminal.status == .connecting
+            isReplacing || terminal.status == .waitingForSize || terminal.status == .connecting,
+            terminal.acquiredTransportGeneration == generation
         {
             transportGeneration = generation
             activationRecoveryAwaitsTransport = false

--- a/Sources/Heeler/Console/ShellTerminalStore.swift
+++ b/Sources/Heeler/Console/ShellTerminalStore.swift
@@ -283,6 +283,7 @@ final class ShellTerminalStore {
     @ObservationIgnored private var lifecycleID: UInt64 = 0
     @ObservationIgnored private var isReplacing = false
     @ObservationIgnored private var replacementID: UInt64 = 0
+    @ObservationIgnored private var activationRecoveryAwaitsTransport = false
 
     init(
         identity: ShellTerminalIdentity,
@@ -297,6 +298,7 @@ final class ShellTerminalStore {
         terminal = Self.makeTerminal(
             terminalID: identity.terminalID,
             input: input,
+            transportGeneration: transportGeneration,
             runTerminal: runTerminal)
     }
 
@@ -346,7 +348,17 @@ final class ShellTerminalStore {
         }
         guard lifecycleState == .active else { return }
         if afterPossibleSuspension {
+            if isReplacing {
+                activationRecoveryAwaitsTransport = true
+                return
+            }
+            if terminal.transportGeneration == transportGeneration,
+                terminal.status == .waitingForSize || terminal.status == .connecting
+            {
+                return
+            }
             input.detachSessionForReplacement()
+            activationRecoveryAwaitsTransport = true
             replaceTerminal()
         } else {
             terminal.didBecomeActive()
@@ -354,9 +366,20 @@ final class ShellTerminalStore {
     }
 
     func transportGenerationDidChange(_ generation: UInt64?) {
-        guard let generation, generation != transportGeneration,
-            lifecycleState == .active
-        else { return }
+        guard let generation, lifecycleState == .active else { return }
+        if activationRecoveryAwaitsTransport,
+            isReplacing || terminal.status == .waitingForSize || terminal.status == .connecting
+        {
+            transportGeneration = generation
+            activationRecoveryAwaitsTransport = false
+            return
+        }
+        activationRecoveryAwaitsTransport = false
+        if terminal.transportGeneration == generation {
+            transportGeneration = generation
+            return
+        }
+        guard generation != transportGeneration else { return }
         transportGeneration = generation
         replaceTerminal()
     }
@@ -381,6 +404,7 @@ final class ShellTerminalStore {
             self.terminal = Self.makeTerminal(
                 terminalID: self.identity.terminalID,
                 input: self.input,
+                transportGeneration: self.transportGeneration,
                 runTerminal: self.runTerminal)
             self.isReplacing = false
         }
@@ -414,6 +438,7 @@ final class ShellTerminalStore {
             self.terminal = Self.makeTerminal(
                 terminalID: self.identity.terminalID,
                 input: self.input,
+                transportGeneration: self.transportGeneration,
                 runTerminal: self.runTerminal)
             self.isReplacing = false
         }
@@ -438,6 +463,7 @@ final class ShellTerminalStore {
         lifecycleState = .left
         replacementID &+= 1
         isReplacing = false
+        activationRecoveryAwaitsTransport = false
         input.cancelPaste()
         // The view may disappear immediately after scheduling this work. A
         // temporary strong capture guarantees the PTY and terminal lease are
@@ -470,12 +496,14 @@ final class ShellTerminalStore {
     private static func makeTerminal(
         terminalID: String,
         input: TerminalInputController,
+        transportGeneration: UInt64?,
         runTerminal: @escaping TerminalSessionRunner
     ) -> AttachTerminalStore {
         AttachTerminalStore(
             target: .terminal(terminalID),
             takeover: true,
             input: input,
+            transportGeneration: transportGeneration,
             runTerminal: runTerminal)
     }
 }

--- a/Sources/Heeler/Transport/EventsSession.swift
+++ b/Sources/Heeler/Transport/EventsSession.swift
@@ -128,6 +128,11 @@ actor EventsSession {
     /// `currentLatency` instead of this payload; see that property.
     nonisolated let latencyUpdates: AsyncStream<Duration>
     private let latencyContinuation: AsyncStream<Duration>.Continuation
+    /// Installed, ping-proven Transport generations. Unlike `.connected`, this
+    /// signal does not wait for the events channel, so a visible terminal can
+    /// recover as soon as its own connection prerequisite is ready.
+    nonisolated let terminalTransportGenerations: AsyncStream<UInt64>
+    private let terminalTransportContinuation: AsyncStream<UInt64>.Continuation
     /// The round trip the Host's *current* connection last proved, or nil
     /// while no live connection has proved one.
     ///
@@ -151,6 +156,7 @@ actor EventsSession {
     private let connect: @Sendable () async throws -> any Transport
     private let reconnectPolicy: ReconnectPolicy
     private let keepalive: KeepalivePolicy?
+    private let terminalWaiterDidRegister: (@Sendable () -> Void)?
 
     private var phase: Phase = .suspended
     /// The Host's live Transport. It never escapes this module; consumers
@@ -196,18 +202,26 @@ actor EventsSession {
     private var terminalInUse = false
     private var terminalWaiters: [TerminalWaiter] = []
     private var terminalIdleWaiters: [CheckedContinuation<Void, Never>] = []
+    private var terminalTransportWaiters: [TerminalTransportWaiter] = []
+    /// An action-required connection failure is sticky until the user starts a
+    /// new activation. Requests arriving after the failed run must receive the
+    /// real failure instead of waiting for work that no longer exists.
+    private var terminalTransportFailure: TransportError?
+    private var isWindingDown = false
 
     init(
         subscriptions: [EventSubscription],
         connect: @escaping @Sendable () async throws -> any Transport,
         reconnectPolicy: ReconnectPolicy = .default,
         keepalive: KeepalivePolicy? = .default,
-        updatesBufferLimit: Int = HerdrEventStream.bufferLimit
+        updatesBufferLimit: Int = HerdrEventStream.bufferLimit,
+        terminalWaiterDidRegister: (@Sendable () -> Void)? = nil
     ) {
         self.subscriptions = subscriptions
         self.connect = connect
         self.reconnectPolicy = reconnectPolicy
         self.keepalive = keepalive
+        self.terminalWaiterDidRegister = terminalWaiterDidRegister
         // Bounded (#22): dropping is safe because every drop is surfaced
         // through `yieldUpdate`'s marker; see the actor doc for the policy
         // and HerdrEventStream.bufferLimit for the sizing rationale.
@@ -217,6 +231,10 @@ actor EventsSession {
         (latencyUpdates, latencyContinuation) = AsyncStream.makeStream(
             of: Duration.self,
             bufferingPolicy: .bufferingNewest(1))
+        (terminalTransportGenerations, terminalTransportContinuation) =
+            AsyncStream.makeStream(
+                of: UInt64.self,
+                bufferingPolicy: .bufferingNewest(1))
     }
 
     /// Activates the session (initially, or after `suspend()`): announces
@@ -324,14 +342,23 @@ actor EventsSession {
 
     /// Runs one terminal lifetime with exclusive access to the Host's
     /// terminal channel. The next caller cannot observe a Transport until
-    /// the previous operation, including its teardown, has returned.
+    /// the previous operation, including its teardown, has returned. A caller
+    /// that races foreground recovery waits for this activation's ping-proven
+    /// Transport instead of failing only because installation is still in
+    /// flight; events subscription and snapshot work are not prerequisites.
     func withTerminalTransport<Value: Sendable>(
-        _ operation: @escaping @Sendable (any Transport) async throws -> Value
+        _ operation: @escaping @Sendable (any Transport, UInt64) async throws -> Value
     ) async throws -> Value {
         try await acquireTerminal()
         do {
             try Task.checkCancellation()
-            let value = try await withTransport(operation)
+            let ready = try await awaitTerminalTransport()
+            try Task.checkCancellation()
+            guard terminalTransportIsCurrent(ready) else {
+                throw TransportError.cancelled
+            }
+            let value = try await operation(ready.transport, ready.transportGeneration)
+            noteConnectionActivity()
             releaseTerminal()
             return value
         } catch {
@@ -347,6 +374,7 @@ actor EventsSession {
     private func activate() {
         guard phase == .suspended else { return }
         phase = .active
+        terminalTransportFailure = nil
         activationGeneration &+= 1
         let generation = activationGeneration
         yieldUpdate(.status(.connecting))
@@ -385,6 +413,7 @@ actor EventsSession {
         yieldUpdate(.status(.ended))
         updatesContinuation.finish()
         latencyContinuation.finish()
+        terminalTransportContinuation.finish()
     }
 
     /// The single gate every update leaves through: yields it and, when the
@@ -451,6 +480,8 @@ actor EventsSession {
                     continue
                 }
                 guard failure.isRetryable else {
+                    recordTerminalTransportFailure(failure)
+                    failTerminalTransportWaiters(failure, for: generation)
                     yieldUpdate(.status(.failed(failure)))
                     return
                 }
@@ -511,6 +542,8 @@ actor EventsSession {
                 ?? .channelFailed(detail: "events stream ended unexpectedly")
             pendingKeepaliveFailure = nil
             guard failure.isRetryable else {
+                recordTerminalTransportFailure(failure)
+                failTerminalTransportWaiters(failure, for: generation)
                 yieldUpdate(.status(.failed(failure)))
                 return
             }
@@ -576,6 +609,7 @@ actor EventsSession {
             throw error
         }
         transportSuspect = false
+        terminalTransportFailure = nil
         noteConnectionActivity()
         currentTransport = transport
         if hasEstablishedTransport {
@@ -583,6 +617,11 @@ actor EventsSession {
         } else {
             hasEstablishedTransport = true
         }
+        terminalTransportContinuation.yield(transportGeneration)
+        resumeTerminalTransportWaiters(
+            with: transport,
+            activationGeneration: generation,
+            transportGeneration: transportGeneration)
         return transport
     }
 
@@ -613,6 +652,8 @@ actor EventsSession {
     /// make any late result harmless, while an installed Transport is still
     /// closed explicitly before lifecycle teardown returns.
     private func windDown() async {
+        isWindingDown = true
+        failTerminalTransportWaiters(TransportError.cancelled)
         backoffSleep?.cancel()
         backoffSleep = nil
         backoffGeneration = nil
@@ -634,7 +675,9 @@ actor EventsSession {
         pendingKeepaliveFailure = nil
         resubscribeRequested = false
         lastConnectionActivity = nil
+        terminalTransportFailure = nil
         dropPaneSubscriptions()
+        isWindingDown = false
     }
 
     // MARK: Keepalive
@@ -751,6 +794,22 @@ actor EventsSession {
         let continuation: CheckedContinuation<Void, any Error>
     }
 
+    private struct TerminalTransportReady: Sendable {
+        let transport: any Transport
+        let activationGeneration: UInt64
+        let transportGeneration: UInt64
+    }
+
+    private struct TerminalTransportWaiter {
+        let id: UUID
+        /// Nil means the request arrived while suspended and belongs to the
+        /// next activation. Active requests are pinned to their exact
+        /// activation so retry, Host replacement, and background invalidation
+        /// cannot hand them a later Transport accidentally.
+        let activationGeneration: UInt64?
+        let continuation: CheckedContinuation<TerminalTransportReady, any Error>
+    }
+
     private func acquireTerminal() async throws {
         let id = UUID()
         try Task.checkCancellation()
@@ -775,6 +834,102 @@ actor EventsSession {
     private func cancelTerminalWaiter(id: UUID) {
         guard let index = terminalWaiters.firstIndex(where: { $0.id == id }) else { return }
         let waiter = terminalWaiters.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func awaitTerminalTransport() async throws -> TerminalTransportReady {
+        let id = UUID()
+        try Task.checkCancellation()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<TerminalTransportReady, any Error>) in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else if isWindingDown || phase == .ended {
+                    continuation.resume(throwing: TransportError.cancelled)
+                } else if phase == .active, !transportSuspect,
+                    let transport = currentTransport
+                {
+                    continuation.resume(
+                        returning: TerminalTransportReady(
+                            transport: transport,
+                            activationGeneration: activationGeneration,
+                            transportGeneration: transportGeneration))
+                } else if let terminalTransportFailure {
+                    continuation.resume(throwing: terminalTransportFailure)
+                } else {
+                    terminalTransportWaiters.append(
+                        TerminalTransportWaiter(
+                            id: id,
+                            activationGeneration: phase == .active ? activationGeneration : nil,
+                            continuation: continuation))
+                    terminalWaiterDidRegister?()
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelTerminalTransportWaiter(id: id) }
+        }
+    }
+
+    private func terminalTransportIsCurrent(_ ready: TerminalTransportReady) -> Bool {
+        phase == .active
+            && !isWindingDown
+            && !transportSuspect
+            && activationGeneration == ready.activationGeneration
+            && transportGeneration == ready.transportGeneration
+            && currentTransport != nil
+    }
+
+    private func resumeTerminalTransportWaiters(
+        with transport: any Transport,
+        activationGeneration: UInt64,
+        transportGeneration: UInt64
+    ) {
+        let ready = TerminalTransportReady(
+            transport: transport,
+            activationGeneration: activationGeneration,
+            transportGeneration: transportGeneration)
+        let waiters = terminalTransportWaiters
+        terminalTransportWaiters.removeAll()
+        for waiter in waiters {
+            if let expected = waiter.activationGeneration,
+                expected != activationGeneration
+            {
+                waiter.continuation.resume(throwing: TransportError.cancelled)
+            } else {
+                waiter.continuation.resume(returning: ready)
+            }
+        }
+    }
+
+    private func failTerminalTransportWaiters(
+        _ failure: TransportError,
+        for activationGeneration: UInt64? = nil
+    ) {
+        var retained: [TerminalTransportWaiter] = []
+        for waiter in terminalTransportWaiters {
+            if let activationGeneration,
+                waiter.activationGeneration != nil,
+                waiter.activationGeneration != activationGeneration
+            {
+                retained.append(waiter)
+            } else {
+                waiter.continuation.resume(throwing: failure)
+            }
+        }
+        terminalTransportWaiters = retained
+    }
+
+    private func recordTerminalTransportFailure(_ failure: TransportError) {
+        guard currentTransport == nil else { return }
+        terminalTransportFailure = failure
+    }
+
+    private func cancelTerminalTransportWaiter(id: UUID) {
+        guard let index = terminalTransportWaiters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let waiter = terminalTransportWaiters.remove(at: index)
         waiter.continuation.resume(throwing: CancellationError())
     }
 

--- a/Tests/HeelerTests/AttachRestorationTraceTests.swift
+++ b/Tests/HeelerTests/AttachRestorationTraceTests.swift
@@ -8,14 +8,27 @@ struct AttachRestorationTraceTests {
     @Test func phaseGateRecordsEachPhaseOnce() {
         var state = AttachRestorationTraceState()
 
+        let recordedRecovery = state.record(.foregroundRecoveryStarted)
+        let recordedRecoveryAgain = state.record(.foregroundRecoveryStarted)
+        let recordedAbort = state.record(.foregroundRecoveryAborted)
+        let recordedAbortAgain = state.record(.foregroundRecoveryAborted)
         let recordedAppearance = state.record(.agentDetailVisible)
         let recordedAppearanceAgain = state.record(.agentDetailVisible)
         let recordedTransport = state.record(.transportAcquired)
 
+        #expect(recordedRecovery)
+        #expect(!recordedRecoveryAgain)
+        #expect(recordedAbort)
+        #expect(!recordedAbortAgain)
         #expect(recordedAppearance)
         #expect(!recordedAppearanceAgain)
         #expect(recordedTransport)
-        #expect(state.emittedPhases == [.agentDetailVisible, .transportAcquired])
+        #expect(state.emittedPhases == [
+            .foregroundRecoveryStarted,
+            .foregroundRecoveryAborted,
+            .agentDetailVisible,
+            .transportAcquired,
+        ])
     }
 
     @Test func separatePipelinesHaveIndependentPhaseGates() {

--- a/Tests/HeelerTests/AttachRestorationTraceTests.swift
+++ b/Tests/HeelerTests/AttachRestorationTraceTests.swift
@@ -1,0 +1,49 @@
+#if DEBUG
+import Testing
+
+@testable import Heeler
+
+@Suite("Attach restoration trace")
+struct AttachRestorationTraceTests {
+    @Test func phaseGateRecordsEachPhaseOnce() {
+        var state = AttachRestorationTraceState()
+
+        let recordedAppearance = state.record(.agentDetailVisible)
+        let recordedAppearanceAgain = state.record(.agentDetailVisible)
+        let recordedTransport = state.record(.transportAcquired)
+
+        #expect(recordedAppearance)
+        #expect(!recordedAppearanceAgain)
+        #expect(recordedTransport)
+        #expect(state.emittedPhases == [.agentDetailVisible, .transportAcquired])
+    }
+
+    @Test func separatePipelinesHaveIndependentPhaseGates() {
+        var initialEntry = AttachRestorationTraceState()
+        var foregroundRecovery = AttachRestorationTraceState()
+
+        let initialRecordedOutput = initialEntry.record(.firstOutputBytes)
+        let recoveryRecordedOutput = foregroundRecovery.record(.firstOutputBytes)
+        let recoveryRecordedOutputAgain = foregroundRecovery.record(.firstOutputBytes)
+
+        #expect(initialRecordedOutput)
+        #expect(recoveryRecordedOutput)
+        #expect(!recoveryRecordedOutputAgain)
+    }
+
+    @Test func replacementPipelineRecordsItsOwnVisibilityAndSwitcherMarkers() {
+        var initialEntry = AttachRestorationTraceState()
+        var foregroundRecovery = AttachRestorationTraceState()
+
+        let initialVisible = initialEntry.record(.agentDetailVisible)
+        let initialSwitcher = initialEntry.record(.agentSnapshotSwitcherAvailable)
+        let recoveryVisible = foregroundRecovery.record(.agentDetailVisible)
+        let recoverySwitcher = foregroundRecovery.record(.agentSnapshotSwitcherAvailable)
+
+        #expect(initialVisible)
+        #expect(initialSwitcher)
+        #expect(recoveryVisible)
+        #expect(recoverySwitcher)
+    }
+}
+#endif

--- a/Tests/HeelerTests/AttachTerminalStoreTests.swift
+++ b/Tests/HeelerTests/AttachTerminalStoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 import Testing
 import UIKit
 
@@ -453,6 +454,62 @@ struct AttachTerminalStoreTests {
 @MainActor
 @Suite("Agent Attach store")
 struct AgentAttachStoreTests {
+    @Test func foregroundRecoveryAbsorbsItsLaterTransportGeneration() async throws {
+        let transport = ScriptedTransport()
+        let generation = TerminalGenerationSource(1)
+        let runner: TerminalSessionRunner = { request, handler in
+            let readyGeneration = await generation.value
+            await handler.transportDidBecomeReady(readyGeneration)
+            let session = try await transport.attachTerminal(request)
+            try await handler.runEndingSession(session)
+        }
+        let store = makeStore(
+            transport: transport,
+            generation: 1,
+            runTerminal: runner)
+
+        let firstSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: firstSessionGate)
+        store.viewDidResize(cols: 80, rows: 24)
+        await firstSessionGate.waitForEntry()
+        var firstStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("first".utf8)))
+        await firstSessionGate.open()
+        _ = await firstStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+
+        await generation.set(2)
+        let predecessorID = store.terminalID
+        var terminalChanges = observeTerminalChanges(of: store)
+        store.didBecomeActive(afterPossibleSuspension: true)
+        _ = await terminalChanges.next()
+        let recoveryID = store.terminalID
+        #expect(recoveryID != predecessorID)
+        #expect(store.terminalStatus == .waitingForSize)
+
+        // This is the projection edge that used to enqueue a second pipeline
+        // after foreground recovery had already built the one waiting for the
+        // ping-proven Transport.
+        store.transportGenerationDidChange(2)
+        #expect(store.terminalID == recoveryID)
+
+        let secondSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: secondSessionGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await secondSessionGate.waitForEntry()
+        #expect(await transport.attachRequests.count == 2)
+        var secondStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("second".utf8)))
+        await secondSessionGate.open()
+        _ = await secondStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+
+        await store.leave().value
+        #expect(store.terminalID == recoveryID)
+        #expect(await transport.attachRequests.count == 2)
+        #expect(await !transport.hasLiveAttachSession)
+    }
+
     @Test func productionAttachTakesOverAnExistingRemoteClient() async throws {
         let transport = ScriptedTransport()
         let store = makeStore(transport: transport, generation: 0)
@@ -2167,6 +2224,32 @@ struct AgentAttachStoreTests {
             closePane: close)
     }
 
+    private func observeTerminalChanges(
+        of store: AgentAttachStore
+    ) -> AsyncStream<Void>.Iterator {
+        let (changes, continuation) = AsyncStream.makeStream(of: Void.self)
+        withObservationTracking {
+            _ = store.terminalID
+        } onChange: {
+            continuation.yield()
+            continuation.finish()
+        }
+        return changes.makeAsyncIterator()
+    }
+
+    private func observeStatusChanges(
+        of store: AgentAttachStore
+    ) -> AsyncStream<Void>.Iterator {
+        let (changes, continuation) = AsyncStream.makeStream(of: Void.self)
+        withObservationTracking {
+            _ = store.terminalStatus
+        } onChange: {
+            continuation.yield()
+            continuation.finish()
+        }
+        return changes.makeAsyncIterator()
+    }
+
     private func tinyJPEGData() throws -> Data {
         let renderer = UIGraphicsImageRenderer(size: CGSize(width: 16, height: 16))
         let image = renderer.image { context in
@@ -2238,6 +2321,18 @@ struct AgentAttachStoreTests {
             }
             await permit.release()
         }
+    }
+}
+
+private actor TerminalGenerationSource {
+    private(set) var value: UInt64
+
+    init(_ value: UInt64) {
+        self.value = value
+    }
+
+    func set(_ value: UInt64) {
+        self.value = value
     }
 }
 

--- a/Tests/HeelerTests/AttachTerminalStoreTests.swift
+++ b/Tests/HeelerTests/AttachTerminalStoreTests.swift
@@ -458,7 +458,7 @@ struct AgentAttachStoreTests {
         let transport = ScriptedTransport()
         let generation = TerminalGenerationSource(1)
         let runner: TerminalSessionRunner = { request, handler in
-            let readyGeneration = await generation.value
+            let readyGeneration = await generation.acquire()
             await handler.transportDidBecomeReady(readyGeneration)
             let session = try await transport.attachTerminal(request)
             try await handler.runEndingSession(session)
@@ -472,17 +472,17 @@ struct AgentAttachStoreTests {
         await transport.gateNextAttachSession(using: firstSessionGate)
         store.viewDidResize(cols: 80, rows: 24)
         await firstSessionGate.waitForEntry()
-        var firstStatusChanges = observeStatusChanges(of: store)
+        let firstStatusChanges = observeStatusChanges(of: store)
         #expect(await transport.emitAttachOutput(Data("first".utf8)))
         await firstSessionGate.open()
-        _ = await firstStatusChanges.next()
+        await firstStatusChanges.next()
         #expect(store.terminalStatus == .live)
 
         await generation.set(2)
         let predecessorID = store.terminalID
-        var terminalChanges = observeTerminalChanges(of: store)
+        let terminalChanges = observeTerminalChanges(of: store)
         store.didBecomeActive(afterPossibleSuspension: true)
-        _ = await terminalChanges.next()
+        await terminalChanges.next()
         let recoveryID = store.terminalID
         #expect(recoveryID != predecessorID)
         #expect(store.terminalStatus == .waitingForSize)
@@ -526,7 +526,7 @@ struct AgentAttachStoreTests {
         let transport = ScriptedTransport()
         let generation = TerminalGenerationSource(1)
         let runner: TerminalSessionRunner = { request, handler in
-            let readyGeneration = await generation.value
+            let readyGeneration = await generation.acquire()
             await handler.transportDidBecomeReady(readyGeneration)
             let session = try await transport.attachTerminal(request)
             try await handler.runEndingSession(session)
@@ -572,6 +572,130 @@ struct AgentAttachStoreTests {
         await store.leave().value
         #expect(store.terminalID == recoveryID)
         #expect(await transport.attachRequests.count == 2)
+        #expect(await !transport.hasLiveAttachSession)
+    }
+
+    @Test func projectionFirstRecoveryAbsorbsItsMatchingAcquisition() async throws {
+        let transport = ScriptedTransport()
+        let generation = TerminalGenerationSource(1)
+        let runner: TerminalSessionRunner = { request, handler in
+            let readyGeneration = await generation.acquire()
+            await handler.transportDidBecomeReady(readyGeneration)
+            let session = try await transport.attachTerminal(request)
+            try await handler.runEndingSession(session)
+        }
+        let store = makeStore(
+            transport: transport,
+            generation: 1,
+            runTerminal: runner)
+
+        let firstSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: firstSessionGate)
+        store.viewDidResize(cols: 80, rows: 24)
+        await firstSessionGate.waitForEntry()
+        let firstStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("first".utf8)))
+        await firstSessionGate.open()
+        await firstStatusChanges.next()
+
+        await generation.set(2)
+        let readyGate = ScriptedTransportCallGate()
+        await generation.gateNextAcquisition(using: readyGate)
+        let recoveryChanges = observeTerminalChanges(of: store)
+        store.didBecomeActive(afterPossibleSuspension: true)
+        await recoveryChanges.next()
+        let recoveryID = store.terminalID
+
+        let secondSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: secondSessionGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await readyGate.waitForEntry()
+
+        // Projection reaches the owner before the waiter records generation 2.
+        store.transportGenerationDidChange(2)
+        #expect(store.terminalID == recoveryID)
+        #expect(await transport.attachRequests.count == 1)
+
+        await readyGate.open()
+        await secondSessionGate.waitForEntry()
+        let secondStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("second".utf8)))
+        await secondSessionGate.open()
+        await secondStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+        #expect(store.terminalID == recoveryID)
+        #expect(await transport.attachRequests.count == 2)
+
+        await store.leave().value
+        #expect(await !transport.hasLiveAttachSession)
+    }
+
+    @Test func projectionFirstRecoveryReplacesOnceForANewerGeneration() async throws {
+        let transport = ScriptedTransport()
+        let generation = TerminalGenerationSource(1)
+        let runner: TerminalSessionRunner = { request, handler in
+            let readyGeneration = await generation.acquire()
+            await handler.transportDidBecomeReady(readyGeneration)
+            let session = try await transport.attachTerminal(request)
+            try await handler.runEndingSession(session)
+        }
+        let store = makeStore(
+            transport: transport,
+            generation: 1,
+            runTerminal: runner)
+
+        let firstSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: firstSessionGate)
+        store.viewDidResize(cols: 80, rows: 24)
+        await firstSessionGate.waitForEntry()
+        let firstStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("first".utf8)))
+        await firstSessionGate.open()
+        await firstStatusChanges.next()
+
+        await generation.set(2)
+        let readyGate = ScriptedTransportCallGate()
+        await generation.gateNextAcquisition(using: readyGate)
+        let recoveryChanges = observeTerminalChanges(of: store)
+        store.didBecomeActive(afterPossibleSuspension: true)
+        await recoveryChanges.next()
+        let recoveryID = store.terminalID
+
+        let secondSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: secondSessionGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await readyGate.waitForEntry()
+
+        // Generation 3 is latched before pipeline 2 records its acquisition.
+        // Reconciliation must replace pipeline 2 once, after its exact
+        // generation becomes known.
+        let replacementChanges = observeTerminalChanges(of: store)
+        store.transportGenerationDidChange(3)
+        #expect(store.terminalID == recoveryID)
+        #expect(await transport.attachRequests.count == 1)
+
+        await readyGate.open()
+        await secondSessionGate.waitForEntry()
+        await secondSessionGate.open()
+        await replacementChanges.next()
+        let latestRecoveryID = store.terminalID
+        #expect(latestRecoveryID != recoveryID)
+        #expect(await transport.attachRequests.count == 2)
+
+        await generation.set(3)
+        let thirdSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: thirdSessionGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await thirdSessionGate.waitForEntry()
+        let latestStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("latest".utf8)))
+        await thirdSessionGate.open()
+        await latestStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+        #expect(store.terminalID == latestRecoveryID)
+        #expect(await transport.attachRequests.count == 3)
+
+        await store.leave().value
         #expect(await !transport.hasLiveAttachSession)
     }
 
@@ -2403,6 +2527,7 @@ private actor ObservationChangeProbe {
 
 private actor TerminalGenerationSource {
     private(set) var value: UInt64
+    private var nextAcquisitionGate: ScriptedTransportCallGate?
 
     init(_ value: UInt64) {
         self.value = value
@@ -2410,6 +2535,18 @@ private actor TerminalGenerationSource {
 
     func set(_ value: UInt64) {
         self.value = value
+    }
+
+    func gateNextAcquisition(using gate: ScriptedTransportCallGate) {
+        nextAcquisitionGate = gate
+    }
+
+    func acquire() async -> UInt64 {
+        let generation = value
+        let gate = nextAcquisitionGate
+        nextAcquisitionGate = nil
+        await gate?.waitUntilOpen()
+        return generation
     }
 }
 

--- a/Tests/HeelerTests/AttachTerminalStoreTests.swift
+++ b/Tests/HeelerTests/AttachTerminalStoreTests.swift
@@ -454,7 +454,7 @@ struct AttachTerminalStoreTests {
 @MainActor
 @Suite("Agent Attach store")
 struct AgentAttachStoreTests {
-    @Test func foregroundRecoveryAbsorbsItsLaterTransportGeneration() async throws {
+    @Test func foregroundRecoveryDoesNotAbsorbANewerTransportGeneration() async throws {
         let transport = ScriptedTransport()
         let generation = TerminalGenerationSource(1)
         let runner: TerminalSessionRunner = { request, handler in
@@ -487,21 +487,86 @@ struct AgentAttachStoreTests {
         #expect(recoveryID != predecessorID)
         #expect(store.terminalStatus == .waitingForSize)
 
-        // This is the projection edge that used to enqueue a second pipeline
-        // after foreground recovery had already built the one waiting for the
-        // ping-proven Transport.
-        store.transportGenerationDidChange(2)
-        #expect(store.terminalID == recoveryID)
-
         let secondSessionGate = ScriptedTransportCallGate()
         await transport.gateNextAttachSession(using: secondSessionGate)
         store.viewDidResize(cols: 100, rows: 30)
         await secondSessionGate.waitForEntry()
         #expect(await transport.attachRequests.count == 2)
-        var secondStatusChanges = observeStatusChanges(of: store)
+
+        // Coalesce away the projection edge for generation 2, then publish 3
+        // while pipeline 2 is still connecting. Generation 3 is not an
+        // acknowledgement of pipeline 2 and must replace it.
+        await generation.set(3)
+        let replacementChanges = observeTerminalChanges(of: store)
+        store.transportGenerationDidChange(3)
+        await secondSessionGate.open()
+        await replacementChanges.next()
+        let latestRecoveryID = store.terminalID
+        #expect(latestRecoveryID != recoveryID)
+        #expect(await transport.attachRequests.count == 2)
+
+        let thirdSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: thirdSessionGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await thirdSessionGate.waitForEntry()
+        #expect(await transport.attachRequests.count == 3)
+        let latestStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("latest".utf8)))
+        await thirdSessionGate.open()
+        await latestStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+
+        await store.leave().value
+        #expect(store.terminalID == latestRecoveryID)
+        #expect(await transport.attachRequests.count == 3)
+        #expect(await !transport.hasLiveAttachSession)
+    }
+
+    @Test func foregroundRecoveryAbsorbsItsAcquiredTransportGeneration() async throws {
+        let transport = ScriptedTransport()
+        let generation = TerminalGenerationSource(1)
+        let runner: TerminalSessionRunner = { request, handler in
+            let readyGeneration = await generation.value
+            await handler.transportDidBecomeReady(readyGeneration)
+            let session = try await transport.attachTerminal(request)
+            try await handler.runEndingSession(session)
+        }
+        let store = makeStore(
+            transport: transport,
+            generation: 1,
+            runTerminal: runner)
+
+        let firstSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: firstSessionGate)
+        store.viewDidResize(cols: 80, rows: 24)
+        await firstSessionGate.waitForEntry()
+        let firstStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("first".utf8)))
+        await firstSessionGate.open()
+        await firstStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+
+        await generation.set(2)
+        let recoveryChanges = observeTerminalChanges(of: store)
+        store.didBecomeActive(afterPossibleSuspension: true)
+        await recoveryChanges.next()
+        let recoveryID = store.terminalID
+
+        let secondSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: secondSessionGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await secondSessionGate.waitForEntry()
+
+        // The exact edge acknowledges this already-acquired pipeline and must
+        // not enqueue a duplicate writer behind it.
+        store.transportGenerationDidChange(2)
+        #expect(store.terminalID == recoveryID)
+        #expect(await transport.attachRequests.count == 2)
+
+        let secondStatusChanges = observeStatusChanges(of: store)
         #expect(await transport.emitAttachOutput(Data("second".utf8)))
         await secondSessionGate.open()
-        _ = await secondStatusChanges.next()
+        await secondStatusChanges.next()
         #expect(store.terminalStatus == .live)
 
         await store.leave().value
@@ -2226,7 +2291,7 @@ struct AgentAttachStoreTests {
 
     private func observeTerminalChanges(
         of store: AgentAttachStore
-    ) -> AsyncStream<Void>.Iterator {
+    ) -> ObservationChangeProbe {
         let (changes, continuation) = AsyncStream.makeStream(of: Void.self)
         withObservationTracking {
             _ = store.terminalID
@@ -2234,12 +2299,12 @@ struct AgentAttachStoreTests {
             continuation.yield()
             continuation.finish()
         }
-        return changes.makeAsyncIterator()
+        return ObservationChangeProbe(changes)
     }
 
     private func observeStatusChanges(
         of store: AgentAttachStore
-    ) -> AsyncStream<Void>.Iterator {
+    ) -> ObservationChangeProbe {
         let (changes, continuation) = AsyncStream.makeStream(of: Void.self)
         withObservationTracking {
             _ = store.terminalStatus
@@ -2247,7 +2312,7 @@ struct AgentAttachStoreTests {
             continuation.yield()
             continuation.finish()
         }
-        return changes.makeAsyncIterator()
+        return ObservationChangeProbe(changes)
     }
 
     private func tinyJPEGData() throws -> Data {
@@ -2321,6 +2386,18 @@ struct AgentAttachStoreTests {
             }
             await permit.release()
         }
+    }
+}
+
+private actor ObservationChangeProbe {
+    private let changes: AsyncStream<Void>
+
+    init(_ changes: AsyncStream<Void>) {
+        self.changes = changes
+    }
+
+    func next() async {
+        for await _ in changes { return }
     }
 }
 

--- a/Tests/HeelerTests/AttachTerminalStoreTests.swift
+++ b/Tests/HeelerTests/AttachTerminalStoreTests.swift
@@ -454,6 +454,71 @@ struct AttachTerminalStoreTests {
 @MainActor
 @Suite("Agent Attach store")
 struct AgentAttachStoreTests {
+    @Test func unchangedGenerationAllowsConsecutiveForegroundRecoveries() async throws {
+        let transport = ScriptedTransport()
+        let generation = TerminalGenerationSource(1)
+        let runner: TerminalSessionRunner = { request, handler in
+            let readyGeneration = await generation.acquire()
+            await handler.transportDidBecomeReady(readyGeneration)
+            let session = try await transport.attachTerminal(request)
+            try await handler.runEndingSession(session)
+        }
+        let store = makeStore(
+            transport: transport,
+            generation: 1,
+            runTerminal: runner)
+
+        let initialSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: initialSessionGate)
+        store.viewDidResize(cols: 80, rows: 24)
+        await initialSessionGate.waitForEntry()
+        let initialStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("initial".utf8)))
+        await initialSessionGate.open()
+        await initialStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+
+        let firstRecoveryChanges = observeTerminalChanges(of: store)
+        store.didBecomeActive(afterPossibleSuspension: true)
+        await firstRecoveryChanges.next()
+        let firstRecoveryID = store.terminalID
+
+        let firstRecoveryGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: firstRecoveryGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await firstRecoveryGate.waitForEntry()
+        #expect(await transport.attachRequests.count == 2)
+        let firstRecoveryStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("first recovery".utf8)))
+        await firstRecoveryGate.open()
+        await firstRecoveryStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+
+        // No second projection is emitted for generation 1. Acquiring the
+        // already-projected generation must still release the recovery latch.
+        let secondRecoveryChanges = observeTerminalChanges(of: store)
+        store.didBecomeActive(afterPossibleSuspension: true)
+        await secondRecoveryChanges.next()
+        let secondRecoveryID = store.terminalID
+        #expect(secondRecoveryID != firstRecoveryID)
+
+        let secondRecoveryGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: secondRecoveryGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await secondRecoveryGate.waitForEntry()
+        #expect(await transport.attachRequests.count == 3)
+        let secondRecoveryStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("second recovery".utf8)))
+        await secondRecoveryGate.open()
+        await secondRecoveryStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+        #expect(store.terminalID == secondRecoveryID)
+
+        await store.leave().value
+        #expect(await transport.attachRequests.count == 3)
+        #expect(await !transport.hasLiveAttachSession)
+    }
+
     @Test func foregroundRecoveryDoesNotAbsorbANewerTransportGeneration() async throws {
         let transport = ScriptedTransport()
         let generation = TerminalGenerationSource(1)

--- a/Tests/HeelerTests/AttachTerminalStoreTests.swift
+++ b/Tests/HeelerTests/AttachTerminalStoreTests.swift
@@ -2447,6 +2447,126 @@ struct AgentAttachStoreTests {
         #expect(await transport.hasLiveAttachSession == false)
     }
 
+    #if DEBUG
+    @Test func foregroundRecoveryTraceAdoptsTheDirectReplacement() async throws {
+        let transport = ScriptedTransport()
+        let endGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachEnd(on: endGate)
+        let store = makeStore(transport: transport, generation: 0)
+        try await goLive(store, transport)
+        let predecessorID = store.terminalID
+
+        store.didBecomeActive(afterPossibleSuspension: true)
+        let trace = try #require(store.pendingForegroundRecoveryTrace)
+        try await waitUntil("recovery should reach predecessor teardown") {
+            await endGate.entryCount == 1
+        }
+        await endGate.open()
+        try await waitUntil("recovery replacement should publish") {
+            store.terminalID != predecessorID
+        }
+
+        #expect(store.terminal.restorationTrace === trace)
+        #expect(store.pendingForegroundRecoveryTrace == nil)
+        await store.leave().value
+    }
+
+    @Test func foregroundRecoveryTraceAdoptsAnAlreadyPendingReplacement() async throws {
+        let transport = ScriptedTransport()
+        let endGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachEnd(on: endGate)
+        let store = makeStore(transport: transport, generation: 0)
+        try await goLive(store, transport)
+        let predecessorID = store.terminalID
+
+        store.transportGenerationDidChange(1)
+        try await waitUntil("ordinary replacement should reach predecessor teardown") {
+            await endGate.entryCount == 1
+        }
+        store.didBecomeActive(afterPossibleSuspension: true)
+        let trace = try #require(store.pendingForegroundRecoveryTrace)
+        await endGate.open()
+        try await waitUntil("pending replacement should publish") {
+            store.terminalID != predecessorID
+        }
+
+        #expect(store.terminal.restorationTrace === trace)
+        #expect(store.pendingForegroundRecoveryTrace == nil)
+        await store.leave().value
+    }
+
+    @Test func repeatedForegroundActivationKeepsOnePendingTrace() async throws {
+        let transport = ScriptedTransport()
+        let endGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachEnd(on: endGate)
+        let store = makeStore(transport: transport, generation: 0)
+        try await goLive(store, transport)
+
+        store.transportGenerationDidChange(1)
+        try await waitUntil("ordinary replacement should reach predecessor teardown") {
+            await endGate.entryCount == 1
+        }
+        store.didBecomeActive(afterPossibleSuspension: true)
+        let trace = try #require(store.pendingForegroundRecoveryTrace)
+        store.didBecomeActive(afterPossibleSuspension: true)
+
+        #expect(store.pendingForegroundRecoveryTrace === trace)
+        #expect(trace.recordedPhases.contains(.foregroundRecoveryStarted))
+        await endGate.open()
+        await store.leave().value
+    }
+
+    @Test func offStageRecoveryAbortRecordsTerminalTraceEventAndClearsPendingTrace() async throws {
+        let transport = ScriptedTransport()
+        let endGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachEnd(on: endGate)
+        var isOnStage = true
+        let store = makeStore(
+            transport: transport, generation: 0, isOnStage: { isOnStage })
+        try await goLive(store, transport)
+
+        store.transportGenerationDidChange(1)
+        try await waitUntil("ordinary replacement should reach predecessor teardown") {
+            await endGate.entryCount == 1
+        }
+        store.didBecomeActive(afterPossibleSuspension: true)
+        let trace = try #require(store.pendingForegroundRecoveryTrace)
+        isOnStage = false
+        await endGate.open()
+        try await waitUntil("off-stage recovery should clear its trace") {
+            store.pendingForegroundRecoveryTrace == nil
+        }
+
+        #expect(trace.recordedPhases.contains(.foregroundRecoveryAborted))
+        await store.leave().value
+    }
+
+    @Test func supersedingOnStageReplacementCarriesPendingForegroundTrace() async throws {
+        let transport = ScriptedTransport()
+        let endGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachEnd(on: endGate)
+        let store = makeStore(transport: transport, generation: 0)
+        try await goLive(store, transport)
+        let predecessorID = store.terminalID
+
+        store.transportGenerationDidChange(1)
+        try await waitUntil("first replacement should reach predecessor teardown") {
+            await endGate.entryCount == 1
+        }
+        store.transportGenerationDidChange(2)
+        store.didBecomeActive(afterPossibleSuspension: true)
+        let trace = try #require(store.pendingForegroundRecoveryTrace)
+        await endGate.open()
+        try await waitUntil("superseding replacement should publish") {
+            store.terminalID != predecessorID
+        }
+
+        #expect(store.terminal.restorationTrace === trace)
+        #expect(store.pendingForegroundRecoveryTrace == nil)
+        await store.leave().value
+    }
+    #endif
+
     private func makeStore(
         transport: ScriptedTransport,
         generation: UInt64?,

--- a/Tests/HeelerTests/EventsSessionSubscriptionsTests.swift
+++ b/Tests/HeelerTests/EventsSessionSubscriptionsTests.swift
@@ -73,6 +73,278 @@ struct EventsSessionSubscriptionsTests {
         await session.end()
     }
 
+    @Test func terminalStartsBeforeEventSubscriptionIsReady() async throws {
+        let first = ScriptedTransport(snapshot: .fixture())
+        let replacement = ScriptedTransport(snapshot: .fixture())
+        let firstSnapshotGate = ScriptedTransportCallGate()
+        let subscriptionGate = ScriptedTransportCallGate()
+        let attachGate = ScriptedTransportCallGate()
+        await first.gateNextSnapshot(using: firstSnapshotGate)
+        await replacement.gateNextSubscription(using: subscriptionGate)
+        await replacement.gateNextAttach(using: attachGate)
+        let connector = SequencedTransportConnector([first, replacement])
+        let session = EventsSession(
+            subscriptions: initial,
+            connect: { try await connector.connect() },
+            reconnectPolicy: ReconnectPolicy(
+                initialDelay: .milliseconds(10), multiplier: 2, maxDelay: .milliseconds(50)),
+            keepalive: nil)
+        let (projection, generationBarrier) = await MainActor.run {
+            let barrier = ProjectionGenerationBarrier()
+            let projection = HostConsoleProjection(
+                host: .fixture(),
+                session: session,
+                snapshotRetryDelay: .milliseconds(10)
+            ) { [barrier] in
+                barrier.record()
+            }
+            barrier.projection = projection
+            return (projection, barrier)
+        }
+        await MainActor.run { projection.start(isActive: true) }
+        await firstSnapshotGate.waitForEntry()
+        let snapshotsBeforeRecovery = await first.snapshotFetchCount
+        await firstSnapshotGate.open()
+        await projection.suspend()
+
+        let terminal = Task { @MainActor in
+            try await projection.terminalRunner()(
+                Self.attachRequest,
+                TerminalSessionHandler { attached in
+                    await attached.end()
+                })
+        }
+        await projection.resume()
+        await subscriptionGate.waitForEntry()
+        await attachGate.waitForEntry()
+        await generationBarrier.wait(for: 1)
+
+        #expect(await replacement.attachRequests == [Self.attachRequest])
+        #expect(await replacement.snapshotFetchCount == 0)
+        #expect(await first.snapshotFetchCount == snapshotsBeforeRecovery)
+        #expect(await MainActor.run { projection.transportGeneration == 1 })
+        await attachGate.open()
+        try await terminal.value
+
+        await subscriptionGate.open()
+        await MainActor.run { projection.end() }
+    }
+
+    @Test func terminalStartsWhileProjectionSnapshotIsStillGated() async throws {
+        let transport = ScriptedTransport(snapshot: .fixture())
+        let snapshotGate = ScriptedTransportCallGate()
+        let attachGate = ScriptedTransportCallGate()
+        await transport.gateNextSnapshot(using: snapshotGate)
+        await transport.gateNextAttach(using: attachGate)
+        let session = makeSession(transport: transport)
+        let projection = await MainActor.run {
+            HostConsoleProjection(
+                host: .fixture(),
+                session: session,
+                snapshotRetryDelay: .milliseconds(10)
+            ) {}
+        }
+        await MainActor.run { projection.start(isActive: true) }
+
+        await snapshotGate.waitForEntry()
+        let terminal = Task { @MainActor in
+            try await projection.terminalRunner()(
+                Self.attachRequest,
+                TerminalSessionHandler { attached in
+                    await attached.end()
+                })
+        }
+        await attachGate.waitForEntry()
+
+        #expect(await transport.attachRequests == [Self.attachRequest])
+        #expect(await snapshotGate.entryCount == 1)
+        await attachGate.open()
+        try await terminal.value
+
+        await snapshotGate.open()
+        await MainActor.run { projection.end() }
+    }
+
+    @Test func terminalWaitsForThePingProvenTransportInstalledAfterItsRequest() async throws {
+        let transport = ScriptedTransport()
+        let pingGate = ScriptedTransportCallGate()
+        let subscriptionGate = ScriptedTransportCallGate()
+        let attachSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextPing(using: pingGate)
+        await transport.gateNextSubscription(using: subscriptionGate)
+        await transport.gateNextAttachSession(using: attachSessionGate)
+        let (registrations, registrationContinuation) = AsyncStream.makeStream(of: Void.self)
+        var registrationIterator = registrations.makeAsyncIterator()
+        let session = EventsSession(
+            subscriptions: initial,
+            connect: { transport },
+            reconnectPolicy: ReconnectPolicy(
+                initialDelay: .milliseconds(10), multiplier: 2, maxDelay: .milliseconds(50)),
+            keepalive: nil,
+            terminalWaiterDidRegister: { registrationContinuation.yield() })
+        let projection = await MainActor.run {
+            HostConsoleProjection(
+                host: .fixture(),
+                session: session,
+                snapshotRetryDelay: .milliseconds(10)
+            ) {}
+        }
+        let terminal = await MainActor.run {
+            AttachTerminalStore(
+                target: "w1:p1",
+                takeover: true,
+                transportGeneration: 0,
+                runTerminal: projection.terminalRunner())
+        }
+        await MainActor.run { terminal.viewDidResize(cols: 80, rows: 24) }
+        _ = await registrationIterator.next()
+        #expect(await transport.attachRequests.isEmpty)
+        #expect(await MainActor.run { terminal.status == .connecting })
+
+        await session.resume()
+        await pingGate.waitForEntry()
+        #expect(await transport.attachRequests.isEmpty)
+        await pingGate.open()
+        await subscriptionGate.waitForEntry()
+        await attachSessionGate.waitForEntry()
+
+        #expect(await transport.attachRequests == [Self.attachRequest])
+        #expect(await MainActor.run { terminal.status == .connecting })
+        await attachSessionGate.open()
+        #expect(await transport.emitAttachOutput(Data("ready".utf8)))
+        await terminal.stop()
+        #expect(await MainActor.run { terminal.status == .stopped })
+
+        await subscriptionGate.open()
+        await MainActor.run { projection.end() }
+        registrationContinuation.finish()
+    }
+
+    @Test func cancellationRemovesAReadinessWaiterAndReleasesTheTerminalPermit() async throws {
+        let transport = ScriptedTransport()
+        let subscriptionGate = ScriptedTransportCallGate()
+        let attachGate = ScriptedTransportCallGate()
+        await transport.gateNextSubscription(using: subscriptionGate)
+        await transport.gateNextAttach(using: attachGate)
+        let (registrations, registrationContinuation) = AsyncStream.makeStream(of: Void.self)
+        var registrationIterator = registrations.makeAsyncIterator()
+        let session = EventsSession(
+            subscriptions: initial,
+            connect: { transport },
+            reconnectPolicy: ReconnectPolicy(
+                initialDelay: .milliseconds(10), multiplier: 2, maxDelay: .milliseconds(50)),
+            keepalive: nil,
+            terminalWaiterDidRegister: { registrationContinuation.yield() })
+        let cancelled = Task {
+            try await session.withTerminalTransport { _, _ in
+                Issue.record("a cancelled readiness waiter reached its operation")
+            }
+        }
+
+        _ = await registrationIterator.next()
+        cancelled.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await cancelled.value
+        }
+
+        await session.resume()
+        await subscriptionGate.waitForEntry()
+        let replacement = Task {
+            try await session.withTerminalTransport { transport, generation in
+                let attached = try await transport.attachTerminal(Self.attachRequest)
+                await attached.end()
+                return generation
+            }
+        }
+        await attachGate.waitForEntry()
+        await attachGate.open()
+        #expect(try await replacement.value == 0)
+        #expect(await transport.attachRequests == [Self.attachRequest])
+
+        await subscriptionGate.open()
+        await session.end()
+        registrationContinuation.finish()
+    }
+
+    @Test func aRequestAfterConnectionFailureReceivesTheRealFailure() async throws {
+        let transport = ScriptedTransport()
+        let failure = TransportError.socketNotFound(path: "/remote/herdr.sock")
+        await transport.failPing(atCall: 1, with: failure)
+        let session = makeSession(transport: transport)
+        var updates = session.updates.makeAsyncIterator()
+
+        await session.resume()
+        #expect(await updates.next() == .status(.connecting))
+        #expect(await updates.next() == .status(.failed(failure)))
+
+        do {
+            try await session.withTerminalTransport { _, _ in
+                Issue.record("a failed session handed out a terminal Transport")
+            }
+        } catch let error as TransportError {
+            #expect(error == failure)
+        } catch {
+            Issue.record("expected \(failure), got \(error)")
+        }
+
+        await session.end()
+    }
+
+    @Test func aNewActivationInvalidatesTheOldReadinessWaiter() async throws {
+        let first = ScriptedTransport()
+        let second = ScriptedTransport()
+        let firstPingGate = ScriptedTransportCallGate()
+        let secondSubscriptionGate = ScriptedTransportCallGate()
+        let secondAttachGate = ScriptedTransportCallGate()
+        await first.gateNextPing(using: firstPingGate)
+        await second.gateNextSubscription(using: secondSubscriptionGate)
+        await second.gateNextAttach(using: secondAttachGate)
+        let connector = SequencedTransportConnector([first, second])
+        let (registrations, registrationContinuation) = AsyncStream.makeStream(of: Void.self)
+        var registrationIterator = registrations.makeAsyncIterator()
+        let session = EventsSession(
+            subscriptions: initial,
+            connect: { try await connector.connect() },
+            reconnectPolicy: ReconnectPolicy(
+                initialDelay: .milliseconds(10), multiplier: 2, maxDelay: .milliseconds(50)),
+            keepalive: nil,
+            terminalWaiterDidRegister: { registrationContinuation.yield() })
+
+        await session.resume()
+        await firstPingGate.waitForEntry()
+        let stale = Task {
+            try await session.withTerminalTransport { transport, _ in
+                _ = try await transport.attachTerminal(Self.attachRequest)
+                Issue.record("an older activation handed out its Transport")
+            }
+        }
+        _ = await registrationIterator.next()
+
+        await session.retry()
+        await #expect(throws: TransportError.cancelled) {
+            try await stale.value
+        }
+        await secondSubscriptionGate.waitForEntry()
+
+        let current = Task {
+            try await session.withTerminalTransport { transport, generation in
+                let attached = try await transport.attachTerminal(Self.attachRequest)
+                await attached.end()
+                return generation
+            }
+        }
+        await secondAttachGate.waitForEntry()
+        await secondAttachGate.open()
+        #expect(try await current.value == 0)
+        #expect(await first.attachRequests.isEmpty)
+        #expect(await second.attachRequests == [Self.attachRequest])
+
+        await firstPingGate.open()
+        await secondSubscriptionGate.open()
+        await session.end()
+        registrationContinuation.finish()
+    }
+
     @Test func unchangedSetIsANoOp() async throws {
         let transport = ScriptedTransport()
         let session = makeSession(transport: transport)
@@ -87,6 +359,9 @@ struct EventsSessionSubscriptionsTests {
         #expect(await transport.capturedSubscriptions == [initial])
         await session.end()
     }
+
+    private static let attachRequest = TerminalAttachRequest(
+        target: "w1:p1", takeover: true, cols: 80, rows: 24)
 
     @Test func updateWhileSuspendedTakesEffectOnResume() async throws {
         let transport = ScriptedTransport()
@@ -380,6 +655,32 @@ struct EventsSessionSubscriptionsTests {
             try await Task.sleep(for: .milliseconds(5))
         }
         Issue.record(Comment(rawValue: message))
+    }
+}
+
+@MainActor
+private final class ProjectionGenerationBarrier {
+    weak var projection: HostConsoleProjection?
+    private var waiters: [
+        (generation: UInt64, continuation: CheckedContinuation<Void, Never>)
+    ] = []
+
+    func record() {
+        guard let generation = projection?.transportGeneration else { return }
+        let reached = waiters.filter { generation >= $0.generation }
+        waiters.removeAll { generation >= $0.generation }
+        for waiter in reached {
+            waiter.continuation.resume()
+        }
+    }
+
+    func wait(for generation: UInt64) async {
+        guard let current = projection?.transportGeneration, current < generation else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append((generation, continuation))
+        }
     }
 }
 

--- a/Tests/HeelerTests/ShellTerminalStoreTests.swift
+++ b/Tests/HeelerTests/ShellTerminalStoreTests.swift
@@ -225,7 +225,7 @@ struct ShellTerminalStoreTests {
         let transport = ScriptedTransport()
         let generation = ShellTerminalGenerationSource(1)
         let runner: TerminalSessionRunner = { request, handler in
-            let readyGeneration = await generation.value
+            let readyGeneration = await generation.acquire()
             await handler.transportDidBecomeReady(readyGeneration)
             let session = try await transport.attachTerminal(request)
             try await handler.runEndingSession(session)
@@ -296,7 +296,7 @@ struct ShellTerminalStoreTests {
         let transport = ScriptedTransport()
         let generation = ShellTerminalGenerationSource(1)
         let runner: TerminalSessionRunner = { request, handler in
-            let readyGeneration = await generation.value
+            let readyGeneration = await generation.acquire()
             await handler.transportDidBecomeReady(readyGeneration)
             let session = try await transport.attachTerminal(request)
             try await handler.runEndingSession(session)
@@ -346,6 +346,120 @@ struct ShellTerminalStoreTests {
         await store.leave().value
         #expect(store.terminalID == recoveryID)
         #expect(await transport.attachRequests.count == 2)
+        #expect(await !transport.hasLiveAttachSession)
+    }
+
+    @Test func projectionFirstRecoveryAbsorbsItsMatchingAcquisition() async throws {
+        let transport = ScriptedTransport()
+        let generation = ShellTerminalGenerationSource(1)
+        let runner: TerminalSessionRunner = { request, handler in
+            let readyGeneration = await generation.acquire()
+            await handler.transportDidBecomeReady(readyGeneration)
+            let session = try await transport.attachTerminal(request)
+            try await handler.runEndingSession(session)
+        }
+        let store = makeShellStore(runner: runner)
+
+        let firstSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: firstSessionGate)
+        store.viewDidResize(cols: 80, rows: 24)
+        await firstSessionGate.waitForEntry()
+        let firstStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("first".utf8)))
+        await firstSessionGate.open()
+        await firstStatusChanges.next()
+
+        await generation.set(2)
+        let readyGate = ScriptedTransportCallGate()
+        await generation.gateNextAcquisition(using: readyGate)
+        let recoveryChanges = observeTerminalChanges(of: store)
+        store.didBecomeActive(afterPossibleSuspension: true)
+        await recoveryChanges.next()
+        let recoveryID = store.terminalID
+
+        let secondSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: secondSessionGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await readyGate.waitForEntry()
+
+        store.transportGenerationDidChange(2)
+        #expect(store.terminalID == recoveryID)
+        #expect(await transport.attachRequests.count == 1)
+
+        await readyGate.open()
+        await secondSessionGate.waitForEntry()
+        let secondStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("second".utf8)))
+        await secondSessionGate.open()
+        await secondStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+        #expect(store.terminalID == recoveryID)
+        #expect(await transport.attachRequests.count == 2)
+
+        await store.leave().value
+        #expect(await !transport.hasLiveAttachSession)
+    }
+
+    @Test func projectionFirstRecoveryReplacesOnceForANewerGeneration() async throws {
+        let transport = ScriptedTransport()
+        let generation = ShellTerminalGenerationSource(1)
+        let runner: TerminalSessionRunner = { request, handler in
+            let readyGeneration = await generation.acquire()
+            await handler.transportDidBecomeReady(readyGeneration)
+            let session = try await transport.attachTerminal(request)
+            try await handler.runEndingSession(session)
+        }
+        let store = makeShellStore(runner: runner)
+
+        let firstSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: firstSessionGate)
+        store.viewDidResize(cols: 80, rows: 24)
+        await firstSessionGate.waitForEntry()
+        let firstStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("first".utf8)))
+        await firstSessionGate.open()
+        await firstStatusChanges.next()
+
+        await generation.set(2)
+        let readyGate = ScriptedTransportCallGate()
+        await generation.gateNextAcquisition(using: readyGate)
+        let recoveryChanges = observeTerminalChanges(of: store)
+        store.didBecomeActive(afterPossibleSuspension: true)
+        await recoveryChanges.next()
+        let recoveryID = store.terminalID
+
+        let secondSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: secondSessionGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await readyGate.waitForEntry()
+
+        let replacementChanges = observeTerminalChanges(of: store)
+        store.transportGenerationDidChange(3)
+        #expect(store.terminalID == recoveryID)
+        #expect(await transport.attachRequests.count == 1)
+
+        await readyGate.open()
+        await secondSessionGate.waitForEntry()
+        await secondSessionGate.open()
+        await replacementChanges.next()
+        let latestRecoveryID = store.terminalID
+        #expect(latestRecoveryID != recoveryID)
+        #expect(await transport.attachRequests.count == 2)
+
+        await generation.set(3)
+        let thirdSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: thirdSessionGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await thirdSessionGate.waitForEntry()
+        let latestStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("latest".utf8)))
+        await thirdSessionGate.open()
+        await latestStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+        #expect(store.terminalID == latestRecoveryID)
+        #expect(await transport.attachRequests.count == 3)
+
+        await store.leave().value
         #expect(await !transport.hasLiveAttachSession)
     }
 
@@ -635,6 +749,19 @@ struct ShellTerminalStoreTests {
         }
     }
 
+    private func makeShellStore(
+        runner: @escaping TerminalSessionRunner
+    ) -> ShellTerminalStore {
+        ShellTerminalStore(
+            identity: ShellTerminalIdentity(
+                paneID: "w1:p-shell",
+                tabID: "w1:t-shell",
+                terminalID: "term-shell"),
+            transportGeneration: 1,
+            isOnStage: { true },
+            runTerminal: runner)
+    }
+
     private func observeTerminalChanges(
         of store: ShellTerminalStore
     ) -> ShellObservationChangeProbe {
@@ -723,6 +850,7 @@ private actor ShellObservationChangeProbe {
 
 private actor ShellTerminalGenerationSource {
     private(set) var value: UInt64
+    private var nextAcquisitionGate: ScriptedTransportCallGate?
 
     init(_ value: UInt64) {
         self.value = value
@@ -730,5 +858,17 @@ private actor ShellTerminalGenerationSource {
 
     func set(_ value: UInt64) {
         self.value = value
+    }
+
+    func gateNextAcquisition(using gate: ScriptedTransportCallGate) {
+        nextAcquisitionGate = gate
+    }
+
+    func acquire() async -> UInt64 {
+        let generation = value
+        let gate = nextAcquisitionGate
+        nextAcquisitionGate = nil
+        await gate?.waitUntilOpen()
+        return generation
     }
 }

--- a/Tests/HeelerTests/ShellTerminalStoreTests.swift
+++ b/Tests/HeelerTests/ShellTerminalStoreTests.swift
@@ -221,6 +221,75 @@ struct ShellTerminalStoreTests {
         #expect(await transport.shellTerminalCreations.count == 1)
     }
 
+    @Test func unchangedGenerationAllowsConsecutiveForegroundRecoveries() async throws {
+        let transport = ScriptedTransport()
+        let generation = ShellTerminalGenerationSource(1)
+        let runner: TerminalSessionRunner = { request, handler in
+            let readyGeneration = await generation.acquire()
+            await handler.transportDidBecomeReady(readyGeneration)
+            let session = try await transport.attachTerminal(request)
+            try await handler.runEndingSession(session)
+        }
+        let store = ShellTerminalStore(
+            identity: ShellTerminalIdentity(
+                paneID: "w1:p-shell",
+                tabID: "w1:t-shell",
+                terminalID: "term-shell"),
+            transportGeneration: 1,
+            isOnStage: { true },
+            runTerminal: runner)
+
+        let initialSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: initialSessionGate)
+        store.viewDidResize(cols: 80, rows: 24)
+        await initialSessionGate.waitForEntry()
+        let initialStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("initial".utf8)))
+        await initialSessionGate.open()
+        await initialStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+
+        let firstRecoveryChanges = observeTerminalChanges(of: store)
+        store.didBecomeActive(afterPossibleSuspension: true)
+        await firstRecoveryChanges.next()
+        let firstRecoveryID = store.terminalID
+
+        let firstRecoveryGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: firstRecoveryGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await firstRecoveryGate.waitForEntry()
+        #expect(await transport.attachRequests.count == 2)
+        let firstRecoveryStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("first recovery".utf8)))
+        await firstRecoveryGate.open()
+        await firstRecoveryStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+
+        // No second projection is emitted for generation 1. Acquiring the
+        // already-projected generation must still release the recovery latch.
+        let secondRecoveryChanges = observeTerminalChanges(of: store)
+        store.didBecomeActive(afterPossibleSuspension: true)
+        await secondRecoveryChanges.next()
+        let secondRecoveryID = store.terminalID
+        #expect(secondRecoveryID != firstRecoveryID)
+
+        let secondRecoveryGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: secondRecoveryGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await secondRecoveryGate.waitForEntry()
+        #expect(await transport.attachRequests.count == 3)
+        let secondRecoveryStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("second recovery".utf8)))
+        await secondRecoveryGate.open()
+        await secondRecoveryStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+        #expect(store.terminalID == secondRecoveryID)
+
+        await store.leave().value
+        #expect(await transport.attachRequests.count == 3)
+        #expect(await !transport.hasLiveAttachSession)
+    }
+
     @Test func foregroundRecoveryDoesNotAbsorbANewerTransportGeneration() async throws {
         let transport = ScriptedTransport()
         let generation = ShellTerminalGenerationSource(1)

--- a/Tests/HeelerTests/ShellTerminalStoreTests.swift
+++ b/Tests/HeelerTests/ShellTerminalStoreTests.swift
@@ -221,6 +221,134 @@ struct ShellTerminalStoreTests {
         #expect(await transport.shellTerminalCreations.count == 1)
     }
 
+    @Test func foregroundRecoveryDoesNotAbsorbANewerTransportGeneration() async throws {
+        let transport = ScriptedTransport()
+        let generation = ShellTerminalGenerationSource(1)
+        let runner: TerminalSessionRunner = { request, handler in
+            let readyGeneration = await generation.value
+            await handler.transportDidBecomeReady(readyGeneration)
+            let session = try await transport.attachTerminal(request)
+            try await handler.runEndingSession(session)
+        }
+        let store = ShellTerminalStore(
+            identity: ShellTerminalIdentity(
+                paneID: "w1:p-shell",
+                tabID: "w1:t-shell",
+                terminalID: "term-shell"),
+            transportGeneration: 1,
+            isOnStage: { true },
+            runTerminal: runner)
+
+        let firstSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: firstSessionGate)
+        store.viewDidResize(cols: 80, rows: 24)
+        await firstSessionGate.waitForEntry()
+        let firstStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("first".utf8)))
+        await firstSessionGate.open()
+        await firstStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+
+        await generation.set(2)
+        let predecessorID = store.terminalID
+        let recoveryChanges = observeTerminalChanges(of: store)
+        store.didBecomeActive(afterPossibleSuspension: true)
+        await recoveryChanges.next()
+        let recoveryID = store.terminalID
+        #expect(recoveryID != predecessorID)
+        #expect(store.terminalStatus == .waitingForSize)
+
+        let secondSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: secondSessionGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await secondSessionGate.waitForEntry()
+        #expect(await transport.attachRequests.count == 2)
+
+        // Coalesce away the projection edge for generation 2. A later edge
+        // for generation 3 must replace the still-connecting pipeline 2.
+        await generation.set(3)
+        let latestRecoveryChanges = observeTerminalChanges(of: store)
+        store.transportGenerationDidChange(3)
+        await secondSessionGate.open()
+        await latestRecoveryChanges.next()
+        let latestRecoveryID = store.terminalID
+        #expect(latestRecoveryID != recoveryID)
+        #expect(await transport.attachRequests.count == 2)
+
+        let thirdSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: thirdSessionGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await thirdSessionGate.waitForEntry()
+        #expect(await transport.attachRequests.count == 3)
+        let latestStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("latest".utf8)))
+        await thirdSessionGate.open()
+        await latestStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+
+        await store.leave().value
+        #expect(store.terminalID == latestRecoveryID)
+        #expect(await transport.attachRequests.count == 3)
+        #expect(await !transport.hasLiveAttachSession)
+    }
+
+    @Test func foregroundRecoveryAbsorbsItsAcquiredTransportGeneration() async throws {
+        let transport = ScriptedTransport()
+        let generation = ShellTerminalGenerationSource(1)
+        let runner: TerminalSessionRunner = { request, handler in
+            let readyGeneration = await generation.value
+            await handler.transportDidBecomeReady(readyGeneration)
+            let session = try await transport.attachTerminal(request)
+            try await handler.runEndingSession(session)
+        }
+        let store = ShellTerminalStore(
+            identity: ShellTerminalIdentity(
+                paneID: "w1:p-shell",
+                tabID: "w1:t-shell",
+                terminalID: "term-shell"),
+            transportGeneration: 1,
+            isOnStage: { true },
+            runTerminal: runner)
+
+        let firstSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: firstSessionGate)
+        store.viewDidResize(cols: 80, rows: 24)
+        await firstSessionGate.waitForEntry()
+        let firstStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("first".utf8)))
+        await firstSessionGate.open()
+        await firstStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+
+        await generation.set(2)
+        let recoveryChanges = observeTerminalChanges(of: store)
+        store.didBecomeActive(afterPossibleSuspension: true)
+        await recoveryChanges.next()
+        let recoveryID = store.terminalID
+
+        let secondSessionGate = ScriptedTransportCallGate()
+        await transport.gateNextAttachSession(using: secondSessionGate)
+        store.viewDidResize(cols: 100, rows: 30)
+        await secondSessionGate.waitForEntry()
+
+        // The exact edge belongs to the already-acquired pipeline and does
+        // not create a second writer for generation 2.
+        store.transportGenerationDidChange(2)
+        #expect(store.terminalID == recoveryID)
+        #expect(await transport.attachRequests.count == 2)
+
+        let secondStatusChanges = observeStatusChanges(of: store)
+        #expect(await transport.emitAttachOutput(Data("second".utf8)))
+        await secondSessionGate.open()
+        await secondStatusChanges.next()
+        #expect(store.terminalStatus == .live)
+
+        await store.leave().value
+        #expect(store.terminalID == recoveryID)
+        #expect(await transport.attachRequests.count == 2)
+        #expect(await !transport.hasLiveAttachSession)
+    }
+
     @Test func offStageAbortedReplacementRejoinsOnTheNextActivationSignal() async throws {
         let transport = ScriptedTransport()
         let endGate = ScriptedTransportCallGate()
@@ -507,6 +635,32 @@ struct ShellTerminalStoreTests {
         }
     }
 
+    private func observeTerminalChanges(
+        of store: ShellTerminalStore
+    ) -> ShellObservationChangeProbe {
+        let (changes, continuation) = AsyncStream.makeStream(of: Void.self)
+        withObservationTracking {
+            _ = store.terminalID
+        } onChange: {
+            continuation.yield()
+            continuation.finish()
+        }
+        return ShellObservationChangeProbe(changes)
+    }
+
+    private func observeStatusChanges(
+        of store: ShellTerminalStore
+    ) -> ShellObservationChangeProbe {
+        let (changes, continuation) = AsyncStream.makeStream(of: Void.self)
+        withObservationTracking {
+            _ = store.terminalStatus
+        } onChange: {
+            continuation.yield()
+            continuation.finish()
+        }
+        return ShellObservationChangeProbe(changes)
+    }
+
     private func shell(in store: AgentOpenTerminalStore) async throws -> ShellTerminalStore {
         try #require(await eventually { store.shell != nil })
         return try #require(store.shell)
@@ -552,5 +706,29 @@ struct ShellTerminalStoreTests {
             repoRoot: "/repo",
             checkoutPath: path,
             isLinkedWorktree: isLinked)
+    }
+}
+
+private actor ShellObservationChangeProbe {
+    private let changes: AsyncStream<Void>
+
+    init(_ changes: AsyncStream<Void>) {
+        self.changes = changes
+    }
+
+    func next() async {
+        for await _ in changes { return }
+    }
+}
+
+private actor ShellTerminalGenerationSource {
+    private(set) var value: UInt64
+
+    init(_ value: UInt64) {
+        self.value = value
+    }
+
+    func set(_ value: UInt64) {
+        self.value = value
     }
 }

--- a/Tests/HeelerTests/Support/ScriptedTransport.swift
+++ b/Tests/HeelerTests/Support/ScriptedTransport.swift
@@ -82,6 +82,8 @@ final actor ScriptedTransport: Transport {
     private var nextSubscriptionGate: ScriptedTransportCallGate?
     private var nextAttachID: UInt64 = 0
     private var liveAttachID: UInt64?
+    private var nextAttachGate: ScriptedTransportCallGate?
+    private var nextAttachSessionGate: ScriptedTransportCallGate?
     private var attachContinuation: AsyncThrowingStream<Data, any Error>.Continuation?
     private var attachInputTask: Task<Void, Never>?
     private var nextAttachEndGate: ScriptedTransportCallGate?
@@ -330,6 +332,19 @@ final actor ScriptedTransport: Transport {
         closeGate = gate
     }
 
+    /// Parks the next terminal open after recording its request. Tests use the
+    /// gate's entry edge as a deterministic proof that Attach startup began.
+    func gateNextAttach(using gate: ScriptedTransportCallGate) {
+        nextAttachGate = gate
+    }
+
+    /// Parks the next terminal open after its session exists but before the
+    /// caller receives it. This lets tests drive buffered output without
+    /// polling for actor scheduling.
+    func gateNextAttachSession(using gate: ScriptedTransportCallGate) {
+        nextAttachSessionGate = gate
+    }
+
     /// Scripts panes that no longer exist on the Host. herdr fails an entire
     /// `events.subscribe` when one pane-scoped entry names a pane that has
     /// exited (verified against a live 0.7.5 server), so the fake rejects the
@@ -522,12 +537,17 @@ final actor ScriptedTransport: Transport {
             throw TransportError.terminalChannelAlreadyOpen
         }
         attachRequests.append(request)
+        let gate = nextAttachGate
+        nextAttachGate = nil
+        await gate?.waitUntilOpen()
         nextAttachID += 1
         let attachID = nextAttachID
         let (output, outputContinuation) = AsyncThrowingStream<Data, any Error>.makeStream()
         let input = TerminalAttachInputQueue()
         let endGate = nextAttachEndGate
         nextAttachEndGate = nil
+        let sessionGate = nextAttachSessionGate
+        nextAttachSessionGate = nil
         liveAttachID = attachID
         attachContinuation = outputContinuation
         attachInputTask = Task {
@@ -535,6 +555,7 @@ final actor ScriptedTransport: Transport {
                 self.recordAttachInput(item)
             }
         }
+        await sessionGate?.waitUntilOpen()
         return TerminalAttachSession(output: { output }, input: input) {
             await endGate?.waitUntilOpen()
             await self.endAttach(id: attachID)
@@ -688,12 +709,27 @@ actor SequencedTransportConnector {
 actor ScriptedTransportCallGate {
     private var isOpen = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var entryWaiters: [
+        (count: Int, continuation: CheckedContinuation<Void, Never>)
+    ] = []
     private(set) var entryCount = 0
 
     func waitUntilOpen() async {
         entryCount += 1
+        let reached = entryWaiters.filter { entryCount >= $0.count }
+        entryWaiters.removeAll { entryCount >= $0.count }
+        for waiter in reached {
+            waiter.continuation.resume()
+        }
         if isOpen { return }
         await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func waitForEntry(count: Int = 1) async {
+        guard entryCount < count else { return }
+        await withCheckedContinuation { continuation in
+            entryWaiters.append((count, continuation))
+        }
     }
 
     func open() {


### PR DESCRIPTION
## Summary

- start Attach restoration as soon as the current Host transport is ready
- preserve and reconcile the exact recovery generation across foreground transitions
- recover same-generation terminals that are still mounting instead of stranding them after delayed leave cleanup
- preserve one writable Attach owner and visible connecting/failure feedback
- add deterministic Agent and Shell regression coverage
- add Debug-only correlated restoration signposts for app-observable phase timing

## Validation

- [x] Focused iPhone 17 Simulator suites: 94 passed, 0 failed
- [x] `AgentAttachStoreTests`: 54 passed, 0 failed
- [x] Final timing-instrumentation suites: 99 passed, 0 failed
- [x] Independent Codex review: Standards PASS, Spec PASS; isolated suites passed with 0 failed or skipped
- [x] Release arm64 Simulator build: passed
- [x] Full `make test` on the exact final tree: app suite 1,322 total (1,217 passed, 105 skipped), 0 failed; HeelerSSH package suite 12 executed, 33 fixture-gated skipped, 0 failed
- [x] GitHub CI on the previous instrumentation head: all five checks passed
- [x] Physical iPhone 17 Pro Max: final Debug build signed, installed, launched, and left running
- [x] Physical Agent Detail: three 22-second background/restoration cycles on the same device, Host, and Agent restored Attach without a blank or failure state
- [x] Same-device and same-Host before/after app-observable restoration timings captured (3 valid replacement chains per side)
- [x] GitHub CI on the exact final tree: all five checks passed; the first attempt's unrelated Jump Host `algorithmNegotiationFailed` did not reproduce on the failed-job rerun

## Physical timing capture

All values are milliseconds from `foreground_recovery_started`, reported as median (range), from three complete, non-aborted replacement chains per build on the same iPhone, Host, and Agent.

| App-observable phase | Before | After |
| --- | ---: | ---: |
| Initial resize | 73.7 (70.5-75.4) | 72.9 (70.9-73.7) |
| Transport acquired | 75.3 (72.2-76.9) | 74.6 (73.0-75.4) |
| Attach request started | 75.3 (72.2-76.9) | 74.6 (73.0-75.4) |
| Attach PTY opened | 1,174.6 (977.3-1,640.4) | 1,286.0 (620.6-1,664.4) |
| First output bytes | 1,731.4 (1,273.3-2,385.7) | 1,356.8 (1,326.4-1,936.9) |

The original Simulator diagnosis identified Attach being gated behind event subscription and projected transport generation. The deterministic regression tests exercise that seam. This physical run did not reproduce that gating: request start was already about 75 ms in both builds. The 374.6 ms median change at first output is entirely in the variable remote PTY/output portion and is not attributed to this patch.

The Debug trace reports app-observable proxies honestly. `attach_request_started` is the combined app request edge, `attach_pty_opened` is `attachTerminal` completion, and `first_output_bytes` is feed receipt. Remote terminal-id resolution inside herdr and a Ghostty renderer-presented frame are not separately observable and are not claimed as measured. UI visibility markers are optional and are not part of the guaranteed correlated chain.

Closes #264
