### PR TITLE
feat: per-pane session name in the Agent list (refs #290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Entries reference the issue that motivated them.
 - Agent sessions can now carry a device-local name, set from the row's
   context menu in the Agent list, so multiple sessions in one workspace are
   distinguishable. Unset names fall back to the workspace label as before.
-  (#290)
+  (#290; PR #291)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Added
+
+- Agent sessions can now carry a device-local name, set from the row's
+  context menu in the Agent list, so multiple sessions in one workspace are
+  distinguishable. Unset names fall back to the workspace label as before.
+  (#290)
+
 ### Changed
 
 - Relicensed the Heeler suite from AGPL-3.0 to Apache License 2.0. (#282)

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		77B45AA7E6B648D1C2531951 /* NotificationRegistrationCeremony.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03953ADE9FBC5162FBFF29F /* NotificationRegistrationCeremony.swift */; };
 		785A44749D305DC59153D679 /* AgentDirectInputChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F93F9925E94FF2C2B0254B /* AgentDirectInputChrome.swift */; };
 		78AB0CC85260D35A1178163A /* AgentComposerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276B4E744F8A3BF386189D8A /* AgentComposerStore.swift */; };
+		7A60255C22EA9256F053DB5D /* PaneNameSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B6F8BD0A555BE62CBD5856 /* PaneNameSheetView.swift */; };
 		7A73A34256C7B55060AAE9DE /* ConsoleDetailPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F44B0C95580FC88ED880FD /* ConsoleDetailPresentationTests.swift */; };
 		7AAD57A0A0BF63FE16C76C17 /* TerminalStatusDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856C56B29DCF048C09AF7C1C /* TerminalStatusDialogTests.swift */; };
 		7B1292E9A9C6175D1272755D /* ConsoleHostStatusPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530D32C2D59D0DD128053804 /* ConsoleHostStatusPresentation.swift */; };
@@ -313,9 +314,11 @@
 		E40D1C6F825ABCD68AA5F196 /* AttachTerminalStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5A562F5A01AE08691B8479 /* AttachTerminalStoreTests.swift */; };
 		E521D6779F4C453B6E098F14 /* TerminalFontSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 427512344847A84699F819A0 /* TerminalFontSettingsTests.swift */; };
 		E563373DB446DBEF8B1701E3 /* DeviceKeyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FCA00B5F2A05A599D74FCCE /* DeviceKeyStoreTests.swift */; };
+		E6743B6A77E33E97143B7E6F /* PaneNameStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915EA5A6B24F033F9E23C7B1 /* PaneNameStoreTests.swift */; };
 		E6C62004AD1258DB773F9B07 /* ShellTerminalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175D872736F56BE7D98A5A40 /* ShellTerminalStore.swift */; };
 		E6D3DCE16CD5B192FD1B9E07 /* SkillsPaneStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9578B0F124B9B77740E8E38F /* SkillsPaneStoreTests.swift */; };
 		E70364D1965B611EB71E6A06 /* TransportErrorPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74CE585C09A319294FB635B /* TransportErrorPresentationTests.swift */; };
+		E79F687C119AC88CC83D393D /* PaneNameStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A419E7A057D90515C4B09427 /* PaneNameStore.swift */; };
 		E7CE4737CFB94163D9EEC8F2 /* FakePairingConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8273181A2428AD3F78FCC27B /* FakePairingConnector.swift */; };
 		E89FDBBF01AA72A922ED0F03 /* Host.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AE04F29C794799B45E5C68 /* Host.swift */; };
 		E9D5DD0D136597844A8FE54B /* HerdrEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764EB7D298185F64BA26C8B2 /* HerdrEvents.swift */; };
