### PR TITLE
fix: show three three-row agents on the lock screen activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Fixed
+
+- The Lock Screen Live Activity shows three Agents with three-row Agent List
+  Fields instead of two before "+N more". The row budget overestimated card
+  height and its test measured only frame minimums, not the rendered text.
+  Four three-row cards exceed ActivityKit's 160 pt limit, so four rows remain
+  only for two-row layouts. (#281)
+
 ## [0.1.6] - 2026-09-09
 
 ### Added

--- a/Sources/HeelerWidgets/AgentActivityDecryptor.swift
+++ b/Sources/HeelerWidgets/AgentActivityDecryptor.swift
@@ -66,7 +66,10 @@ enum AgentActivityPresentation: Equatable, Sendable {
     }
 
     /// Keep configured rows, independent tap targets, padding, and the
-    /// overflow/stale caption within the 160 pt lock-screen budget.
+    /// overflow/stale caption within the 160 pt lock-screen budget. The
+    /// estimate mirrors the rendered layout: three three-row cards plus the
+    /// caption fit (about 158 pt), a fourth never does, and four two-row
+    /// cards still fit as before.
     func lockScreenAgents(isStale: Bool) -> [AgentActivityDetails.AgentDetail] {
         let total = counts.total
         guard total > 0 else { return [] }
@@ -78,8 +81,12 @@ enum AgentActivityPresentation: Equatable, Sendable {
             let rowHeight = prefix.reduce(0) {
                 $0 + max(target, AgentActivityRowMetrics.minimumHeight(for: $1))
             }
-            let captionHeight = isStale || total > shown ? 12 : 0
-            if rowHeight + CGFloat(16 + captionHeight) <= 160 { return prefix }
+            let captionHeight = isStale || total > shown
+                ? AgentActivityRowMetrics.lockScreenCaptionHeight : 0
+            let padding = AgentActivityRowMetrics.lockScreenBannerVerticalPadding * 2
+            if rowHeight + padding + captionHeight <= AgentActivityRowMetrics.lockScreenHeightBudget {
+                return prefix
+            }
         }
         return Array(candidates.prefix(1))
     }

--- a/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
+++ b/Sources/HeelerWidgets/AgentLiveActivityWidget.swift
@@ -156,7 +156,7 @@ struct AgentActivityLockScreenView: View {
                 #endif
             }
             .padding(.horizontal, 14)
-            .padding(.vertical, 8)
+            .padding(.vertical, AgentActivityRowMetrics.lockScreenBannerVerticalPadding)
         }
         .widgetURL(AgentActivityLink.consoleURL(hostID: hostID))
     }
@@ -312,8 +312,20 @@ enum AgentActivityRowMetrics {
         agentCount <= 3 ? comfortableMinimumHeight : denseMinimumHeight
     }
 
+    /// Three configured rows render at about 43.5 pt (caption + 2 x caption2
+    /// plus the card's vertical padding), so a three-row card is held to the
+    /// comfortable 44 pt target; two rows or fewer fit the dense target.
+    static let threeRowMinimumHeight: CGFloat = comfortableMinimumHeight
+
+    /// Vertical padding of the whole lock-screen banner.
+    static let lockScreenBannerVerticalPadding: CGFloat = 6
+    /// Rendered height of the trailing caption2 line (overflow / stale).
+    static let lockScreenCaptionHeight: CGFloat = 14
+    /// ActivityKit's lock-screen presentation height limit.
+    static let lockScreenHeightBudget: CGFloat = 160
+
     static func minimumHeight(for agent: AgentActivityDetails.AgentDetail) -> CGFloat {
-        AgentActivityFields.rows(for: agent).count > 2 ? 48 : denseMinimumHeight
+        AgentActivityFields.rows(for: agent).count > 2 ? threeRowMinimumHeight : denseMinimumHeight
     }
 }
 
@@ -470,7 +482,7 @@ struct AgentActivityRowView: View {
                 }
             }
         }
-        .padding(.vertical, agent.rows == nil ? 0 : 2)
+        .padding(.vertical, agent.rows == nil ? 0 : 1)
         .layoutPriority(1)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(AgentActivityNarration.rowLabel(for: agent))

