### PR TITLE
docs(readme): download buttons, Trendshift badge, App Store status

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -13,6 +13,8 @@
 [![iOS](https://img.shields.io/badge/iOS-18%2B-000000?logo=apple&logoColor=white)](https://developer.apple.com/ios/)
 [![TestFlight](https://img.shields.io/badge/TestFlight-beta-0D96F6?logo=apple&logoColor=white)](https://testflight.apple.com/join/aXSxRn4r)
 
+<a href="https://trendshift.io/repositories/151670?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-151670" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/151670/daily?language=Swift" alt="ZingerLittleBee%2FHeeler | Trendshift" width="250" height="55"/></a>
+
 **[通过 TestFlight 加入 beta](https://testflight.apple.com/join/aXSxRn4r)**
 
 [English](./README.md) | 简体中文

--- a/README-zh.md
+++ b/README-zh.md
@@ -6,12 +6,12 @@
 
 **[herdr](https://herdr.dev) 的原生 iOS 伴侣应用 —— herdr 是一个 agent 优先的终端运行时。**
 
-[![CI](https://github.com/ZingerLittleBee/Heeler/actions/workflows/ci.yml/badge.svg)](https://github.com/ZingerLittleBee/Heeler/actions/workflows/ci.yml)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat)](https://github.com/ZingerLittleBee/Heeler/stargazers)
-[![Swift](https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white)](https://www.swift.org)
-[![iOS](https://img.shields.io/badge/iOS-18%2B-000000?logo=apple&logoColor=white)](https://developer.apple.com/ios/)
-[![App Store](https://img.shields.io/badge/App_Store-available-0D96F6?logo=apple&logoColor=white)](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135)
+[![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat-square)](https://github.com/ZingerLittleBee/Heeler/stargazers)
+[![CI](https://img.shields.io/github/actions/workflow/status/ZingerLittleBee/Heeler/ci.yml?branch=main&label=CI&style=flat-square)](https://github.com/ZingerLittleBee/Heeler/actions/workflows/ci.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
+[![Swift](https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white&style=flat-square)](https://www.swift.org)
+[![iOS](https://img.shields.io/badge/iOS-18%2B-000000?logo=apple&logoColor=white&style=flat-square)](https://developer.apple.com/ios/)
+[![App Store](https://img.shields.io/badge/App_Store-available-0D96F6?logo=apple&logoColor=white&style=flat-square)](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135)
 
 <a href="https://trendshift.io/repositories/151670?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-151670" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/151670/daily?language=Swift" alt="ZingerLittleBee%2FHeeler | Trendshift" width="250" height="55"/></a>
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -11,11 +11,11 @@
 [![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat)](https://github.com/ZingerLittleBee/Heeler/stargazers)
 [![Swift](https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white)](https://www.swift.org)
 [![iOS](https://img.shields.io/badge/iOS-18%2B-000000?logo=apple&logoColor=white)](https://developer.apple.com/ios/)
-[![TestFlight](https://img.shields.io/badge/TestFlight-beta-0D96F6?logo=apple&logoColor=white)](https://testflight.apple.com/join/aXSxRn4r)
+[![App Store](https://img.shields.io/badge/App_Store-available-0D96F6?logo=apple&logoColor=white)](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135)
 
 <a href="https://trendshift.io/repositories/151670?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-151670" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/151670/daily?language=Swift" alt="ZingerLittleBee%2FHeeler | Trendshift" width="250" height="55"/></a>
 
-<a href="https://testflight.apple.com/join/aXSxRn4r"><img src="docs/images/testflight-badge-zh.svg" alt="在 TestFlight 加入 beta 测试" height="40" /></a>
+<a href="https://testflight.apple.com/join/aXSxRn4r"><img src="docs/images/testflight-badge-zh.svg" alt="在 TestFlight 下载" height="40" /></a>
 <a href="https://apps.apple.com/us/app/heeler-for-herdr/id6797263135"><img src="https://toolbox.marketingtools.apple.com/api/badges/download-on-the-app-store/black/zh-cn?size=250x83" alt="在 App Store 下载" height="40" /></a>
 
 [English](./README.md) | 简体中文

--- a/README-zh.md
+++ b/README-zh.md
@@ -15,7 +15,7 @@
 
 <a href="https://trendshift.io/repositories/151670?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-151670" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/151670/daily?language=Swift" alt="ZingerLittleBee%2FHeeler | Trendshift" width="250" height="55"/></a>
 
-[![加入 beta](https://img.shields.io/badge/TestFlight-加入_beta-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/aXSxRn4r)
+<a href="https://testflight.apple.com/join/aXSxRn4r"><img src="docs/images/testflight-badge-zh.svg" alt="在 TestFlight 加入 beta 测试" height="40" /></a>
 <a href="https://apps.apple.com/us/app/heeler-for-herdr/id6797263135"><img src="https://toolbox.marketingtools.apple.com/api/badges/download-on-the-app-store/black/zh-cn?size=250x83" alt="在 App Store 下载" height="40" /></a>
 
 [English](./README.md) | 简体中文

--- a/README-zh.md
+++ b/README-zh.md
@@ -15,7 +15,8 @@
 
 <a href="https://trendshift.io/repositories/151670?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-151670" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/151670/daily?language=Swift" alt="ZingerLittleBee%2FHeeler | Trendshift" width="250" height="55"/></a>
 
-**[通过 TestFlight 加入 beta](https://testflight.apple.com/join/aXSxRn4r)**
+[![加入 beta](https://img.shields.io/badge/TestFlight-加入_beta-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/aXSxRn4r)
+[![下载](https://img.shields.io/badge/App_Store-下载-000000?style=for-the-badge&logo=apple&logoColor=white)](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135)
 
 [English](./README.md) | 简体中文
 
@@ -100,4 +101,4 @@ host key 指纹和 SSH 密钥注册全部由配对码承载。在应用里为该
 
 ## 状态
 
-Beta，已上 [TestFlight](https://testflight.apple.com/join/aXSxRn4r)。以个人日常使用打磨为先，仍有粗糙之处，迭代较快。与 herdr 项目无隶属关系。
+已在 [App Store](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135) 上发布；部分国家和地区尚未上架，可以继续使用 [TestFlight](https://testflight.apple.com/join/aXSxRn4r)。以个人日常使用打磨为先，仍有粗糙之处，迭代较快。与 herdr 项目无隶属关系。

--- a/README-zh.md
+++ b/README-zh.md
@@ -93,7 +93,7 @@ host key 指纹和 SSH 密钥注册全部由配对码承载。在应用里为该
 - 仓库内 `Packages/HeelerSSH`（libssh2 + OpenSSL）负责 SSH
 - [libghostty-spm](https://github.com/lakr233/libghostty-spm) 负责终端仿真与 Metal 渲染
 
-选型缘由见 `docs/adr/`（传输层的故事尤其不直观）。
+选型依据见 `docs/adr/`，其中传输层方案经过多轮验证后才最终确定。
 
 ## 参与贡献
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -9,7 +9,7 @@
 
 **[herdr](https://herdr.dev) 的原生 iOS 伴侣应用 —— herdr 是一个 agent 优先的终端运行时。**
 
-[![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat-square&color=E3A008&logo=github&logoColor=white)](https://github.com/ZingerLittleBee/Heeler/stargazers)
+[![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat-square&color=E8B923&logo=github&logoColor=white)](https://github.com/ZingerLittleBee/Heeler/stargazers)
 [![CI](https://img.shields.io/github/actions/workflow/status/ZingerLittleBee/Heeler/ci.yml?branch=main&label=CI&style=flat-square)](https://github.com/ZingerLittleBee/Heeler/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-6F42C1?style=flat-square)](LICENSE)
 [![Swift](https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white&style=flat-square)](https://www.swift.org)

--- a/README-zh.md
+++ b/README-zh.md
@@ -16,7 +16,7 @@
 <a href="https://trendshift.io/repositories/151670?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-151670" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/151670/daily?language=Swift" alt="ZingerLittleBee%2FHeeler | Trendshift" width="250" height="55"/></a>
 
 [![加入 beta](https://img.shields.io/badge/TestFlight-加入_beta-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/aXSxRn4r)
-[![下载](https://img.shields.io/badge/App_Store-下载-000000?style=for-the-badge&logo=apple&logoColor=white)](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135)
+<a href="https://apps.apple.com/us/app/heeler-for-herdr/id6797263135"><img src="https://toolbox.marketingtools.apple.com/api/badges/download-on-the-app-store/black/zh-cn?size=250x83" alt="在 App Store 下载" height="40" /></a>
 
 [English](./README.md) | 简体中文
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -9,9 +9,9 @@
 
 **[herdr](https://herdr.dev) 的原生 iOS 伴侣应用 —— herdr 是一个 agent 优先的终端运行时。**
 
-[![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat-square)](https://github.com/ZingerLittleBee/Heeler/stargazers)
+[![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat-square&color=E3A008&logo=github&logoColor=white)](https://github.com/ZingerLittleBee/Heeler/stargazers)
 [![CI](https://img.shields.io/github/actions/workflow/status/ZingerLittleBee/Heeler/ci.yml?branch=main&label=CI&style=flat-square)](https://github.com/ZingerLittleBee/Heeler/actions/workflows/ci.yml)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-6F42C1?style=flat-square)](LICENSE)
 [![Swift](https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white&style=flat-square)](https://www.swift.org)
 [![iOS](https://img.shields.io/badge/iOS-18%2B-000000?logo=apple&logoColor=white&style=flat-square)](https://developer.apple.com/ios/)
 [![App Store](https://img.shields.io/badge/App_Store-available-0D96F6?logo=apple&logoColor=white&style=flat-square)](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135)

--- a/README-zh.md
+++ b/README-zh.md
@@ -4,6 +4,9 @@
 
 # Heeler
 
+<a href="https://testflight.apple.com/join/aXSxRn4r"><img src="docs/images/testflight-badge-zh.svg" alt="在 TestFlight 下载" height="40" /></a>
+<a href="https://apps.apple.com/us/app/heeler-for-herdr/id6797263135"><img src="https://toolbox.marketingtools.apple.com/api/badges/download-on-the-app-store/black/zh-cn?size=250x83" alt="在 App Store 下载" height="40" /></a>
+
 **[herdr](https://herdr.dev) 的原生 iOS 伴侣应用 —— herdr 是一个 agent 优先的终端运行时。**
 
 [![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat-square)](https://github.com/ZingerLittleBee/Heeler/stargazers)
@@ -14,9 +17,6 @@
 [![App Store](https://img.shields.io/badge/App_Store-available-0D96F6?logo=apple&logoColor=white&style=flat-square)](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135)
 
 <a href="https://trendshift.io/repositories/151670?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-151670" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/151670/daily?language=Swift" alt="ZingerLittleBee%2FHeeler | Trendshift" width="250" height="55"/></a>
-
-<a href="https://testflight.apple.com/join/aXSxRn4r"><img src="docs/images/testflight-badge-zh.svg" alt="在 TestFlight 下载" height="40" /></a>
-<a href="https://apps.apple.com/us/app/heeler-for-herdr/id6797263135"><img src="https://toolbox.marketingtools.apple.com/api/badges/download-on-the-app-store/black/zh-cn?size=250x83" alt="在 App Store 下载" height="40" /></a>
 
 [English](./README.md) | 简体中文
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <a href="https://trendshift.io/repositories/151670?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-151670" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/151670/daily?language=Swift" alt="ZingerLittleBee%2FHeeler | Trendshift" width="250" height="55"/></a>
 
-[![Join the beta](https://img.shields.io/badge/TestFlight-Join_the_beta-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/aXSxRn4r)
+<a href="https://testflight.apple.com/join/aXSxRn4r"><img src="docs/images/testflight-badge.svg" alt="Join the beta on TestFlight" height="40" /></a>
 <a href="https://apps.apple.com/us/app/heeler-for-herdr/id6797263135"><img src="https://toolbox.marketingtools.apple.com/api/badges/download-on-the-app-store/black/en-us?size=250x83" alt="Download on the App Store" height="40" /></a>
 
 English | [简体中文](./README-zh.md)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <a href="https://trendshift.io/repositories/151670?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-151670" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/151670/daily?language=Swift" alt="ZingerLittleBee%2FHeeler | Trendshift" width="250" height="55"/></a>
 
 [![Join the beta](https://img.shields.io/badge/TestFlight-Join_the_beta-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/aXSxRn4r)
-[![Download](https://img.shields.io/badge/App_Store-Download-000000?style=for-the-badge&logo=apple&logoColor=white)](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135)
+<a href="https://apps.apple.com/us/app/heeler-for-herdr/id6797263135"><img src="https://toolbox.marketingtools.apple.com/api/badges/download-on-the-app-store/black/en-us?size=250x83" alt="Download on the App Store" height="40" /></a>
 
 English | [简体中文](./README-zh.md)
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 **A native iOS companion app for [herdr](https://herdr.dev) — an agent-first terminal runtime.**
 
-[![CI](https://github.com/ZingerLittleBee/Heeler/actions/workflows/ci.yml/badge.svg)](https://github.com/ZingerLittleBee/Heeler/actions/workflows/ci.yml)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat)](https://github.com/ZingerLittleBee/Heeler/stargazers)
-[![Swift](https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white)](https://www.swift.org)
-[![iOS](https://img.shields.io/badge/iOS-18%2B-000000?logo=apple&logoColor=white)](https://developer.apple.com/ios/)
-[![App Store](https://img.shields.io/badge/App_Store-available-0D96F6?logo=apple&logoColor=white)](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135)
+[![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat-square)](https://github.com/ZingerLittleBee/Heeler/stargazers)
+[![CI](https://img.shields.io/github/actions/workflow/status/ZingerLittleBee/Heeler/ci.yml?branch=main&label=CI&style=flat-square)](https://github.com/ZingerLittleBee/Heeler/actions/workflows/ci.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
+[![Swift](https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white&style=flat-square)](https://www.swift.org)
+[![iOS](https://img.shields.io/badge/iOS-18%2B-000000?logo=apple&logoColor=white&style=flat-square)](https://developer.apple.com/ios/)
+[![App Store](https://img.shields.io/badge/App_Store-available-0D96F6?logo=apple&logoColor=white&style=flat-square)](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135)
 
 <a href="https://trendshift.io/repositories/151670?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-151670" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/151670/daily?language=Swift" alt="ZingerLittleBee%2FHeeler | Trendshift" width="250" height="55"/></a>
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 [![iOS](https://img.shields.io/badge/iOS-18%2B-000000?logo=apple&logoColor=white)](https://developer.apple.com/ios/)
 [![TestFlight](https://img.shields.io/badge/TestFlight-beta-0D96F6?logo=apple&logoColor=white)](https://testflight.apple.com/join/aXSxRn4r)
 
+<a href="https://trendshift.io/repositories/151670?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-151670" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/151670/daily?language=Swift" alt="ZingerLittleBee%2FHeeler | Trendshift" width="250" height="55"/></a>
+
 **[Join the beta on TestFlight](https://testflight.apple.com/join/aXSxRn4r)**
 
 English | [简体中文](./README-zh.md)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 
 <a href="https://trendshift.io/repositories/151670?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-151670" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/151670/daily?language=Swift" alt="ZingerLittleBee%2FHeeler | Trendshift" width="250" height="55"/></a>
 
-**[Join the beta on TestFlight](https://testflight.apple.com/join/aXSxRn4r)**
+[![Join the beta](https://img.shields.io/badge/TestFlight-Join_the_beta-0D96F6?style=for-the-badge&logo=apple&logoColor=white)](https://testflight.apple.com/join/aXSxRn4r)
+[![Download](https://img.shields.io/badge/App_Store-Download-000000?style=for-the-badge&logo=apple&logoColor=white)](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135)
 
 English | [简体中文](./README-zh.md)
 
@@ -109,6 +110,8 @@ layout, build/test, and conventions.
 
 ## Status
 
-Beta, on [TestFlight](https://testflight.apple.com/join/aXSxRn4r). Built for
-personal use first and shaped by daily driving, so expect rough edges and
+Released on the [App Store](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135).
+It is not yet available in every country or region; where it is missing, the
+[TestFlight](https://testflight.apple.com/join/aXSxRn4r) beta stays open. Built
+for personal use first and shaped by daily driving, so expect rough edges and
 fast iteration. Not affiliated with the herdr project.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 # Heeler
 
+<a href="https://testflight.apple.com/join/aXSxRn4r"><img src="docs/images/testflight-badge.svg" alt="Available on TestFlight" height="40" /></a>
+<a href="https://apps.apple.com/us/app/heeler-for-herdr/id6797263135"><img src="https://toolbox.marketingtools.apple.com/api/badges/download-on-the-app-store/black/en-us?size=250x83" alt="Download on the App Store" height="40" /></a>
+
 **A native iOS companion app for [herdr](https://herdr.dev) — an agent-first terminal runtime.**
 
 [![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat-square)](https://github.com/ZingerLittleBee/Heeler/stargazers)
@@ -14,9 +17,6 @@
 [![App Store](https://img.shields.io/badge/App_Store-available-0D96F6?logo=apple&logoColor=white&style=flat-square)](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135)
 
 <a href="https://trendshift.io/repositories/151670?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-151670" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/151670/daily?language=Swift" alt="ZingerLittleBee%2FHeeler | Trendshift" width="250" height="55"/></a>
-
-<a href="https://testflight.apple.com/join/aXSxRn4r"><img src="docs/images/testflight-badge.svg" alt="Available on TestFlight" height="40" /></a>
-<a href="https://apps.apple.com/us/app/heeler-for-herdr/id6797263135"><img src="https://toolbox.marketingtools.apple.com/api/badges/download-on-the-app-store/black/en-us?size=250x83" alt="Download on the App Store" height="40" /></a>
 
 English | [简体中文](./README-zh.md)
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 **A native iOS companion app for [herdr](https://herdr.dev) — an agent-first terminal runtime.**
 
-[![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat-square)](https://github.com/ZingerLittleBee/Heeler/stargazers)
+[![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat-square&color=E3A008&logo=github&logoColor=white)](https://github.com/ZingerLittleBee/Heeler/stargazers)
 [![CI](https://img.shields.io/github/actions/workflow/status/ZingerLittleBee/Heeler/ci.yml?branch=main&label=CI&style=flat-square)](https://github.com/ZingerLittleBee/Heeler/actions/workflows/ci.yml)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-6F42C1?style=flat-square)](LICENSE)
 [![Swift](https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white&style=flat-square)](https://www.swift.org)
 [![iOS](https://img.shields.io/badge/iOS-18%2B-000000?logo=apple&logoColor=white&style=flat-square)](https://developer.apple.com/ios/)
 [![App Store](https://img.shields.io/badge/App_Store-available-0D96F6?logo=apple&logoColor=white&style=flat-square)](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **A native iOS companion app for [herdr](https://herdr.dev) — an agent-first terminal runtime.**
 
-[![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat-square&color=E3A008&logo=github&logoColor=white)](https://github.com/ZingerLittleBee/Heeler/stargazers)
+[![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat-square&color=E8B923&logo=github&logoColor=white)](https://github.com/ZingerLittleBee/Heeler/stargazers)
 [![CI](https://img.shields.io/github/actions/workflow/status/ZingerLittleBee/Heeler/ci.yml?branch=main&label=CI&style=flat-square)](https://github.com/ZingerLittleBee/Heeler/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-6F42C1?style=flat-square)](LICENSE)
 [![Swift](https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white&style=flat-square)](https://www.swift.org)

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 [![GitHub stars](https://img.shields.io/github/stars/ZingerLittleBee/Heeler?style=flat)](https://github.com/ZingerLittleBee/Heeler/stargazers)
 [![Swift](https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white)](https://www.swift.org)
 [![iOS](https://img.shields.io/badge/iOS-18%2B-000000?logo=apple&logoColor=white)](https://developer.apple.com/ios/)
-[![TestFlight](https://img.shields.io/badge/TestFlight-beta-0D96F6?logo=apple&logoColor=white)](https://testflight.apple.com/join/aXSxRn4r)
+[![App Store](https://img.shields.io/badge/App_Store-available-0D96F6?logo=apple&logoColor=white)](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135)
 
 <a href="https://trendshift.io/repositories/151670?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-151670" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/151670/daily?language=Swift" alt="ZingerLittleBee%2FHeeler | Trendshift" width="250" height="55"/></a>
 
-<a href="https://testflight.apple.com/join/aXSxRn4r"><img src="docs/images/testflight-badge.svg" alt="Join the beta on TestFlight" height="40" /></a>
+<a href="https://testflight.apple.com/join/aXSxRn4r"><img src="docs/images/testflight-badge.svg" alt="Available on TestFlight" height="40" /></a>
 <a href="https://apps.apple.com/us/app/heeler-for-herdr/id6797263135"><img src="https://toolbox.marketingtools.apple.com/api/badges/download-on-the-app-store/black/en-us?size=250x83" alt="Download on the App Store" height="40" /></a>
 
 English | [简体中文](./README-zh.md)
@@ -112,6 +112,6 @@ layout, build/test, and conventions.
 
 Released on the [App Store](https://apps.apple.com/us/app/heeler-for-herdr/id6797263135).
 It is not yet available in every country or region; where it is missing, the
-[TestFlight](https://testflight.apple.com/join/aXSxRn4r) beta stays open. Built
-for personal use first and shaped by daily driving, so expect rough edges and
+[TestFlight](https://testflight.apple.com/join/aXSxRn4r) build stays available.
+Built for personal use first and shaped by daily driving, so expect rough edges and
 fast iteration. Not affiliated with the herdr project.

--- a/docs/images/testflight-badge-zh.svg
+++ b/docs/images/testflight-badge-zh.svg
@@ -1,8 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="128" height="40" viewBox="0 0 128 40" role="img" aria-label="加入 beta 测试 TestFlight">
-  <rect x="0.5" y="0.5" width="127" height="39" rx="5" fill="#000" stroke="#a6a6a6"/>
-  <path d="M26.5 9.5 L8 17.2 L15.4 20.4 L22.8 14.4 L17.6 21.2 L17.6 29.5 L21.2 24.3 L25 26 Z" fill="#fff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="108" height="40" viewBox="0 0 108 40" role="img" aria-label="TestFlight 下载">
+  <rect x="0.5" y="0.5" width="107" height="39" rx="5" fill="#000" stroke="#a6a6a6"/>
   <g fill="#fff" font-family="-apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'PingFang SC', 'Segoe UI', Arial, sans-serif">
-    <text x="33" y="20" font-size="17" font-weight="600" letter-spacing="-0.2">TestFlight</text>
-    <text x="33" y="32" font-size="9">加入 beta 测试</text>
+    <text x="12" y="20" font-size="17" font-weight="600" letter-spacing="-0.2">TestFlight</text>
+    <text x="12" y="32" font-size="9">下载</text>
   </g>
 </svg>

--- a/docs/images/testflight-badge-zh.svg
+++ b/docs/images/testflight-badge-zh.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="40" viewBox="0 0 128 40" role="img" aria-label="加入 beta 测试 TestFlight">
+  <rect x="0.5" y="0.5" width="127" height="39" rx="5" fill="#000" stroke="#a6a6a6"/>
+  <path d="M26.5 9.5 L8 17.2 L15.4 20.4 L22.8 14.4 L17.6 21.2 L17.6 29.5 L21.2 24.3 L25 26 Z" fill="#fff"/>
+  <g fill="#fff" font-family="-apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'PingFang SC', 'Segoe UI', Arial, sans-serif">
+    <text x="33" y="20" font-size="17" font-weight="600" letter-spacing="-0.2">TestFlight</text>
+    <text x="33" y="32" font-size="9">加入 beta 测试</text>
+  </g>
+</svg>

--- a/docs/images/testflight-badge.svg
+++ b/docs/images/testflight-badge.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="40" viewBox="0 0 128 40" role="img" aria-label="Join the beta on TestFlight">
+  <rect x="0.5" y="0.5" width="127" height="39" rx="5" fill="#000" stroke="#a6a6a6"/>
+  <path d="M26.5 9.5 L8 17.2 L15.4 20.4 L22.8 14.4 L17.6 21.2 L17.6 29.5 L21.2 24.3 L25 26 Z" fill="#fff"/>
+  <g fill="#fff" font-family="-apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'PingFang SC', 'Segoe UI', Arial, sans-serif">
+    <text x="33" y="15" font-size="9">Join the beta on</text>
+    <text x="33" y="31" font-size="17" font-weight="600" letter-spacing="-0.2">TestFlight</text>
+  </g>
+</svg>

--- a/docs/images/testflight-badge.svg
+++ b/docs/images/testflight-badge.svg
@@ -1,8 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="128" height="40" viewBox="0 0 128 40" role="img" aria-label="Join the beta on TestFlight">
-  <rect x="0.5" y="0.5" width="127" height="39" rx="5" fill="#000" stroke="#a6a6a6"/>
-  <path d="M26.5 9.5 L8 17.2 L15.4 20.4 L22.8 14.4 L17.6 21.2 L17.6 29.5 L21.2 24.3 L25 26 Z" fill="#fff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="108" height="40" viewBox="0 0 108 40" role="img" aria-label="Available on TestFlight">
+  <rect x="0.5" y="0.5" width="107" height="39" rx="5" fill="#000" stroke="#a6a6a6"/>
   <g fill="#fff" font-family="-apple-system, BlinkMacSystemFont, 'Helvetica Neue', 'PingFang SC', 'Segoe UI', Arial, sans-serif">
-    <text x="33" y="15" font-size="9">Join the beta on</text>
-    <text x="33" y="31" font-size="17" font-weight="600" letter-spacing="-0.2">TestFlight</text>
+    <text x="12" y="15" font-size="9">Available on</text>
+    <text x="12" y="31" font-size="17" font-weight="600" letter-spacing="-0.2">TestFlight</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

- Add the Trendshift badge to both READMEs.
- Replace the bold TestFlight text link with two download buttons: a text-only TestFlight badge drawn as SVG (`docs/images/testflight-badge*.svg`, no Apple artwork) followed by Apple's official App Store badge served from `toolbox.marketingtools.apple.com` (`en-us` / `zh-cn`).
- Swap the small `TestFlight · beta` shields badge for an `App Store · available` one.
- Update the Status section: released on the App Store, TestFlight build stays available where the app is not yet listed. Drop the remaining beta wording.

## Notes

- The TestFlight badge is text only on purpose: Apple ships no TestFlight badge and its marketing guidelines forbid standalone Apple logos and self-made App Store-style badges.
- Rendering checked locally in headless Chrome; the badges align at 40px height next to the App Store badge.