### PR TITLE
ci: improve iOS reliability and reduce runner time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ name: CI
 #   in a comment or assert an in-app URL string, and the `SKILL.md` paths belong
 #   to remote fixtures. `CHANGELOG.md` is included too — scripts/publish.sh
 #   consumes it, but that runs from `make publish`, never from CI.
+# - `output/**` is App Store screenshot export material. No job here reads it;
+#   the files are committed for store listings and local composition only.
 #
 # paths-ignore only skips a run when *every* changed path matches, so a commit
 # touching prose alongside Swift still runs the full suite. A change to this
@@ -47,6 +49,7 @@ on:
       - .github/workflows/landing.yml
       - '**.md'
       - docs/**
+      - output/**
   push:
     branches: [main]
     paths-ignore:
@@ -54,6 +57,7 @@ on:
       - .github/workflows/landing.yml
       - '**.md'
       - docs/**
+      - output/**
 
 # One in-flight run per ref; a new push cancels the previous run.
 concurrency:
@@ -142,7 +146,7 @@ jobs:
           HEELER_CI_MANDATORY: "1"
         run: scripts/run-ci-ios-tests.sh
 
-      - name: Upload iOS timeout diagnostics
+      - name: Upload iOS CI diagnostics
         if: failure()
         uses: actions/upload-artifact@v4
         with:
@@ -170,7 +174,7 @@ jobs:
           HEELER_CI_MANDATORY: "1"
         run: scripts/run-ci-ios-tests.sh
 
-      - name: Upload package timeout diagnostics
+      - name: Upload package CI diagnostics
         if: failure()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,20 @@ jobs:
         with:
           node-version: 24
 
+      # libghostty-spm's prebuilt XCFramework dominates cold build-for-testing
+      # wall-clock (~3–4 minutes of "Checking out" on run 33488345559). Cache
+      # the cloned SourcePackages tree and the SwiftPM download cache keyed on
+      # Package.resolved so a pin change still misses and re-fetches.
+      - name: Cache SwiftPM checkouts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .ci/source-packages
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-${{ runner.os }}-${{ hashFiles('Heeler.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
       - name: Test VPS SSH access scripts
         run: scripts/test-vps-ssh-access-scripts.sh
 
@@ -125,10 +139,12 @@ jobs:
       - name: Verify HeelerSSH native artifacts
         run: make verify-ssh-artifacts
 
-      - name: Show Xcode and simulator versions
-        run: |
-          xcodebuild -version
-          xcrun simctl list runtimes
+      # xcodebuild -version is enough to pin the image. Listing every
+      # simulator runtime cold-starts CoreSimulator on the critical path
+      # (~12–29s on hosted macOS-26); the gate's own simctl boot overlaps
+      # that work with the build instead.
+      - name: Show Xcode version
+        run: xcodebuild -version
 
       - name: Test CI watchdog
         run: scripts/test-run-with-timeout.sh
@@ -162,10 +178,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Show Xcode and simulator versions
-        run: |
-          xcodebuild -version
-          xcrun simctl list runtimes
+      # Same rationale as the app job: avoid a critical-path CoreSimulator
+      # cold-start; package-lane boot overlaps with build-for-testing.
+      - name: Show Xcode version
+        run: xcodebuild -version
 
       - name: Run package E2E
         timeout-minutes: 12

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ DerivedData/
 # SPM
 .build/
 .swiftpm/
+# Hosted CI restores SwiftPM checkouts here between runs.
+.ci/
 
 # Node (pairing plugin)
 plugin/node_modules/

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		1CF0CDEFC1C46433C1F4CF06 /* IBMPlexMono-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6FF0DA87C092E176838C1EF7 /* IBMPlexMono-Bold.ttf */; };
 		1EDDD0227C94C6B7C2586A68 /* ImagePreparerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4889F56EFEFCC5004A55B4C /* ImagePreparerTests.swift */; };
 		20D4C5FBFAE65D07558E684B /* TerminalThemeSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921CA559141776BD0F02FDA7 /* TerminalThemeSettingsTests.swift */; };
+		210403DB0109B2C3E58A7975 /* StagingPhaseBarrierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A3D919A216A921D420F00D /* StagingPhaseBarrierTests.swift */; };
 		2148C7A8E3AD93AD1943AD77 /* AppActivityCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB39D40748D247CC747A83D /* AppActivityCoordinatorTests.swift */; };
 		21EA3C700022C6362774EF1A /* notification-payload-v1.json in Resources */ = {isa = PBXBuildFile; fileRef = EEB863EF2AD319A412DB564A /* notification-payload-v1.json */; };
 		2292C89F605CE42073D49B11 /* Preflight.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0B6961E10487A3AC3547E9 /* Preflight.swift */; };
@@ -261,6 +262,7 @@
 		C345ECAFFFA3CBDC2C4B2BB7 /* NotificationRegistrationFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297D9D4C1F200A21A2A0AA64 /* NotificationRegistrationFileTests.swift */; };
 		C3A7347C5A4C2219832A9F46 /* SkillsPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444F11A4450A3CA904B26658 /* SkillsPickerView.swift */; };
 		C3CAE683F15A2DB5866FE702 /* HeelerSSHJumpHostGateE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F5C337F9BC29D46E48E35E /* HeelerSSHJumpHostGateE2ETests.swift */; };
+		C3D2936548DD57036A1FB254 /* CancellablePhaseGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD631568D2A021F6DF490B8 /* CancellablePhaseGate.swift */; };
 		C626797B247A8ED6513D2EBB /* HeelerSSHSessionE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1AEA55D1F06B12005DEEE5F /* HeelerSSHSessionE2ETests.swift */; };
 		C6E6E92365F39EDDD50CDE49 /* WeakNetworkE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB8C5EA497D1094E86F69C4 /* WeakNetworkE2ETests.swift */; };
 		C783E750C9EBBD811D16D150 /* NotificationKeyMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91F0473741A92D7EFA40CBA /* NotificationKeyMirror.swift */; };
@@ -440,6 +442,7 @@
 		362EF66CE6DA07688C3E5F63 /* AgentComposerStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentComposerStoreTests.swift; sourceTree = "<group>"; };
 		365757614D9876F58A48CEDA /* NotificationConfigFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationConfigFileTests.swift; sourceTree = "<group>"; };
 		36B41E884E430DCF9BE26B91 /* AgentArgumentsField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentArgumentsField.swift; sourceTree = "<group>"; };
+		37A3D919A216A921D420F00D /* StagingPhaseBarrierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagingPhaseBarrierTests.swift; sourceTree = "<group>"; };
 		3801638051F3E5F394CF3FBD /* ReconnectPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconnectPolicyTests.swift; sourceTree = "<group>"; };
 		381B00805D3CDEEE94DAE35B /* RenameStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameStore.swift; sourceTree = "<group>"; };
 		39AD641EA732307D72698216 /* EventsSessionSubscriptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSessionSubscriptionsTests.swift; sourceTree = "<group>"; };
@@ -585,6 +588,7 @@
 		AACC0F2C9582DE0932380D35 /* KnownHostsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnownHostsStoreTests.swift; sourceTree = "<group>"; };
 		AB48C946E14722E93FAAA410 /* TerminalAttach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAttach.swift; sourceTree = "<group>"; };
 		AD69BB4579A415BE96578319 /* HeelerWidgets.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = HeelerWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		AFD631568D2A021F6DF490B8 /* CancellablePhaseGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancellablePhaseGate.swift; sourceTree = "<group>"; };
 		B1AEA55D1F06B12005DEEE5F /* HeelerSSHSessionE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeelerSSHSessionE2ETests.swift; sourceTree = "<group>"; };
 		B2437B1D6B97638031514C0F /* PinnedAgentsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedAgentsStore.swift; sourceTree = "<group>"; };
 		B24EF5EA39899292A1907226 /* StartAgentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStore.swift; sourceTree = "<group>"; };
@@ -823,6 +827,7 @@
 				9F979754410821940D0C4DEC /* SolvingOrbRendererTests.swift */,
 				A579E1DA3F59AFBC3ECAD69C /* SSHChannelAdmissionTests.swift */,
 				65CFDDFD7A676ECD4EF29BDE /* SSHSourcePolicyTests.swift */,
+				37A3D919A216A921D420F00D /* StagingPhaseBarrierTests.swift */,
 				84DA8573DB6A7EBC95A57F2F /* StartAgentStoreTests.swift */,
 				DA59306306EAEAA6DA78E337 /* TerminalAgentSwitcherTests.swift */,
 				07528112F1EC851708049E85 /* TerminalAttachTests.swift */,
@@ -1149,6 +1154,7 @@
 			isa = PBXGroup;
 			children = (
 				52D3780EB6489DF2E1EA1D77 /* AuthorizedKeysTestLock.swift */,
+				AFD631568D2A021F6DF490B8 /* CancellablePhaseGate.swift */,
 				856A8398D8F0FB87F252D193 /* FakeLiveActivityController.swift */,
 				8273181A2428AD3F78FCC27B /* FakePairingConnector.swift */,
 				696C6905D9D6EEFF77A64E2E /* FakeTransportConnector.swift */,
@@ -1404,8 +1410,8 @@
 			targets = (
 				081A3B29EFF2C7B2FCAA3248 /* Heeler */,
 				DFFB82C74B73FA5CBCE6D5D2 /* HeelerNotificationService */,
-				134E6CD1AC1396155DAB93E2 /* HeelerWidgets */,
 				9806EA6C63028F1217417282 /* HeelerTests */,
+				134E6CD1AC1396155DAB93E2 /* HeelerWidgets */,
 			);
 		};
 /* End PBXProject section */
@@ -1671,6 +1677,7 @@
 				3776558F9FD16419AC405116 /* AttachRestorationTraceTests.swift in Sources */,
 				E40D1C6F825ABCD68AA5F196 /* AttachTerminalStoreTests.swift in Sources */,
 				5150B659FACE9AFD9ECF9F6D /* AuthorizedKeysTestLock.swift in Sources */,
+				C3D2936548DD57036A1FB254 /* CancellablePhaseGate.swift in Sources */,
 				61F58007C6B81F14D2F6B58B /* ClosePaneStoreTests.swift in Sources */,
 				179292D9C3E605BC46282FE0 /* ComposerAttachmentTests.swift in Sources */,
 				847FCB04EA7913ACB390C978 /* ComposerStagingStoreTests.swift in Sources */,
@@ -1758,6 +1765,7 @@
 				3C887B853B2B6DFAADEAD38E /* SnippetStoreTests.swift in Sources */,
 				9650868D94494A36E70CF651 /* SnippetTests.swift in Sources */,
 				A65D5B9E1A885A8287AD762C /* SolvingOrbRendererTests.swift in Sources */,
