### PR TITLE
fix: end events stream before transport teardown

### DIFF
--- a/Sources/Heeler/Transport/EventsSession.swift
+++ b/Sources/Heeler/Transport/EventsSession.swift
@@ -663,12 +663,15 @@ actor EventsSession {
         task?.cancel()
         let stream = liveStream
         liveStream = nil
+        if let stream {
+            // End the events channel before closing the transport it rides on.
+            // Otherwise close can queue behind the still-running reader on the
+            // same SSH session and turn a bounded teardown into an unbounded one.
+            await stream.end()
+        }
         if let transport = currentTransport {
             currentTransport = nil
             try? await transport.close()
-        }
-        if let stream {
-            await stream.end()
         }
         await waitForTerminalIdle()
         transportSuspect = false


### PR DESCRIPTION
## Summary
- end the live events stream before closing the SSH transport during `EventsSession` teardown
- avoid queueing connection teardown behind the still-running events reader on weak links
- fix the weak-network backgrounding hang that was timing out local app CI

## Test plan
- [x] `xcodebuild test -project Heeler.xcodeproj -scheme Heeler -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:HeelerTests/AppForegroundRecoveryTests`
- [x] `HEELER_CI_LANE=app HEELER_CI_MANDATORY=0 scripts/run-ci-ios-tests.sh`