### PR TITLE
fix: make terminal grid settling lifecycle-driven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Entries reference the issue that motivated them.
 
 ### Fixed
 
+- A terminal whose keyboard claim is refused as it appears no longer holds its
+  grid — and its layout — frozen until the half-second safety timeout. It gives
+  the freeze up as soon as the claim fails, so the surface lays out and the
+  Host learns its size right away. (#263)
+
 - New Agent now detects supported Agent CLIs from the Host's standard
   user-local, Bun, Cargo, Homebrew, and Linuxbrew install paths over SSH.
   (#254)

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		82600FB64A99ADAD1C60D451 /* PairingCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D419158B027AF5F38B73AD8B /* PairingCodeTests.swift */; };
 		836C6CE781A0FE57FBA87727 /* JSONValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F261A0911D08819AFC013F1E /* JSONValueTests.swift */; };
 		83AAFC996DF32402681F38AB /* HostDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A63EFEB7D00E59949CF331 /* HostDraft.swift */; };
+		845B6E45C06C55CCC011D6F0 /* TerminalGridReportPhaseRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747773ABBBA6ECEDAD7786DE /* TerminalGridReportPhaseRecorder.swift */; };
 		847FCB04EA7913ACB390C978 /* ComposerStagingStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239FD696B72E804AE3D85D72 /* ComposerStagingStoreTests.swift */; };
 		84B56C16C6227F12CFBF2B1D /* InMemorySecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B4AAB6885E0EB9D8C4A131 /* InMemorySecretStore.swift */; };
 		84C252AF6731EA693B93494A /* GitBranchName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D6996CA1550E32EE6AC3669 /* GitBranchName.swift */; };
@@ -514,6 +515,7 @@
 		733AB85D0EBE3F90487289EA /* AgentDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetailView.swift; sourceTree = "<group>"; };
 		7374E36C37E07625B05361AE /* ContentViewActivityDriverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewActivityDriverTests.swift; sourceTree = "<group>"; };
 		7461B7A0FD2A4CDF34352D45 /* PairingCodeVectorFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCodeVectorFile.swift; sourceTree = "<group>"; };
+		747773ABBBA6ECEDAD7786DE /* TerminalGridReportPhaseRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalGridReportPhaseRecorder.swift; sourceTree = "<group>"; };
 		7625958E48639DCE4F5A8391 /* EventsSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsSession.swift; sourceTree = "<group>"; };
 		764EB7D298185F64BA26C8B2 /* HerdrEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrEvents.swift; sourceTree = "<group>"; };
 		768235F2FBD7790800281BC3 /* PinnedAgentsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedAgentsStoreTests.swift; sourceTree = "<group>"; };
@@ -1167,6 +1169,7 @@
 				7461B7A0FD2A4CDF34352D45 /* PairingCodeVectorFile.swift */,
 				31B3368D352EFC805C2534F9 /* RealSSHFixture.swift */,
 				B64F59C086BFF5B062ADCE8C /* ScriptedTransport.swift */,
+				747773ABBBA6ECEDAD7786DE /* TerminalGridReportPhaseRecorder.swift */,
 				069388B06CE04D1F3CC24740 /* TestWindow.swift */,
 				F44E8A7E5D2D96096928B69C /* WeakNetworkProxy.swift */,
 			);
@@ -1770,6 +1773,7 @@
 				AFA3583DF83EFBAFEEE91E28 /* TerminalAgentSwitcherTests.swift in Sources */,
 				D5750879A465E0B27C9B4431 /* TerminalAttachTests.swift in Sources */,
 				E521D6779F4C453B6E098F14 /* TerminalFontSettingsTests.swift in Sources */,
+				845B6E45C06C55CCC011D6F0 /* TerminalGridReportPhaseRecorder.swift in Sources */,
 				31E4ADB22D4D655E7CFDB749 /* TerminalInputControllerTests.swift in Sources */,
 				96C9E9E62BB96A66A68570E9 /* TerminalKeysKeyboardTests.swift in Sources */,
 				4712E2A7878E4962BDEC7E8C /* TerminalMouseReportingTests.swift in Sources */,

--- a/Sources/Heeler/Terminal/TerminalScreenView.swift
+++ b/Sources/Heeler/Terminal/TerminalScreenView.swift
@@ -257,6 +257,34 @@ struct TerminalScreenView: UIViewRepresentable {
     }
 }
 