@@ -556,6 +559,7 @@
 		84DA8573DB6A7EBC95A57F2F /* StartAgentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAgentStoreTests.swift; sourceTree = "<group>"; };
 		856A8398D8F0FB87F252D193 /* FakeLiveActivityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeLiveActivityController.swift; sourceTree = "<group>"; };
 		856C56B29DCF048C09AF7C1C /* TerminalStatusDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalStatusDialogTests.swift; sourceTree = "<group>"; };
+		85B6F8BD0A555BE62CBD5856 /* PaneNameSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneNameSheetView.swift; sourceTree = "<group>"; };
 		85BEE99E7BEFA0D0D985162C /* AttachUserMessageIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachUserMessageIndex.swift; sourceTree = "<group>"; };
 		86642A7BA9C1F1E3456D64E3 /* SSHChannelAdmission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHChannelAdmission.swift; sourceTree = "<group>"; };
 		86CF5F0136C3ED0B1F7F4EED /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
@@ -572,6 +576,7 @@
 		8F1676B4E6BAB1C28E5596A7 /* AgentNotificationRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationRouterTests.swift; sourceTree = "<group>"; };
 		90A97F1827BC65B4A271F28C /* NotificationRelaySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRelaySettings.swift; sourceTree = "<group>"; };
 		915C9462A4A8AA91C0B91498 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		915EA5A6B24F033F9E23C7B1 /* PaneNameStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneNameStoreTests.swift; sourceTree = "<group>"; };
 		921CA559141776BD0F02FDA7 /* TerminalThemeSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemeSettingsTests.swift; sourceTree = "<group>"; };
 		93417EFE29FA2DC3DD3FAF9F /* AsyncDeadlineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDeadlineTests.swift; sourceTree = "<group>"; };
 		9394E039D63A2FEE9BAB1D25 /* HeelerNotificationService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HeelerNotificationService.entitlements; sourceTree = "<group>"; };
@@ -596,6 +601,7 @@
 		A2CED0240EA91B680CF3A758 /* TerminalZoomSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalZoomSettings.swift; sourceTree = "<group>"; };
 		A2FDB99BA76C2379B0590B3B /* HostTelemetryPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostTelemetryPresentationTests.swift; sourceTree = "<group>"; };
 		A30FA0CFA49274EB428AD3E0 /* HerdrWireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HerdrWireTests.swift; sourceTree = "<group>"; };
+		A419E7A057D90515C4B09427 /* PaneNameStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneNameStore.swift; sourceTree = "<group>"; };
 		A4B83DAB243F0D4C697FA3B8 /* LiveActivityControlling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityControlling.swift; sourceTree = "<group>"; };
 		A579E1DA3F59AFBC3ECAD69C /* SSHChannelAdmissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHChannelAdmissionTests.swift; sourceTree = "<group>"; };
 		A5C6340A9A91119C998F64C3 /* SkillFrontmatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillFrontmatterTests.swift; sourceTree = "<group>"; };
@@ -829,6 +835,7 @@
 				1F0763484EE05424146492C1 /* PairingCeremonyTests.swift */,
 				D419158B027AF5F38B73AD8B /* PairingCodeTests.swift */,
 				D026719294E631141C3A59F9 /* PairingScanStoreTests.swift */,
+				915EA5A6B24F033F9E23C7B1 /* PaneNameStoreTests.swift */,
 				768235F2FBD7790800281BC3 /* PinnedAgentsStoreTests.swift */,
 				151586845D0A1EE54968B536 /* PreflightReportTests.swift */,
 				BEE35062339F9D6B0A9E684B /* PushRegistrationStoreTests.swift */,
@@ -1028,6 +1035,8 @@
 				88E1434C9C39A6419A3A0D79 /* HostConsoleProjection.swift */,
 				6CAC72199BF308E484F37439 /* HostTelemetryPresentation.swift */,
 				17631B548FA0C56DD5318D7A /* MessageJumpControl.swift */,
+				85B6F8BD0A555BE62CBD5856 /* PaneNameSheetView.swift */,
+				A419E7A057D90515C4B09427 /* PaneNameStore.swift */,
 				B2437B1D6B97638031514C0F /* PinnedAgentsStore.swift */,
 				C7BD377C8BB7AA8205DD8AFC /* RecentWorkspaceStore.swift */,
 				C82C6169E59B0000AA3FF5CC /* RenameSheetView.swift */,