+				210403DB0109B2C3E58A7975 /* StagingPhaseBarrierTests.swift in Sources */,
 				3ECC4677BDBD122A9ABF9CAF /* StartAgentStoreTests.swift in Sources */,
 				AFA3583DF83EFBAFEEE91E28 /* TerminalAgentSwitcherTests.swift in Sources */,
 				D5750879A465E0B27C9B4431 /* TerminalAttachTests.swift in Sources */,

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -2154,8 +2154,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/lakr233/libghostty-spm.git";
 			requirement = {
-				kind = exactVersion;
-				version = 1.4.0;
+				kind = revision;
+				revision = 356f730bec03281fc7b83666a129b0246137ea26;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Heeler.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Heeler.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lakr233/libghostty-spm.git",
       "state" : {
-        "revision" : "356f730bec03281fc7b83666a129b0246137ea26",
-        "version" : "1.4.0"
+        "revision" : "356f730bec03281fc7b83666a129b0246137ea26"
       }
     },
     {

--- a/Packages/HeelerSSH/README.md
+++ b/Packages/HeelerSSH/README.md
@@ -149,7 +149,7 @@ package runner asserts only that something executed, not an exact count, so
 machines without the disposable sshd fixture can skip the E2E suite cleanly.
 
 The E2E integration package must update `scripts/run-ci-ios-tests.sh` before
-merge so its package lane expects **45** executed tests and pins these
+merge so its package lane expects **48** executed tests and pins these
 display names exactly:
 
 - `handshake negotiates post-quantum key exchange`

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -3,6 +3,12 @@ import CHeelerSSHSupport
 import Darwin
 import Foundation
 
+#if DEBUG
+enum HandshakeFailureObservation {
+    @TaskLocal static var observer: (@Sendable (Int32) -> Void)? = nil
+}
+#endif
+
 actor SessionDriver {
     enum BridgeWriteResult: Equatable {
         case blocked
@@ -2084,6 +2090,9 @@ actor SessionDriver {
             libssh2_session_handshake(createdSession, descriptor)
         }
         guard handshakeResult == 0 else {
+#if DEBUG
+            HandshakeFailureObservation.observer?(handshakeResult)
+#endif
             throw mapSessionError(handshakeResult)
         }
         return try extractHostKey(createdSession)
@@ -4122,12 +4131,16 @@ actor SessionDriver {
     private func mapSessionError(_ code: Int32) -> SSHError {
         switch code {
         case LIBSSH2_ERROR_KEX_FAILURE,
-            LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE,
             LIBSSH2_ERROR_METHOD_NONE,
             LIBSSH2_ERROR_METHOD_NOT_SUPPORTED,
-            LIBSSH2_ERROR_ALGO_UNSUPPORTED,
-            LIBSSH2_ERROR_HOSTKEY_INIT:
+            LIBSSH2_ERROR_ALGO_UNSUPPORTED:
             return .algorithmNegotiationFailed
+        // libssh2 emits KEY_EXCHANGE_FAILURE only after it has selected the
+        // algorithms and entered the chosen method's exchange_keys callback.
+        // That callback's transport, protocol, or crypto error is wrapped by
+        // this code, so it is not evidence that the peers had no common method.
+        case LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE:
+            return .connectionFailed
         case LIBSSH2_ERROR_AUTHENTICATION_FAILED,
             LIBSSH2_ERROR_PASSWORD_EXPIRED:
             return .authenticationFailed

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -1464,7 +1464,7 @@ actor SessionDriver {
 
             while offset < data.count {
                 await acquireOperation()
-                let progress: (written: Int, wait: SessionWaitPlan)
+                let progress: (written: Int, wait: SessionWaitPlan, parkedOutbound: Bool)
                 do {
                     try checkProgress(deadline: deadline)
                     try await waitForTransportSendAdmission(
@@ -1498,7 +1498,10 @@ actor SessionDriver {
                         throw mappedError
                     }
                     applyTransportSendOwnerDisposition(disposition)
-                    progress = (written, sessionWaitPlan(session))
+                    progress = (
+                        written,
+                        sessionWaitPlan(session),
+                        written == Int(LIBSSH2_ERROR_EAGAIN) && transportSendOwner == owner)
                     releaseOperation()
                 } catch {
                     let normalized = normalize(error)
@@ -1514,6 +1517,11 @@ actor SessionDriver {
                     offset += progress.written
                     await Task.yield()
                 } else {
+#if DEBUG
+                    if progress.parkedOutbound {
+                        await holdOutboundWriteParkForTestingIfNeeded()
+                    }
+#endif
                     do {
                         try await awaitSessionProgress(progress.wait, until: deadline)
                     } catch {

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SessionDriver.swift
@@ -1501,7 +1501,7 @@ actor SessionDriver {
                     progress = (
                         written,
                         sessionWaitPlan(session),
-                        written == Int(LIBSSH2_ERROR_EAGAIN) && transportSendOwner == owner)
+                        written == Int(LIBSSH2_ERROR_EAGAIN))
                     releaseOperation()
                 } catch {
                     let normalized = normalize(error)

--- a/Packages/HeelerSSH/Sources/HeelerSSH/SocketConnector.swift
+++ b/Packages/HeelerSSH/Sources/HeelerSSH/SocketConnector.swift
@@ -3,6 +3,68 @@ import Dispatch
 import Foundation
 
 enum SocketConnector {
+    enum ConnectionState: Sendable {
+        case connected
+        case inProgress
+        case failed
+    }
+
+    struct Operations: Sendable {
+        let now: @Sendable () -> ContinuousClock.Instant
+        let makeSocket: @Sendable (Int32, Int32, Int32) -> Int32
+        let setNonBlocking: @Sendable (Int32) -> Bool
+        let beginConnection: @Sendable (Int32, SocketAddress) -> ConnectionState
+        let waitUntilWritable:
+            @Sendable (Int32, ContinuousClock.Instant) async throws -> Void
+        let connectionSucceeded: @Sendable (Int32) -> Bool
+        let closeSocket: @Sendable (Int32) -> Void
+
+        static func live(
+            makeSocket: @escaping @Sendable (Int32, Int32, Int32) -> Int32 = {
+                socket($0, $1, $2)
+            }
+        ) -> Self {
+            Operations(
+                now: { ContinuousClock.now },
+                makeSocket: makeSocket,
+                setNonBlocking: { descriptor in
+                    let flags = fcntl(descriptor, F_GETFL, 0)
+                    return flags >= 0
+                        && fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) == 0
+                },
+                beginConnection: { descriptor, address in
+                    let result = address.bytes.withUnsafeBytes { bytes -> Int32 in
+                        guard let baseAddress = bytes.baseAddress else { return -1 }
+                        return Darwin.connect(
+                            descriptor,
+                            baseAddress.assumingMemoryBound(to: sockaddr.self),
+                            socklen_t(bytes.count))
+                    }
+                    if result == 0 { return .connected }
+                    return errno == EINPROGRESS ? .inProgress : .failed
+                },
+                waitUntilWritable: { descriptor, deadline in
+                    try await SocketReadiness.wait(
+                        descriptor: descriptor,
+                        directions: .write,
+                        until: deadline)
+                },
+                connectionSucceeded: { descriptor in
+                    var socketError: Int32 = 0
+                    var length = socklen_t(MemoryLayout<Int32>.size)
+                    return getsockopt(
+                        descriptor,
+                        SOL_SOCKET,
+                        SO_ERROR,
+                        &socketError,
+                        &length) == 0 && socketError == 0
+                },
+                closeSocket: { descriptor in
+                    _ = Darwin.close(descriptor)
+                })
+        }
+    }
+
     static func connect(
         to endpoint: SSHEndpoint,
         until deadline: ContinuousClock.Instant
@@ -11,7 +73,7 @@ enum SocketConnector {
             to: endpoint,
             until: deadline,
             resolver: DNSServiceAddressResolver(),
-            makeSocket: { socket($0, $1, $2) })
+            operations: .live())
     }
 
     static func connect(
@@ -20,23 +82,47 @@ enum SocketConnector {
         resolver: any SocketAddressResolving,
         makeSocket: @escaping @Sendable (Int32, Int32, Int32) -> Int32
     ) async throws -> Int32 {
+        try await connect(
+            to: endpoint,
+            until: deadline,
+            resolver: resolver,
+            operations: .live(makeSocket: makeSocket))
+    }
+
+    static func connect(
+        to endpoint: SSHEndpoint,
+        until deadline: ContinuousClock.Instant,
+        resolver: any SocketAddressResolving,
+        operations: Operations
+    ) async throws -> Int32 {
         guard !endpoint.host.isEmpty, endpoint.port > 0 else {
             throw SSHError.invalidEndpoint
         }
 
-        try checkProgress(until: deadline)
+        try checkProgress(until: deadline, now: operations.now())
         let addresses = try await resolver.resolve(endpoint, until: deadline)
         var lastError: SSHError = .connectionFailed
-        for address in addresses {
+        for (index, address) in addresses.enumerated() {
             do {
-                try checkProgress(until: deadline)
+                let candidateStart = operations.now()
+                try checkProgress(until: deadline, now: candidateStart)
+                let remainingCandidates = addresses.count - index
+                // Split the time still owned by the caller evenly across the
+                // candidates that have not yet had a chance to connect.
+                let candidateDeadline = min(
+                    candidateStart.advanced(
+                        by: candidateStart.duration(to: deadline) / remainingCandidates),
+                    deadline)
                 return try await connect(
                     to: address,
-                    until: deadline,
-                    makeSocket: makeSocket)
+                    until: candidateDeadline,
+                    operations: operations)
             } catch let error as SSHError {
-                if error == .cancelled || error == .timedOut {
-                    throw error
+                if error == .cancelled { throw error }
+                if error == .timedOut {
+                    lastError = error
+                    try checkProgress(until: deadline, now: operations.now())
+                    continue
                 }
                 lastError = error
             }
@@ -47,42 +133,29 @@ enum SocketConnector {
     private static func connect(
         to address: SocketAddress,
         until deadline: ContinuousClock.Instant,
-        makeSocket: @escaping @Sendable (Int32, Int32, Int32) -> Int32
+        operations: Operations
     ) async throws -> Int32 {
-        let descriptor = makeSocket(address.family, address.type, address.protocol)
+        let descriptor = operations.makeSocket(address.family, address.type, address.protocol)
         guard descriptor >= 0 else { throw SSHError.connectionFailed }
         var ownsDescriptor = true
         defer {
-            if ownsDescriptor { Darwin.close(descriptor) }
+            if ownsDescriptor { operations.closeSocket(descriptor) }
         }
 
-        let flags = fcntl(descriptor, F_GETFL, 0)
-        guard flags >= 0, fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) == 0 else {
+        guard operations.setNonBlocking(descriptor) else {
             throw SSHError.connectionFailed
         }
 
-        let result = address.bytes.withUnsafeBytes { bytes -> Int32 in
-            guard let baseAddress = bytes.baseAddress else { return -1 }
-            return Darwin.connect(
-                descriptor,
-                baseAddress.assumingMemoryBound(to: sockaddr.self),
-                socklen_t(bytes.count))
-        }
-        if result != 0 {
-            guard errno == EINPROGRESS else { throw SSHError.connectionFailed }
-            try await SocketReadiness.wait(
-                descriptor: descriptor,
-                directions: .write,
-                until: deadline)
-
-            var socketError: Int32 = 0
-            var length = socklen_t(MemoryLayout<Int32>.size)
-            guard
-                getsockopt(descriptor, SOL_SOCKET, SO_ERROR, &socketError, &length) == 0,
-                socketError == 0
-            else {
+        switch operations.beginConnection(descriptor, address) {
+        case .connected:
+            break
+        case .inProgress:
+            try await operations.waitUntilWritable(descriptor, deadline)
+            guard operations.connectionSucceeded(descriptor) else {
                 throw SSHError.connectionFailed
             }
+        case .failed:
+            throw SSHError.connectionFailed
         }
 
         ownsDescriptor = false
@@ -90,10 +163,11 @@ enum SocketConnector {
     }
 
     private static func checkProgress(
-        until deadline: ContinuousClock.Instant
+        until deadline: ContinuousClock.Instant,
+        now: ContinuousClock.Instant
     ) throws {
         if Task.isCancelled { throw SSHError.cancelled }
-        if ContinuousClock.now >= deadline { throw SSHError.timedOut }
+        if now >= deadline { throw SSHError.timedOut }
     }
 }
 

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/HandshakeLifecycleTests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/HandshakeLifecycleTests.swift
@@ -1,0 +1,248 @@
+import CLibSSH2
+import Darwin
+import Foundation
+import Testing
+
+@testable import HeelerSSH
+
+extension SessionDriverE2ETests {
+    /// The server completes algorithm selection with production-supported
+    /// methods, then drops the transport while Curve25519 key exchange is in
+    /// flight. libssh2 reports that later phase with
+    /// LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE, which must not be presented as the
+    /// no-common-algorithm error from LIBSSH2_ERROR_KEX_FAILURE.
+    @Test("post-negotiation transport loss is not an algorithm mismatch")
+    func postNegotiationTransportLossIsNotAlgorithmMismatch() async throws {
+        let server = try HandshakeCutoffServer.start()
+        let failureCode = HandshakeFailureCodeRecorder()
+
+        await #expect(throws: SSHError.connectionFailed) {
+            _ = try await HandshakeFailureObservation.$observer.withValue(
+                failureCode.record
+            ) {
+                try await SSHConnection.connect(
+                    to: SSHEndpoint(host: "127.0.0.1", port: server.port),
+                    timeout: .seconds(5))
+            }
+        }
+        #expect(failureCode.value == LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE)
+        try await server.waitForCompletion()
+    }
+}
+
+private final class HandshakeFailureCodeRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: Int32?
+
+    func record(_ code: Int32) {
+        lock.withLock { storedValue = code }
+    }
+
+    var value: Int32? {
+        lock.withLock { storedValue }
+    }
+}
+
+/// A minimal loopback SSH peer that selects production-supported algorithms,
+/// observes the client's key-exchange request, then closes before replying.
+/// It intentionally implements no authentication or session behavior.
+private struct HandshakeCutoffServer: Sendable {
+    let port: UInt16
+    private let task: Task<Void, any Error>
+
+    static func start() throws -> HandshakeCutoffServer {
+        let listener = socket(AF_INET, SOCK_STREAM, 0)
+        guard listener >= 0 else { throw HandshakeCutoffServerError.socketFailed }
+
+        do {
+            var reuse: Int32 = 1
+            guard setsockopt(
+                listener,
+                SOL_SOCKET,
+                SO_REUSEADDR,
+                &reuse,
+                socklen_t(MemoryLayout<Int32>.size)) == 0
+            else { throw HandshakeCutoffServerError.socketFailed }
+
+            var address = sockaddr_in()
+            address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+            address.sin_family = sa_family_t(AF_INET)
+            address.sin_port = 0
+            guard inet_pton(AF_INET, "127.0.0.1", &address.sin_addr) == 1 else {
+                throw HandshakeCutoffServerError.socketFailed
+            }
+            let bound = withUnsafePointer(to: &address) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    bind(listener, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+                }
+            }
+            guard bound == 0, listen(listener, 1) == 0 else {
+                throw HandshakeCutoffServerError.socketFailed
+            }
+
+            var localAddress = sockaddr_in()
+            var localAddressLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+            let named = withUnsafeMutablePointer(to: &localAddress) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    getsockname(listener, $0, &localAddressLength)
+                }
+            }
+            guard named == 0 else { throw HandshakeCutoffServerError.socketFailed }
+            let port = UInt16(bigEndian: localAddress.sin_port)
+
+            let task = Task { try await serve(listener: listener) }
+            return HandshakeCutoffServer(port: port, task: task)
+        } catch {
+            Darwin.close(listener)
+            throw error
+        }
+    }
+
+    func waitForCompletion() async throws {
+        try await task.value
+    }
+
+    private static let queue = DispatchQueue(label: "heelerssh.handshake-cutoff-server")
+
+    private static func serve(listener: Int32) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            queue.async {
+                continuation.resume(with: Result { try serveBlocking(listener: listener) })
+            }
+        }
+    }
+
+    private static func serveBlocking(listener: Int32) throws {
+        var ownsListener = true
+        defer {
+            if ownsListener { Darwin.close(listener) }
+        }
+
+        var readiness = pollfd(fd: listener, events: Int16(POLLIN), revents: 0)
+        guard poll(&readiness, 1, 5_000) == 1 else {
+            throw HandshakeCutoffServerError.acceptFailed
+        }
+        let connection = accept(listener, nil, nil)
+        guard connection >= 0 else {
+            throw HandshakeCutoffServerError.acceptFailed
+        }
+        Darwin.close(listener)
+        ownsListener = false
+        defer { Darwin.close(connection) }
+
+        // Bound the blocking calls so a failed peer cannot strand the queue or
+        // leave the checked continuation un-resumed.
+        var limit = timeval(tv_sec: 5, tv_usec: 0)
+        let limitSize = socklen_t(MemoryLayout<timeval>.size)
+        guard
+            setsockopt(connection, SOL_SOCKET, SO_RCVTIMEO, &limit, limitSize) == 0,
+            setsockopt(connection, SOL_SOCKET, SO_SNDTIMEO, &limit, limitSize) == 0
+        else { throw HandshakeCutoffServerError.socketFailed }
+
+        try writeAll(Data("SSH-2.0-HeelerHandshakeCutoff\r\n".utf8), to: connection)
+        try readIdentification(from: connection)
+        _ = try readPacket(from: connection)
+        try writeAll(kexInitPacket(), to: connection)
+        _ = try readPacket(from: connection)
+    }
+
+    private static func readIdentification(from descriptor: Int32) throws {
+        var byte: UInt8 = 0
+        var bytesRead = 0
+        while bytesRead < 255 {
+            let count = Darwin.read(descriptor, &byte, 1)
+            guard count == 1 else { throw HandshakeCutoffServerError.readFailed }
+            bytesRead += 1
+            if byte == UInt8(ascii: "\n") { return }
+        }
+        throw HandshakeCutoffServerError.invalidIdentification
+    }
+
+    private static func readPacket(from descriptor: Int32) throws -> Data {
+        let header = try readExactly(4, from: descriptor)
+        let packetLength = header.reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+        guard packetLength >= 5, packetLength <= 64 * 1024 else {
+            throw HandshakeCutoffServerError.invalidPacket
+        }
+        return try readExactly(Int(packetLength), from: descriptor)
+    }
+
+    private static func readExactly(_ count: Int, from descriptor: Int32) throws -> Data {
+        var data = Data(count: count)
+        var offset = 0
+        try data.withUnsafeMutableBytes { bytes in
+            guard let base = bytes.baseAddress else { return }
+            while offset < count {
+                let read = Darwin.read(descriptor, base + offset, count - offset)
+                guard read > 0 else { throw HandshakeCutoffServerError.readFailed }
+                offset += read
+            }
+        }
+        return data
+    }
+
+    private static func writeAll(_ data: Data, to descriptor: Int32) throws {
+        var offset = 0
+        try data.withUnsafeBytes { bytes in
+            guard let base = bytes.baseAddress else { return }
+            while offset < bytes.count {
+                let written = Darwin.send(
+                    descriptor,
+                    base + offset,
+                    bytes.count - offset,
+                    MSG_NOSIGNAL)
+                guard written > 0 else { throw HandshakeCutoffServerError.writeFailed }
+                offset += written
+            }
+        }
+    }
+
+    private static func kexInitPacket() -> Data {
+        var payload = Data([20])
+        payload.append(Data(repeating: 0xA5, count: 16))
+        appendNameList("curve25519-sha256", to: &payload)
+        appendNameList("ssh-ed25519", to: &payload)
+        appendNameList("aes128-ctr", to: &payload)
+        appendNameList("aes128-ctr", to: &payload)
+        appendNameList("hmac-sha2-256", to: &payload)
+        appendNameList("hmac-sha2-256", to: &payload)
+        appendNameList("none", to: &payload)
+        appendNameList("none", to: &payload)
+        appendNameList("", to: &payload)
+        appendNameList("", to: &payload)
+        payload.append(0)
+        appendUInt32(0, to: &payload)
+
+        var paddingLength = 8 - ((5 + payload.count) % 8)
+        if paddingLength < 4 { paddingLength += 8 }
+        let packetLength = UInt32(1 + payload.count + paddingLength)
+        var packet = Data()
+        appendUInt32(packetLength, to: &packet)
+        packet.append(UInt8(paddingLength))
+        packet.append(payload)
+        packet.append(Data(repeating: 0x5A, count: paddingLength))
+        return packet
+    }
+
+    private static func appendNameList(_ value: String, to data: inout Data) {
+        let bytes = Data(value.utf8)
+        appendUInt32(UInt32(bytes.count), to: &data)
+        data.append(bytes)
+    }
+
+    private static func appendUInt32(_ value: UInt32, to data: inout Data) {
+        data.append(UInt8((value >> 24) & 0xFF))
+        data.append(UInt8((value >> 16) & 0xFF))
+        data.append(UInt8((value >> 8) & 0xFF))
+        data.append(UInt8(value & 0xFF))
+    }
+}
+
+private enum HandshakeCutoffServerError: Error {
+    case acceptFailed
+    case invalidIdentification
+    case invalidPacket
+    case readFailed
+    case socketFailed
+    case writeFailed
+}

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SessionDriverE2ETests.swift
@@ -326,13 +326,18 @@ struct SessionDriverE2ETests {
             #expect(firstMismatch == nil, Comment(rawValue: firstMismatch ?? "payload matched"))
             #expect(offset == payloadSize)
             #expect(reachedEOF)
-            #expect(try await launched.completedByteCount(using: observer) == payloadSize)
+            let completedBytes = try await runDirectTCPIPFixturePhase("account transferred bytes") {
+                try await launched.completedByteCount(using: observer)
+            }
+            #expect(completedBytes == payloadSize)
 
-            Darwin.close(descriptor)
-            descriptor = -1
-            try await opened.close(timeout: .seconds(5))
-            transport = nil
-            try await driver.close(timeout: .seconds(2))
+            try await runDirectTCPIPFixturePhase("close transport") {
+                Darwin.close(descriptor)
+                descriptor = -1
+                try await opened.close(timeout: .seconds(5))
+                transport = nil
+                try await driver.close(timeout: .seconds(2))
+            }
         } catch {
             await bufferFullHold.release()
             if descriptor >= 0 { Darwin.close(descriptor) }
@@ -348,11 +353,13 @@ struct SessionDriverE2ETests {
         do {
             let cleanupDirectory = directory
             let cleanupObserver = observer
-            try await Task.detached {
-                try await RawTCPWriter.cleanup(
-                    directory: cleanupDirectory,
-                    using: cleanupObserver)
-            }.value
+            try await runDirectTCPIPFixturePhase("cleanup remote writer") {
+                try await Task.detached {
+                    try await RawTCPWriter.cleanup(
+                        directory: cleanupDirectory,
+                        using: cleanupObserver)
+                }.value
+            }
         } catch {
             if primaryError == nil {
                 primaryError = error
@@ -360,7 +367,9 @@ struct SessionDriverE2ETests {
         }
 
         do {
-            try await observer.close(timeout: .seconds(2))
+            try await runDirectTCPIPFixturePhase("close observer") {
+                try await observer.close(timeout: .seconds(2))
+            }
         } catch {
             if primaryError == nil {
                 primaryError = error

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SocketConnectorTests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SocketConnectorTests.swift
@@ -1,0 +1,272 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import HeelerSSH
+
+@Suite("Socket candidate fallback", .serialized)
+struct SocketConnectorTests {
+    @Test("a timed-out candidate leaves budget for the next address")
+    func timedOutCandidateFallsBackWithinOverallDeadline() async throws {
+        let start = ContinuousClock.now
+        let deadline = start + .seconds(12)
+        let fixture = ScriptedSocketFixture(
+            now: start,
+            outcomes: [.timedOut, .connected])
+
+        let descriptor = try await SocketConnector.connect(
+            to: SSHEndpoint(host: "example.test", port: 22),
+            until: deadline,
+            resolver: FixedSocketAddressResolver.twoCandidates,
+            operations: fixture.operations)
+
+        #expect(descriptor == 101)
+        #expect(fixture.snapshot == ScriptedSocketFixture.Snapshot(
+            openedFamilies: [AF_INET6, AF_INET],
+            waitDeadlines: [start + .seconds(6), deadline],
+            closedDescriptors: [100]))
+        #expect(fixture.snapshot.waitDeadlines.allSatisfy { $0 <= deadline })
+    }
+
+    @Test("exhausting every candidate preserves the last connection failure")
+    func allCandidatesExhausted() async {
+        let start = ContinuousClock.now
+        let deadline = start + .seconds(12)
+        let fixture = ScriptedSocketFixture(
+            now: start,
+            outcomes: [.rejected, .rejected])
+
+        await #expect(throws: SSHError.connectionFailed) {
+            _ = try await SocketConnector.connect(
+                to: SSHEndpoint(host: "example.test", port: 22),
+                until: deadline,
+                resolver: FixedSocketAddressResolver.twoCandidates,
+                operations: fixture.operations)
+        }
+
+        #expect(fixture.snapshot == ScriptedSocketFixture.Snapshot(
+            openedFamilies: [AF_INET6, AF_INET],
+            waitDeadlines: [start + .seconds(6), deadline],
+            closedDescriptors: [100, 101]))
+        #expect(fixture.snapshot.waitDeadlines.allSatisfy { $0 <= deadline })
+    }
+
+    @Test("caller cancellation stops the active candidate immediately")
+    func cancellationStopsWithoutTryingAnotherCandidate() async {
+        let cancellationWait = CancellationWait()
+        let fixture = ScriptedSocketFixture(
+            now: ContinuousClock.now,
+            outcomes: [.waitForCancellation, .connected],
+            cancellationWait: cancellationWait)
+        let task = Task {
+            try await SocketConnector.connect(
+                to: SSHEndpoint(host: "example.test", port: 22),
+                until: ContinuousClock.now + .seconds(30),
+                resolver: FixedSocketAddressResolver.twoCandidates,
+                operations: fixture.operations)
+        }
+        await cancellationWait.waitUntilEntered()
+
+        task.cancel()
+
+        await #expect(throws: SSHError.cancelled) {
+            _ = try await task.value
+        }
+        #expect(fixture.snapshot.openedFamilies == [AF_INET6])
+        #expect(fixture.snapshot.closedDescriptors == [100])
+    }
+}
+
+private struct FixedSocketAddressResolver: SocketAddressResolving {
+    let addresses: [SocketAddress]
+
+    static let twoCandidates = FixedSocketAddressResolver(addresses: [
+        SocketAddress(
+            family: AF_INET6,
+            type: SOCK_STREAM,
+            protocol: IPPROTO_TCP,
+            bytes: Data([6])),
+        SocketAddress(
+            family: AF_INET,
+            type: SOCK_STREAM,
+            protocol: IPPROTO_TCP,
+            bytes: Data([4])),
+    ])
+
+    func resolve(
+        _ endpoint: SSHEndpoint,
+        until deadline: ContinuousClock.Instant
+    ) async throws -> [SocketAddress] {
+        addresses
+    }
+}
+
+private enum ScriptedCandidateOutcome: Sendable, Equatable {
+    case timedOut
+    case rejected
+    case connected
+    case waitForCancellation
+}
+
+private final class ScriptedSocketFixture: @unchecked Sendable {
+    struct Snapshot: Equatable {
+        let openedFamilies: [Int32]
+        let waitDeadlines: [ContinuousClock.Instant]
+        let closedDescriptors: [Int32]
+    }
+
+    private let lock = NSLock()
+    private let outcomes: [ScriptedCandidateOutcome]
+    private let cancellationWait: CancellationWait?
+    private var currentTime: ContinuousClock.Instant
+    private var openedFamilies: [Int32] = []
+    private var waitDeadlines: [ContinuousClock.Instant] = []
+    private var closedDescriptors: [Int32] = []
+
+    init(
+        now: ContinuousClock.Instant,
+        outcomes: [ScriptedCandidateOutcome],
+        cancellationWait: CancellationWait? = nil
+    ) {
+        currentTime = now
+        self.outcomes = outcomes
+        self.cancellationWait = cancellationWait
+    }
+
+    var operations: SocketConnector.Operations {
+        SocketConnector.Operations(
+            now: { [self] in now() },
+            makeSocket: { [self] family, _, _ in openSocket(family: family) },
+            setNonBlocking: { _ in true },
+            beginConnection: { _, _ in .inProgress },
+            waitUntilWritable: { [self] descriptor, deadline in
+                try await wait(descriptor: descriptor, until: deadline)
+            },
+            connectionSucceeded: { [self] descriptor in
+                outcome(for: descriptor) == .connected
+            },
+            closeSocket: { [self] descriptor in closeSocket(descriptor) })
+    }
+
+    var snapshot: Snapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        return Snapshot(
+            openedFamilies: openedFamilies,
+            waitDeadlines: waitDeadlines,
+            closedDescriptors: closedDescriptors)
+    }
+
+    private func now() -> ContinuousClock.Instant {
+        lock.lock()
+        defer { lock.unlock() }
+        return currentTime
+    }
+
+    private func openSocket(family: Int32) -> Int32 {
+        lock.lock()
+        defer { lock.unlock() }
+        let descriptor = Int32(100 + openedFamilies.count)
+        openedFamilies.append(family)
+        return descriptor
+    }
+
+    private func wait(
+        descriptor: Int32,
+        until deadline: ContinuousClock.Instant
+    ) async throws {
+        let outcome = recordWait(descriptor: descriptor, until: deadline)
+        switch outcome {
+        case .timedOut:
+            throw SSHError.timedOut
+        case .rejected, .connected:
+            return
+        case .waitForCancellation:
+            guard let cancellationWait else { throw SSHError.connectionFailed }
+            try await cancellationWait.wait()
+        }
+    }
+
+    private func recordWait(
+        descriptor: Int32,
+        until deadline: ContinuousClock.Instant
+    ) -> ScriptedCandidateOutcome {
+        lock.lock()
+        defer { lock.unlock() }
+        waitDeadlines.append(deadline)
+        let outcome = outcomeLocked(for: descriptor)
+        if outcome == .timedOut { currentTime = deadline }
+        return outcome
+    }
+
+    private func outcome(for descriptor: Int32) -> ScriptedCandidateOutcome {
+        lock.lock()
+        defer { lock.unlock() }
+        return outcomeLocked(for: descriptor)
+    }
+
+    private func outcomeLocked(for descriptor: Int32) -> ScriptedCandidateOutcome {
+        let index = Int(descriptor - 100)
+        guard outcomes.indices.contains(index) else { return .rejected }
+        return outcomes[index]
+    }
+
+    private func closeSocket(_ descriptor: Int32) {
+        lock.lock()
+        closedDescriptors.append(descriptor)
+        lock.unlock()
+    }
+}
+
+private final class CancellationWait: @unchecked Sendable {
+    private let lock = NSLock()
+    private var entered = false
+    private var cancelled = false
+    private var waitContinuation: CheckedContinuation<Void, any Error>?
+    private var entryContinuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async throws {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                lock.lock()
+                if cancelled {
+                    lock.unlock()
+                    continuation.resume(throwing: SSHError.cancelled)
+                    return
+                }
+                entered = true
+                waitContinuation = continuation
+                let entryContinuations = self.entryContinuations
+                self.entryContinuations.removeAll()
+                lock.unlock()
+                for entryContinuation in entryContinuations {
+                    entryContinuation.resume()
+                }
+            }
+        } onCancel: {
+            cancel()
+        }
+    }
+
+    func waitUntilEntered() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if entered {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                entryContinuations.append(continuation)
+                lock.unlock()
+            }
+        }
+    }
+
+    private func cancel() {
+        lock.lock()
+        cancelled = true
+        let waitContinuation = self.waitContinuation
+        self.waitContinuation = nil
+        lock.unlock()
+        waitContinuation?.resume(throwing: SSHError.cancelled)
+    }
+}

--- a/Packages/HeelerSSH/Tests/HeelerSSHTests/SocketConnectorTests.swift
+++ b/Packages/HeelerSSH/Tests/HeelerSSHTests/SocketConnectorTests.swift
@@ -227,7 +227,8 @@ private final class CancellationWait: @unchecked Sendable {
 
     func wait() async throws {
         try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
                 lock.lock()
                 if cancelled {
                     lock.unlock()

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -1247,9 +1247,14 @@ actor HeelerSSHTransport: Transport {
             throw AttachmentStagingError.transferFailed
         }
 
+        // Zero-byte progress fires only after the remote staging parent exists.
+        // That is the sole production-visible seam between setup and payload
+        // writing: weak-network tests park here to arm `.severe` before any
+        // SFTP write, so connection and directory creation are not starved by
+        // the cancellation-under-backpressure profile.
+        let parentDirectory = try await createStageParentDirectory()
         await progress(
             AttachmentStageProgress(transferredBytes: 0, totalBytes: source.byteCount))
-        let parentDirectory = try await createStageParentDirectory()
         let operationID = UUID()
 
         do {

--- a/Sources/Heeler/Transport/HeelerSSHTransport.swift
+++ b/Sources/Heeler/Transport/HeelerSSHTransport.swift
@@ -49,6 +49,15 @@ struct HeelerSSHNotificationFileStateForTesting: Sendable, Equatable {
     let connectionChannelCount: Int
     let writeIsDelayed: Bool
 }
+
+/// Internal staging milestones for deterministic test barriers. Not user-visible
+/// progress — `AttachmentStageProgress` keeps its numeric meaning unchanged.
+enum AttachmentStagingPhaseForTesting: Sendable, Hashable {
+    /// Remote staging parent directory exists; payload transfer has not begun.
+    case remoteParentReady
+    /// About to enter the SFTP payload write loop.
+    case payloadWriteReady
+}
 #endif
 
 private actor HeelerSSHNotificationFileCompletion {
@@ -322,6 +331,10 @@ actor HeelerSSHTransport: Transport {
     private var imageStageClients: [UUID: SSHSFTPClient] = [:]
     private var notificationFileClients: [UUID: SSHSFTPClient] = [:]
     private var notificationTemporaryPaths: [UUID: String] = [:]
+#if DEBUG
+    private var stagingPhaseHoldsForTesting:
+        [AttachmentStagingPhaseForTesting: @Sendable () async -> Void] = [:]
+#endif
 
     /// Establishes the libssh2 Transport through the same app-owned
     /// credentials and TOFU policy as the production connection path.
@@ -1026,6 +1039,19 @@ actor HeelerSSHTransport: Transport {
         await connection.delayNextSFTPWriteForTesting(delay)
     }
 
+    func holdNextOutboundWriteParkForTesting(
+        _ hold: @escaping @Sendable () async -> Void
+    ) async {
+        await connection.holdNextOutboundWriteParkForTesting(hold)
+    }
+
+    func holdStagingPhaseForTesting(
+        _ phase: AttachmentStagingPhaseForTesting,
+        _ hold: @escaping @Sendable () async -> Void
+    ) {
+        stagingPhaseHoldsForTesting[phase] = hold
+    }
+
     func notificationFileStateForTesting() async -> HeelerSSHNotificationFileStateForTesting {
         let admission = await channelAdmission.snapshot()
         return HeelerSSHNotificationFileStateForTesting(
@@ -1247,14 +1273,12 @@ actor HeelerSSHTransport: Transport {
             throw AttachmentStagingError.transferFailed
         }
 
-        // Zero-byte progress fires only after the remote staging parent exists.
-        // That is the sole production-visible seam between setup and payload
-        // writing: weak-network tests park here to arm `.severe` before any
-        // SFTP write, so connection and directory creation are not starved by
-        // the cancellation-under-backpressure profile.
-        let parentDirectory = try await createStageParentDirectory()
         await progress(
             AttachmentStageProgress(transferredBytes: 0, totalBytes: source.byteCount))
+        let parentDirectory = try await createStageParentDirectory()
+#if DEBUG
+        await signalStagingPhaseForTesting(.remoteParentReady)
+#endif
         let operationID = UUID()
 
         do {
@@ -1428,6 +1452,9 @@ actor HeelerSSHTransport: Transport {
             timeout: requestTimeout)
         do {
             try await enforcePermissions(0o600, at: remotePath, over: sftp)
+#if DEBUG
+            await signalStagingPhaseForTesting(.payloadWriteReady)
+#endif
             let chunkSize = 64 * 1_024
             var transferred: Int64 = 0
             while transferred < byteCount {
@@ -1455,6 +1482,13 @@ actor HeelerSSHTransport: Transport {
             throw error
         }
     }
+
+#if DEBUG
+    private func signalStagingPhaseForTesting(_ phase: AttachmentStagingPhaseForTesting) async {
+        guard let hold = stagingPhaseHoldsForTesting.removeValue(forKey: phase) else { return }
+        await hold()
+    }
+#endif
 
     /// Unlinks one abandoned `.part` so the user's attachment bytes do not outlive
     /// the failed operation, on the SFTP client that operation already owns.

--- a/Tests/HeelerTests/PairingCeremonyE2ETests.swift
+++ b/Tests/HeelerTests/PairingCeremonyE2ETests.swift
@@ -286,7 +286,7 @@ struct PairingCeremonyE2ETests {
                 hostKeyFingerprint: pinned,
                 bootstrap: .init(seed: staged.seed, expiresAt: staged.expiresAt))
             let connector = SSHPairingConnector(
-                perAddressTimeout: .seconds(2),
+                perAddressTimeout: Self.perAddressTimeout,
                 enrollTimeout: .milliseconds(150),
                 deviceKeyComment: "heeler-e2e")
 
@@ -412,8 +412,15 @@ struct PairingCeremonyE2ETests {
         }
     }
 
+    /// TCP/handshake budget for ceremony e2e. Matches production
+    /// `SSHPairingConnector.perAddressTimeout` (4s) and stays within the
+    /// 5s host-key-discovery connect budget below. The prior 2s harness
+    /// budget was tighter than production and surfaced raw
+    /// `SSHError.timedOut` on slow hosted runners before Enrollment.
+    private static let perAddressTimeout: Duration = .seconds(4)
+
     private static let connector = SSHPairingConnector(
-        perAddressTimeout: .seconds(2), deviceKeyComment: "heeler-e2e")
+        perAddressTimeout: perAddressTimeout, deviceKeyComment: "heeler-e2e")
 
     /// The fingerprint the localhost sshd actually presents, discovered the
     /// same way the plugin discovers it at code-generation time. Pinning it

--- a/Tests/HeelerTests/StagingPhaseBarrierTests.swift
+++ b/Tests/HeelerTests/StagingPhaseBarrierTests.swift
@@ -107,4 +107,207 @@ struct StagingPhaseBarrierTests {
         await gate.release()
         await hold.value
     }
+
+    @Test("entry waiter registration tracks the active count")
+    func entryWaiterRegistrationTracksActiveCount() async throws {
+        let gate = CancellablePhaseGate()
+        #expect(await gate.entryWaiterCount == 0)
+
+        let waiter = Task {
+            try await gate.waitUntilEntered()
+        }
+        try await gate.waitForEntryWaiterRegistration(count: 1)
+        #expect(await gate.entryWaiterCount == 1)
+
+        await gate.release()
+        await #expect(throws: PhaseGateError.releasedWithoutEntry) {
+            try await waiter.value
+        }
+        #expect(await gate.entryWaiterCount == 0)
+    }
+
+    @Test("registration waits for a new active waiter after cancellation")
+    func registrationWaitsForNewActiveWaiterAfterCancellation() async throws {
+        let gate = CancellablePhaseGate()
+        let first = Task {
+            try await gate.waitUntilEntered()
+        }
+        try await gate.waitForEntryWaiterRegistration(count: 1)
+        first.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await first.value
+        }
+        #expect(await gate.entryWaiterCount == 0)
+
+        let second = Task {
+            try await gate.waitUntilEntered()
+        }
+        try await gate.waitForEntryWaiterRegistration(count: 1)
+        #expect(await gate.entryWaiterCount == 1)
+
+        second.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await second.value
+        }
+        #expect(await gate.entryWaiterCount == 0)
+    }
+
+    @Test("entry registration observer cancellation resumes once")
+    func entryRegistrationObserverCancellationResumesOnce() async throws {
+        let gate = CancellablePhaseGate()
+        let observer = Task {
+            try await gate.waitForEntryWaiterRegistration(count: 1)
+        }
+        observer.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await observer.value
+        }
+    }
+
+    @Test("phase gate fails registration observers when released before threshold")
+    func phaseGateFailsRegistrationBeforeThresholdOnRelease() async throws {
+        let gate = CancellablePhaseGate()
+        let waiter = Task {
+            try await gate.waitUntilEntered()
+        }
+        try await gate.waitForEntryWaiterRegistration(count: 1)
+
+        let observer = Task {
+            try await gate.waitForEntryWaiterRegistration(count: 2)
+        }
+        await gate.release()
+
+        await #expect(throws: PhaseGateError.registrationThresholdUnreachable) {
+            try await observer.value
+        }
+        await #expect(throws: PhaseGateError.releasedWithoutEntry) {
+            try await waiter.value
+        }
+    }
+
+    @Test("phase gate fails registration observers when entered before threshold")
+    func phaseGateFailsRegistrationBeforeThresholdOnEnter() async throws {
+        let gate = CancellablePhaseGate()
+        let waiter = Task {
+            try await gate.waitUntilEntered()
+        }
+        try await gate.waitForEntryWaiterRegistration(count: 1)
+
+        let observer = Task {
+            try await gate.waitForEntryWaiterRegistration(count: 2)
+        }
+        let hold = Task {
+            await gate.enterAndHold()
+        }
+
+        try await waiter.value
+        await #expect(throws: PhaseGateError.registrationThresholdUnreachable) {
+            try await observer.value
+        }
+        await gate.release()
+        await hold.value
+    }
+
+    @Test("failure signal registration tracks the active count")
+    func failureSignalRegistrationTracksActiveCount() async throws {
+        let failures = StagingFailureSignal()
+        #expect(await failures.waiterCount == 0)
+
+        let waiter = Task {
+            try await failures.wait(phase: "remote staging setup")
+        }
+        try await failures.waitForWaiterRegistration(count: 1)
+        #expect(await failures.waiterCount == 1)
+
+        await failures.recordSuccess()
+        await #expect(throws: StagingBarrierError.finishedEarly(phase: "remote staging setup")) {
+            try await waiter.value
+        }
+        #expect(await failures.waiterCount == 0)
+    }
+
+    @Test("failure signal registration waits for a new active waiter after cancellation")
+    func failureSignalRegistrationWaitsAfterCancellation() async throws {
+        let failures = StagingFailureSignal()
+        let first = Task {
+            try await failures.wait(phase: "remote staging setup")
+        }
+        try await failures.waitForWaiterRegistration(count: 1)
+        first.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await first.value
+        }
+        #expect(await failures.waiterCount == 0)
+
+        let second = Task {
+            try await failures.wait(phase: "remote staging setup")
+        }
+        try await failures.waitForWaiterRegistration(count: 1)
+        #expect(await failures.waiterCount == 1)
+
+        second.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await second.value
+        }
+        #expect(await failures.waiterCount == 0)
+    }
+
+    @Test("failure signal registration observer cancellation resumes once")
+    func failureSignalRegistrationObserverCancellationResumesOnce() async throws {
+        let failures = StagingFailureSignal()
+        let observer = Task {
+            try await failures.waitForWaiterRegistration(count: 1)
+        }
+        observer.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await observer.value
+        }
+    }
+
+    @Test("failure signal fails registration observers when recorded before threshold")
+    func failureSignalFailsRegistrationBeforeThresholdOnRecord() async throws {
+        let failures = StagingFailureSignal()
+        let waiter = Task {
+            try await failures.wait(phase: "remote staging setup")
+        }
+        try await failures.waitForWaiterRegistration(count: 1)
+
+        let observer = Task {
+            try await failures.waitForWaiterRegistration(count: 2)
+        }
+        await failures.record(AttachmentStagingError.remoteTemporaryDirectoryFailed)
+
+        await #expect(throws: StagingFailureSignalError.registrationThresholdUnreachable) {
+            try await observer.value
+        }
+        await #expect(throws: StagingBarrierError.failed(
+            phase: "remote staging setup",
+            detail: String(describing: AttachmentStagingError.remoteTemporaryDirectoryFailed))
+        ) {
+            try await waiter.value
+        }
+    }
+
+    @Test("failure signal fails registration observers when success arrives before threshold")
+    func failureSignalFailsRegistrationBeforeThresholdOnSuccess() async throws {
+        let failures = StagingFailureSignal()
+        let waiter = Task {
+            try await failures.wait(phase: "severe-profile payload backpressure")
+        }
+        try await failures.waitForWaiterRegistration(count: 1)
+
+        let observer = Task {
+            try await failures.waitForWaiterRegistration(count: 2)
+        }
+        await failures.recordSuccess()
+
+        await #expect(throws: StagingFailureSignalError.registrationThresholdUnreachable) {
+            try await observer.value
+        }
+        await #expect(throws: StagingBarrierError.finishedEarly(
+            phase: "severe-profile payload backpressure")
+        ) {
+            try await waiter.value
+        }
+    }
 }