+/// A grid as the Host is told about it: the columns and rows a resize report
+/// carries, with the pixel metrics Ghostty measures them from left behind.
+struct TerminalGridSize: Equatable, Sendable, CustomStringConvertible {
+    let columns: Int
+    let rows: Int
+
+    var description: String { "\(columns)x\(rows)" }
+}
+
+/// What the keyboard-transition grid freeze is doing.
+///
+/// The freeze's edges are lifecycle facts — a keyboard claimed, a settled
+/// frame published, the last in-flight callback consumed — but until this
+/// existed the only trace of them was *when* resize reports happened to reach
+/// the Host. Timing is exactly what cannot be read back: the thaw rides
+/// Ghostty's asynchronous resize callbacks, so silence means "still frozen",
+/// "nothing to report" and "the engine has not answered yet" all at once, and
+/// a caller waiting on reports cannot tell which (#263).
+enum TerminalGridReportPhase: Equatable, Sendable {
+    /// Reports reach the Host as they arrive.
+    case live
+    /// Every report is held back; the keyboard is still moving.
+    case deferring
+    /// The thaw was asked for and is waiting on the callbacks that had
+    /// already left Ghostty when it was.
+    case flushing
+}
+
 /// Bridges Ghostty's sendable session callbacks onto the UI's main-actor
 /// closures without making the transport layer depend on Ghostty types.
 private final class TerminalResizeSequence: @unchecked Sendable {
@@ -288,6 +316,13 @@ final class TerminalSessionCallbackBridge {
     var isSizeReportCurrent: ((_ columns: Int, _ rows: Int) -> Bool)?
     var onReliableInput: (() -> Void)?
     var onTerminalInput: ((Data) -> Void)?
+    /// Reports every freeze transition. The return to `.live` carries the grid
+    /// the thaw forwarded, or `nil` when the freeze had none to forward —
+    /// the difference between "the settled grid reached the Host" and "the
+    /// freeze ended having told it nothing", which nothing else records.
+    var onGridReportPhaseChanged: ((
+        _ phase: TerminalGridReportPhase, _ forwarded: TerminalGridSize?
+    ) -> Void)?
     nonisolated private let resizeSequence = TerminalResizeSequence()
     private var pendingResizeReports: [UInt64: InMemoryTerminalViewport] = [:]
     private var lastProcessedResizeSequence: UInt64 = 0
@@ -296,6 +331,14 @@ final class TerminalSessionCallbackBridge {
     private var deferredSize: (columns: Int, rows: Int)?
     private var finishesSizeReportDeferralThrough: UInt64?
     private var suppressesDuplicateSize: (columns: Int, rows: Int)?
+    private var lastNotifiedGridReportPhase = TerminalGridReportPhase.live
+
+    /// Derived from the deferral bookkeeping rather than tracked alongside it,
+    /// so the phase callers observe cannot drift from the one the reports obey.
+    var gridReportPhase: TerminalGridReportPhase {
+        guard defersSizeReports else { return .live }
+        return finishesSizeReportDeferralThrough == nil ? .deferring : .flushing
+    }
 
     init(
         onSizeChanged: ((Int, Int) -> Void)?,
@@ -341,6 +384,7 @@ final class TerminalSessionCallbackBridge {
         deferredSize = nil
         finishesSizeReportDeferralThrough = nil
         suppressesDuplicateSize = nil
+        notifyGridReportPhase()
     }
 
     func finishSizeReportDeferral() {
@@ -349,6 +393,7 @@ final class TerminalSessionCallbackBridge {
         // in force until every callback that had already left Ghostty when the
         // thaw was requested has been consumed in sequence.
         finishesSizeReportDeferralThrough = resizeSequence.current()
+        notifyGridReportPhase()
         completeSizeReportDeferralIfReady()
     }
 
@@ -364,6 +409,7 @@ final class TerminalSessionCallbackBridge {
         deferredSize = nil
         finishesSizeReportDeferralThrough = nil
         suppressesDuplicateSize = nil
+        notifyGridReportPhase()
     }
 
     private func receiveResize(
@@ -397,15 +443,35 @@ final class TerminalSessionCallbackBridge {
         else { return }
         finishesSizeReportDeferralThrough = nil
         defersSizeReports = false
-        guard let deferredSize else { return }
+        // The Host hears the settled grid first, and the phase says `.live`
+        // only once it has: an observer woken by the thaw must find the
+        // report already delivered, not on its way.
+        let forwarded = forwardDeferredSize()
+        notifyGridReportPhase(forwarded: forwarded)
+    }
+
+    /// Hands the Host the one grid the freeze settled on and returns it, or
+    /// returns `nil` when the freeze never learned a grid to forward — the
+    /// next ordinary report speaks for it then.
+    private func forwardDeferredSize() -> TerminalGridSize? {
+        guard let deferredSize else { return nil }
         self.deferredSize = nil
-        guard let onSizeChanged else { return }
+        guard let onSizeChanged else { return nil }
         onSizeChanged(deferredSize.columns, deferredSize.rows)
         // The surface delegate supplied the settled grid synchronously. The
         // equivalent engine callback can still be in Ghostty's IO pipeline;
         // consume that one duplicate when it arrives. A different current
         // grid clears the token and is delivered normally.
         suppressesDuplicateSize = deferredSize
+        return TerminalGridSize(
+            columns: deferredSize.columns, rows: deferredSize.rows)
+    }
+
+    private func notifyGridReportPhase(forwarded: TerminalGridSize? = nil) {
+        let phase = gridReportPhase
+        guard phase != lastNotifiedGridReportPhase else { return }
+        lastNotifiedGridReportPhase = phase
+        onGridReportPhaseChanged?(phase, forwarded)
     }
 
     private func deliverSize(_ size: (columns: Int, rows: Int)) {
@@ -933,6 +999,16 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
         // A keyboard that never left reports no did-show, only a frame change.
         beginKeyboardTransitionLayoutDeferral(endsOnFrameChange: true)
         raiseKeyboard()
+        // Only a first responder is handed the settle signal that ends this
+        // freeze (see `notificationSettlesOwnKeyboard`), so a claim UIKit
+        // refused leaves nothing that can end it: the grid stays frozen and
+        // `layoutSubviews` stays suppressed until the wall-clock leash fires.
+        // No keyboard is coming, so end it here on the same terms the leash
+        // would have — thawing rather than cancelling, because the surface's
+        // first grid still has to reach the Host.
+        if !isFirstResponder {
+            finishKeyboardTransitionLayout(handoffOutcome: .cancelled)
+        }
     }
 
     /// Raises the keyboard, and records that the user wants it up.
@@ -1373,6 +1449,28 @@ final class HeelerTerminalView: UITerminalView, TerminalByteSink {
 
         terminalSession.sendInput(report)
         return true
+    }
+
+    /// The grid Ghostty last measured this surface against, or `nil` before
+    /// the surface has reported one. This is the value a thawing freeze
+    /// forwards to the Host as the settled grid.
+    var measuredGrid: TerminalGridSize? {
+        guard hasTerminalGridMetrics else { return nil }
+        return TerminalGridSize(
+            columns: terminalGridSize.columns, rows: terminalGridSize.rows)
+    }
+
+    /// Where the keyboard-transition grid freeze currently stands.
+    var gridReportPhase: TerminalGridReportPhase {
+        callbackBridge.gridReportPhase
+    }
+
+    /// Observes the freeze's transitions. See ``TerminalGridReportPhase``.
+    var onGridReportPhaseChanged: ((
+        _ phase: TerminalGridReportPhase, _ forwarded: TerminalGridSize?
+    ) -> Void)? {
+        get { callbackBridge.onGridReportPhaseChanged }
+        set { callbackBridge.onGridReportPhaseChanged = newValue }
     }
 
     /// Where Ghostty's grid currently sits inside the view, rebuilt from the

--- a/Tests/HeelerTests/Support/GridReportSettling.swift
+++ b/Tests/HeelerTests/Support/GridReportSettling.swift
@@ -1,8 +1,23 @@
 import Testing
 
-/// The settle wait ran out of polls with the reports still absent or
-/// still churning; the caller's assertions cannot trust the state.
-struct GridReportsNeverSettledError: Error {}
+/// The settle wait ran out of polls. Which way it ran out matters: no report
+/// ever arrived is a terminal that never measured a grid — or a freeze still
+/// holding one back — while reports that kept changing is a layout that never
+/// came to rest. Reporting them as one error sent #263 looking for a stalled
+/// engine when the freeze itself was the question.
+enum GridReportsNeverSettledError: Error, CustomStringConvertible {
+    case noReportArrived
+    case reportsKeptChanging(count: Int)
+
+    var description: String {
+        switch self {
+        case .noReportArrived:
+            "no grid report ever arrived"
+        case .reportsKeptChanging(let count):
+            "grid reports never went quiet (\(count) so far)"
+        }
+    }
+}
 
 /// Waits until grid reports have arrived *and* gone quiet. Quiet alone is
 /// not settlement: the report a thaw schedules rides two timers, so on a
@@ -11,6 +26,10 @@ struct GridReportsNeverSettledError: Error {}
 /// on exists (#225). Only proven quiet returns; exhausting the poll cap
 /// throws, so a report that never comes or never stops churning fails
 /// loud instead of handing the caller a state it cannot trust.
+///
+/// Prefer ``TerminalGridReportPhaseRecorder`` wherever the freeze's own
+/// lifecycle answers the question: this poll infers a phase from report
+/// timing, which is Ghostty's to decide and no runner's to promise.
 @MainActor
 func waitForGridReportsToSettle(count: () -> Int) async throws {
     var stablePolls = 0
@@ -25,5 +44,7 @@ func waitForGridReportsToSettle(count: () -> Int) async throws {
             stablePolls = 0
         }
     }
-    throw GridReportsNeverSettledError()
+    throw count() == 0
+        ? GridReportsNeverSettledError.noReportArrived
+        : GridReportsNeverSettledError.reportsKeptChanging(count: count())
 }

--- a/Tests/HeelerTests/Support/TerminalGridReportPhaseRecorder.swift
+++ b/Tests/HeelerTests/Support/TerminalGridReportPhaseRecorder.swift
@@ -53,6 +53,15 @@ final class TerminalGridReportPhaseRecorder {
     /// Every transition seen, oldest first — the freeze's history, for a
     /// failure message that can say where it stopped.
     private(set) var phases: [TerminalGridReportPhase] = []
+    /// Runs once, inside a wait's set-up, at the one instant that matters:
+    /// after that wait has searched the history and before its waiter is
+    /// registered. Whatever it publishes therefore lands in the gap between
+    /// "has it happened yet?" and "wake me when it does" — by call position,
+    /// not by which job an executor picks up first. That gap is where a
+    /// recorder that registers from a later job loses the transition, so it
+    /// is the only place a regression test can prove the loss cannot happen
+    /// here. Nothing outside the recorder's own test sets this.
+    var onWaitAboutToRegister: (@MainActor () -> Void)?
 
     init(observing terminal: HeelerTerminalView) {
         currentPhase = { [weak terminal] in terminal?.gridReportPhase ?? .live }
@@ -101,13 +110,22 @@ final class TerminalGridReportPhaseRecorder {
         // happened, reported as the timeout of a freeze that thawed fine.
         let wakeup = await withCheckedContinuation {
             (continuation: CheckedContinuation<Wakeup, Never>) in
-            if let index = self.unclaimed.firstIndex(where: { $0.phase == phase }) {
-                let claimed = self.unclaimed[index]
-                self.unclaimed.removeSubrange(...index)
+            if let claimed = self.claimBuffered(phase) {
                 continuation.resume(returning: .reached(claimed.forwarded))
                 return
             }
+            let beganWaiting = self.onWaitAboutToRegister
+            self.onWaitAboutToRegister = nil
+            beganWaiting?()
             self.waiters[id] = Waiter(phase: phase, continuation: continuation)
+            // Registration alone is not enough, and this is the second half of
+            // the same rule: a transition that landed while this wait was
+            // being set up was buffered against a waiter that did not exist
+            // yet. Read the buffer again from behind the registration, or that
+            // transition is waited out to the deadline.
+            guard let late = self.claimBuffered(phase) else { return }
+            self.waiters.removeValue(forKey: id)
+            continuation.resume(returning: .reached(late.forwarded))
         }
 
         switch wakeup {
@@ -117,6 +135,21 @@ final class TerminalGridReportPhaseRecorder {
             throw GridReportPhaseNeverReachedError(
                 expected: phase, actual: currentPhase(), observed: phases)
         }
+    }
+
+    /// Removes the earliest buffered `phase` transition and returns it, or
+    /// `nil` when none was seen. The transition's own payload is optional, so
+    /// the two kinds of "nothing" stay distinct: no such transition buffered
+    /// at all, versus a thaw that forwarded no grid.
+    private func claimBuffered(
+        _ phase: TerminalGridReportPhase
+    ) -> (phase: TerminalGridReportPhase, forwarded: TerminalGridSize?)? {
+        guard let index = unclaimed.firstIndex(where: { $0.phase == phase }) else {
+            return nil
+        }
+        let claimed = unclaimed[index]
+        unclaimed.removeSubrange(...index)
+        return claimed
     }
 
     private func record(_ phase: TerminalGridReportPhase, forwarded: TerminalGridSize?) {

--- a/Tests/HeelerTests/Support/TerminalGridReportPhaseRecorder.swift
+++ b/Tests/HeelerTests/Support/TerminalGridReportPhaseRecorder.swift
@@ -29,6 +29,11 @@ struct GridReportPhaseNeverReachedError: Error, CustomStringConvertible {
 /// made the wait runner-speed dependent — reports are Ghostty's to send, on
 /// its own thread, and a terminal whose surface never measured a grid sends
 /// none at all while still thawing perfectly correctly (#263).
+///
+/// Transitions are buffered, so a caller that asks after the fact still gets
+/// its answer, and the buffer check and the waiter's registration happen in
+/// one synchronous main-actor step — a barrier that can drop the very event
+/// it exists to catch is worth less than no barrier at all.
 @MainActor
 final class TerminalGridReportPhaseRecorder {
     private enum Wakeup: Sendable {
@@ -36,9 +41,14 @@ final class TerminalGridReportPhaseRecorder {
         case timedOut
     }
 
+    private struct Waiter {
+        let phase: TerminalGridReportPhase
+        let continuation: CheckedContinuation<Wakeup, Never>
+    }
+
     private let currentPhase: @MainActor () -> TerminalGridReportPhase
-    private var pending: (phase: TerminalGridReportPhase,
-                          continuation: CheckedContinuation<Wakeup, Never>)?
+    /// Keyed so a deadline can only ever resume the wait that armed it.
+    private var waiters: [UUID: Waiter] = [:]
     private var unclaimed: [(phase: TerminalGridReportPhase, forwarded: TerminalGridSize?)] = []
     /// Every transition seen, oldest first — the freeze's history, for a
     /// failure message that can say where it stopped.
@@ -73,27 +83,34 @@ final class TerminalGridReportPhaseRecorder {
         reaching phase: TerminalGridReportPhase,
         within deadline: Duration = .seconds(5)
     ) async throws -> TerminalGridSize? {
-        if let index = unclaimed.firstIndex(where: { $0.phase == phase }) {
-            let claimed = unclaimed[index]
-            unclaimed.removeSubrange(...index)
-            return claimed.forwarded
-        }
-
-        let waiter = Task { @MainActor in
-            await withCheckedContinuation { (continuation: CheckedContinuation<Wakeup, Never>) in
-                self.pending = (phase, continuation)
-            }
-        }
+        let id = UUID()
         let deadlineTask = Task { @MainActor in
             try? await Task.sleep(for: deadline)
-            guard !Task.isCancelled, let waiting = self.pending, waiting.phase == phase
+            guard !Task.isCancelled, let waiter = self.waiters.removeValue(forKey: id)
             else { return }
-            self.pending = nil
-            waiting.continuation.resume(returning: .timedOut)
+            waiter.continuation.resume(returning: .timedOut)
         }
         defer { deadlineTask.cancel() }
 
-        switch await waiter.value {
+        // Claiming the history and registering the waiter are one synchronous
+        // main-actor step. Split across a suspension — a check here, a waiter
+        // installed from a separate task there — a transition published in
+        // between is lost twice over: `record` buffers it because no waiter is
+        // registered yet, and the waiter then registers without looking at the
+        // buffer again. That is a wait that hangs on an event that already
+        // happened, reported as the timeout of a freeze that thawed fine.
+        let wakeup = await withCheckedContinuation {
+            (continuation: CheckedContinuation<Wakeup, Never>) in
+            if let index = self.unclaimed.firstIndex(where: { $0.phase == phase }) {
+                let claimed = self.unclaimed[index]
+                self.unclaimed.removeSubrange(...index)
+                continuation.resume(returning: .reached(claimed.forwarded))
+                return
+            }
+            self.waiters[id] = Waiter(phase: phase, continuation: continuation)
+        }
+
+        switch wakeup {
         case .reached(let forwarded):
             return forwarded
         case .timedOut:
@@ -104,11 +121,12 @@ final class TerminalGridReportPhaseRecorder {
 
     private func record(_ phase: TerminalGridReportPhase, forwarded: TerminalGridSize?) {
         phases.append(phase)
-        guard let waiting = pending, waiting.phase == phase else {
+        guard let id = waiters.first(where: { $0.value.phase == phase })?.key,
+              let waiter = waiters.removeValue(forKey: id)
+        else {
             unclaimed.append((phase, forwarded))
             return
         }
-        pending = nil
-        waiting.continuation.resume(returning: .reached(forwarded))
+        waiter.continuation.resume(returning: .reached(forwarded))
     }
 }

--- a/Tests/HeelerTests/Support/TerminalGridReportPhaseRecorder.swift
+++ b/Tests/HeelerTests/Support/TerminalGridReportPhaseRecorder.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+@testable import Heeler
+
+/// The grid freeze never reached the phase the caller was waiting for. Names
+/// the phase it was actually stuck in: "still deferring" (the keyboard's
+/// settle signal never landed) and "still flushing" (a Ghostty callback the
+/// thaw is waiting on never arrived) are different bugs, and a caller waiting
+/// on resize reports alone cannot tell either from "nothing left to report".
+struct GridReportPhaseNeverReachedError: Error, CustomStringConvertible {
+    let expected: TerminalGridReportPhase
+    let actual: TerminalGridReportPhase
+    let observed: [TerminalGridReportPhase]
+
+    var description: String {
+        """
+        the grid freeze never reached \(expected); still \(actual) \
+        after \(observed)
+        """
+    }
+}
+
+/// Records a terminal's grid-freeze transitions and hands the caller the one
+/// it is waiting for.
+///
+/// This is the barrier the freeze's own lifecycle provides: the thaw is a
+/// fact the terminal publishes (``TerminalGridReportPhase``), not something to
+/// be inferred from when resize reports happen to arrive. Inference is what
+/// made the wait runner-speed dependent — reports are Ghostty's to send, on
+/// its own thread, and a terminal whose surface never measured a grid sends
+/// none at all while still thawing perfectly correctly (#263).
+@MainActor
+final class TerminalGridReportPhaseRecorder {
+    private enum Wakeup: Sendable {
+        case reached(TerminalGridSize?)
+        case timedOut
+    }
+
+    private let currentPhase: @MainActor () -> TerminalGridReportPhase
+    private var pending: (phase: TerminalGridReportPhase,
+                          continuation: CheckedContinuation<Wakeup, Never>)?
+    private var unclaimed: [(phase: TerminalGridReportPhase, forwarded: TerminalGridSize?)] = []
+    /// Every transition seen, oldest first — the freeze's history, for a
+    /// failure message that can say where it stopped.
+    private(set) var phases: [TerminalGridReportPhase] = []
+
+    init(observing terminal: HeelerTerminalView) {
+        currentPhase = { [weak terminal] in terminal?.gridReportPhase ?? .live }
+        terminal.onGridReportPhaseChanged = { [weak self] phase, forwarded in
+            self?.record(phase, forwarded: forwarded)
+        }
+    }
+
+    init(observing bridge: TerminalSessionCallbackBridge) {
+        currentPhase = { [weak bridge] in bridge?.gridReportPhase ?? .live }
+        bridge.onGridReportPhaseChanged = { [weak self] phase, forwarded in
+            self?.record(phase, forwarded: forwarded)
+        }
+    }
+
+    /// Waits for the freeze to thaw and returns the grid it forwarded to the
+    /// Host, or `nil` when it had none to forward.
+    @discardableResult
+    func thawedGrid(within deadline: Duration = .seconds(5)) async throws -> TerminalGridSize? {
+        try await forwardedGrid(reaching: .live, within: deadline)
+    }
+
+    /// Waits for `phase`. The deadline is a diagnostic bound, not a
+    /// correctness window: the passing path resumes on the terminal's own
+    /// transition, so only a lifecycle that stalled ever reaches it.
+    @discardableResult
+    func forwardedGrid(
+        reaching phase: TerminalGridReportPhase,
+        within deadline: Duration = .seconds(5)
+    ) async throws -> TerminalGridSize? {
+        if let index = unclaimed.firstIndex(where: { $0.phase == phase }) {
+            let claimed = unclaimed[index]
+            unclaimed.removeSubrange(...index)
+            return claimed.forwarded
+        }
+
+        let waiter = Task { @MainActor in
+            await withCheckedContinuation { (continuation: CheckedContinuation<Wakeup, Never>) in
+                self.pending = (phase, continuation)
+            }
+        }
+        let deadlineTask = Task { @MainActor in
+            try? await Task.sleep(for: deadline)
+            guard !Task.isCancelled, let waiting = self.pending, waiting.phase == phase
+            else { return }
+            self.pending = nil
+            waiting.continuation.resume(returning: .timedOut)
+        }
+        defer { deadlineTask.cancel() }
+
+        switch await waiter.value {
+        case .reached(let forwarded):
+            return forwarded
+        case .timedOut:
+            throw GridReportPhaseNeverReachedError(
+                expected: phase, actual: currentPhase(), observed: phases)
+        }
+    }
+
+    private func record(_ phase: TerminalGridReportPhase, forwarded: TerminalGridSize?) {
+        phases.append(phase)
+        guard let waiting = pending, waiting.phase == phase else {
+            unclaimed.append((phase, forwarded))
+            return
+        }
+        pending = nil
+        waiting.continuation.resume(returning: .reached(forwarded))
+    }
+}

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GhosttyTerminal
 import Testing
 import SwiftUI
 import UIKit
@@ -770,6 +771,13 @@ struct TerminalAgentSwitcherTests {
                 reportedGrids.append(TerminalGrid(columns: columns, rows: rows))
             },
             notificationCenter: center)
+        // The freeze's own transitions, so each step below waits on the fact
+        // it is about to assert rather than on how quickly this runner gets
+        // Ghostty to answer. Polling for reports to appear and go quiet timed
+        // out here for thirteen seconds on merge CI, and could not say whether
+        // the freeze was still holding or had thawed with nothing to forward
+        // (#263).
+        let phases = TerminalGridReportPhaseRecorder(observing: terminal)
         let host = UIViewController()
         let window = try await makeTestWindow(
             frame: CGRect(x: 0, y: 0, width: 390, height: 700),
@@ -789,6 +797,11 @@ struct TerminalAgentSwitcherTests {
         terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 600)
         host.view.addSubview(terminal)
         window.layoutIfNeeded()
+        // Only a first responder is handed the settle signal that ends this
+        // freeze, so a refused claim is a different failure from a freeze that
+        // would not thaw — and has to be told apart from one.
+        #expect(terminal.isFirstResponder)
+        #expect(terminal.gridReportPhase == .deferring)
         let ownKeyboardEndFrame = window.convert(
             localKeyboardFrame, to: window.screen.coordinateSpace)
 
@@ -800,7 +813,10 @@ struct TerminalAgentSwitcherTests {
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil)
 
         // The keyboard is arriving: every bounds UIKit animates through here
-        // is a half-built grid Ghostty must not be measured against.
+        // is a half-built grid Ghostty must not be measured against. The pause
+        // gives the engine's own callbacks a chance to escape the freeze; it
+        // proves nothing on its own, which is what the phase assertions are
+        // for.
         for height: CGFloat in [520, 440, 360] {
             terminal.frame.size.height = height
             terminal.setNeedsLayout()
@@ -808,45 +824,85 @@ struct TerminalAgentSwitcherTests {
             try await Task.sleep(for: .milliseconds(30))
         }
         #expect(reportedGrids.isEmpty)
+        #expect(terminal.gridReportPhase == .deferring)
 
         // The first owned frame still includes both responders' accessories.
         // It rebuilds the input views but must leave the grid frozen until
         // UIKit republishes the destination-only frame.
+        let rebuildsBeforeOwnedFrame = terminal.inputViewRebuildCount
         center.post(
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
         #expect(reportedGrids.isEmpty)
+        #expect(terminal.gridReportPhase == .deferring)
         await Self.waitForMainQueueTurn()
+        #expect(terminal.inputViewRebuildCount > rebuildsBeforeOwnedFrame)
+        #expect(terminal.gridReportPhase == .deferring)
+
+        // Ghostty measures the surface through this delegate call, and the
+        // thaw forwards whatever it measured last — the settled layout's own
+        // measurement, taken inside the thaw, when the surface is answering.
+        // Standing in for it here is what keeps this off the engine's
+        // schedule: a runner whose surface has not answered at all would
+        // otherwise leave the freeze with nothing to forward, and the
+        // assertions below with nothing to hold it to.
+        terminal.terminalDidResize(
+            TerminalGridMetrics(
+                columns: 39, rows: 22,
+                widthPixels: 1_170, heightPixels: 1_080,
+                cellWidthPixels: 30, cellHeightPixels: 49))
 
         // The rebuilt input views republish the settled destination frame.
         center.post(
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
-        try await waitForGridReportsToSettle { reportedGrids.count }
+        let forwarded = try await phases.thawedGrid()
         let escaped = reportedGrids
-        #expect(!escaped.isEmpty, "the settled grid never made it past the freeze")
-
-        // Ghostty reports one settled layout more than once, and the thaw only
-        // coalesces the reports that land inside its window, so how many escape
-        // is a matter of how busy the machine is. What must hold whatever the
-        // schedule is that every one of them carries the settled grid and none
-        // of the taller or half-built ones the freeze held back. So measure the
-        // settled bounds again here, through the ordinary unfrozen path, and
-        // hold what escaped against it.
-        reportedGrids = []
-        for height: CGFloat in [600, 360] {
-            terminal.frame.size.height = height
-            terminal.setNeedsLayout()
-            terminal.layoutIfNeeded()
-            try await Task.sleep(for: .milliseconds(30))
-        }
-        try await waitForGridReportsToSettle { reportedGrids.count }
         let settled = try #require(
-            reportedGrids.last, "the terminal never measured its settled bounds")
+            forwarded, "the freeze ended without telling the Host any grid")
 
         #expect(
-            Set(escaped) == [settled],
+            settled == terminal.measuredGrid,
+            "the thaw forwarded \(settled), not the grid the surface settled on")
+        // Whatever escaped has to be that one grid — never a taller or
+        // half-built one from inside the freeze, and never nothing at all.
+        #expect(
+            escaped == [TerminalGrid(columns: settled.columns, rows: settled.rows)],
             "the freeze let a grid other than the settled \(settled) out: \(escaped)")
+    }
+
+    /// The freeze suppresses `layoutSubviews` outright, so entering it commits
+    /// the terminal to a settle signal only a first responder is sent. A claim
+    /// UIKit refuses leaves nothing that can end it — the grid would stay
+    /// frozen, and the surface unlaid, until the wall-clock leash.
+    @MainActor
+    @Test func aRefusedKeyboardClaimThawsTheGridWithoutTheLeash() async throws {
+        let center = NotificationCenter()
+        let terminal = TerminalScreenView.makeConfiguredTerminal(
+            notificationCenter: center)
+        let phases = TerminalGridReportPhaseRecorder(observing: terminal)
+        let host = UIViewController()
+        let window = try await makeTestWindow(
+            frame: CGRect(x: 0, y: 0, width: 390, height: 700),
+            rootViewController: host)
+        defer {
+            terminal.removeFromSuperview()
+            window.isHidden = true
+        }
+
+        // Local input is what UIKit asks about in `canBecomeFirstResponder`,
+        // so this is a claim that cannot be granted. The leash is stretched
+        // past any plausible test: only the refusal itself can thaw this.
+        terminal.setLocalInputEnabled(false)
+        terminal.keyboardTransitionFallbackDelay = 60
+        terminal.raisesKeyboardWhenReady = true
+        terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 600)
+        host.view.addSubview(terminal)
+        window.layoutIfNeeded()
+
+        #expect(!terminal.isFirstResponder)
+        try await phases.thawedGrid()
+        #expect(terminal.gridReportPhase == .live)
     }
 
     /// `becomeFirstResponder()` and `reloadInputViews()` may synchronously
@@ -1105,6 +1161,7 @@ struct TerminalAgentSwitcherTests {
                 reportedGrids.append(TerminalGrid(columns: columns, rows: rows))
             },
             notificationCenter: center)
+        let phases = TerminalGridReportPhaseRecorder(observing: terminal)
         let localKeyboardFrame = CGRect(x: 0, y: 400, width: 390, height: 300)
         terminal.keyboardLayoutFrameProvider = { _ in localKeyboardFrame }
         let foreignHost = UIViewController()
@@ -1126,7 +1183,11 @@ struct TerminalAgentSwitcherTests {
         foreignHost.view.addSubview(foreign)
 
         // The handoff itself: the terminal claims the keyboard as it reaches
-        // its window and freezes its grid until that keyboard settles.
+        // its window and freezes its grid until that keyboard settles. This
+        // test drives that settle explicitly, so the wall-clock fallback stays
+        // out of it — a loaded runner must not thaw the freeze the foreign
+        // events below are supposed to leave alone (#225).
+        terminal.keyboardTransitionFallbackDelay = 60
         terminal.raisesKeyboardWhenReady = true
         terminal.frame = CGRect(x: 0, y: 0, width: 390, height: 600)
         host.view.addSubview(terminal)
@@ -1169,6 +1230,7 @@ struct TerminalAgentSwitcherTests {
         }
         #expect(terminal.inputViewRebuildCount == rebuildsBeforeForeignEvent)
         #expect(reportedGrids.isEmpty)
+        #expect(terminal.gridReportPhase == .deferring)
 
         // The first owned frame rebuilds the destination input views while
         // retaining the freeze; their republished frame then thaws it.
@@ -1178,12 +1240,20 @@ struct TerminalAgentSwitcherTests {
         await Self.waitForMainQueueTurn()
         #expect(terminal.inputViewRebuildCount > rebuildsBeforeForeignEvent)
         #expect(reportedGrids.isEmpty)
+        #expect(terminal.gridReportPhase == .deferring)
+        // Stands in for Ghostty measuring the settled layout, so the thaw has
+        // a grid to forward whatever the engine's schedule is here.
+        terminal.terminalDidResize(
+            TerminalGridMetrics(
+                columns: 39, rows: 22,
+                widthPixels: 1_170, heightPixels: 1_080,
+                cellWidthPixels: 30, cellHeightPixels: 49))
         center.post(
             name: UIResponder.keyboardDidChangeFrameNotification, object: nil,
             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: ownKeyboardEndFrame])
-        try await waitForGridReportsToSettle { reportedGrids.count }
+        let forwarded = try await phases.thawedGrid()
         #expect(
-            !reportedGrids.isEmpty,
+            forwarded != nil,
             "the terminal's own settle never made it past the freeze")
     }
 

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -41,6 +41,7 @@ struct TerminalAttachTests {
             onSend: nil,
             onScroll: nil,
             onPaste: nil)
+        let phases = TerminalGridReportPhaseRecorder(observing: bridge)
         let stale = InMemoryTerminalViewport(columns: 33, rows: 20)
 
         bridge.beginSizeReportDeferral()
@@ -51,8 +52,68 @@ struct TerminalAttachTests {
         bridge.onViewport = nil
         bridge.provideAuthoritativeDeferredSize(columns: 33, rows: 14)
         bridge.finishSizeReportDeferral()
-        try await waitForGridReportsToSettle { reportedGrids.count }
+        let forwarded = try await phases.thawedGrid()
+        #expect(forwarded == TerminalGridSize(columns: 33, rows: 14))
         #expect(reportedGrids == [ReportedGrid(columns: 33, rows: 14)])
+    }
+
+    /// A freeze can thaw having learned no grid at all — nothing measured the
+    /// surface while it held. That is a lifecycle outcome, not silence: the
+    /// Host is told nothing and the next ordinary report speaks for it. The
+    /// thaw has to say so, because a caller watching resize reports alone
+    /// cannot tell it from a freeze that never ended (#263).
+    @MainActor
+    @Test func aThawWithNothingMeasuredForwardsNoGridAndSaysSo() async throws {
+        var reportedGrids: [ReportedGrid] = []
+        let bridge = TerminalSessionCallbackBridge(
+            onSizeChanged: { columns, rows in
+                reportedGrids.append(ReportedGrid(columns: columns, rows: rows))
+            },
+            onViewportTextChanged: nil,
+            onSend: nil,
+            onScroll: nil,
+            onPaste: nil)
+        let phases = TerminalGridReportPhaseRecorder(observing: bridge)
+
+        bridge.beginSizeReportDeferral()
+        #expect(bridge.gridReportPhase == .deferring)
+        bridge.finishSizeReportDeferral()
+
+        let forwarded = try await phases.thawedGrid()
+        #expect(forwarded == nil)
+        #expect(bridge.gridReportPhase == .live)
+        #expect(reportedGrids.isEmpty)
+
+        // Live again: the report that arrives next is the Host's first.
+        await withCheckedContinuation { continuation in
+            bridge.onViewport = { _ in continuation.resume() }
+            bridge.resize(InMemoryTerminalViewport(columns: 33, rows: 14))
+        }
+        #expect(reportedGrids == [ReportedGrid(columns: 33, rows: 14)])
+    }
+
+    /// A cancelled freeze forwards nothing: there was no settled grid, only a
+    /// handoff that stopped happening.
+    @MainActor
+    @Test func aCancelledFreezeForwardsNoGrid() async throws {
+        var reportedGrids: [ReportedGrid] = []
+        let bridge = TerminalSessionCallbackBridge(
+            onSizeChanged: { columns, rows in
+                reportedGrids.append(ReportedGrid(columns: columns, rows: rows))
+            },
+            onViewportTextChanged: nil,
+            onSend: nil,
+            onScroll: nil,
+            onPaste: nil)
+        let phases = TerminalGridReportPhaseRecorder(observing: bridge)
+
+        bridge.beginSizeReportDeferral()
+        bridge.provideAuthoritativeDeferredSize(columns: 33, rows: 14)
+        bridge.cancelSizeReportDeferral()
+
+        let forwarded = try await phases.thawedGrid()
+        #expect(forwarded == nil)
+        #expect(reportedGrids.isEmpty)
     }
 
     /// Ghostty can publish the engine resize after the surface delegate has
@@ -70,6 +131,7 @@ struct TerminalAttachTests {
             onSend: nil,
             onScroll: nil,
             onPaste: nil)
+        let phases = TerminalGridReportPhaseRecorder(observing: bridge)
         bridge.isSizeReportCurrent = { columns, rows in
             columns == 33 && rows == 14
         }
@@ -77,7 +139,7 @@ struct TerminalAttachTests {
         bridge.beginSizeReportDeferral()
         bridge.provideAuthoritativeDeferredSize(columns: 33, rows: 14)
         bridge.finishSizeReportDeferral()
-        try await waitForGridReportsToSettle { reportedGrids.count }
+        try await phases.thawedGrid()
 
         await withCheckedContinuation { continuation in
             bridge.onViewport = { _ in continuation.resume() }
@@ -100,12 +162,17 @@ struct TerminalAttachTests {
             onSend: nil,
             onScroll: nil,
             onPaste: nil)
+        let phases = TerminalGridReportPhaseRecorder(observing: bridge)
         let settled = InMemoryTerminalViewport(columns: 33, rows: 14)
 
         bridge.beginSizeReportDeferral()
         bridge.resize(settled)
         bridge.finishSizeReportDeferral()
-        try await waitForGridReportsToSettle { reportedGrids.count }
+        // The queued resize has not landed yet, so the thaw is still waiting
+        // on it — the phase says so rather than the caller having to infer it.
+        #expect(bridge.gridReportPhase == .flushing)
+        let forwarded = try await phases.thawedGrid()
+        #expect(forwarded == TerminalGridSize(columns: 33, rows: 14))
         #expect(reportedGrids == [ReportedGrid(columns: 33, rows: 14)])
     }
 
@@ -1279,6 +1346,10 @@ struct TerminalAttachTests {
         terminal.removeFromSuperview()
         terminal.raisesKeyboardWhenReady = true
         host.view.addSubview(terminal)
+        // The freeze below belongs to a keyboard this terminal actually
+        // claimed: a refused claim gives it up on the spot, and would leave
+        // the coalescing assertions measuring nothing.
+        #expect(terminal.isFirstResponder)
 
         for height: CGFloat in [440, 520, 600] {
             terminal.frame.size.height = height
@@ -1328,6 +1399,10 @@ struct TerminalAttachTests {
         terminal.removeFromSuperview()
         terminal.raisesKeyboardWhenReady = true
         host.view.addSubview(terminal)
+        // The freeze below belongs to a keyboard this terminal actually
+        // claimed: a refused claim gives it up on the spot, and would leave
+        // the coalescing assertions measuring nothing.
+        #expect(terminal.isFirstResponder)
 
         // A transient height, then a stall longer than the production
         // fallback, then another — the shape of the handoff on the runner
@@ -1381,6 +1456,10 @@ struct TerminalAttachTests {
         terminal.removeFromSuperview()
         terminal.raisesKeyboardWhenReady = true
         host.view.addSubview(terminal)
+        // The freeze below belongs to a keyboard this terminal actually
+        // claimed: a refused claim gives it up on the spot, and would leave
+        // the coalescing assertions measuring nothing.
+        #expect(terminal.isFirstResponder)
 
         terminal.frame.size.height = 600
         terminal.setNeedsLayout()

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -177,11 +177,20 @@ struct TerminalAttachTests {
     }
 
     /// The barrier every freeze assertion here rests on, held to its own
-    /// contract. The thaw is published by main-actor work that was already
-    /// queued when the wait began, so it lands in the gap between "has it
-    /// happened yet?" and "wake me when it does". A barrier that answers those
-    /// two questions in separate turns loses the transition in that gap and
-    /// waits out its deadline for an event that already happened.
+    /// contract.
+    ///
+    /// A transition can land in the gap between "has it happened yet?" and
+    /// "wake me when it does". `onWaitAboutToRegister` *is* that gap: the
+    /// recorder calls it after the wait has searched its history and before
+    /// the wait's waiter exists, so this thaw is published there by call
+    /// position and not by which job an executor happens to run first.
+    ///
+    /// A recorder that answers the two questions in separate jobs has, by
+    /// construction, registered nothing when this runs — `record` buffers the
+    /// thaw against a waiter that does not exist — and never reads the buffer
+    /// again from behind its registration. That recorder waits the thaw out
+    /// to its deadline and reports a freeze that thawed correctly as a
+    /// timeout, which is the failure this whole barrier exists to end.
     @MainActor
     @Test func aThawPublishedAsTheWaitBeginsIsStillClaimed() async throws {
         var reportedGrids: [ReportedGrid] = []
@@ -197,14 +206,38 @@ struct TerminalAttachTests {
 
         bridge.beginSizeReportDeferral()
         bridge.provideAuthoritativeDeferredSize(columns: 33, rows: 14)
-        // Queued behind this turn of the main actor: it therefore runs at the
-        // first suspension inside the wait below, which is exactly the gap.
-        Task { @MainActor in bridge.finishSizeReportDeferral() }
+        phases.onWaitAboutToRegister = { bridge.finishSizeReportDeferral() }
 
+        // The thaw is already history by the time this wait can suspend, and
+        // the wait still has to come back with it rather than with a deadline.
         let forwarded = try await phases.thawedGrid()
         #expect(forwarded == TerminalGridSize(columns: 33, rows: 14))
         #expect(bridge.gridReportPhase == .live)
         #expect(reportedGrids == [ReportedGrid(columns: 33, rows: 14)])
+    }
+
+    /// The same gap, from the other side: a wait whose phase never comes must
+    /// still end at its deadline, and say which phase the freeze stopped at.
+    /// A barrier that claimed a buffered transition it should not have, or
+    /// resumed twice, shows up here rather than as a hang.
+    @MainActor
+    @Test func aPhaseThatNeverArrivesEndsAtItsDeadlineNamingThePhase() async throws {
+        let bridge = TerminalSessionCallbackBridge(
+            onSizeChanged: nil,
+            onViewportTextChanged: nil,
+            onSend: nil,
+            onScroll: nil,
+            onPaste: nil)
+        let phases = TerminalGridReportPhaseRecorder(observing: bridge)
+
+        bridge.beginSizeReportDeferral()
+        // `.deferring` is in the history and `.live` never follows it, so the
+        // wait below has nothing to claim and nothing to wake it.
+        await #expect(throws: GridReportPhaseNeverReachedError.self) {
+            try await phases.thawedGrid(within: .milliseconds(50))
+        }
+        #expect(phases.phases == [.deferring])
+        #expect(bridge.gridReportPhase == .deferring)
     }
 
     @Test func attachOutputPumpWithholdsStartupChatterUntilTheHandshake() async throws {

--- a/Tests/HeelerTests/TerminalAttachTests.swift
+++ b/Tests/HeelerTests/TerminalAttachTests.swift
@@ -176,6 +176,37 @@ struct TerminalAttachTests {
         #expect(reportedGrids == [ReportedGrid(columns: 33, rows: 14)])
     }
 
+    /// The barrier every freeze assertion here rests on, held to its own
+    /// contract. The thaw is published by main-actor work that was already
+    /// queued when the wait began, so it lands in the gap between "has it
+    /// happened yet?" and "wake me when it does". A barrier that answers those
+    /// two questions in separate turns loses the transition in that gap and
+    /// waits out its deadline for an event that already happened.
+    @MainActor
+    @Test func aThawPublishedAsTheWaitBeginsIsStillClaimed() async throws {
+        var reportedGrids: [ReportedGrid] = []
+        let bridge = TerminalSessionCallbackBridge(
+            onSizeChanged: { columns, rows in
+                reportedGrids.append(ReportedGrid(columns: columns, rows: rows))
+            },
+            onViewportTextChanged: nil,
+            onSend: nil,
+            onScroll: nil,
+            onPaste: nil)
+        let phases = TerminalGridReportPhaseRecorder(observing: bridge)
+
+        bridge.beginSizeReportDeferral()
+        bridge.provideAuthoritativeDeferredSize(columns: 33, rows: 14)
+        // Queued behind this turn of the main actor: it therefore runs at the
+        // first suspension inside the wait below, which is exactly the gap.
+        Task { @MainActor in bridge.finishSizeReportDeferral() }
+
+        let forwarded = try await phases.thawedGrid()
+        #expect(forwarded == TerminalGridSize(columns: 33, rows: 14))
+        #expect(bridge.gridReportPhase == .live)
+        #expect(reportedGrids == [ReportedGrid(columns: 33, rows: 14)])
+    }
+
     @Test func attachOutputPumpWithholdsStartupChatterUntilTheHandshake() async throws {
         let chatter = Data("ssh rc startup chatter\r\n".utf8)
         let terminalFrame = Data("TUI".utf8)


### PR DESCRIPTION
## Summary

- expose the terminal grid-report lifecycle as explicit live, deferring, and flushing phases
- deliver the settled grid before announcing that reporting is live again
- thaw immediately when UIKit refuses a keyboard claim
- replace timing-based terminal grid assertions with lifecycle-driven test synchronization and clearer diagnostics

## Verification

- `scripts/generate-wire-types.py --check --schema scripts/herdr-schema.json`
- `npm ci && npm test` in `plugin/` (222 tests)
- `npm test` in `relay/` (88 tests)
- `HEELER_CI_LANE=package HEELER_CI_MANDATORY=1 scripts/run-ci-ios-tests.sh` (49 mandatory HeelerSSH tests)
- focused Terminal Agent Switcher and Attach suites (118 tests)

The local full app lane on iOS 26.5 still hits the pre-existing `AgentDirectInputTests.composerAndDirectInputTransferVisibleKeyboardWithoutReloading()` Simulator-keyboard failure. The same 23-test suite fails on `main` at `d84a882` under the identical Simulator configuration, so this is not introduced by this branch. PR CI remains the merge-gate validation for that environment.

Closes #263