@@ -1437,8 +1446,8 @@
 			targets = (
 				081A3B29EFF2C7B2FCAA3248 /* Heeler */,
 				DFFB82C74B73FA5CBCE6D5D2 /* HeelerNotificationService */,
-				9806EA6C63028F1217417282 /* HeelerTests */,
 				134E6CD1AC1396155DAB93E2 /* HeelerWidgets */,
+				9806EA6C63028F1217417282 /* HeelerTests */,
 			);
 		};
 /* End PBXProject section */
@@ -1599,6 +1608,8 @@
 				14F3A10674FAF72C63042108 /* PairingConnector.swift in Sources */,
 				DB3815F790623647C0050290 /* PairingScanStore.swift in Sources */,
 				430EDF8111CC397CA9BD2008 /* PairingScanView.swift in Sources */,
+				7A60255C22EA9256F053DB5D /* PaneNameSheetView.swift in Sources */,
+				E79F687C119AC88CC83D393D /* PaneNameStore.swift in Sources */,
 				D08663BD250210835FE7ED49 /* PhotosPickerImageSelection.swift in Sources */,
 				DDD5A27BA1126296E5AF7EAA /* PinnedAgentsStore.swift in Sources */,
 				2292C89F605CE42073D49B11 /* Preflight.swift in Sources */,
@@ -1778,6 +1789,7 @@
 				82600FB64A99ADAD1C60D451 /* PairingCodeTests.swift in Sources */,
 				B3C490CC3562CC5B4B2EB993 /* PairingCodeVectorFile.swift in Sources */,
 				F6A1A833DFFB748716D13EA9 /* PairingScanStoreTests.swift in Sources */,
+				E6743B6A77E33E97143B7E6F /* PaneNameStoreTests.swift in Sources */,
 				DC580B52C0F6509F92BB289C /* PinnedAgentsStoreTests.swift in Sources */,
 				A194C27FBF0EF6641215D33A /* PreflightReportTests.swift in Sources */,
 				630CF9C336B79F04A9477C58 /* PushRegistrationStoreTests.swift in Sources */,

--- a/Sources/Heeler/Console/AgentTerminalView.swift
+++ b/Sources/Heeler/Console/AgentTerminalView.swift
@@ -1425,7 +1425,8 @@ struct AgentTerminalView: View {
     }
 
     static func displayTitle(for agent: ConsoleAgent) -> String {
-        agent.agent.title.isEmpty ? agent.agent.displayName : agent.agent.title
+        if let paneName = agent.paneName { return paneName }
+        return agent.agent.title.isEmpty ? agent.agent.displayName : agent.agent.title
     }
 }
 

--- a/Sources/Heeler/Console/ConsoleAgent.swift
+++ b/Sources/Heeler/Console/ConsoleAgent.swift
@@ -27,6 +27,11 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
     /// Trailing terminal output (`pane.read`, ANSI stripped), fetched after
     /// snapshots and status changes; nil until the first read lands.
     var lastOutputSnippet: String?
+    /// A user-set local name for this pane session (`PaneNameStore`), applied
+    /// when the row is built; nil until the user names the session. Wins
+    /// wherever the session is named, mirroring how herdr's own sidebar shows
+    /// the agent name ahead of the workspace.
+    var paneName: String?
 
     var id: ID { ID(hostID: hostID, paneID: agent.paneID) }
 
@@ -37,7 +42,8 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
         workspaceLabel: String?,
         repositoryCheckout: RepositoryCheckout?,
         lastOutputSnippet: String? = nil,
-        hostUsername: String? = nil
+        hostUsername: String? = nil,
+        paneName: String? = nil
     ) {
         self.hostID = hostID
         self.hostName = hostName
@@ -46,6 +52,7 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
         self.workspaceLabel = workspaceLabel
         self.repositoryCheckout = repositoryCheckout
         self.lastOutputSnippet = lastOutputSnippet
+        self.paneName = paneName
     }
 
     var repoName: String? { repositoryCheckout?.repoName }
@@ -65,12 +72,13 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
         }
     }
 