--- a/Tests/HeelerTests/StagingPhaseBarrierTests.swift
+++ b/Tests/HeelerTests/StagingPhaseBarrierTests.swift
@@ -158,10 +158,14 @@ struct StagingPhaseBarrierTests {
         let observer = Task {
             try await gate.waitForEntryWaiterRegistration(count: 1)
         }
+        await gate.waitForRegistrationObserver(count: 1)
+        #expect(await gate.registrationObserverCount == 1)
+
         observer.cancel()
         await #expect(throws: CancellationError.self) {
             try await observer.value
         }
+        #expect(await gate.registrationObserverCount == 0)
     }
 
     @Test("phase gate fails registration observers when released before threshold")
@@ -175,11 +179,15 @@ struct StagingPhaseBarrierTests {
         let observer = Task {
             try await gate.waitForEntryWaiterRegistration(count: 2)
         }
+        await gate.waitForRegistrationObserver(count: 1)
+        #expect(await gate.registrationObserverCount == 1)
+
         await gate.release()
 
         await #expect(throws: PhaseGateError.registrationThresholdUnreachable) {
             try await observer.value
         }
+        #expect(await gate.registrationObserverCount == 0)
         await #expect(throws: PhaseGateError.releasedWithoutEntry) {
             try await waiter.value
         }
@@ -196,6 +204,9 @@ struct StagingPhaseBarrierTests {
         let observer = Task {
             try await gate.waitForEntryWaiterRegistration(count: 2)
         }
+        await gate.waitForRegistrationObserver(count: 1)
+        #expect(await gate.registrationObserverCount == 1)
+
         let hold = Task {
             await gate.enterAndHold()
         }
@@ -204,6 +215,7 @@ struct StagingPhaseBarrierTests {
         await #expect(throws: PhaseGateError.registrationThresholdUnreachable) {
             try await observer.value
         }
+        #expect(await gate.registrationObserverCount == 0)
         await gate.release()
         await hold.value
     }
@@ -258,10 +270,14 @@ struct StagingPhaseBarrierTests {
         let observer = Task {
             try await failures.waitForWaiterRegistration(count: 1)
         }
+        await failures.waitForRegistrationObserver(count: 1)
+        #expect(await failures.registrationObserverCount == 1)
+
         observer.cancel()
         await #expect(throws: CancellationError.self) {
             try await observer.value
         }
+        #expect(await failures.registrationObserverCount == 0)
     }
 
     @Test("failure signal fails registration observers when recorded before threshold")
@@ -275,11 +291,15 @@ struct StagingPhaseBarrierTests {
         let observer = Task {
             try await failures.waitForWaiterRegistration(count: 2)
         }
+        await failures.waitForRegistrationObserver(count: 1)
+        #expect(await failures.registrationObserverCount == 1)
+
         await failures.record(AttachmentStagingError.remoteTemporaryDirectoryFailed)
 
         await #expect(throws: StagingFailureSignalError.registrationThresholdUnreachable) {
             try await observer.value
         }
+        #expect(await failures.registrationObserverCount == 0)
         await #expect(throws: StagingBarrierError.failed(
             phase: "remote staging setup",
             detail: String(describing: AttachmentStagingError.remoteTemporaryDirectoryFailed))
@@ -299,11 +319,15 @@ struct StagingPhaseBarrierTests {
         let observer = Task {
             try await failures.waitForWaiterRegistration(count: 2)
         }
+        await failures.waitForRegistrationObserver(count: 1)
+        #expect(await failures.registrationObserverCount == 1)
+
         await failures.recordSuccess()
 
         await #expect(throws: StagingFailureSignalError.registrationThresholdUnreachable) {
             try await observer.value
         }
+        #expect(await failures.registrationObserverCount == 0)
         await #expect(throws: StagingBarrierError.finishedEarly(
             phase: "severe-profile payload backpressure")
         ) {

--- a/Tests/HeelerTests/StagingPhaseBarrierTests.swift
+++ b/Tests/HeelerTests/StagingPhaseBarrierTests.swift
@@ -11,7 +11,7 @@ struct StagingPhaseBarrierTests {
         let waiter = Task {
             try await gate.waitUntilEntered()
         }
-        await Task.yield()
+        try await gate.waitForEntryWaiterRegistration()
         await gate.release()
         await #expect(throws: PhaseGateError.releasedWithoutEntry) {
             try await waiter.value
@@ -31,7 +31,8 @@ struct StagingPhaseBarrierTests {
                 failures: failures,
                 timeout: .seconds(2))
         }
-        await Task.yield()
+        try await gate.waitForEntryWaiterRegistration()
+        try await failures.waitForWaiterRegistration()
 
         // Production order: record the outcome, then release gates.
         await failures.record(AttachmentStagingError.remoteTemporaryDirectoryFailed)
@@ -58,7 +59,8 @@ struct StagingPhaseBarrierTests {
                 failures: failures,
                 timeout: .seconds(2))
         }
-        await Task.yield()
+        try await gate.waitForEntryWaiterRegistration()
+        try await failures.waitForWaiterRegistration()
 
         await failures.recordSuccess()
         await gate.release()
@@ -96,6 +98,7 @@ struct StagingPhaseBarrierTests {
                 failures: failures,
                 timeout: .seconds(2))
         }
+        try await gate.waitForEntryWaiterRegistration()
         let hold = Task {
             await gate.enterAndHold()
         }

--- a/Tests/HeelerTests/StagingPhaseBarrierTests.swift
+++ b/Tests/HeelerTests/StagingPhaseBarrierTests.swift
@@ -158,7 +158,7 @@ struct StagingPhaseBarrierTests {
         let observer = Task {
             try await gate.waitForEntryWaiterRegistration(count: 1)
         }
-        await gate.waitForRegistrationObserver(count: 1)
+        try await gate.waitForRegistrationObserver(count: 1)
         #expect(await gate.registrationObserverCount == 1)
 
         observer.cancel()
@@ -179,7 +179,7 @@ struct StagingPhaseBarrierTests {
         let observer = Task {
             try await gate.waitForEntryWaiterRegistration(count: 2)
         }
-        await gate.waitForRegistrationObserver(count: 1)
+        try await gate.waitForRegistrationObserver(count: 1)
         #expect(await gate.registrationObserverCount == 1)
 
         await gate.release()
@@ -204,7 +204,7 @@ struct StagingPhaseBarrierTests {
         let observer = Task {
             try await gate.waitForEntryWaiterRegistration(count: 2)
         }
-        await gate.waitForRegistrationObserver(count: 1)
+        try await gate.waitForRegistrationObserver(count: 1)
         #expect(await gate.registrationObserverCount == 1)
 
         let hold = Task {
@@ -270,7 +270,7 @@ struct StagingPhaseBarrierTests {
         let observer = Task {
             try await failures.waitForWaiterRegistration(count: 1)
         }
-        await failures.waitForRegistrationObserver(count: 1)
+        try await failures.waitForRegistrationObserver(count: 1)
         #expect(await failures.registrationObserverCount == 1)
 
         observer.cancel()
@@ -291,7 +291,7 @@ struct StagingPhaseBarrierTests {
         let observer = Task {
             try await failures.waitForWaiterRegistration(count: 2)
         }
-        await failures.waitForRegistrationObserver(count: 1)
+        try await failures.waitForRegistrationObserver(count: 1)
         #expect(await failures.registrationObserverCount == 1)
 
         await failures.record(AttachmentStagingError.remoteTemporaryDirectoryFailed)
@@ -319,7 +319,7 @@ struct StagingPhaseBarrierTests {
         let observer = Task {
             try await failures.waitForWaiterRegistration(count: 2)
         }
-        await failures.waitForRegistrationObserver(count: 1)
+        try await failures.waitForRegistrationObserver(count: 1)
         #expect(await failures.registrationObserverCount == 1)
 
         await failures.recordSuccess()
@@ -332,6 +332,128 @@ struct StagingPhaseBarrierTests {
             phase: "severe-profile payload backpressure")
         ) {
             try await waiter.value
+        }
+    }
+
+    @Test("registration observer barrier cancellation resumes once")
+    func registrationObserverBarrierCancellationResumesOnce() async throws {
+        let gate = CancellablePhaseGate()
+        let barrier = Task {
+            try await gate.waitForRegistrationObserver(count: 1)
+        }
+        try await gate.waitForRegistrationObserverBarrier(count: 1)
+        #expect(await gate.registrationObserverBarrierCount == 1)
+
+        barrier.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await barrier.value
+        }
+        #expect(await gate.registrationObserverBarrierCount == 0)
+    }
+
+    @Test("registration observer barrier fails when released before threshold")
+    func registrationObserverBarrierFailsBeforeThresholdOnRelease() async throws {
+        let gate = CancellablePhaseGate()
+        let barrier = Task {
+            try await gate.waitForRegistrationObserver(count: 1)
+        }
+        try await gate.waitForRegistrationObserverBarrier(count: 1)
+        #expect(await gate.registrationObserverBarrierCount == 1)
+
+        await gate.release()
+
+        await #expect(throws: PhaseGateError.registrationThresholdUnreachable) {
+            try await barrier.value
+        }
+        #expect(await gate.registrationObserverBarrierCount == 0)
+    }
+
+    @Test("registration observer barrier fails when entered before threshold")
+    func registrationObserverBarrierFailsBeforeThresholdOnEnter() async throws {
+        let gate = CancellablePhaseGate()
+        let barrier = Task {
+            try await gate.waitForRegistrationObserver(count: 1)
+        }
+        try await gate.waitForRegistrationObserverBarrier(count: 1)
+        #expect(await gate.registrationObserverBarrierCount == 1)
+
+        let hold = Task {
+            await gate.enterAndHold()
+        }
+
+        await #expect(throws: PhaseGateError.registrationThresholdUnreachable) {
+            try await barrier.value
+        }
+        #expect(await gate.registrationObserverBarrierCount == 0)
+        await gate.release()
+        await hold.value
+    }
+
+    @Test("registration observer barrier fails when invoked after terminal")
+    func registrationObserverBarrierFailsAfterTerminal() async throws {
+        let gate = CancellablePhaseGate()
+        await gate.release()
+        await #expect(throws: PhaseGateError.registrationThresholdUnreachable) {
+            try await gate.waitForRegistrationObserver(count: 1)
+        }
+    }
+
+    @Test("failure signal registration observer barrier cancellation resumes once")
+    func failureSignalRegistrationObserverBarrierCancellationResumesOnce() async throws {
+        let failures = StagingFailureSignal()
+        let barrier = Task {
+            try await failures.waitForRegistrationObserver(count: 1)
+        }
+        try await failures.waitForRegistrationObserverBarrier(count: 1)
+        #expect(await failures.registrationObserverBarrierCount == 1)
+
+        barrier.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await barrier.value
+        }
+        #expect(await failures.registrationObserverBarrierCount == 0)
+    }
+
+    @Test("failure signal registration observer barrier fails when recorded before threshold")
+    func failureSignalRegistrationObserverBarrierFailsBeforeThresholdOnRecord() async throws {
+        let failures = StagingFailureSignal()
+        let barrier = Task {
+            try await failures.waitForRegistrationObserver(count: 1)
+        }
+        try await failures.waitForRegistrationObserverBarrier(count: 1)
+        #expect(await failures.registrationObserverBarrierCount == 1)
+
+        await failures.record(AttachmentStagingError.remoteTemporaryDirectoryFailed)
+
+        await #expect(throws: StagingFailureSignalError.registrationThresholdUnreachable) {
+            try await barrier.value
+        }
+        #expect(await failures.registrationObserverBarrierCount == 0)
+    }
+
+    @Test("failure signal registration observer barrier fails when success arrives before threshold")
+    func failureSignalRegistrationObserverBarrierFailsBeforeThresholdOnSuccess() async throws {
+        let failures = StagingFailureSignal()
+        let barrier = Task {
+            try await failures.waitForRegistrationObserver(count: 1)
+        }
+        try await failures.waitForRegistrationObserverBarrier(count: 1)
+        #expect(await failures.registrationObserverBarrierCount == 1)
+
+        await failures.recordSuccess()
+
+        await #expect(throws: StagingFailureSignalError.registrationThresholdUnreachable) {
+            try await barrier.value
+        }
+        #expect(await failures.registrationObserverBarrierCount == 0)
+    }
+
+    @Test("failure signal registration observer barrier fails when invoked after terminal")
+    func failureSignalRegistrationObserverBarrierFailsAfterTerminal() async throws {
+        let failures = StagingFailureSignal()
+        await failures.recordSuccess()
+        await #expect(throws: StagingFailureSignalError.registrationThresholdUnreachable) {
+            try await failures.waitForRegistrationObserver(count: 1)
         }
     }
 }

