### PR TITLE
fix(transport): add mise shims to the discovery PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Entries reference the issue that motivated them.
 
 ### Fixed
 
+- New Agent now discovers agents installed through mise. The discovery PATH
+  includes mise's shims directory, resolved from `MISE_DATA_DIR` or
+  `XDG_DATA_HOME` when either reaches the non-interactive SSH environment,
+  otherwise `~/.local/share/mise/shims`. (#293)
 - The Lock Screen Live Activity shows three Agents with three-row Agent List
   Fields instead of two before "+N more". The row budget overestimated card
   height and its test measured only frame minimums, not the rendered text.

--- a/Sources/Heeler/Transport/HerdrHostPath.swift
+++ b/Sources/Heeler/Transport/HerdrHostPath.swift
@@ -24,10 +24,22 @@ import Foundation
 ///   only at the command word, so it cannot see an inner `herdr`.
 enum HerdrHostPath: Sendable {
     /// Directories appended to `PATH` on herdr CLI and Agent discovery
-    /// execs. `$HOME` is expanded by the remote `/bin/sh`, not by Swift.
+    /// execs. `$HOME` and the parameter expansions are evaluated by the
+    /// remote `/bin/sh`, not by Swift.
+    ///
+    /// mise exposes its tools to non-interactive shells through its shims
+    /// directory (#293); `mise activate` lives in interactive rc files the
+    /// probe never reads. The expansion follows mise's own resolution order,
+    /// `MISE_DATA_DIR`, then `XDG_DATA_HOME/mise`, then
+    /// `~/.local/share/mise`, but only sees a value that reaches the
+    /// non-interactive environment. One set solely in `.zshrc` or `.bashrc`
+    /// still resolves to the default.
     static let extraPATH =
-        "$HOME/.local/bin:$HOME/.linuxbrew/bin:$HOME/.cargo/bin:$HOME/.bun/bin:"
+        "$HOME/.local/bin:\(miseShims):$HOME/.linuxbrew/bin:$HOME/.cargo/bin:$HOME/.bun/bin:"
         + "/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin"
+
+    /// POSIX sh expansion of mise's shims directory.
+    static let miseShims = "${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims"
 
     static var pathAssignment: String {
         "PATH=\"$PATH:\(extraPATH)\""

--- a/Tests/HeelerTests/HerdrHostPathTests.swift
+++ b/Tests/HeelerTests/HerdrHostPathTests.swift
@@ -13,6 +13,10 @@ struct HerdrHostPathTests {
         #expect(HerdrHostPath.extraPATH.contains("$HOME/.cargo/bin"))
         #expect(HerdrHostPath.extraPATH.contains("$HOME/.bun/bin"))
         #expect(HerdrHostPath.extraPATH.contains("/usr/local/bin"))
+        // mise shims resolve the data dir the way mise does, default last (#293).
+        #expect(
+            HerdrHostPath.extraPATH.contains(
+                "${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims"))
         // Existing PATH entries keep priority over the extra prefixes.
         #expect(HerdrHostPath.pathExport.hasPrefix("export PATH=\"$PATH:"))
     }


### PR DESCRIPTION
## Summary

- New Agent discovery now includes mise's shims directory on the exec PATH, next to the existing Homebrew, cargo, bun, and `~/.local/bin` prefixes.
- Discovery runs under non-interactive POSIX `sh`, so it never sees `mise activate` from rc files; the shims directory is the same approach already used for other tool installs.
- The path follows mise's own resolution as a POSIX `sh` expansion evaluated on the Host: `MISE_DATA_DIR`, then `XDG_DATA_HOME/mise`, then `~/.local/share/mise`. A value set only in `.zshrc` / `.bashrc` does not reach the probe and falls back to the default.

## Verification

- `xcodebuild test -project Heeler.xcodeproj -scheme Heeler -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:HeelerTests/HerdrHostPathTests` — suite passed, including the mise shims expansion in `extraPATH`.

CHANGELOG entry added under Unreleased → Fixed.

Closes #293