-    /// The keyboard switcher's chip label. The project leads, as it does on
-    /// the card, but without the card's `label · repo` pairing: a chip has
-    /// room for one word, and a console full of `claude` is told apart by
-    /// where each one is working.
+    /// The keyboard switcher's chip label and card headline. A user-set pane
+    /// name leads; otherwise the project leads, as it does on the card, but
+    /// without the card's `label · repo` pairing: a chip has room for one
+    /// word, and a console full of `claude` is told apart by where each one
+    /// is working.
     var switcherLabel: String {
-        workspaceLabel ?? repoName ?? agent.displayName
+        paneName ?? workspaceLabel ?? repoName ?? agent.displayName
     }
 
     /// The directory the skills probe treats as the agent's project root:

--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -76,16 +76,32 @@ final class ConsoleStore {
     /// Shared with the Console list: a pin toggle must re-sort `agents` in
     /// the same turn, so the store lives here rather than only on the view.
     let pins: PinnedAgentsStore
+    /// Local per-pane session names (#290). Shared with the list like `pins`
+    /// because a name change must republish rows in the same turn.
+    let paneNames: PaneNameStore
 
     init(
         snapshotRetryDelay: Duration = .seconds(2),
         pins: PinnedAgentsStore = PinnedAgentsStore(),
+        paneNames: PaneNameStore = PaneNameStore(),
         makeSession: @escaping @Sendable (Host, [EventSubscription]) -> EventsSession =
             ConsoleStore.sshSessionFactory()
     ) {
         self.snapshotRetryDelay = snapshotRetryDelay
         self.pins = pins
+        self.paneNames = paneNames
         self.makeSession = makeSession
+    }
+
+    /// Names (or, with an empty name, un-names) one pane session and
+    /// republishes the list immediately — a name change must not wait on a
+    /// snapshot round-trip.
+    func setPaneName(_ name: String, paneID: String, on hostID: Host.ID) {
+        paneNames.set(name, hostID: hostID, paneID: paneID)
+        for projection in projections.values {
+            projection.restampPaneNames()
+        }
+        rebuild()
     }
 
     /// Pins or unpins the Agent and re-sorts the published list in the same
@@ -457,7 +473,10 @@ final class ConsoleStore {
         let projection = HostConsoleProjection(
             host: host,
             session: session,
-            snapshotRetryDelay: snapshotRetryDelay
+            snapshotRetryDelay: snapshotRetryDelay,
+            paneName: { [weak self] hostID, paneID in
+                self?.paneNames.name(hostID: hostID, paneID: paneID)
+            }
         ) { [weak self] in
             self?.rebuild()
         }

--- a/Sources/Heeler/Console/ConsoleView.swift
+++ b/Sources/Heeler/Console/ConsoleView.swift
@@ -23,6 +23,7 @@ struct ConsoleView: View {
     /// pauses its work on real suspensions only.
     let activity: AppActivityCoordinator
     @State private var hostSheet: HostSheet?
+    @State private var paneNameSheet: PaneNameSheetIdentity?
     @State private var isStartingAgent = false
     @State private var isShowingSettings = false
     /// Hosts whose Host-detail Reconnect request is in flight, including the
@@ -395,6 +396,19 @@ struct ConsoleView: View {
                 console.togglePin(
                     hostID: agent.hostID, paneID: agent.agent.paneID)
             }
+            Button("Name Session", systemImage: "tag") {
+                paneNameSheet = PaneNameSheetIdentity(
+                    hostID: agent.hostID, paneID: agent.agent.paneID)
+            }
+        }
+        .sheet(item: $paneNameSheet) { identity in
+            PaneNameSheetView(
+                currentName: console.paneNames.name(
+                    hostID: identity.hostID, paneID: identity.paneID)
+            ) { name in
+                console.setPaneName(
+                    name, paneID: identity.paneID, on: identity.hostID)
+            }
         }
     }
 
@@ -450,6 +464,12 @@ struct ConsoleView: View {
     private struct HostSheet: Identifiable {
         let id = UUID()
         let hostID: Host.ID?
+    }
+
+    private struct PaneNameSheetIdentity: Identifiable {
+        let id = UUID()
+        let hostID: Host.ID
+        let paneID: String
     }
 
     /// One actionable status per Host. A disconnected session takes priority;

--- a/Sources/Heeler/Console/HostConsoleProjection.swift
+++ b/Sources/Heeler/Console/HostConsoleProjection.swift
@@ -11,6 +11,10 @@ final class HostConsoleProjection {
 
     private(set) var agentsByPane: [String: ConsoleAgent] = [:]
     private(set) var workspaces: [ConsoleWorkspace] = []
+    /// Resolves the user-set local name for a pane session (`PaneNameStore`);
+    /// nil until the user names the session.
+    private let paneName: @MainActor (Host.ID, String) -> String?
+
     private(set) var status: EventsSessionStatus?
     /// The failure that last stopped automatic recovery, retained after the
     /// next activation begins and discarded when that activation resolves.
@@ -81,11 +85,13 @@ final class HostConsoleProjection {
         host: Host,
         session: EventsSession,
         snapshotRetryDelay: Duration,
+        paneName: @escaping @MainActor (Host.ID, String) -> String? = { _, _ in nil },
         onChange: @escaping @MainActor @Sendable () -> Void
     ) {
         self.host = host
         self.session = session
         self.snapshotRetryDelay = snapshotRetryDelay
+        self.paneName = paneName
         self.onChange = onChange
     }
 
@@ -591,6 +597,20 @@ final class HostConsoleProjection {
         }
     }
 
+    /// Reapplies pane names from the store without a resync, so a name
+    /// change lands in the list on the same turn it is saved — mirroring the
+    /// in-place row mutation `lastOutputSnippet` already uses.
+    func restampPaneNames() {
+        for paneID in agentsByPane.keys {
+            guard var row = agentsByPane[paneID] else { continue }
+            let name = paneName(row.hostID, paneID)
+            if row.paneName != name {
+                row.paneName = name
+                agentsByPane[paneID] = row
+            }
+        }
+    }
+
     private func scheduleSnapshotRetry() {
         guard resyncRetryTask == nil, !hasEnded, status == .connected else { return }
         resyncRetryTask = Task { [weak self] in
@@ -638,7 +658,8 @@ final class HostConsoleProjection {
                 workspaceLabel: workspace?.label,
                 repositoryCheckout: workspace?.worktree.map(RepositoryCheckout.init),
                 lastOutputSnippet: agentsByPane[agent.paneID]?.lastOutputSnippet,
-                hostUsername: host.username)
+                hostUsername: host.username,
+                paneName: paneName(host.id, agent.paneID))
         }
         for (paneID, change) in latestStatusChanges
         where change.revision > snapshotStartRevision {

--- a/Sources/Heeler/Console/PaneNameSheetView.swift
+++ b/Sources/Heeler/Console/PaneNameSheetView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// Sets or clears the local pane name for one session (#290): a trimmed,
+/// non-empty name sticks; an empty submit clears it back to the default
+/// label. Unlike RenameSheetView there is no server validation — the name
+/// never leaves the device.
+struct PaneNameSheetView: View {
+    let currentName: String?
+    let save: (String) -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var input: String
+
+    init(currentName: String?, save: @escaping (String) -> Void) {
+        self.currentName = currentName
+        self.save = save
+        _input = State(initialValue: currentName ?? "")
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("e.g. backend fix", text: $input)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                } footer: {
+                    Text(
+                        "A name for this session, shown in the Agent list. "
+                        + "Leave it empty to clear the name and fall back to "
+                        + "the workspace label.")
+                }
+            }
+            .navigationTitle("Name Session")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        save(input)
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium])
+    }
+}