--- a/Tests/HeelerTests/StagingPhaseBarrierTests.swift
+++ b/Tests/HeelerTests/StagingPhaseBarrierTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@Suite("Staging phase barriers")
+struct StagingPhaseBarrierTests {
+    @Test("release without enter fails entry waiters instead of succeeding")
+    func releaseWithoutEnterFailsEntryWaiters() async throws {
+        let gate = CancellablePhaseGate()
+        let waiter = Task {
+            try await gate.waitUntilEntered()
+        }
+        await Task.yield()
+        await gate.release()
+        await #expect(throws: PhaseGateError.releasedWithoutEntry) {
+            try await waiter.value
+        }
+    }
+
+    @Test("staging failure wins when it races cleanup release")
+    func stagingFailureWinsOverCleanupRelease() async throws {
+        let gate = CancellablePhaseGate()
+        let failures = StagingFailureSignal()
+        let phase = "remote staging setup"
+
+        let wait = Task {
+            try await StagingPhaseWait.awaitEntry(
+                phase,
+                gate: gate,
+                failures: failures,
+                timeout: .seconds(2))
+        }
+        await Task.yield()
+
+        // Production order: record the outcome, then release gates.
+        await failures.record(AttachmentStagingError.remoteTemporaryDirectoryFailed)
+        await gate.release()
+
+        await #expect(throws: StagingBarrierError.failed(
+            phase: phase,
+            detail: String(describing: AttachmentStagingError.remoteTemporaryDirectoryFailed))
+        ) {
+            try await wait.value
+        }
+    }
+
+    @Test("successful staging finish wins when it races cleanup release")
+    func stagingSuccessWinsOverCleanupRelease() async throws {
+        let gate = CancellablePhaseGate()
+        let failures = StagingFailureSignal()
+        let phase = "severe-profile payload backpressure"
+
+        let wait = Task {
+            try await StagingPhaseWait.awaitEntry(
+                phase,
+                gate: gate,
+                failures: failures,
+                timeout: .seconds(2))
+        }
+        await Task.yield()
+
+        await failures.recordSuccess()
+        await gate.release()
+
+        await #expect(throws: StagingBarrierError.finishedEarly(phase: phase)) {
+            try await wait.value
+        }
+    }
+
+    @Test("missing phase entry times out without treating release as entry")
+    func missingPhaseEntryTimesOut() async throws {
+        let gate = CancellablePhaseGate()
+        let failures = StagingFailureSignal()
+        let phase = "severe-profile payload backpressure"
+
+        await #expect(throws: StagingBarrierError.timedOut(phase: phase)) {
+            try await StagingPhaseWait.awaitEntry(
+                phase,
+                gate: gate,
+                failures: failures,
+                timeout: .milliseconds(50))
+        }
+    }
+
+    @Test("real enterAndHold still satisfies the phase waiter")
+    func enterAndHoldSatisfiesPhaseWaiter() async throws {
+        let gate = CancellablePhaseGate()
+        let failures = StagingFailureSignal()
+        let phase = "remote staging setup"
+
+        let wait = Task {
+            try await StagingPhaseWait.awaitEntry(
+                phase,
+                gate: gate,
+                failures: failures,
+                timeout: .seconds(2))
+        }
+        let hold = Task {
+            await gate.enterAndHold()
+        }
+
+        try await wait.value
+        await gate.release()
+        await hold.value
+    }
+}

--- a/Tests/HeelerTests/Support/CancellablePhaseGate.swift
+++ b/Tests/HeelerTests/Support/CancellablePhaseGate.swift
@@ -26,6 +26,8 @@ enum StagingBarrierError: Error, Equatable, CustomStringConvertible {
 enum PhaseGateError: Error, Equatable {
     /// `release()` ran before `enterAndHold()`, so this is cleanup — not entry.
     case releasedWithoutEntry
+    /// The gate became terminal before the requested active-waiter count could be reached.
+    case registrationThresholdUnreachable
 }
 
 /// Hold/observe gate whose stored continuations always resume via `release()`,
@@ -38,20 +40,30 @@ actor CancellablePhaseGate {
     private var isReleased = false
     private var entryWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
     private var holdWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
+    /// Currently registered entry waiters (not a historical counter).
     private(set) var entryWaiterCount = 0
     private var registrationWaiters: [UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)] =
         [:]
 
-    /// Suspends until at least `count` entry waiters have registered. Proves an
-    /// active waiter before release/failure injection — not a scheduling hint.
+    private var isRegistrationTerminal: Bool {
+        hasEntered || isReleased
+    }
+
+    /// Suspends until at least `count` entry waiters are actively registered.
+    /// Proves an active waiter before release/failure injection — not a scheduling hint.
     func waitForEntryWaiterRegistration(count: Int = 1) async throws {
         if entryWaiterCount >= count { return }
+        if isRegistrationTerminal {
+            throw PhaseGateError.registrationThresholdUnreachable
+        }
         let id = UUID()
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation {
                 (continuation: CheckedContinuation<Void, any Error>) in
                 if self.entryWaiterCount >= count {
                     continuation.resume()
+                } else if self.hasEntered || self.isReleased {
+                    continuation.resume(throwing: PhaseGateError.registrationThresholdUnreachable)
                 } else {
                     self.registrationWaiters[id] = (count, continuation)
                 }
@@ -64,6 +76,7 @@ actor CancellablePhaseGate {
     func enterAndHold() async {
         hasEntered = true
         resumeEntryWaitersSuccessfully()
+        closeUnreachableRegistrationWaiters()
         if isReleased { return }
         let id = UUID()
         do {
@@ -112,6 +125,7 @@ actor CancellablePhaseGate {
         isReleased = true
         let entries = entryWaiters
         entryWaiters.removeAll()
+        entryWaiterCount = 0
         for (_, waiter) in entries {
             if hasEntered {
                 waiter.resume()
@@ -119,6 +133,7 @@ actor CancellablePhaseGate {
                 waiter.resume(throwing: PhaseGateError.releasedWithoutEntry)
             }
         }
+        closeUnreachableRegistrationWaiters()
         let holds = holdWaiters
         holdWaiters.removeAll()
         for (_, waiter) in holds {
@@ -129,6 +144,7 @@ actor CancellablePhaseGate {
     private func resumeEntryWaitersSuccessfully() {
         let waiters = entryWaiters
         entryWaiters.removeAll()
+        entryWaiterCount = 0
         for (_, waiter) in waiters {
             waiter.resume()
         }
@@ -144,6 +160,16 @@ actor CancellablePhaseGate {
         }
     }
 
+    /// Terminal gates cannot grow the active waiter set; fail observers still short of threshold.
+    private func closeUnreachableRegistrationWaiters() {
+        resumeRegistrationWaitersIfReady()
+        let pending = registrationWaiters
+        registrationWaiters.removeAll()
+        for (_, waiter) in pending {
+            waiter.continuation.resume(throwing: PhaseGateError.registrationThresholdUnreachable)
+        }
+    }
+
     private func cancelRegistrationWaiter(_ id: UUID) {
         guard let waiter = registrationWaiters.removeValue(forKey: id) else { return }
         waiter.continuation.resume(throwing: CancellationError())
@@ -151,6 +177,9 @@ actor CancellablePhaseGate {
 
     private func resumeEntryWaiter(_ id: UUID, throwing error: any Error) {
         guard let waiter = entryWaiters.removeValue(forKey: id) else { return }
+        if entryWaiterCount > 0 {
+            entryWaiterCount -= 1
+        }
         waiter.resume(throwing: error)
     }
 
@@ -160,6 +189,11 @@ actor CancellablePhaseGate {
     }
 }
 
+enum StagingFailureSignalError: Error, Equatable {
+    /// The signal became terminal before the requested active-waiter count could be reached.
+    case registrationThresholdUnreachable
+}
+
 /// Staging reports outcomes here from its own task body so waiters do not
 /// suspend on `Task.result` after the phase has moved on.
 actor StagingFailureSignal {
@@ -167,19 +201,30 @@ actor StagingFailureSignal {
     private var finishedSuccessfully = false
     private var waiters: [UUID: (phase: String, continuation: CheckedContinuation<Void, any Error>)] =
         [:]
+    /// Currently registered outcome waiters (not a historical counter).
     private(set) var waiterCount = 0
     private var registrationWaiters: [UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)] =
         [:]
 
-    /// Suspends until at least `count` outcome waiters have registered.
+    private var isRegistrationTerminal: Bool {
+        detail != nil || finishedSuccessfully
+    }
+
+    /// Suspends until at least `count` outcome waiters are actively registered.
     func waitForWaiterRegistration(count: Int = 1) async throws {
         if waiterCount >= count { return }
+        if isRegistrationTerminal {
+            throw StagingFailureSignalError.registrationThresholdUnreachable
+        }
         let id = UUID()
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation {
                 (continuation: CheckedContinuation<Void, any Error>) in
                 if self.waiterCount >= count {
                     continuation.resume()
+                } else if self.detail != nil || self.finishedSuccessfully {
+                    continuation.resume(
+                        throwing: StagingFailureSignalError.registrationThresholdUnreachable)
                 } else {
                     self.registrationWaiters[id] = (count, continuation)
                 }
@@ -194,20 +239,24 @@ actor StagingFailureSignal {
         self.detail = detail
         let captured = waiters
         waiters.removeAll()
+        waiterCount = 0
         for (_, waiter) in captured {
             waiter.continuation.resume(
                 throwing: StagingBarrierError.failed(phase: waiter.phase, detail: detail))
         }
+        closeUnreachableRegistrationWaiters()
     }
 
     func recordSuccess() {
         finishedSuccessfully = true
         let captured = waiters
         waiters.removeAll()
+        waiterCount = 0
         for (_, waiter) in captured {
             waiter.continuation.resume(
                 throwing: StagingBarrierError.finishedEarly(phase: waiter.phase))
         }
+        closeUnreachableRegistrationWaiters()
     }
 
     func barrierErrorIfPresent(phase: String) -> StagingBarrierError? {
@@ -255,6 +304,16 @@ actor StagingFailureSignal {
         }
     }
 
+    private func closeUnreachableRegistrationWaiters() {
+        resumeRegistrationWaitersIfReady()
+        let pending = registrationWaiters
+        registrationWaiters.removeAll()
+        for (_, waiter) in pending {
+            waiter.continuation.resume(
+                throwing: StagingFailureSignalError.registrationThresholdUnreachable)
+        }
+    }
+
     private func cancelRegistrationWaiter(_ id: UUID) {
         guard let waiter = registrationWaiters.removeValue(forKey: id) else { return }
         waiter.continuation.resume(throwing: CancellationError())
@@ -262,6 +321,9 @@ actor StagingFailureSignal {
 
     private func cancelWaiter(_ id: UUID) {
         guard let waiter = waiters.removeValue(forKey: id) else { return }
+        if waiterCount > 0 {
+            waiterCount -= 1
+        }
         waiter.continuation.resume(throwing: CancellationError())
     }
 }

--- a/Tests/HeelerTests/Support/CancellablePhaseGate.swift
+++ b/Tests/HeelerTests/Support/CancellablePhaseGate.swift
@@ -1,0 +1,249 @@
+import Foundation
+
+@testable import Heeler
+
+/// Surfaces a staging outcome under the phase that was waiting.
+enum StagingBarrierError: Error, Equatable, CustomStringConvertible {
+    case finishedEarly(phase: String)
+    case failed(phase: String, detail: String)
+    case releasedWithoutEntry(phase: String)
+    case timedOut(phase: String)
+
+    var description: String {
+        switch self {
+        case .finishedEarly(let phase):
+            "staging finished during \(phase) before the barrier armed"
+        case .failed(let phase, let detail):
+            "staging failed during \(phase): \(detail)"
+        case .releasedWithoutEntry(let phase):
+            "phase \(phase) was released without enterAndHold"
+        case .timedOut(let phase):
+            "timed out waiting for \(phase)"
+        }
+    }
+}
+
+enum PhaseGateError: Error, Equatable {
+    /// `release()` ran before `enterAndHold()`, so this is cleanup — not entry.
+    case releasedWithoutEntry
+}
+
+/// Hold/observe gate whose stored continuations always resume via `release()`,
+/// successful `enterAndHold()`, or task cancellation.
+///
+/// `release()` unblocks hold waiters and fails entry waiters when entry never
+/// happened, so cleanup cannot be mistaken for phase entry.
+actor CancellablePhaseGate {
+    private var hasEntered = false
+    private var isReleased = false
+    private var entryWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
+    private var holdWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
+
+    func enterAndHold() async {
+        hasEntered = true
+        resumeEntryWaitersSuccessfully()
+        if isReleased { return }
+        let id = UUID()
+        do {
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation {
+                    (continuation: CheckedContinuation<Void, any Error>) in
+                    if self.isReleased {
+                        continuation.resume()
+                    } else {
+                        self.holdWaiters[id] = continuation
+                    }
+                }
+            } onCancel: {
+                Task { await self.resumeHoldWaiter(id, throwing: CancellationError()) }
+            }
+        } catch {
+            return
+        }
+    }
+
+    func waitUntilEntered() async throws {
+        if hasEntered { return }
+        if isReleased {
+            throw PhaseGateError.releasedWithoutEntry
+        }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                if self.hasEntered {
+                    continuation.resume()
+                } else if self.isReleased {
+                    continuation.resume(throwing: PhaseGateError.releasedWithoutEntry)
+                } else {
+                    self.entryWaiters[id] = continuation
+                }
+            }
+        } onCancel: {
+            Task { await self.resumeEntryWaiter(id, throwing: CancellationError()) }
+        }
+    }
+
+    func release() {
+        isReleased = true
+        let entries = entryWaiters
+        entryWaiters.removeAll()
+        for (_, waiter) in entries {
+            if hasEntered {
+                waiter.resume()
+            } else {
+                waiter.resume(throwing: PhaseGateError.releasedWithoutEntry)
+            }
+        }
+        let holds = holdWaiters
+        holdWaiters.removeAll()
+        for (_, waiter) in holds {
+            waiter.resume()
+        }
+    }
+
+    private func resumeEntryWaitersSuccessfully() {
+        let waiters = entryWaiters
+        entryWaiters.removeAll()
+        for (_, waiter) in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func resumeEntryWaiter(_ id: UUID, throwing error: any Error) {
+        guard let waiter = entryWaiters.removeValue(forKey: id) else { return }
+        waiter.resume(throwing: error)
+    }
+
+    private func resumeHoldWaiter(_ id: UUID, throwing error: any Error) {
+        guard let waiter = holdWaiters.removeValue(forKey: id) else { return }
+        waiter.resume(throwing: error)
+    }
+}
+
+/// Staging reports outcomes here from its own task body so waiters do not
+/// suspend on `Task.result` after the phase has moved on.
+actor StagingFailureSignal {
+    private var detail: String?
+    private var finishedSuccessfully = false
+    private var waiters: [UUID: (phase: String, continuation: CheckedContinuation<Void, any Error>)] =
+        [:]
+
+    func record(_ error: any Error) {
+        let detail = String(describing: error)
+        self.detail = detail
+        let captured = waiters
+        waiters.removeAll()
+        for (_, waiter) in captured {
+            waiter.continuation.resume(
+                throwing: StagingBarrierError.failed(phase: waiter.phase, detail: detail))
+        }
+    }
+
+    func recordSuccess() {
+        finishedSuccessfully = true
+        let captured = waiters
+        waiters.removeAll()
+        for (_, waiter) in captured {
+            waiter.continuation.resume(
+                throwing: StagingBarrierError.finishedEarly(phase: waiter.phase))
+        }
+    }
+
+    func barrierErrorIfPresent(phase: String) -> StagingBarrierError? {
+        if let detail {
+            return .failed(phase: phase, detail: detail)
+        }
+        if finishedSuccessfully {
+            return .finishedEarly(phase: phase)
+        }
+        return nil
+    }
+
+    func wait(phase: String) async throws {
+        if let error = barrierErrorIfPresent(phase: phase) {
+            throw error
+        }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                if let detail = self.detail {
+                    continuation.resume(
+                        throwing: StagingBarrierError.failed(phase: phase, detail: detail))
+                } else if self.finishedSuccessfully {
+                    continuation.resume(
+                        throwing: StagingBarrierError.finishedEarly(phase: phase))
+                } else {
+                    waiters[id] = (phase, continuation)
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id) }
+        }
+    }
+
+    private func cancelWaiter(_ id: UUID) {
+        guard let waiter = waiters.removeValue(forKey: id) else { return }
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+}
+
+/// Races phase entry against a staging outcome and a wall-clock deadline.
+enum StagingPhaseWait {
+    static func awaitEntry(
+        _ phase: String,
+        gate: CancellablePhaseGate,
+        failures: StagingFailureSignal,
+        timeout: Duration = .seconds(15)
+    ) async throws {
+        do {
+            try await AsyncDeadline.run(
+                for: timeout,
+                onTimeout: {
+                    await gate.release()
+                }
+            ) {
+                try await raceEntry(phase, gate: gate, failures: failures)
+            }
+        } catch AsyncDeadlineError.timedOut {
+            if let error = await failures.barrierErrorIfPresent(phase: phase) {
+                throw error
+            }
+            throw StagingBarrierError.timedOut(phase: phase)
+        }
+    }
+
+    private static func raceEntry(
+        _ phase: String,
+        gate: CancellablePhaseGate,
+        failures: StagingFailureSignal
+    ) async throws {
+        try await withThrowingTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                do {
+                    try await gate.waitUntilEntered()
+                    return true
+                } catch PhaseGateError.releasedWithoutEntry {
+                    return false
+                }
+            }
+            group.addTask {
+                try await failures.wait(phase: phase)
+                // `wait` only resumes by throwing.
+                return false
+            }
+            let entered = try await group.next()!
+            group.cancelAll()
+            if entered {
+                return
+            }
+            // `record` / `recordSuccess` always run before `release` in the
+            // staging task, so a cleanup wake must observe that outcome here.
+            if let error = await failures.barrierErrorIfPresent(phase: phase) {
+                throw error
+            }
+            throw StagingBarrierError.releasedWithoutEntry(phase: phase)
+        }
+    }
+}

--- a/Tests/HeelerTests/Support/CancellablePhaseGate.swift
+++ b/Tests/HeelerTests/Support/CancellablePhaseGate.swift
@@ -38,6 +38,28 @@ actor CancellablePhaseGate {
     private var isReleased = false
     private var entryWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
     private var holdWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
+    private(set) var entryWaiterCount = 0
+    private var registrationWaiters: [UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)] =
+        [:]
+
+    /// Suspends until at least `count` entry waiters have registered. Proves an
+    /// active waiter before release/failure injection — not a scheduling hint.
+    func waitForEntryWaiterRegistration(count: Int = 1) async throws {
+        if entryWaiterCount >= count { return }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                if self.entryWaiterCount >= count {
+                    continuation.resume()
+                } else {
+                    self.registrationWaiters[id] = (count, continuation)
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelRegistrationWaiter(id) }
+        }
+    }
 
     func enterAndHold() async {
         hasEntered = true
@@ -77,6 +99,8 @@ actor CancellablePhaseGate {
                     continuation.resume(throwing: PhaseGateError.releasedWithoutEntry)
                 } else {
                     self.entryWaiters[id] = continuation
+                    self.entryWaiterCount += 1
+                    self.resumeRegistrationWaitersIfReady()
                 }
             }
         } onCancel: {
@@ -110,6 +134,21 @@ actor CancellablePhaseGate {
         }
     }
 
+    private func resumeRegistrationWaitersIfReady() {
+        let ready = registrationWaiters.filter { entryWaiterCount >= $0.value.count }
+        for (id, _) in ready {
+            registrationWaiters.removeValue(forKey: id)
+        }
+        for (_, waiter) in ready {
+            waiter.continuation.resume()
+        }
+    }
+
+    private func cancelRegistrationWaiter(_ id: UUID) {
+        guard let waiter = registrationWaiters.removeValue(forKey: id) else { return }
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
     private func resumeEntryWaiter(_ id: UUID, throwing error: any Error) {
         guard let waiter = entryWaiters.removeValue(forKey: id) else { return }
         waiter.resume(throwing: error)
@@ -128,6 +167,27 @@ actor StagingFailureSignal {
     private var finishedSuccessfully = false
     private var waiters: [UUID: (phase: String, continuation: CheckedContinuation<Void, any Error>)] =
         [:]
+    private(set) var waiterCount = 0
+    private var registrationWaiters: [UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)] =
+        [:]
+
+    /// Suspends until at least `count` outcome waiters have registered.
+    func waitForWaiterRegistration(count: Int = 1) async throws {
+        if waiterCount >= count { return }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                if self.waiterCount >= count {
+                    continuation.resume()
+                } else {
+                    self.registrationWaiters[id] = (count, continuation)
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelRegistrationWaiter(id) }
+        }
+    }
 
     func record(_ error: any Error) {
         let detail = String(describing: error)
@@ -176,11 +236,28 @@ actor StagingFailureSignal {
                         throwing: StagingBarrierError.finishedEarly(phase: phase))
                 } else {
                     waiters[id] = (phase, continuation)
+                    waiterCount += 1
+                    resumeRegistrationWaitersIfReady()
                 }
             }
         } onCancel: {
             Task { await self.cancelWaiter(id) }
         }
+    }
+
+    private func resumeRegistrationWaitersIfReady() {
+        let ready = registrationWaiters.filter { waiterCount >= $0.value.count }
+        for (id, _) in ready {
+            registrationWaiters.removeValue(forKey: id)
+        }
+        for (_, waiter) in ready {
+            waiter.continuation.resume()
+        }
+    }
+
+    private func cancelRegistrationWaiter(_ id: UUID) {
+        guard let waiter = registrationWaiters.removeValue(forKey: id) else { return }
+        waiter.continuation.resume(throwing: CancellationError())
     }
 
     private func cancelWaiter(_ id: UUID) {

--- a/Tests/HeelerTests/Support/CancellablePhaseGate.swift
+++ b/Tests/HeelerTests/Support/CancellablePhaseGate.swift
@@ -42,8 +42,12 @@ actor CancellablePhaseGate {
     private var holdWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
     /// Currently registered entry waiters (not a historical counter).
     private(set) var entryWaiterCount = 0
+    /// Stored registration observers awaiting an active-waiter threshold.
+    private(set) var registrationObserverCount = 0
     private var registrationWaiters: [UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)] =
         [:]
+    private var registrationObserverBarriers:
+        [UUID: (count: Int, continuation: CheckedContinuation<Void, Never>)] = [:]
 
     private var isRegistrationTerminal: Bool {
         hasEntered || isReleased
@@ -66,10 +70,24 @@ actor CancellablePhaseGate {
                     continuation.resume(throwing: PhaseGateError.registrationThresholdUnreachable)
                 } else {
                     self.registrationWaiters[id] = (count, continuation)
+                    self.noteRegistrationObserversChanged()
                 }
             }
         } onCancel: {
             Task { await self.cancelRegistrationWaiter(id) }
+        }
+    }
+
+    /// Suspends until at least `count` registration observers have stored continuations.
+    func waitForRegistrationObserver(count: Int = 1) async {
+        if registrationObserverCount >= count { return }
+        let id = UUID()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            if self.registrationObserverCount >= count {
+                continuation.resume()
+            } else {
+                self.registrationObserverBarriers[id] = (count, continuation)
+            }
         }
     }
 
@@ -155,6 +173,7 @@ actor CancellablePhaseGate {
         for (id, _) in ready {
             registrationWaiters.removeValue(forKey: id)
         }
+        noteRegistrationObserversChanged()
         for (_, waiter) in ready {
             waiter.continuation.resume()
         }
@@ -165,13 +184,28 @@ actor CancellablePhaseGate {
         resumeRegistrationWaitersIfReady()
         let pending = registrationWaiters
         registrationWaiters.removeAll()
+        noteRegistrationObserversChanged()
         for (_, waiter) in pending {
             waiter.continuation.resume(throwing: PhaseGateError.registrationThresholdUnreachable)
         }
     }
 
+    private func noteRegistrationObserversChanged() {
+        registrationObserverCount = registrationWaiters.count
+        let ready = registrationObserverBarriers.filter {
+            registrationObserverCount >= $0.value.count
+        }
+        for (id, _) in ready {
+            registrationObserverBarriers.removeValue(forKey: id)
+        }
+        for (_, barrier) in ready {
+            barrier.continuation.resume()
+        }
+    }
+
     private func cancelRegistrationWaiter(_ id: UUID) {
         guard let waiter = registrationWaiters.removeValue(forKey: id) else { return }
+        noteRegistrationObserversChanged()
         waiter.continuation.resume(throwing: CancellationError())
     }
 
@@ -203,8 +237,12 @@ actor StagingFailureSignal {
         [:]
     /// Currently registered outcome waiters (not a historical counter).
     private(set) var waiterCount = 0
+    /// Stored registration observers awaiting an active-waiter threshold.
+    private(set) var registrationObserverCount = 0
     private var registrationWaiters: [UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)] =
         [:]
+    private var registrationObserverBarriers:
+        [UUID: (count: Int, continuation: CheckedContinuation<Void, Never>)] = [:]
 
     private var isRegistrationTerminal: Bool {
         detail != nil || finishedSuccessfully
@@ -227,10 +265,24 @@ actor StagingFailureSignal {
                         throwing: StagingFailureSignalError.registrationThresholdUnreachable)
                 } else {
                     self.registrationWaiters[id] = (count, continuation)
+                    self.noteRegistrationObserversChanged()
                 }
             }
         } onCancel: {
             Task { await self.cancelRegistrationWaiter(id) }
+        }
+    }
+
+    /// Suspends until at least `count` registration observers have stored continuations.
+    func waitForRegistrationObserver(count: Int = 1) async {
+        if registrationObserverCount >= count { return }
+        let id = UUID()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            if self.registrationObserverCount >= count {
+                continuation.resume()
+            } else {
+                self.registrationObserverBarriers[id] = (count, continuation)
+            }
         }
     }
 
@@ -299,6 +351,7 @@ actor StagingFailureSignal {
         for (id, _) in ready {
             registrationWaiters.removeValue(forKey: id)
         }
+        noteRegistrationObserversChanged()
         for (_, waiter) in ready {
             waiter.continuation.resume()
         }
@@ -308,14 +361,29 @@ actor StagingFailureSignal {
         resumeRegistrationWaitersIfReady()
         let pending = registrationWaiters
         registrationWaiters.removeAll()
+        noteRegistrationObserversChanged()
         for (_, waiter) in pending {
             waiter.continuation.resume(
                 throwing: StagingFailureSignalError.registrationThresholdUnreachable)
         }
     }
 
+    private func noteRegistrationObserversChanged() {
+        registrationObserverCount = registrationWaiters.count
+        let ready = registrationObserverBarriers.filter {
+            registrationObserverCount >= $0.value.count
+        }
+        for (id, _) in ready {
+            registrationObserverBarriers.removeValue(forKey: id)
+        }
+        for (_, barrier) in ready {
+            barrier.continuation.resume()
+        }
+    }
+
     private func cancelRegistrationWaiter(_ id: UUID) {
         guard let waiter = registrationWaiters.removeValue(forKey: id) else { return }
+        noteRegistrationObserversChanged()
         waiter.continuation.resume(throwing: CancellationError())
     }
 

--- a/Tests/HeelerTests/Support/CancellablePhaseGate.swift
+++ b/Tests/HeelerTests/Support/CancellablePhaseGate.swift
@@ -44,10 +44,14 @@ actor CancellablePhaseGate {
     private(set) var entryWaiterCount = 0
     /// Stored registration observers awaiting an active-waiter threshold.
     private(set) var registrationObserverCount = 0
+    /// Stored `waitForRegistrationObserver` barriers awaiting an observer threshold.
+    private(set) var registrationObserverBarrierCount = 0
     private var registrationWaiters: [UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)] =
         [:]
     private var registrationObserverBarriers:
-        [UUID: (count: Int, continuation: CheckedContinuation<Void, Never>)] = [:]
+        [UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)] = [:]
+    private var registrationObserverBarrierWatchers:
+        [UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)] = [:]
 
     private var isRegistrationTerminal: Bool {
         hasEntered || isReleased
@@ -79,15 +83,49 @@ actor CancellablePhaseGate {
     }
 
     /// Suspends until at least `count` registration observers have stored continuations.
-    func waitForRegistrationObserver(count: Int = 1) async {
+    func waitForRegistrationObserver(count: Int = 1) async throws {
         if registrationObserverCount >= count { return }
+        if isRegistrationTerminal {
+            throw PhaseGateError.registrationThresholdUnreachable
+        }
         let id = UUID()
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            if self.registrationObserverCount >= count {
-                continuation.resume()
-            } else {
-                self.registrationObserverBarriers[id] = (count, continuation)
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                if self.registrationObserverCount >= count {
+                    continuation.resume()
+                } else if self.hasEntered || self.isReleased {
+                    continuation.resume(throwing: PhaseGateError.registrationThresholdUnreachable)
+                } else {
+                    self.registrationObserverBarriers[id] = (count, continuation)
+                    self.noteRegistrationObserverBarriersChanged()
+                }
             }
+        } onCancel: {
+            Task { await self.cancelRegistrationObserverBarrier(id) }
+        }
+    }
+
+    /// Suspends until at least `count` registration-observer barriers have stored continuations.
+    func waitForRegistrationObserverBarrier(count: Int = 1) async throws {
+        if registrationObserverBarrierCount >= count { return }
+        if isRegistrationTerminal {
+            throw PhaseGateError.registrationThresholdUnreachable
+        }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                if self.registrationObserverBarrierCount >= count {
+                    continuation.resume()
+                } else if self.hasEntered || self.isReleased {
+                    continuation.resume(throwing: PhaseGateError.registrationThresholdUnreachable)
+                } else {
+                    self.registrationObserverBarrierWatchers[id] = (count, continuation)
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelRegistrationObserverBarrierWatcher(id) }
         }
     }
 
