### PR TITLE
Add Cloud Agent dev environment config + commit-msg co-author hook

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,10 @@
+{
+  "name": "Heeler (Node subprojects)",
+  "install": "npm ci --prefix plugin && npm ci --prefix landing",
+  "terminals": [
+    {
+      "name": "landing-dev",
+      "command": "npm --prefix landing run dev -- --host 127.0.0.1 --port 4321"
+    }
+  ]
+}

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,6 @@
 {
   "name": "Heeler (Node subprojects)",
-  "install": "npm ci --prefix plugin && npm ci --prefix landing",
+  "install": "git config core.hooksPath .githooks && npm ci --prefix plugin && npm ci --prefix landing",
   "terminals": [
     {
       "name": "landing-dev",

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# commit-msg hook: strip "Co-authored-by:" trailers so no co-author / bot
+# identity is ever recorded in this repository's history.
+#
+# Enabled via `git config core.hooksPath .githooks` (done in .cursor/environment.json
+# for Cloud Agents; run it once manually in other clones).
+#
+set -euo pipefail
+
+msg_file="$1"
+
+awk '
+  tolower($0) ~ /^[[:space:]]*co-authored-by:/ { next }
+  { buf[++n] = $0 }
+  END {
+    while (n > 0 && buf[n] ~ /^[[:space:]]*$/) n--
+    for (i = 1; i <= n; i++) print buf[i]
+  }
+' "$msg_file" > "$msg_file.tmp"
+
+mv "$msg_file.tmp" "$msg_file"


### PR DESCRIPTION
## Summary

Two related bits of Cloud Agent repo hygiene. Commits follow [Conventional Commits](https://www.conventionalcommits.org/) and carry no `Co-authored-by:` trailers.

### 1. `chore(cloud-agent)`: `.cursor/environment.json`

Lets Cursor Cloud Agents (Linux) reproducibly set up the repository's Linux-runnable subprojects. The iOS/SwiftUI app itself needs macOS + Xcode and cannot build on the Linux Cloud Agent, so this config scopes to the Node/Astro sibling deliverables:

- `install`: enables the git hook (`core.hooksPath .githooks`) and runs `npm ci` for `plugin/` and `landing/` (`relay/` is dependency-free).
- `terminals`: runs the Astro `landing/` dev server on `127.0.0.1:4321`.

### 2. `chore(git-hooks)`: `.githooks/commit-msg` — strip `Co-authored-by:` trailers

A `commit-msg` hook that removes any `Co-authored-by:` trailer from commit messages, so no co-author / bot identity is ever recorded in history. Enabled via `core.hooksPath` (wired into the environment install above; run `git config core.hooksPath .githooks` once in other clones).

## Validation (all run on the Linux Cloud Agent)

- `relay/`: `node --test` -> **88 tests pass**.
- `plugin/`: `npm ci` + `node --test` -> **222 tests pass**.
- `landing/`: `npm ci` + `npm run build` -> build succeeds (2 pages), and `npm run dev` serves **HTTP 200** at `http://127.0.0.1:4321/` with title `Heeler — an agent console for herdr`.
- `scripts/generate-wire-types.py --check --schema scripts/herdr-schema.json` -> `up to date` (no codegen drift).
- **Hook verified**: with the hook enabled, committing a message containing `Co-authored-by:` trailers produces a stored message with **zero** such lines. All commits on this branch are authored and committed by `ZingerLittleBee <6970999@gmail.com>` with no co-author trailer.

## Notes

- Internal tooling/config change (no user-visible app change), so no `CHANGELOG.md` entry.
- A committed `.cursor/environment.json` takes precedence over dashboard-managed environments and follows branches/PRs.
- `core.hooksPath` is not auto-enabled by cloning (git security); it's applied by the environment `install` step and must be run manually in other local clones.