--- a/Sources/Heeler/Console/PaneNameStore.swift
+++ b/Sources/Heeler/Console/PaneNameStore.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// A user-chosen name for one pane session, kept on this device (#290).
+///
+/// herdr's server-side `agent.rename` is restricted to `^[a-z][a-z0-9_-]{0,31}$`
+/// and only covers Agents; the Console otherwise names a row by its workspace
+/// label, which is identical for every Agent in one workspace. A local name
+/// tells sessions apart without a Host round-trip, accepts free text, and
+/// works for every pane. It never leaves the device, so it never conflicts
+/// with herdr's own rename.
+@MainActor
+final class PaneNameStore {
+    private static let defaultsKey = "pane-names"
+    private static let blobVersion = 1
+
+    private struct PersistedBlob: Codable {
+        let version: Int
+        let entries: [Entry]
+    }
+
+    private struct Entry: Codable, Equatable {
+        let hostID: UUID
+        let paneID: String
+        let name: String
+    }
+
+    private var entries: [Entry]
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        guard let data = defaults.data(forKey: Self.defaultsKey) else {
+            entries = []
+            return
+        }
+        do {
+            let blob = try JSONDecoder().decode(PersistedBlob.self, from: data)
+            guard blob.version == Self.blobVersion else {
+                // Names are cheap to lose: unknown versions start empty and
+                // the next write clobbers them, like PinnedAgentsStore.
+                entries = []
+                return
+            }
+            entries = blob.entries
+        } catch {
+            entries = []
+        }
+    }
+
+    /// The stored name for one pane session, nil when unset.
+    func name(hostID: Host.ID, paneID: String) -> String? {
+        entries.first { $0.hostID == hostID && $0.paneID == paneID }?.name
+    }
+
+    /// Sets the name for one pane session. Empty or whitespace-only input
+    /// clears the entry back to unset.
+    func set(_ name: String, hostID: Host.ID, paneID: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        entries.removeAll { $0.hostID == hostID && $0.paneID == paneID }
+        guard !trimmed.isEmpty else {
+            persist()
+            return
+        }
+        entries.append(Entry(hostID: hostID, paneID: paneID, name: trimmed))
+        persist()
+    }
+
+    private func persist() {
+        let blob = PersistedBlob(version: Self.blobVersion, entries: entries)
+        guard let data = try? JSONEncoder().encode(blob) else { return }
+        defaults.set(data, forKey: Self.defaultsKey)
+    }
+}