@@ -188,18 +226,64 @@ actor CancellablePhaseGate {
         for (_, waiter) in pending {
             waiter.continuation.resume(throwing: PhaseGateError.registrationThresholdUnreachable)
         }
+        failUnreachableRegistrationObserverBarriers()
     }
 
     private func noteRegistrationObserversChanged() {
         registrationObserverCount = registrationWaiters.count
+        resumeRegistrationObserverBarriersIfReady()
+    }
+
+    private func resumeRegistrationObserverBarriersIfReady() {
         let ready = registrationObserverBarriers.filter {
             registrationObserverCount >= $0.value.count
         }
         for (id, _) in ready {
             registrationObserverBarriers.removeValue(forKey: id)
         }
+        noteRegistrationObserverBarriersChanged()
         for (_, barrier) in ready {
             barrier.continuation.resume()
+        }
+    }
+
+    private func failUnreachableRegistrationObserverBarriers() {
+        resumeRegistrationObserverBarriersIfReady()
+        let pending = registrationObserverBarriers
+        registrationObserverBarriers.removeAll()
+        noteRegistrationObserverBarriersChanged()
+        for (_, barrier) in pending {
+            barrier.continuation.resume(throwing: PhaseGateError.registrationThresholdUnreachable)
+        }
+        failUnreachableRegistrationObserverBarrierWatchers()
+    }
+
+    private func noteRegistrationObserverBarriersChanged() {
+        registrationObserverBarrierCount = registrationObserverBarriers.count
+        let ready = registrationObserverBarrierWatchers.filter {
+            registrationObserverBarrierCount >= $0.value.count
+        }
+        for (id, _) in ready {
+            registrationObserverBarrierWatchers.removeValue(forKey: id)
+        }
+        for (_, watcher) in ready {
+            watcher.continuation.resume()
+        }
+    }
+
+    private func failUnreachableRegistrationObserverBarrierWatchers() {
+        let ready = registrationObserverBarrierWatchers.filter {
+            registrationObserverBarrierCount >= $0.value.count
+        }
+        let unreachable = registrationObserverBarrierWatchers.filter {
+            registrationObserverBarrierCount < $0.value.count
+        }
+        registrationObserverBarrierWatchers.removeAll()
+        for (_, watcher) in ready {
+            watcher.continuation.resume()
+        }
+        for (_, watcher) in unreachable {
+            watcher.continuation.resume(throwing: PhaseGateError.registrationThresholdUnreachable)
         }
     }
 
@@ -207,6 +291,19 @@ actor CancellablePhaseGate {
         guard let waiter = registrationWaiters.removeValue(forKey: id) else { return }
         noteRegistrationObserversChanged()
         waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func cancelRegistrationObserverBarrier(_ id: UUID) {
+        guard let barrier = registrationObserverBarriers.removeValue(forKey: id) else { return }
+        noteRegistrationObserverBarriersChanged()
+        barrier.continuation.resume(throwing: CancellationError())
+    }
+
+    private func cancelRegistrationObserverBarrierWatcher(_ id: UUID) {
+        guard let watcher = registrationObserverBarrierWatchers.removeValue(forKey: id) else {
+            return
+        }
+        watcher.continuation.resume(throwing: CancellationError())
     }
 
     private func resumeEntryWaiter(_ id: UUID, throwing error: any Error) {
@@ -239,10 +336,14 @@ actor StagingFailureSignal {
     private(set) var waiterCount = 0
     /// Stored registration observers awaiting an active-waiter threshold.
     private(set) var registrationObserverCount = 0
+    /// Stored `waitForRegistrationObserver` barriers awaiting an observer threshold.
+    private(set) var registrationObserverBarrierCount = 0
     private var registrationWaiters: [UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)] =
         [:]
     private var registrationObserverBarriers:
-        [UUID: (count: Int, continuation: CheckedContinuation<Void, Never>)] = [:]
+        [UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)] = [:]
+    private var registrationObserverBarrierWatchers:
+        [UUID: (count: Int, continuation: CheckedContinuation<Void, any Error>)] = [:]
 
     private var isRegistrationTerminal: Bool {
         detail != nil || finishedSuccessfully
@@ -274,15 +375,51 @@ actor StagingFailureSignal {
     }
 
     /// Suspends until at least `count` registration observers have stored continuations.
-    func waitForRegistrationObserver(count: Int = 1) async {
+    func waitForRegistrationObserver(count: Int = 1) async throws {
         if registrationObserverCount >= count { return }
+        if isRegistrationTerminal {
+            throw StagingFailureSignalError.registrationThresholdUnreachable
+        }
         let id = UUID()
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            if self.registrationObserverCount >= count {
-                continuation.resume()
-            } else {
-                self.registrationObserverBarriers[id] = (count, continuation)
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                if self.registrationObserverCount >= count {
+                    continuation.resume()
+                } else if self.detail != nil || self.finishedSuccessfully {
+                    continuation.resume(
+                        throwing: StagingFailureSignalError.registrationThresholdUnreachable)
+                } else {
+                    self.registrationObserverBarriers[id] = (count, continuation)
+                    self.noteRegistrationObserverBarriersChanged()
+                }
             }
+        } onCancel: {
+            Task { await self.cancelRegistrationObserverBarrier(id) }
+        }
+    }
+
+    /// Suspends until at least `count` registration-observer barriers have stored continuations.
+    func waitForRegistrationObserverBarrier(count: Int = 1) async throws {
+        if registrationObserverBarrierCount >= count { return }
+        if isRegistrationTerminal {
+            throw StagingFailureSignalError.registrationThresholdUnreachable
+        }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                if self.registrationObserverBarrierCount >= count {
+                    continuation.resume()
+                } else if self.detail != nil || self.finishedSuccessfully {
+                    continuation.resume(
+                        throwing: StagingFailureSignalError.registrationThresholdUnreachable)
+                } else {
+                    self.registrationObserverBarrierWatchers[id] = (count, continuation)
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelRegistrationObserverBarrierWatcher(id) }
         }
     }
 
@@ -366,18 +503,66 @@ actor StagingFailureSignal {
             waiter.continuation.resume(
                 throwing: StagingFailureSignalError.registrationThresholdUnreachable)
         }
+        failUnreachableRegistrationObserverBarriers()
     }
 
     private func noteRegistrationObserversChanged() {
         registrationObserverCount = registrationWaiters.count
+        resumeRegistrationObserverBarriersIfReady()
+    }
+
+    private func resumeRegistrationObserverBarriersIfReady() {
         let ready = registrationObserverBarriers.filter {
             registrationObserverCount >= $0.value.count
         }
         for (id, _) in ready {
             registrationObserverBarriers.removeValue(forKey: id)
         }
+        noteRegistrationObserverBarriersChanged()
         for (_, barrier) in ready {
             barrier.continuation.resume()
+        }
+    }
+
+    private func failUnreachableRegistrationObserverBarriers() {
+        resumeRegistrationObserverBarriersIfReady()
+        let pending = registrationObserverBarriers
+        registrationObserverBarriers.removeAll()
+        noteRegistrationObserverBarriersChanged()
+        for (_, barrier) in pending {
+            barrier.continuation.resume(
+                throwing: StagingFailureSignalError.registrationThresholdUnreachable)
+        }
+        failUnreachableRegistrationObserverBarrierWatchers()
+    }
+
+    private func noteRegistrationObserverBarriersChanged() {
+        registrationObserverBarrierCount = registrationObserverBarriers.count
+        let ready = registrationObserverBarrierWatchers.filter {
+            registrationObserverBarrierCount >= $0.value.count
+        }
+        for (id, _) in ready {
+            registrationObserverBarrierWatchers.removeValue(forKey: id)
+        }
+        for (_, watcher) in ready {
+            watcher.continuation.resume()
+        }
+    }
+
+    private func failUnreachableRegistrationObserverBarrierWatchers() {
+        let ready = registrationObserverBarrierWatchers.filter {
+            registrationObserverBarrierCount >= $0.value.count
+        }
+        let unreachable = registrationObserverBarrierWatchers.filter {
+            registrationObserverBarrierCount < $0.value.count
+        }
+        registrationObserverBarrierWatchers.removeAll()
+        for (_, watcher) in ready {
+            watcher.continuation.resume()
+        }
+        for (_, watcher) in unreachable {
+            watcher.continuation.resume(
+                throwing: StagingFailureSignalError.registrationThresholdUnreachable)
         }
     }
 