--- a/Tests/HeelerTests/AgentActivityPresentationTests.swift
+++ b/Tests/HeelerTests/AgentActivityPresentationTests.swift
@@ -253,14 +253,28 @@ struct AgentActivityPresentationTests {
 
     @Test func threeRowCardsReserveSpaceForOverflowAndStaleness() {
         let presentation = configuredPresentation(agentCount: 5)
-        #expect(presentation.lockScreenAgents(isStale: false).map(\.paneID) == ["w1:p0", "w1:p1"])
+        #expect(
+            presentation.lockScreenAgents(isStale: false).map(\.paneID)
+                == ["w1:p0", "w1:p1", "w1:p2"])
+        #expect(presentation.lockScreenAgents(isStale: true).count == 3)
         #expect(presentation.lockScreenTrailingCaption(isStale: true)
-            == "+3 more · May be out of date")
+            == "+2 more · May be out of date")
         #expect(presentation.secondaryAgents.count == 1)
         #expect(presentation.overflowCount == 3)
         let three = configuredPresentation(agentCount: 3)
         #expect(three.lockScreenAgents(isStale: false).count == 3)
-        #expect(three.lockScreenAgents(isStale: true).count == 2)
+        #expect(three.lockScreenAgents(isStale: true).count == 3)
+        let four = configuredPresentation(agentCount: 4)
+        #expect(four.lockScreenAgents(isStale: false).count == 3)
+        #expect(four.lockScreenTrailingCaption(isStale: false) == "+1 more")
+    }
+
+    @Test func threeRowCardsUseTheComfortableTargetHeight() {
+        var agent = agentDetail(paneID: "w1:p1")
+        agent.rows = [[.init(text: "1")], [.init(text: "2")], [.init(text: "3")]]
+        #expect(AgentActivityRowMetrics.minimumHeight(for: agent) == 44)
+        agent.rows = [[.init(text: "1")], [.init(text: "2")]]
+        #expect(AgentActivityRowMetrics.minimumHeight(for: agent) == 28)
     }
 
     @Test func styledFieldsPreserveHexColorAndSecondarySemantics() {
@@ -300,22 +314,26 @@ struct AgentActivityPresentationTests {
         }
     }
 
+    /// Measures the rendered banner, not `sizeThatFits`: a hosting
+    /// controller reports only the row frames' minimum heights and misses
+    /// the text, which is what let three-row cards overrun the budget.
     @MainActor
     @Test func threeRowBannersFitTheLockScreenHeightBudget() throws {
-        for count in [3, 5] {
+        for count in [3, 4, 5] {
             for stale in [false, true] {
                 let view = AgentActivityLockScreenView(
                     presentation: configuredPresentation(agentCount: count),
                     hostID: "host", isStale: stale)
-                let controller = UIHostingController(rootView: view)
-                let size = controller.sizeThatFits(in: CGSize(width: 360, height: 0))
-                #expect(size.height <= 160, "\(count) Agents, stale=\(stale): \(size.height) pt")
-                #expect(size.height > 0)
                 let renderer = ImageRenderer(content: view
-                    .frame(width: 360, height: size.height)
+                    .frame(width: 360)
                     .environment(\.colorScheme, .light))
                 renderer.scale = 2
                 let image = try #require(renderer.uiImage)
+                let height = image.size.height
+                #expect(height <= 160, "\(count) Agents, stale=\(stale): \(height) pt")
+                // Three three-row cards are drawn, so the banner is far
+                // taller than the two-card layout (about 104 pt).
+                #expect(height > 140, "\(count) Agents, stale=\(stale): \(height) pt")
                 Attachment.record(image,
                     named: "activity-fields-\(count)-agents-stale-\(stale)", as: .png)
             }


### PR DESCRIPTION
## Summary

- The lock-screen Live Activity now shows three Agents with three-row Agent List Fields before falling back to "+N more".
- The previous budget treated a three-row card as 48 pt and the caption as 12 pt, so three cards plus overflow looked like they exceeded ActivityKit's 160 pt limit and the banner dropped to two.
- The rendered card is about 45.5 pt and the caption 13.5 pt; with 1 pt card padding and 6 pt banner padding, three cards fit at 157.5 pt. Four three-row cards still need 211 pt and stay out of reach.
- The fit test now measures the rendered image instead of `sizeThatFits`, which only reported row-frame minimums and ignored text.

## Verification

- `xcodebuild test -project Heeler.xcodeproj -scheme Heeler -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:HeelerTests/AgentActivityPresentationTests` — suite passed, including `threeRowCardsReserveSpaceForOverflowAndStaleness`, `threeRowCardsUseTheComfortableTargetHeight`, and `threeRowBannersFitTheLockScreenHeightBudget`.

CHANGELOG entry added under Unreleased → Fixed. Refs #281.