--- a/Tests/HeelerTests/PaneNameStoreTests.swift
+++ b/Tests/HeelerTests/PaneNameStoreTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+/// The device-local per-pane name store (#290): names keyed by
+/// `(hostID, paneID)`, versioned UserDefaults blob, trimmed writes.
+@MainActor
+@Suite("Pane name store")
+struct PaneNameStoreTests {
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "pane-name-store-tests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    @Test func unsetNamesAreNil() {
+        let store = PaneNameStore(defaults: makeDefaults())
+        #expect(store.name(hostID: UUID(), paneID: "w1:p1") == nil)
+    }
+
+    @Test func setAndReadSurviveReload() {
+        let defaults = makeDefaults()
+        let hostID = UUID()
+        PaneNameStore(defaults: defaults).set(
+            "backend fix", hostID: hostID, paneID: "w1:p1")
+        let reloaded = PaneNameStore(defaults: defaults)
+        #expect(reloaded.name(hostID: hostID, paneID: "w1:p1") == "backend fix")
+    }
+
+    @Test func namesAreScopedToPaneAndHost() {
+        let store = PaneNameStore(defaults: makeDefaults())
+        let hostID = UUID()
+        store.set("a", hostID: hostID, paneID: "w1:p1")
+        store.set("b", hostID: hostID, paneID: "w1:p2")
+        #expect(store.name(hostID: hostID, paneID: "w1:p1") == "a")
+        #expect(store.name(hostID: hostID, paneID: "w1:p2") == "b")
+        #expect(store.name(hostID: UUID(), paneID: "w1:p1") == nil)
+    }
+
+    @Test func emptyAndWhitespaceNamesClear() {
+        let store = PaneNameStore(defaults: makeDefaults())
+        let hostID = UUID()
+        store.set("old", hostID: hostID, paneID: "w1:p1")
+        store.set("   ", hostID: hostID, paneID: "w1:p1")
+        #expect(store.name(hostID: hostID, paneID: "w1:p1") == nil)
+    }
+
+    @Test func namesAreTrimmed() {
+        let store = PaneNameStore(defaults: makeDefaults())
+        let hostID = UUID()
+        store.set("  frontend  ", hostID: hostID, paneID: "w1:p1")
+        #expect(store.name(hostID: hostID, paneID: "w1:p1") == "frontend")
+    }
+}