@@ -385,6 +570,19 @@ actor StagingFailureSignal {
         guard let waiter = registrationWaiters.removeValue(forKey: id) else { return }
         noteRegistrationObserversChanged()
         waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func cancelRegistrationObserverBarrier(_ id: UUID) {
+        guard let barrier = registrationObserverBarriers.removeValue(forKey: id) else { return }
+        noteRegistrationObserverBarriersChanged()
+        barrier.continuation.resume(throwing: CancellationError())
+    }
+
+    private func cancelRegistrationObserverBarrierWatcher(_ id: UUID) {
+        guard let watcher = registrationObserverBarrierWatchers.removeValue(forKey: id) else {
+            return
+        }
+        watcher.continuation.resume(throwing: CancellationError())
     }
 
     private func cancelWaiter(_ id: UUID) {

--- a/Tests/HeelerTests/WeakNetworkE2ETests.swift
+++ b/Tests/HeelerTests/WeakNetworkE2ETests.swift
@@ -146,7 +146,7 @@ struct WeakNetworkE2ETests {
         }
 
         do {
-            try await awaitPhaseEntry(
+            try await StagingPhaseWait.awaitEntry(
                 "remote staging setup",
                 gate: setupGate,
                 failures: failures)
@@ -163,7 +163,7 @@ struct WeakNetworkE2ETests {
             }
             await setupGate.release()
 
-            try await awaitPhaseEntry(
+            try await StagingPhaseWait.awaitEntry(
                 "severe-profile payload write",
                 gate: payloadReadyGate,
                 failures: failures)
@@ -175,7 +175,7 @@ struct WeakNetworkE2ETests {
             }
             await payloadReadyGate.release()
 
-            try await awaitPhaseEntry(
+            try await StagingPhaseWait.awaitEntry(
                 "severe-profile payload backpressure",
                 gate: backpressureGate,
                 failures: failures)
@@ -429,23 +429,6 @@ struct WeakNetworkE2ETests {
             bytes)
     }
 
-    private func awaitPhaseEntry(
-        _ phase: String,
-        gate: CancellablePhaseGate,
-        failures: StagingFailureSignal
-    ) async throws {
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask {
-                try await gate.waitUntilEntered()
-            }
-            group.addTask {
-                try await failures.wait(phase: phase)
-            }
-            try await group.next()
-            group.cancelAll()
-        }
-    }
-
     private func finishStaging<Success: Sendable>(
         _ staging: Task<Success, any Error>,
         gates: CancellablePhaseGate...
@@ -482,160 +465,6 @@ struct WeakNetworkE2ETests {
         var hasReconnected: Bool {
             statuses.contains { if case .reconnecting = $0 { true } else { false } }
         }
-    }
-}
-
-/// Surfaces a staging failure under the phase that was waiting, instead of
-/// letting a parallel waiter stall until an outer runner limit.
-private enum StagingBarrierError: Error, CustomStringConvertible {
-    case finishedEarly(phase: String)
-    case failed(phase: String, detail: String)
-
-    var description: String {
-        switch self {
-        case .finishedEarly(let phase):
-            "staging finished during \(phase) before the barrier armed"
-        case .failed(let phase, let detail):
-            "staging failed during \(phase): \(detail)"
-        }
-    }
-}
-
-/// Hold/observe gate whose stored continuations always resume via `release()`
-/// or task cancellation — never left pending after the waiter returns.
-private actor CancellablePhaseGate {
-    private var hasEntered = false
-    private var isReleased = false
-    private var entryWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
-    private var holdWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
-
-    func enterAndHold() async {
-        hasEntered = true
-        resumeEntryWaiters()
-        if isReleased { return }
-        let id = UUID()
-        do {
-            try await withTaskCancellationHandler {
-                try await withCheckedThrowingContinuation {
-                    (continuation: CheckedContinuation<Void, any Error>) in
-                    if self.isReleased {
-                        continuation.resume()
-                    } else {
-                        self.holdWaiters[id] = continuation
-                    }
-                }
-            } onCancel: {
-                Task { await self.resumeHoldWaiter(id, throwing: CancellationError()) }
-            }
-        } catch {
-            return
-        }
-    }
-
-    func waitUntilEntered() async throws {
-        if hasEntered { return }
-        let id = UUID()
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation {
-                (continuation: CheckedContinuation<Void, any Error>) in
-                if self.hasEntered {
-                    continuation.resume()
-                } else {
-                    self.entryWaiters[id] = continuation
-                }
-            }
-        } onCancel: {
-            Task { await self.resumeEntryWaiter(id, throwing: CancellationError()) }
-        }
-    }
-
-    func release() {
-        isReleased = true
-        resumeEntryWaiters()
-        let holds = holdWaiters
-        holdWaiters.removeAll()
-        for (_, waiter) in holds {
-            waiter.resume()
-        }
-    }
-
-    private func resumeEntryWaiters() {
-        let waiters = entryWaiters
-        entryWaiters.removeAll()
-        for (_, waiter) in waiters {
-            waiter.resume()
-        }
-    }
-
-    private func resumeEntryWaiter(_ id: UUID, throwing error: any Error) {
-        guard let waiter = entryWaiters.removeValue(forKey: id) else { return }
-        waiter.resume(throwing: error)
-    }
-
-    private func resumeHoldWaiter(_ id: UUID, throwing error: any Error) {
-        guard let waiter = holdWaiters.removeValue(forKey: id) else { return }
-        waiter.resume(throwing: error)
-    }
-}
-
-/// Staging reports failures here from its own task body so waiters do not
-/// suspend on `Task.result` after the phase has moved on.
-private actor StagingFailureSignal {
-    private var detail: String?
-    private var finishedSuccessfully = false
-    private var waiters: [UUID: (phase: String, continuation: CheckedContinuation<Void, any Error>)] =
-        [:]
-
-    func record(_ error: any Error) {
-        let detail = String(describing: error)
-        self.detail = detail
-        let captured = waiters
-        waiters.removeAll()
-        for (_, waiter) in captured {
-            waiter.continuation.resume(
-                throwing: StagingBarrierError.failed(phase: waiter.phase, detail: detail))
-        }
-    }
-
-    func recordSuccess() {
-        finishedSuccessfully = true
-        let captured = waiters
-        waiters.removeAll()
-        for (_, waiter) in captured {
-            waiter.continuation.resume(
-                throwing: StagingBarrierError.finishedEarly(phase: waiter.phase))
-        }
-    }
-
-    func wait(phase: String) async throws {
-        if let detail {
-            throw StagingBarrierError.failed(phase: phase, detail: detail)
-        }
-        if finishedSuccessfully {
-            throw StagingBarrierError.finishedEarly(phase: phase)
-        }
-        let id = UUID()
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation {
-                (continuation: CheckedContinuation<Void, any Error>) in
-                if let detail {
-                    continuation.resume(
-                        throwing: StagingBarrierError.failed(phase: phase, detail: detail))
-                } else if finishedSuccessfully {
-                    continuation.resume(
-                        throwing: StagingBarrierError.finishedEarly(phase: phase))
-                } else {
-                    waiters[id] = (phase, continuation)
-                }
-            }
-        } onCancel: {
-            Task { await self.cancelWaiter(id) }
-        }
-    }
-
-    private func cancelWaiter(_ id: UUID) {
-        guard let waiter = waiters.removeValue(forKey: id) else { return }
-        waiter.continuation.resume(throwing: CancellationError())
     }
 }
 

--- a/Tests/HeelerTests/WeakNetworkE2ETests.swift
+++ b/Tests/HeelerTests/WeakNetworkE2ETests.swift
@@ -107,59 +107,97 @@ struct WeakNetworkE2ETests {
         try await fixture.control.reset()
         // Connection and remote staging-directory setup stay on the degraded
         // profile. Applying `.severe` before that races the setup exec against
-        // the same ~15 s budget the progress waiter used to share, and a loaded
-        // runner fails with `.remoteTemporaryDirectoryFailed` before the
-        // cancellation-under-backpressure behaviour is exercised.
+        // the product's request deadline, and a loaded runner fails with
+        // `.remoteTemporaryDirectoryFailed` before cancellation-under-backpressure
+        // is exercised.
         try await fixture.control.apply(.degraded)
 
         let prepared = try makePreparedImage(byteCount: 1_024 * 1_024)
         defer { try? FileManager.default.removeItem(at: prepared.image.fileURL) }
         let transport = try await HeelerSSHTransport.connect(settings: fixture.settings())
 
-        // Zero-byte progress is the setup→payload barrier in the production
-        // staging path. Parking there lets this test arm `.severe` before any
-        // SFTP write without a sleep, a polled waiter, or a bypass of `stageImage`.
-        let setupBarrier = ScriptedTransportCallGate()
-        // Pre-opened: first transferred chunk only signals entry, it must not
-        // hold the upload (cancel has to land on genuine link backpressure).
-        let payloadSignal = ScriptedTransportCallGate()
-        await payloadSignal.open()
+        let setupGate = CancellablePhaseGate()
+        let payloadReadyGate = CancellablePhaseGate()
+        let backpressureGate = CancellablePhaseGate()
+        let failures = StagingFailureSignal()
+
+        await transport.holdStagingPhaseForTesting(.remoteParentReady) {
+            await setupGate.enterAndHold()
+        }
+        await transport.holdStagingPhaseForTesting(.payloadWriteReady) {
+            await payloadReadyGate.enterAndHold()
+        }
 
         let staging = Task {
-            try await transport.stageImage(prepared.image) { value in
-                if value.transferredBytes == 0 {
-                    await setupBarrier.waitUntilOpen()
-                } else {
-                    await payloadSignal.waitUntilOpen()
-                }
+            do {
+                let staged = try await transport.stageImage(prepared.image) { _ in }
+                await failures.recordSuccess()
+                await setupGate.release()
+                await payloadReadyGate.release()
+                await backpressureGate.release()
+                return staged
+            } catch {
+                await failures.record(error)
+                await setupGate.release()
+                await payloadReadyGate.release()
+                await backpressureGate.release()
+                throw error
             }
         }
 
-        try await awaitStagingPhase(
-            "remote staging setup",
-            gate: setupBarrier,
-            racing: staging)
+        do {
+            try await awaitPhaseEntry(
+                "remote staging setup",
+                gate: setupGate,
+                failures: failures)
 
-        // Arm the cancellation-under-backpressure portion only after setup.
-        try await fixture.control.apply(.severe)
-        await setupBarrier.open()
+            do {
+                try await fixture.control.apply(.severe)
+            } catch {
+                await finishStaging(
+                    staging,
+                    gates: setupGate, payloadReadyGate, backpressureGate)
+                throw StagingBarrierError.failed(
+                    phase: "arming severe profile",
+                    detail: String(describing: error))
+            }
+            await setupGate.release()
 
-        try await awaitStagingPhase(
-            "severe-profile payload backpressure",
-            gate: payloadSignal,
-            racing: staging)
+            try await awaitPhaseEntry(
+                "severe-profile payload write",
+                gate: payloadReadyGate,
+                failures: failures)
 
-        // Cancellation itself is honoured promptly even while the write is
-        // blocked on the link, and "promptly" is asserted rather than asserted
-        // in prose: the compensation path spends at most its two two-second
-        // SFTP closes, so anything approaching ten seconds means the cancel is
-        // waiting on the link instead of abandoning it.
-        let cancelledAt = ContinuousClock.now
-        staging.cancel()
-        await #expect(throws: AttachmentStagingError.cancelled) {
-            _ = try await staging.value
+            // Arm the park observer only once payload writes are about to
+            // start, so an earlier openSFTP/mkdir park cannot satisfy it.
+            await transport.holdNextOutboundWriteParkForTesting {
+                await backpressureGate.enterAndHold()
+            }
+            await payloadReadyGate.release()
+
+            try await awaitPhaseEntry(
+                "severe-profile payload backpressure",
+                gate: backpressureGate,
+                failures: failures)
+
+            // Cancellation itself is honoured promptly even while the write is
+            // blocked on the link, and "promptly" is asserted rather than asserted
+            // in prose: the compensation path spends at most its two two-second
+            // SFTP closes, so anything approaching ten seconds means the cancel is
+            // waiting on the link instead of abandoning it.
+            let cancelledAt = ContinuousClock.now
+            staging.cancel()
+            await backpressureGate.release()
+            await #expect(throws: AttachmentStagingError.cancelled) {
+                _ = try await staging.value
+            }
+            #expect(cancelledAt.duration(to: .now) < .seconds(10))
+        } catch {
+            await finishStaging(
+                staging,
+                gates: setupGate, payloadReadyGate, backpressureGate)
+            throw error
         }
-        #expect(cancelledAt.duration(to: .now) < .seconds(10))
 
         try await fixture.control.apply(.degraded)
         // The reuse property is what a cancelled upload owes the rest of the
@@ -391,45 +429,32 @@ struct WeakNetworkE2ETests {
             bytes)
     }
 
-    private func awaitStagingPhase<Success: Sendable>(
+    private func awaitPhaseEntry(
         _ phase: String,
-        gate: ScriptedTransportCallGate,
-        racing staging: Task<Success, any Error>
+        gate: CancellablePhaseGate,
+        failures: StagingFailureSignal
     ) async throws {
-        let probe = StagingPhaseProbe(phase: phase)
-        // Unstructured on purpose: awaiting `staging.result` inside the task
-        // group would keep the group alive until staging finishes, and
-        // `staging.value` would cancel the upload when the group tears down.
-        let observer = Task {
-            switch await staging.result {
-            case .success:
-                await probe.reportFinishedEarly()
-            case .failure(let error):
-                await probe.reportFailure(error)
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await gate.waitUntilEntered()
             }
+            group.addTask {
+                try await failures.wait(phase: phase)
+            }
+            try await group.next()
+            group.cancelAll()
         }
-        defer { observer.cancel() }
+    }
 
-        do {
-            try await withThrowingTaskGroup(of: Void.self) { group in
-                group.addTask {
-                    await gate.waitForEntry()
-                }
-                group.addTask {
-                    try await probe.wait()
-                }
-                // Barrier entry wins with a bare return; a staging failure
-                // rethrows from `probe.wait`. Resume the probe waiter before
-                // cancelling the group so a cancelled-but-suspended
-                // continuation cannot deadlock group teardown.
-                try await group.next()
-                await probe.abandon()
-                group.cancelAll()
-            }
-        } catch {
-            await probe.abandon()
-            throw error
+    private func finishStaging<Success: Sendable>(
+        _ staging: Task<Success, any Error>,
+        gates: CancellablePhaseGate...
+    ) async {
+        for gate in gates {
+            await gate.release()
         }
+        staging.cancel()
+        _ = await staging.result
     }
 
     private func waitUntil(
@@ -461,7 +486,7 @@ struct WeakNetworkE2ETests {
 }
 
 /// Surfaces a staging failure under the phase that was waiting, instead of
-/// letting a parallel progress waiter time out and misreport the cause.
+/// letting a parallel waiter stall until an outer runner limit.
 private enum StagingBarrierError: Error, CustomStringConvertible {
     case finishedEarly(phase: String)
     case failed(phase: String, detail: String)
@@ -476,51 +501,141 @@ private enum StagingBarrierError: Error, CustomStringConvertible {
     }
 }
 
-/// One-shot race partner for `awaitStagingPhase`: either the production barrier
-/// fires, or staging fails first and the failure is named by phase.
-private actor StagingPhaseProbe {
-    private let phase: String
-    private var outcome: StagingBarrierError?
-    private var abandoned = false
-    private var waiter: CheckedContinuation<Void, any Error>?
+/// Hold/observe gate whose stored continuations always resume via `release()`
+/// or task cancellation — never left pending after the waiter returns.
+private actor CancellablePhaseGate {
+    private var hasEntered = false
+    private var isReleased = false
+    private var entryWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
+    private var holdWaiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
 
-    init(phase: String) {
-        self.phase = phase
-    }
-
-    func reportFinishedEarly() {
-        deliver(.finishedEarly(phase: phase))
-    }
-
-    func reportFailure(_ error: any Error) {
-        deliver(.failed(phase: phase, detail: String(describing: error)))
-    }
-
-    func wait() async throws {
-        if abandoned { return }
-        if let outcome {
-            throw outcome
-        }
-        try await withCheckedThrowingContinuation { continuation in
-            waiter = continuation
-        }
-        if abandoned { return }
-        if let outcome {
-            throw outcome
+    func enterAndHold() async {
+        hasEntered = true
+        resumeEntryWaiters()
+        if isReleased { return }
+        let id = UUID()
+        do {
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation {
+                    (continuation: CheckedContinuation<Void, any Error>) in
+                    if self.isReleased {
+                        continuation.resume()
+                    } else {
+                        self.holdWaiters[id] = continuation
+                    }
+                }
+            } onCancel: {
+                Task { await self.resumeHoldWaiter(id, throwing: CancellationError()) }
+            }
+        } catch {
+            return
         }
     }
 
-    func abandon() {
-        abandoned = true
-        waiter?.resume()
-        waiter = nil
+    func waitUntilEntered() async throws {
+        if hasEntered { return }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                if self.hasEntered {
+                    continuation.resume()
+                } else {
+                    self.entryWaiters[id] = continuation
+                }
+            }
+        } onCancel: {
+            Task { await self.resumeEntryWaiter(id, throwing: CancellationError()) }
+        }
     }
 
-    private func deliver(_ error: StagingBarrierError) {
-        guard !abandoned else { return }
-        outcome = error
-        waiter?.resume(throwing: error)
-        waiter = nil
+    func release() {
+        isReleased = true
+        resumeEntryWaiters()
+        let holds = holdWaiters
+        holdWaiters.removeAll()
+        for (_, waiter) in holds {
+            waiter.resume()
+        }
+    }
+
+    private func resumeEntryWaiters() {
+        let waiters = entryWaiters
+        entryWaiters.removeAll()
+        for (_, waiter) in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func resumeEntryWaiter(_ id: UUID, throwing error: any Error) {
+        guard let waiter = entryWaiters.removeValue(forKey: id) else { return }
+        waiter.resume(throwing: error)
+    }
+
+    private func resumeHoldWaiter(_ id: UUID, throwing error: any Error) {
+        guard let waiter = holdWaiters.removeValue(forKey: id) else { return }
+        waiter.resume(throwing: error)
+    }
+}
+
+/// Staging reports failures here from its own task body so waiters do not
+/// suspend on `Task.result` after the phase has moved on.
+private actor StagingFailureSignal {
+    private var detail: String?
+    private var finishedSuccessfully = false
+    private var waiters: [UUID: (phase: String, continuation: CheckedContinuation<Void, any Error>)] =
+        [:]
+
+    func record(_ error: any Error) {
+        let detail = String(describing: error)
+        self.detail = detail
+        let captured = waiters
+        waiters.removeAll()
+        for (_, waiter) in captured {
+            waiter.continuation.resume(
+                throwing: StagingBarrierError.failed(phase: waiter.phase, detail: detail))
+        }
+    }
+
+    func recordSuccess() {
+        finishedSuccessfully = true
+        let captured = waiters
+        waiters.removeAll()
+        for (_, waiter) in captured {
+            waiter.continuation.resume(
+                throwing: StagingBarrierError.finishedEarly(phase: waiter.phase))
+        }
+    }
+
+    func wait(phase: String) async throws {
+        if let detail {
+            throw StagingBarrierError.failed(phase: phase, detail: detail)
+        }
+        if finishedSuccessfully {
+            throw StagingBarrierError.finishedEarly(phase: phase)
+        }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, any Error>) in
+                if let detail {
+                    continuation.resume(
+                        throwing: StagingBarrierError.failed(phase: phase, detail: detail))
+                } else if finishedSuccessfully {
+                    continuation.resume(
+                        throwing: StagingBarrierError.finishedEarly(phase: phase))
+                } else {
+                    waiters[id] = (phase, continuation)
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id) }
+        }
+    }
+
+    private func cancelWaiter(_ id: UUID) {
+        guard let waiter = waiters.removeValue(forKey: id) else { return }
+        waiter.continuation.resume(throwing: CancellationError())
     }
 }
 

--- a/Tests/HeelerTests/WeakNetworkE2ETests.swift
+++ b/Tests/HeelerTests/WeakNetworkE2ETests.swift
@@ -105,22 +105,50 @@ struct WeakNetworkE2ETests {
     func cancellationUnderBackpressureKeepsTheConnectionUsable() async throws {
         let fixture = try #require(WeakNetworkFixture.current)
         try await fixture.control.reset()
-        try await fixture.control.apply(.severe)
+        // Connection and remote staging-directory setup stay on the degraded
+        // profile. Applying `.severe` before that races the setup exec against
+        // the same ~15 s budget the progress waiter used to share, and a loaded
+        // runner fails with `.remoteTemporaryDirectoryFailed` before the
+        // cancellation-under-backpressure behaviour is exercised.
+        try await fixture.control.apply(.degraded)
 
         let prepared = try makePreparedImage(byteCount: 1_024 * 1_024)
         defer { try? FileManager.default.removeItem(at: prepared.image.fileURL) }
         let transport = try await HeelerSSHTransport.connect(settings: fixture.settings())
-        let progressed = ProgressGate()
+
+        // Zero-byte progress is the setup→payload barrier in the production
+        // staging path. Parking there lets this test arm `.severe` before any
+        // SFTP write without a sleep, a polled waiter, or a bypass of `stageImage`.
+        let setupBarrier = ScriptedTransportCallGate()
+        // Pre-opened: first transferred chunk only signals entry, it must not
+        // hold the upload (cancel has to land on genuine link backpressure).
+        let payloadSignal = ScriptedTransportCallGate()
+        await payloadSignal.open()
+
         let staging = Task {
             try await transport.stageImage(prepared.image) { value in
-                if value.transferredBytes > 0 { await progressed.record() }
+                if value.transferredBytes == 0 {
+                    await setupBarrier.waitUntilOpen()
+                } else {
+                    await payloadSignal.waitUntilOpen()
+                }
             }
         }
-        // Cancel while the upload is genuinely blocked on link backpressure,
-        // not before it has written anything.
-        try await waitUntil("the upload should report a transferred chunk") {
-            await progressed.count > 0
-        }
+
+        try await awaitStagingPhase(
+            "remote staging setup",
+            gate: setupBarrier,
+            racing: staging)
+
+        // Arm the cancellation-under-backpressure portion only after setup.
+        try await fixture.control.apply(.severe)
+        await setupBarrier.open()
+
+        try await awaitStagingPhase(
+            "severe-profile payload backpressure",
+            gate: payloadSignal,
+            racing: staging)
+
         // Cancellation itself is honoured promptly even while the write is
         // blocked on the link, and "promptly" is asserted rather than asserted
         // in prose: the compensation path spends at most its two two-second
@@ -363,6 +391,47 @@ struct WeakNetworkE2ETests {
             bytes)
     }
 
+    private func awaitStagingPhase<Success: Sendable>(
+        _ phase: String,
+        gate: ScriptedTransportCallGate,
+        racing staging: Task<Success, any Error>
+    ) async throws {
+        let probe = StagingPhaseProbe(phase: phase)
+        // Unstructured on purpose: awaiting `staging.result` inside the task
+        // group would keep the group alive until staging finishes, and
+        // `staging.value` would cancel the upload when the group tears down.
+        let observer = Task {
+            switch await staging.result {
+            case .success:
+                await probe.reportFinishedEarly()
+            case .failure(let error):
+                await probe.reportFailure(error)
+            }
+        }
+        defer { observer.cancel() }
+
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    await gate.waitForEntry()
+                }
+                group.addTask {
+                    try await probe.wait()
+                }
+                // Barrier entry wins with a bare return; a staging failure
+                // rethrows from `probe.wait`. Resume the probe waiter before
+                // cancelling the group so a cancelled-but-suspended
+                // continuation cannot deadlock group teardown.
+                try await group.next()
+                await probe.abandon()
+                group.cancelAll()
+            }
+        } catch {
+            await probe.abandon()
+            throw error
+        }
+    }
+
     private func waitUntil(
         _ comment: Comment,
         timeout: Duration = .seconds(15),
@@ -374,12 +443,6 @@ struct WeakNetworkE2ETests {
             try await Task.sleep(for: .milliseconds(20))
         }
         #expect(await condition(), comment)
-    }
-
-    private actor ProgressGate {
-        private(set) var count = 0
-
-        func record() { count += 1 }
     }
 
     private actor StatusRecorder {
@@ -394,6 +457,70 @@ struct WeakNetworkE2ETests {
         var hasReconnected: Bool {
             statuses.contains { if case .reconnecting = $0 { true } else { false } }
         }
+    }
+}
+
+/// Surfaces a staging failure under the phase that was waiting, instead of
+/// letting a parallel progress waiter time out and misreport the cause.
+private enum StagingBarrierError: Error, CustomStringConvertible {
+    case finishedEarly(phase: String)
+    case failed(phase: String, detail: String)
+
+    var description: String {
+        switch self {
+        case .finishedEarly(let phase):
+            "staging finished during \(phase) before the barrier armed"
+        case .failed(let phase, let detail):
+            "staging failed during \(phase): \(detail)"
+        }
+    }
+}
+
+/// One-shot race partner for `awaitStagingPhase`: either the production barrier
+/// fires, or staging fails first and the failure is named by phase.
+private actor StagingPhaseProbe {
+    private let phase: String
+    private var outcome: StagingBarrierError?
+    private var abandoned = false
+    private var waiter: CheckedContinuation<Void, any Error>?
+
+    init(phase: String) {
+        self.phase = phase
+    }
+
+    func reportFinishedEarly() {
+        deliver(.finishedEarly(phase: phase))
+    }
+
+    func reportFailure(_ error: any Error) {
+        deliver(.failed(phase: phase, detail: String(describing: error)))
+    }
+
+    func wait() async throws {
+        if abandoned { return }
+        if let outcome {
+            throw outcome
+        }
+        try await withCheckedThrowingContinuation { continuation in
+            waiter = continuation
+        }
+        if abandoned { return }
+        if let outcome {
+            throw outcome
+        }
+    }
+
+    func abandon() {
+        abandoned = true
+        waiter?.resume()
+        waiter = nil
+    }
+
+    private func deliver(_ error: StagingBarrierError) {
+        guard !abandoned else { return }
+        outcome = error
+        waiter?.resume(throwing: error)
+        waiter = nil
     }
 }
 

--- a/project.yml
+++ b/project.yml
@@ -19,11 +19,12 @@ packages:
   # checked-in native artifacts. The one SSH backend (ADR 0011).
   HeelerSSH:
     path: Packages/HeelerSSH
-  # Pinned because this package embeds a prebuilt libghostty XCFramework and
-  # libghostty's public API is still evolving independently from Ghostty.
+  # Pin the reviewed 1.4.0 source commit because upstream removed its release
+  # tag. This keeps the same prebuilt libghostty checksum without taking the
+  # much larger, unaudited 1.5.1 source and binary update.
   GhosttyTerminal:
     url: https://github.com/lakr233/libghostty-spm.git
-    exactVersion: "1.4.0"
+    revision: "356f730bec03281fc7b83666a129b0246137ea26"
 
 targets:
   Heeler:

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -1910,7 +1910,7 @@ clear_simulator_environment
 
 if grep -q 'Suite "Session driver resource e2e" skipped' "$package_e2e_log" \
     || grep -q 'skipped:' "$package_e2e_log" \
-    || ! grep -q 'Test run with 45 tests in 2 suites passed' "$package_e2e_log" \
+    || ! grep -q 'Test run with 48 tests in 3 suites passed' "$package_e2e_log" \
     || ! grep -q \
         'Test "handshake negotiates post-quantum key exchange" passed' \
         "$package_e2e_log" \
@@ -2001,7 +2001,7 @@ if grep -q 'Suite "Session driver resource e2e" skipped' "$package_e2e_log" \
     || ! grep -q \
         'Test "a bridge write to a closed peer reports peerClosed" passed' \
         "$package_e2e_log"; then
-    echo "The mandatory HeelerSSH package suites did not execute all forty-five tests" >&2
+    echo "The mandatory HeelerSSH package suites did not execute all forty-eight tests" >&2
     exit 1
 fi
 exit 0

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -79,6 +79,10 @@ lock_owner_start="$(ps -o lstart= -p "$$" | sed 's/^ *//; s/ *$//')"
 fixture_dir="$(mktemp -d /tmp/heeler-ci.XXXXXX)"
 app_derived_data_path="$fixture_dir/AppDerivedData"
 package_derived_data_path="$fixture_dir/PackageDerivedData"
+# Stable SourcePackages tree for the app lane. Hosted CI restores this via
+# actions/cache so libghostty's XCFramework is not re-fetched every run.
+# Package-lane builds have no remote SwiftPM deps and leave this unused.
+source_packages_dir="${HEELER_CI_SOURCE_PACKAGES_DIR:-$repo_root/.ci/source-packages}"
 diagnostic_run_id="${GITHUB_RUN_ID:-local-$$}"
 diagnostic_attempt="${GITHUB_RUN_ATTEMPT:-1}"
 diagnostic_root="${RUNNER_TEMP:-/tmp}/heeler-ci-diagnostics-$diagnostic_run_id-$diagnostic_attempt"
@@ -142,6 +146,13 @@ run_xcodebuild() {
         shift
         set -- "$action" -disableAutomaticPackageResolution "$@"
         echo "==> $label: skipping automatic package resolution"
+    fi
+    # Keep remote checkouts outside the disposable DerivedData path so a
+    # restored CI cache survives fixture cleanup. Local path packages such as
+    # HeelerSSH are unaffected.
+    if [[ "$ci_lane" == "app" ]]; then
+        mkdir -p "$source_packages_dir"
+        set -- "$@" -clonedSourcePackagesDirPath "$source_packages_dir"
     fi
     if "$repo_root/scripts/run-with-timeout.py" \
         --timeout-seconds "$timeout_seconds" \
@@ -893,6 +904,106 @@ claim_port_block
 printf 'Claimed fixture port block %s-%s\n' \
     "$modern_port" "$((modern_port + port_block_size - 1))" >&2
 
+# Claim the simulator before fixture keygen/sshd work so boot overlaps that
+# setup as well as build-for-testing. Ports alone are not enough for two runs
+# to coexist: the fixture reaches the tests through `simctl launchctl setenv`,
+# which is per-device state. Two runs sharing one device overwrite each other's
+# HEELER_SSH_E2E_* and one of them tests the other's fixture -- silently,
+# unlike a port clash.
+#
+# Candidates come back last-first, preserving the previous choice of the last
+# matching device for a run that finds the machine idle.
+simulator_candidates=()
+while IFS= read -r candidate; do
+    [[ -n "$candidate" ]] && simulator_candidates+=("$candidate")
+done < <(xcrun simctl list devices available | awk '
+    /iPhone 17 \(/ {
+        candidate = ""
+        for (field = 1; field <= NF; field += 1) {
+            value = $field
+            gsub(/[()]/, "", value)
+            if (value ~ /^[0-9A-F-]{36}$/) {
+                candidate = value
+            }
+        }
+        if (candidate != "") {
+            list[++count] = candidate
+        }
+    }
+    END { for (index_ = count; index_ >= 1; index_ -= 1) print list[index_] }
+')
+if [[ "${#simulator_candidates[@]}" -eq 0 ]]; then
+    echo "No available iPhone 17 Simulator was found" >&2
+    exit 1
+fi
+
+# Reports the live pid holding this device, nothing if it is free.
+simulator_held_by() {
+    local udid=$1
+    local owner
+
+    owner=$(cat "$lock_root/device-$udid/pid" 2>/dev/null)
+    if [[ -n "$owner" ]] && kill -0 "$owner" 2>/dev/null; then
+        printf '%s' "$owner"
+        return 0
+    fi
+    return 1
+}
+
+# The device uses the same token-checked resource claim as a port block. A
+# separate device claim is necessary because its launchctl environment is
+# shared even when the fixture ports are not.
+claim_simulator() {
+    local udid=$1
+    local lock="$lock_root/device-$udid"
+
+    if claim_resource_lock "$lock" "simulator $udid"; then
+        device_lock_dir="$lock"
+        return 0
+    fi
+    return 1
+}
+
+requested_simulator_udid="${HEELER_CI_SIMULATOR_UDID:-}"
+simulator_udid=""
+if [[ -n "$requested_simulator_udid" ]]; then
+    if claim_simulator "$requested_simulator_udid"; then
+        simulator_udid="$requested_simulator_udid"
+    else
+        printf 'Requested simulator %s is claimed by live run pid %s.\n' \
+            "$requested_simulator_udid" \
+            "$(simulator_held_by "$requested_simulator_udid" || printf 'unknown')" >&2
+        echo "Choose a different HEELER_CI_SIMULATOR_UDID or wait for that run." >&2
+        exit 1
+    fi
+else
+    for candidate in "${simulator_candidates[@]}"; do
+        if claim_simulator "$candidate"; then
+            simulator_udid="$candidate"
+            break
+        fi
+    done
+fi
+if [[ -z "$simulator_udid" ]]; then
+    echo "Every available iPhone 17 Simulator is claimed by a live run." >&2
+    for candidate in "${simulator_candidates[@]}"; do
+        printf '  %s: held by pid %s\n' \
+            "$candidate" "$(simulator_held_by "$candidate")" >&2
+    done
+    echo >&2
+    echo "A run needs a device of its own: the fixture is delivered through" >&2
+    echo "per-device launchctl environment, which two runs would overwrite." >&2
+    echo "Create another iPhone 17 with 'xcrun simctl create', or pin one" >&2
+    echo "explicitly with HEELER_CI_SIMULATOR_UDID=<udid>." >&2
+    exit 1
+fi
+printf 'Claimed simulator %s\n' "$simulator_udid" >&2
+simulator_destination="platform=iOS Simulator,id=$simulator_udid"
+# Kick the boot off now and wait for it only after build-for-testing below:
+# compilation needs the destination to exist, not to be booted, so boot
+# happens under fixture provisioning and build instead of in front of them.
+xcrun simctl boot "$simulator_udid" >/dev/null 2>&1 || true
+
 sftp_server=""
 for candidate in /usr/libexec/sftp-server /usr/lib/openssh/sftp-server; do
     if [[ -x "$candidate" ]]; then
@@ -1430,104 +1541,6 @@ if [[ "$ci_lane" == "app" ]]; then
     pairing_fixture_configuration_base64=$(printf \
         '%s' "$pairing_fixture_configuration" | base64)
 fi
-# A disjoint port block is necessary for two runs to coexist but not
-# sufficient: the fixture reaches the tests through `simctl launchctl setenv`,
-# which is per-device state. Two runs sharing one device overwrite each other's
-# HEELER_SSH_E2E_* and one of them tests the other's fixture -- silently, unlike
-# a port clash. So the device is claimed alongside the block.
-#
-# Candidates come back last-first, preserving the previous choice of the last
-# matching device for a run that finds the machine idle.
-simulator_candidates=()
-while IFS= read -r candidate; do
-    [[ -n "$candidate" ]] && simulator_candidates+=("$candidate")
-done < <(xcrun simctl list devices available | awk '
-    /iPhone 17 \(/ {
-        candidate = ""
-        for (field = 1; field <= NF; field += 1) {
-            value = $field
-            gsub(/[()]/, "", value)
-            if (value ~ /^[0-9A-F-]{36}$/) {
-                candidate = value
-            }
-        }
-        if (candidate != "") {
-            list[++count] = candidate
-        }
-    }
-    END { for (index_ = count; index_ >= 1; index_ -= 1) print list[index_] }
-')
-if [[ "${#simulator_candidates[@]}" -eq 0 ]]; then
-    echo "No available iPhone 17 Simulator was found" >&2
-    exit 1
-fi
-
-# Reports the live pid holding this device, nothing if it is free.
-simulator_held_by() {
-    local udid=$1
-    local owner
-
-    owner=$(cat "$lock_root/device-$udid/pid" 2>/dev/null)
-    if [[ -n "$owner" ]] && kill -0 "$owner" 2>/dev/null; then
-        printf '%s' "$owner"
-        return 0
-    fi
-    return 1
-}
-
-# The device uses the same token-checked resource claim as a port block. A
-# separate device claim is necessary because its launchctl environment is
-# shared even when the fixture ports are not.
-claim_simulator() {
-    local udid=$1
-    local lock="$lock_root/device-$udid"
-
-    if claim_resource_lock "$lock" "simulator $udid"; then
-        device_lock_dir="$lock"
-        return 0
-    fi
-    return 1
-}
-
-requested_simulator_udid="${HEELER_CI_SIMULATOR_UDID:-}"
-simulator_udid=""
-if [[ -n "$requested_simulator_udid" ]]; then
-    if claim_simulator "$requested_simulator_udid"; then
-        simulator_udid="$requested_simulator_udid"
-    else
-        printf 'Requested simulator %s is claimed by live run pid %s.\n' \
-            "$requested_simulator_udid" \
-            "$(simulator_held_by "$requested_simulator_udid" || printf 'unknown')" >&2
-        echo "Choose a different HEELER_CI_SIMULATOR_UDID or wait for that run." >&2
-        exit 1
-    fi
-else
-    for candidate in "${simulator_candidates[@]}"; do
-        if claim_simulator "$candidate"; then
-            simulator_udid="$candidate"
-            break
-        fi
-    done
-fi
-if [[ -z "$simulator_udid" ]]; then
-    echo "Every available iPhone 17 Simulator is claimed by a live run." >&2
-    for candidate in "${simulator_candidates[@]}"; do
-        printf '  %s: held by pid %s\n' \
-            "$candidate" "$(simulator_held_by "$candidate")" >&2
-    done
-    echo >&2
-    echo "A run needs a device of its own: the fixture is delivered through" >&2
-    echo "per-device launchctl environment, which two runs would overwrite." >&2
-    echo "Create another iPhone 17 with 'xcrun simctl create', or pin one" >&2
-    echo "explicitly with HEELER_CI_SIMULATOR_UDID=<udid>." >&2
-    exit 1
-fi
-printf 'Claimed simulator %s\n' "$simulator_udid" >&2
-simulator_destination="platform=iOS Simulator,id=$simulator_udid"
-# Kick the boot off now and wait for it only after build-for-testing below:
-# compilation needs the destination to exist, not to be booted, so the minute
-# of boot happens under the minutes of build instead of in front of them.
-xcrun simctl boot "$simulator_udid" >/dev/null 2>&1 || true
 
 # Every lane whose executed count and skip budget this script pins exactly. The
 # full lane's provenance assertion draws its evidence from these, so a lane that

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -1910,7 +1910,10 @@ clear_simulator_environment
 
 if grep -q 'Suite "Session driver resource e2e" skipped' "$package_e2e_log" \
     || grep -q 'skipped:' "$package_e2e_log" \
-    || ! grep -q 'Test run with 48 tests in 3 suites passed' "$package_e2e_log" \
+    || ! grep -q 'Test run with 49 tests in 3 suites passed' "$package_e2e_log" \
+    || ! grep -q \
+        'Test "post-negotiation transport loss is not an algorithm mismatch" passed' \
+        "$package_e2e_log" \
     || ! grep -q \
         'Test "handshake negotiates post-quantum key exchange" passed' \
         "$package_e2e_log" \
@@ -2001,7 +2004,7 @@ if grep -q 'Suite "Session driver resource e2e" skipped' "$package_e2e_log" \
     || ! grep -q \
         'Test "a bridge write to a closed peer reports peerClosed" passed' \
         "$package_e2e_log"; then
-    echo "The mandatory HeelerSSH package suites did not execute all forty-eight tests" >&2
+    echo "The mandatory HeelerSSH package suites did not execute all forty-nine tests" >&2
     exit 1
 fi
 exit 0

--- a/scripts/run-ci-ios-tests.sh
+++ b/scripts/run-ci-ios-tests.sh
@@ -129,10 +129,20 @@ run_xcodebuild() {
     local safe_label
     local status
     local started_at=$SECONDS
+    local action
     shift 2
 
     safe_label=$(printf '%s' "$label" | tr -cs 'A-Za-z0-9._-' '-')
     echo "::group::$label"
+    # build-for-testing already resolved packages. Repeating that on
+    # test-without-building is the half-minute of redundant work this flag
+    # removes; it does not skip plugin validation or change the resolved pin.
+    if [[ "${1:-}" == "test-without-building" ]]; then
+        action=$1
+        shift
+        set -- "$action" -disableAutomaticPackageResolution "$@"
+        echo "==> $label: skipping automatic package resolution"
+    fi
     if "$repo_root/scripts/run-with-timeout.py" \
         --timeout-seconds "$timeout_seconds" \
         --label "$label" \
@@ -263,6 +273,70 @@ release_resource_lock() {
     release_claim_guard "$active_claim_guard"
 }
 
+# Last 80 lines of each fixture log. Enough to see an sshd refusal or proxy
+# stall without dumping private keys or a multi-megabyte xcodebuild capture.
+fixture_log_tail_lines=80
+
+dump_fixture_logs() {
+    local log
+    local name
+    [[ -d "$fixture_dir" ]] || return 0
+    # Lane xcodebuild logs already stream through tee into the job. Print
+    # only the fixture process logs that otherwise die with the temp dir.
+    for log in "$fixture_dir"/*.log; do
+        [[ -s "$log" ]] || continue
+        name=$(basename "$log")
+        case "$name" in
+            sshd-*.log | weak-network.log | fake-herdr.log) ;;
+            *) continue ;;
+        esac
+        echo "===== $log (last $fixture_log_tail_lines lines)" >&2
+        tail -n "$fixture_log_tail_lines" "$log" >&2
+    done
+}
+
+# Copy lane logs, sshd logs, the weak-network proxy log, and xcresult
+# bundles out of the disposable fixture directory before cleanup deletes it.
+# Print the same log tails to the job so a later artifact-upload failure
+# still leaves a bounded diagnosis. Never copies key material.
+preserve_failure_diagnostics() {
+    local status=$1
+    local dest
+    local log
+
+    [[ "$status" -ne 0 ]] || return 0
+
+    if [[ -n "${diagnostic_root:-}" ]]; then
+        dest="$diagnostic_root/fixture"
+        mkdir -p "$dest/logs"
+        printf '%s\n' "$status" > "$dest/exit-status.txt"
+        if [[ -d "$fixture_dir" ]]; then
+            for log in "$fixture_dir"/*.log; do
+                [[ -f "$log" ]] || continue
+                cp "$log" "$dest/logs/" 2>/dev/null \
+                    || echo "could not preserve $log" >&2
+            done
+        fi
+        if [[ -n "${app_derived_data_path:-}" \
+            && -d "$app_derived_data_path/Logs/Test" ]]; then
+            mkdir -p "$dest/AppDerivedData-Logs-Test"
+            cp -R "$app_derived_data_path/Logs/Test/." \
+                "$dest/AppDerivedData-Logs-Test/" 2>/dev/null \
+                || echo "could not preserve app test logs" >&2
+        fi
+        if [[ -n "${package_derived_data_path:-}" \
+            && -d "$package_derived_data_path/Logs/Test" ]]; then
+            mkdir -p "$dest/PackageDerivedData-Logs-Test"
+            cp -R "$package_derived_data_path/Logs/Test/." \
+                "$dest/PackageDerivedData-Logs-Test/" 2>/dev/null \
+                || echo "could not preserve package test logs" >&2
+        fi
+        echo "==> Preserved failure diagnostics in $dest (status $status)" >&2
+    fi
+
+    dump_fixture_logs
+}
+
 cleanup() {
     local status=$?
     local preserve_password_fixture=0
@@ -330,6 +404,7 @@ cleanup() {
             fi
         fi
     fi
+    preserve_failure_diagnostics "$status"
     if [[ "$preserve_password_fixture" != "1" && -d "$fixture_dir" ]]; then
         rm -rf -- "$fixture_dir"
     fi
@@ -1257,15 +1332,6 @@ fixture_is_listening() {
     return 0
 }
 
-dump_fixture_logs() {
-    local log
-    for log in "$fixture_dir"/*.log; do
-        [[ -f "$log" ]] || continue
-        echo "===== $log" >&2
-        cat "$log" >&2
-    done
-}
-
 for attempt in $(seq 1 50); do
     if fixture_is_listening; then
         break
@@ -1796,8 +1862,6 @@ assert_behavior "weak-network descriptor reclamation" WeakNetworkE2ETests \
 assert_behavior "disconnect is reported" WeakNetworkE2ETests \
     '"a severed link makes the transport report itself disconnected"'
 
-else
-    xcrun simctl bootstatus "$simulator_udid" -b
 fi
 
 if [[ "$ci_lane" == "app" ]]; then
@@ -1805,6 +1869,21 @@ if [[ "$ci_lane" == "app" ]]; then
 fi
 
 if [[ "$ci_lane" == "package" ]]; then
+# Same overlap as the app lane: compilation needs the destination to exist,
+# not to be booted, so remaining simulator boot runs under the build.
+(
+    cd Packages/HeelerSSH
+    run_xcodebuild "HeelerSSH package build" "$xcodebuild_build_timeout_seconds" \
+        build-for-testing \
+        -scheme HeelerSSH \
+        -derivedDataPath "$package_derived_data_path" \
+        -destination "$simulator_destination" \
+        -collect-test-diagnostics never
+)
+boot_wait_started=$SECONDS
+xcrun simctl bootstatus "$simulator_udid" -b
+echo "==> Simulator boot wait after the build overlap: $((SECONDS - boot_wait_started))s"
+
 push_simulator_environment \
     HEELER_SSH_E2E_REQUIRED \
     HEELER_SSH_E2E_HOST \
@@ -1820,7 +1899,8 @@ push_simulator_environment \
 package_e2e_log="$fixture_dir/package-e2e.log"
 (
     cd Packages/HeelerSSH
-    run_xcodebuild "HeelerSSH package E2E" "$xcodebuild_test_timeout_seconds" test \
+    run_xcodebuild "HeelerSSH package E2E" "$xcodebuild_test_timeout_seconds" \
+        test-without-building \
         -scheme HeelerSSH \
         -derivedDataPath "$package_derived_data_path" \
         -destination "$simulator_destination" \

--- a/scripts/run-with-timeout.py
+++ b/scripts/run-with-timeout.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run one command with a hard deadline and capture timeout diagnostics."""
+"""Run one command with a hard deadline and preserve useful failure diagnostics."""
 
 from __future__ import annotations
 
@@ -164,6 +164,33 @@ def capture_artifacts(
             print(f"could not preserve {source}: {error}", file=sys.stderr)
 
 
+def record_exit_status(diagnostics_dir: Path, status: int) -> None:
+    diagnostics_dir.mkdir(parents=True, exist_ok=True)
+    (diagnostics_dir / "status.txt").write_text(f"{status}\n", encoding="utf-8")
+
+
+def preserve_nonzero_exit(
+    arguments: argparse.Namespace,
+    status: int,
+) -> None:
+    """Copy requested artifacts for any nonzero child exit. Timeout-only
+    process snapshots stay on the timeout path.
+    """
+    try:
+        record_exit_status(arguments.diagnostics_dir, status)
+    except OSError as error:
+        print(f"could not record exit status: {error}", file=sys.stderr)
+    capture_artifacts(
+        arguments.diagnostics_dir,
+        arguments.artifact_path,
+        arguments.artifact_glob,
+    )
+    print(
+        f"{arguments.label} exited {status}; diagnostics: {arguments.diagnostics_dir}",
+        file=sys.stderr,
+    )
+
+
 def terminate_process_group(process: subprocess.Popen[bytes]) -> None:
     if process.poll() is not None:
         return
@@ -201,10 +228,14 @@ def run(arguments: argparse.Namespace) -> int:
 
     signal.signal(signal.SIGTERM, forward_sigterm)
     try:
-        return shell_exit_status(process.wait(timeout=arguments.timeout_seconds))
+        status = shell_exit_status(process.wait(timeout=arguments.timeout_seconds))
+        if status != 0:
+            preserve_nonzero_exit(arguments, status)
+        return status
     except subprocess.TimeoutExpired:
         arguments.diagnostics_dir.mkdir(parents=True, exist_ok=True)
         try:
+            record_exit_status(arguments.diagnostics_dir, TIMEOUT_EXIT_STATUS)
             (arguments.diagnostics_dir / "timeout.txt").write_text(
                 f"{arguments.label} exceeded {arguments.timeout_seconds:g} seconds\n",
                 encoding="utf-8",

--- a/scripts/test-run-ci-ios-tests-guards.sh
+++ b/scripts/test-run-ci-ios-tests-guards.sh
@@ -142,6 +142,40 @@ awk '
     END { exit ok ? 0 : 1 }
 ' "$gate_script" \
     || die "package lane does not overlap simulator boot with build-for-testing"
+# Simulator claim/boot must precede fixture keygen so boot overlaps setup, not
+# only build-for-testing. A late claim puts CoreSimulator wake back on the
+# critical path in front of compilation.
+awk '
+    /^claim_port_block$/ { claimed_ports = NR }
+    /xcrun simctl boot "/ { boot = NR }
+    /host_ed25519"/ && /ssh-keygen/ { keygen = NR }
+    END { exit (claimed_ports && boot && keygen \
+        && claimed_ports < boot && boot < keygen) ? 0 : 1 }
+' "$gate_script" \
+    || die "simulator boot must start before fixture keygen"
+# shellcheck disable=SC2016
+grep -qF 'clonedSourcePackagesDirPath "$source_packages_dir"' "$gate_script" \
+    || die "app lane must pin a stable clonedSourcePackagesDirPath"
+# shellcheck disable=SC2016
+grep -qF 'if [[ "$ci_lane" == "app" ]]; then' "$gate_script" \
+    || die "clonedSourcePackagesDirPath must stay app-lane only"
+awk '
+    /^run_xcodebuild\(\) \{/ { inside = 1 }
+    inside && /ci_lane" == "app"/ { app_gate = 1 }
+    inside && /clonedSourcePackagesDirPath/ { flag = 1 }
+    inside && /^}$/ { exit (app_gate && flag) ? 0 : 1 }
+    END { exit (app_gate && flag) ? 0 : 1 }
+' "$gate_script" \
+    || die "clonedSourcePackagesDirPath must be gated inside run_xcodebuild"
+grep -qF 'Cache SwiftPM checkouts' "$repo_root/.github/workflows/ci.yml" \
+    || die "workflow must cache SwiftPM checkouts for the app job"
+grep -qF '.ci/source-packages' "$repo_root/.github/workflows/ci.yml" \
+    || die "workflow cache must include .ci/source-packages"
+if grep -qE '^[[:space:]]+xcrun simctl list runtimes' "$repo_root/.github/workflows/ci.yml"; then
+    die "workflow must not cold-start CoreSimulator via simctl list runtimes"
+fi
+grep -qF 'Show Xcode version' "$repo_root/.github/workflows/ci.yml" \
+    || die "workflow must keep a lightweight Xcode version step"
 
 # cleanup reads these ownership slots even when a case never claimed a
 # resource. The real gate initializes them before installing its trap; the

--- a/scripts/test-run-ci-ios-tests-guards.sh
+++ b/scripts/test-run-ci-ios-tests-guards.sh
@@ -50,7 +50,7 @@ trap 'rm -rf "$work"' EXIT
 expected_full_lane_total=864
 expected_full_lane_skips=95
 expected_capture_executed=769
-expected_cases=38
+expected_cases=39
 
 # The lanes run-ci-ios-tests.sh writes, in the order it writes them. The capture
 # is the concatenation of exactly these, so splitting it on the xcodebuild
@@ -93,6 +93,8 @@ extract_shipped_function() {
 extract_shipped_function assert_full_lane_coverage
 extract_shipped_function assert_behavior
 extract_shipped_function run_suite
+extract_shipped_function dump_fixture_logs
+extract_shipped_function preserve_failure_diagnostics
 extract_shipped_function cleanup
 extract_shipped_function clear_simulator_environment
 extract_shipped_function stop_privileged_sshd
@@ -126,6 +128,20 @@ awk '
     END { exit cleared ? 0 : 1 }
 ' "$gate_script" \
     || die "app lane does not clear fixture environment before the full test lane"
+awk '
+    /if \[\[ "\$ci_lane" == "package" \]\]; then/ { in_pkg = 1 }
+    in_pkg && /HeelerSSH package build/ { saw_build_label = 1 }
+    in_pkg && /build-for-testing/ { build = NR }
+    in_pkg && /simctl bootstatus/ { boot = NR }
+    in_pkg && /test-without-building/ { test_action = NR }
+    in_pkg && /^exit 0$/ {
+        ok = (saw_build_label && build && boot && test_action \
+            && build < boot && boot < test_action)
+        exit
+    }
+    END { exit ok ? 0 : 1 }
+' "$gate_script" \
+    || die "package lane does not overlap simulator boot with build-for-testing"
 
 # cleanup reads these ownership slots even when a case never claimed a
 # resource. The real gate initializes them before installing its trap; the
@@ -138,6 +154,10 @@ awk '
     account_lock_dir=""
     run_lock_dir=""
     device_lock_dir=""
+    diagnostic_root=""
+    app_derived_data_path=""
+    package_derived_data_path=""
+    fixture_log_tail_lines=80
 }
 
 # The floor is read out of the gate's own call site rather than restated here.
@@ -937,6 +957,86 @@ else
     printf 'FAIL  exit=%-3s  %s\n          (%s)\n' "$cleanup_exit" \
         "password account deletion failure preserves evidence" "$reason"
     failed=$((failed + 1))
+fi
+
+echo
+echo "== a failed run copies diagnostics then deletes the fixture =="
+case_dir=$(new_case failed-run-diagnostics)
+diagnostic_copy="$work/failed-run-diagnostics-copy"
+printf 'sshd-ready-marker\n' > "$case_dir/sshd-modern.log"
+printf 'weak-proxy-marker\n' > "$case_dir/weak-network.log"
+printf 'BEGIN PRIVATE KEY\nSECRET-KEY-MATERIAL\n' > "$case_dir/device_key"
+mkdir -p "$case_dir/AppDerivedData/Logs/Test/Sample.xcresult"
+printf 'xcresult-marker\n' \
+    > "$case_dir/AppDerivedData/Logs/Test/Sample.xcresult/Info.plist"
+# The extracted cleanup function consumes these variables and command stubs
+# through eval, which static analysis cannot follow.
+# shellcheck disable=SC2034,SC2329
+cleanup_output=$(
+    (
+        fixture_dir="$case_dir"
+        diagnostic_root="$diagnostic_copy"
+        app_derived_data_path="$case_dir/AppDerivedData"
+        package_derived_data_path="$case_dir/PackageDerivedData"
+        fixture_username=ci
+        fixture_home="$case_dir/home"
+        simulator_udid=""
+        stall_pid=""
+        fake_herdr_pid=""
+        weak_network_pid=""
+        unprivileged_sshd_pids=()
+        password_pid=""
+        password_pid_file="$case_dir/sshd-password.pid"
+        password_log="$case_dir/sshd-password.log"
+        password_log_printed=0
+        password_username=heeler-ci-password
+        password_user_cleanup_needed=0
+        password_ssh_sacl_added=0
+        fixture_log_tail_lines=80
+
+        false
+        cleanup
+    ) 2>&1
+)
+cleanup_exit=$?
+reason=""
+if [[ "$cleanup_exit" == 0 ]]; then
+    reason="cleanup succeeded after a failed run"
+elif [[ -d "$case_dir" ]]; then
+    reason="cleanup left the fixture directory after copying diagnostics"
+elif [[ ! -f "$diagnostic_copy/fixture/exit-status.txt" ]]; then
+    reason="cleanup did not record the original nonzero status"
+elif [[ "$(cat "$diagnostic_copy/fixture/exit-status.txt")" != 1 ]]; then
+    reason="cleanup recorded $(cat "$diagnostic_copy/fixture/exit-status.txt") instead of 1"
+elif [[ ! -f "$diagnostic_copy/fixture/logs/sshd-modern.log" ]]; then
+    reason="cleanup did not copy the fixture sshd log"
+elif [[ ! -f "$diagnostic_copy/fixture/logs/weak-network.log" ]]; then
+    reason="cleanup did not copy the weak-network proxy log"
+elif [[ ! -f "$diagnostic_copy/fixture/AppDerivedData-Logs-Test/Sample.xcresult/Info.plist" ]]; then
+    reason="cleanup did not copy the xcresult bundle"
+elif [[ -e "$diagnostic_copy/fixture/device_key" \
+    || -e "$diagnostic_copy/fixture/logs/device_key" ]]; then
+    reason="cleanup copied private-key material into diagnostics"
+elif ! printf '%s\n' "$cleanup_output" | grep -qF "sshd-ready-marker"; then
+    reason="cleanup did not print a bounded sshd log tail"
+elif ! printf '%s\n' "$cleanup_output" | grep -qF "weak-proxy-marker"; then
+    reason="cleanup did not print a bounded weak-network log tail"
+elif printf '%s\n' "$cleanup_output" | grep -qF "SECRET-KEY-MATERIAL"; then
+    reason="cleanup printed private-key material"
+elif printf '%s\n' "$cleanup_output" | grep -qF "BEGIN PRIVATE KEY"; then
+    reason="cleanup printed private-key PEM header"
+fi
+case_labels+=("a failed run copies diagnostics then deletes the fixture")
+ran=$((ran + 1))
+if [[ -z "$reason" ]]; then
+    printf 'ok    expected-pass  exit=%-3s  %s\n' "$cleanup_exit" \
+        "a failed run copies diagnostics then deletes the fixture"
+    passed=$((passed + 1))
+else
+    printf 'FAIL  exit=%-3s  %s\n          (%s)\n' "$cleanup_exit" \
+        "a failed run copies diagnostics then deletes the fixture" "$reason"
+    failed=$((failed + 1))
+    printf '%s\n' "$cleanup_output" | sed 's/^/        | /'
 fi
 
 echo

--- a/scripts/test-run-with-timeout.sh
+++ b/scripts/test-run-with-timeout.sh
@@ -20,6 +20,15 @@ trap 'rm -rf "$work"' EXIT
     --diagnostics-dir "$work/success" \
     -- /bin/sh -c 'printf "success\n"'
 
+[[ ! -e "$work/success/status.txt" ]] || {
+    echo "successful runs must not write failure diagnostics" >&2
+    exit 1
+}
+[[ ! -e "$work/success/processes.txt" ]] || {
+    echo "successful runs must not capture a process snapshot" >&2
+    exit 1
+}
+
 set +e
 mkdir -p "$work/evidence"
 printf 'partial xcresult' > "$work/evidence/result.txt"
@@ -48,6 +57,14 @@ set -e
     echo "watchdog did not capture the process table" >&2
     exit 1
 }
+[[ -s "$work/timeout/timeout.txt" ]] || {
+    echo "watchdog did not record the timeout" >&2
+    exit 1
+}
+[[ "$(cat "$work/timeout/status.txt")" == 124 ]] || {
+    echo "watchdog did not record timeout status 124" >&2
+    exit 1
+}
 [[ -s "$work/timeout/artifacts/01-evidence/result.txt" ]] || {
     echo "watchdog did not preserve the requested diagnostic artifact" >&2
     exit 1
@@ -63,8 +80,8 @@ if grep -qE '^[[:space:]]*xcodebuild ' "$gate_script"; then
     exit 1
 fi
 wrapped_calls=$(grep -cE '^[[:space:]]*run_xcodebuild "' "$gate_script")
-[[ "$wrapped_calls" == 4 ]] || {
-    echo "expected 4 watchdog-wrapped xcodebuild call sites, found $wrapped_calls" >&2
+[[ "$wrapped_calls" == 5 ]] || {
+    echo "expected 5 watchdog-wrapped xcodebuild call sites, found $wrapped_calls" >&2
     exit 1
 }
 [[ "$(grep -c 'timeout-minutes: 35' "$workflow")" == 1 ]] || {
@@ -77,16 +94,105 @@ wrapped_calls=$(grep -cE '^[[:space:]]*run_xcodebuild "' "$gate_script")
 }
 
 set +e
+mkdir -p "$work/failure-evidence"
+printf 'failure xcresult' > "$work/failure-evidence/result.txt"
 "$runner" \
     --timeout-seconds 2 \
     --label failure \
     --diagnostics-dir "$work/failure" \
-    -- /bin/sh -c 'exit 23'
+    --artifact-path "$work/failure-evidence" \
+    -- /bin/sh -c 'exit 65'
 failure_status=$?
 set -e
 
-[[ "$failure_status" == 23 ]] || {
-    echo "watchdog changed child exit 23 to $failure_status" >&2
+[[ "$failure_status" == 65 ]] || {
+    echo "watchdog changed child exit 65 to $failure_status" >&2
+    exit 1
+}
+[[ "$(cat "$work/failure/status.txt")" == 65 ]] || {
+    echo "watchdog did not record the original nonzero status" >&2
+    exit 1
+}
+[[ -s "$work/failure/artifacts/01-failure-evidence/result.txt" ]] || {
+    echo "watchdog did not preserve artifacts for a nonzero child exit" >&2
+    exit 1
+}
+[[ ! -e "$work/failure/processes.txt" ]] || {
+    echo "process snapshots must stay timeout-only" >&2
+    exit 1
+}
+[[ ! -e "$work/failure/timeout.txt" ]] || {
+    echo "timeout.txt must stay timeout-only" >&2
+    exit 1
+}
+shopt -s nullglob
+failure_samples=("$work/failure"/sample-*)
+shopt -u nullglob
+[[ "${#failure_samples[@]}" == 0 ]] || {
+    echo "sample diagnostics must stay timeout-only" >&2
+    exit 1
+}
+
+awk '
+    /^run_xcodebuild\(\) \{/ { inside = 1 }
+    inside && /test-without-building/ { gated = 1 }
+    inside && /-disableAutomaticPackageResolution/ { flag = 1 }
+    inside && /^}$/ { exit (gated && flag) ? 0 : 1 }
+    END { exit (gated && flag) ? 0 : 1 }
+' "$gate_script" || {
+    echo "test-without-building must skip automatic package resolution" >&2
+    exit 1
+}
+if grep -E '^[[:space:]]*run_xcodebuild "Build for testing"' -A 8 "$gate_script" \
+    | grep -q -- '-disableAutomaticPackageResolution'; then
+    echo "build-for-testing must keep automatic package resolution" >&2
+    exit 1
+fi
+awk '
+    /if \[\[ "\$ci_lane" == "package" \]\]; then/ { in_pkg = 1 }
+    in_pkg && /HeelerSSH package build/ { saw_build_label = 1 }
+    in_pkg && /build-for-testing/ { build = NR }
+    in_pkg && /simctl bootstatus/ { boot = NR }
+    in_pkg && /test-without-building/ { test_action = NR }
+    in_pkg && /^exit 0$/ {
+        ok = (saw_build_label && build && boot && test_action \
+            && build < boot && boot < test_action)
+        exit
+    }
+    END { exit ok ? 0 : 1 }
+' "$gate_script" || {
+    echo "package lane must overlap simulator boot with build-for-testing" >&2
+    exit 1
+}
+[[ "$(grep -cF '==> Simulator boot wait after the build overlap:' "$gate_script")" == 2 ]] || {
+    echo "app and package lanes must each attribute the boot/build overlap" >&2
+    exit 1
+}
+[[ "$(grep -cF -- '-disableAutomaticPackageResolution' "$gate_script")" == 1 ]] || {
+    echo "package-resolution skip must stay a single run_xcodebuild gate" >&2
+    exit 1
+}
+
+if ! awk '
+    /pull_request:/ { in_pr = 1 }
+    in_pr && /output\/\*\*/ { found = 1 }
+    in_pr && /^  push:/ { exit found ? 0 : 1 }
+    END { exit found ? 0 : 1 }
+' "$workflow"; then
+    echo "pull_request paths-ignore must include output/**" >&2
+    exit 1
+fi
+if ! awk '
+    /^  push:/ { in_push = 1 }
+    in_push && /output\/\*\*/ { found = 1 }
+    in_push && /^# One in-flight/ { exit found ? 0 : 1 }
+    END { exit found ? 0 : 1 }
+' "$workflow"; then
+    echo "push paths-ignore must include output/**" >&2
+    exit 1
+fi
+[[ "$(grep -cE '^[[:space:]]+- output/\*\*' "$workflow")" == 2 ]] || {
+    echo "output/** must appear once per paths-ignore list" >&2
     exit 1
 }
 

--- a/scripts/test-run-with-timeout.sh
+++ b/scripts/test-run-with-timeout.sh
@@ -172,6 +172,42 @@ awk '
     echo "package-resolution skip must stay a single run_xcodebuild gate" >&2
     exit 1
 }
+awk '
+    /^run_xcodebuild\(\) \{/ { inside = 1 }
+    inside && /ci_lane" == "app"/ { app_gate = 1 }
+    inside && /clonedSourcePackagesDirPath/ { flag = 1 }
+    inside && /^}$/ { exit (app_gate && flag) ? 0 : 1 }
+    END { exit (app_gate && flag) ? 0 : 1 }
+' "$gate_script" || {
+    echo "app lane must reuse a cached clonedSourcePackagesDirPath" >&2
+    exit 1
+}
+if grep -E '^[[:space:]]*run_xcodebuild "HeelerSSH package' -A 12 "$gate_script" \
+    | grep -q -- '-clonedSourcePackagesDirPath'; then
+    echo "package lane must not take the app SourcePackages cache path" >&2
+    exit 1
+fi
+[[ "$(grep -cF 'Cache SwiftPM checkouts' "$workflow")" == 1 ]] || {
+    echo "the app job must cache SwiftPM checkouts" >&2
+    exit 1
+}
+if grep -qE '^[[:space:]]+xcrun simctl list runtimes' "$workflow"; then
+    echo "CI must not list simulator runtimes on the critical path" >&2
+    exit 1
+fi
+[[ "$(grep -cF 'Show Xcode version' "$workflow")" == 2 ]] || {
+    echo "both macOS jobs must keep the lightweight Xcode version step" >&2
+    exit 1
+}
+awk '
+    /^claim_port_block$/ { ports = NR }
+    /xcrun simctl boot "/ { boot = NR }
+    /ssh-keygen -q -t rsa -b 3072/ { keygen = NR }
+    END { exit (ports && boot && keygen && ports < boot && boot < keygen) ? 0 : 1 }
+' "$gate_script" || {
+    echo "simulator boot must overlap fixture provisioning, not follow it" >&2
+    exit 1
+}
 
 if ! awk '
     /pull_request:/ { in_pr = 1 }


### PR DESCRIPTION
## Summary

- split the iOS app and HeelerSSH package lanes so hosted macOS work can run in parallel
- reuse build-for-testing outputs, avoid repeated package resolution, overlap simulator boot with builds, and preserve bounded failure diagnostics
- make weak-network upload cancellation wait on the real outbound backpressure phase with deterministic, cancellation-safe test barriers
- give each resolved socket candidate a fair share of the remaining connection deadline while preserving immediate caller cancellation

## Motivation

Recent hosted runs exposed three different failure modes: socket candidates consuming the entire deadline, weak-network cancellation racing before upload backpressure, and long-running lanes producing weak failure evidence. This change addresses those repository-controlled causes while keeping hosted-runner variance visible instead of hiding failures behind automatic retries.

## Validation

- `make test`
  - Heeler app: 1,353 tests in 130 suites passed
  - HeelerSSH: 15 tests executed and passed; 33 disposable-sshd fixture tests skipped by the documented local gate
- CI watchdog behavior tests passed
- CI guard tests passed, 39/39
- independent package reviews accepted the exact implementation SHAs

## Hosted CI

This PR is intentionally opened to validate both macOS lanes on GitHub-hosted runners and compare their wall-clock time and diagnostics with the earlier monolithic workflow.