--- a/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
+++ b/Tests/HeelerTests/TerminalAgentSwitcherTests.swift
@@ -15,6 +15,7 @@ struct TerminalAgentSwitcherTests {
         workspace: String? = nil,
         repo: String? = nil,
         name: String? = nil,
+        paneName: String? = nil,
         status: AgentStatus = .idle,
         host: UUID = UUID()
     ) -> ConsoleAgent {
@@ -34,7 +35,8 @@ struct TerminalAgentSwitcherTests {
                     checkoutPath: "/work/\($0)",
                     isLinkedWorktree: false)
             },
-            lastOutputSnippet: nil)
+            lastOutputSnippet: nil,
+            paneName: paneName)
     }
 
     private static func makeItem(
@@ -60,6 +62,15 @@ struct TerminalAgentSwitcherTests {
         #expect(Self.makeAgent(pane: "p2", repo: "repo").switcherLabel == "repo")
         #expect(Self.makeAgent(pane: "p3", name: "reviewer").switcherLabel == "reviewer")
         #expect(Self.makeAgent(pane: "p4").switcherLabel == "claude")
+    }
+
+    /// A user-set pane name is the session's own identity (#290): it leads
+    /// the workspace label so two Agents in one workspace are
+    /// distinguishable, and unset names leave the fallback chain intact.
+    @Test func aSetPaneNameLeadsEverything() {
+        #expect(
+            Self.makeAgent(pane: "p5", workspace: "proj", paneName: "backend fix")
+                .switcherLabel == "backend fix")
     }
 
     @MainActor


### PR DESCRIPTION
## What

Multiple Agents running in one workspace render **identical Console rows** — the card headline is the workspace label and herdr's own agent name is only consulted when no workspace label exists. With several agents in one project the list is N identical rows (refs #290).

This PR adds a **device-local, free-form name per pane session** (`hostID + paneID`, versioned UserDefaults blob), set from the row's long-press menu:

- A set name leads wherever a session is named: the card headline, the keyboard switcher chip, and the Agent detail title.
- Unset names keep the existing `workspace label -> repo -> agent name/kind` fallback, so nothing changes until the user names a session.
- The name never leaves the device, so it complements rather than competes with herdr's server-side `agent.rename`: it accepts free text (e.g. Chinese labels), works for every pane, and needs no Host round-trip or server name-pattern compliance (`^[a-z][a-z0-9_-]{0,31}$`).

## Files

- `Sources/Heeler/Console/PaneNameStore.swift` — the new store (pattern-mirrors `PinnedAgentsStore`).
- `Sources/Heeler/Console/PaneNameSheetView.swift` — the naming sheet ("leave empty to clear").
- `ConsoleAgent` — `paneName` field; `switcherLabel` = `paneName ?? workspaceLabel ?? repoName ?? displayName`.
- `HostConsoleProjection` — row build applies the store's name; `restampPaneNames()` refreshes rows without a snapshot round-trip.
- `ConsoleStore` — owns `PaneNameStore` (like `pins`) and `setPaneName(...)` republishes the list immediately.
- `ConsoleView` — "Name Session" in the row context menu + sheet.
- `AgentTerminalView` — detail title prefers the pane name.
- Tests: `PaneNameStoreTests` (persistence, per-pane scoping, trim/clear) + a switcher-label precedence case.

## Verification

- New suites pass locally (Xcode 26.3): `PaneNameStoreTests` 5/5, `TerminalAgentSwitcherTests` 30/30, `ConsoleStoreTests` + `ConsoleDetailPresentationTests` 72/72.
- Regenerated `Heeler.xcodeproj` via `xcodegen` and committed it (CI builds the committed project).
- Note: this machine's Xcode 26.3 rejects two **pre-existing** files that CI (Xcode 26.6, green on main) accepts — `Packages/HeelerSSH` (`sending 'createdSession'`) and `AgentStatusPaletteTests` (`Int`/`CGFloat` literal). Both are untouched by this PR; I verified my changes with temporary local workarounds that are not part of the diff.

CHANGELOG entry added under Unreleased → Added, refs #290.