### PR TITLE
feat: add muse as a supported agent kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Added
+
+- New Agent now offers Muse. herdr 0.9.0 reports the canonical kind and
+  executable as `muse` (`herdr agent start --kind` lists it; detection
+  manifest `id = "muse"`). (#289)
+
 ### Fixed
 
 - New Agent now discovers agents installed through mise. The discovery PATH

--- a/Sources/Heeler/Transport/Transport.swift
+++ b/Sources/Heeler/Transport/Transport.swift
@@ -326,6 +326,7 @@ enum SupportedAgentKind: String, CaseIterable, Identifiable, Sendable, Equatable
     case qodercli
     case maki
     case qwen
+    case muse
 
     var id: String { rawValue }
 
@@ -353,6 +354,7 @@ enum SupportedAgentKind: String, CaseIterable, Identifiable, Sendable, Equatable
         case .qodercli: "Qoder CLI"
         case .maki: "Maki"
         case .qwen: "Qwen Code"
+        case .muse: "Muse"
         }
     }
 

--- a/Sources/HeelerNotificationCore/AgentNotificationIdentity.swift
+++ b/Sources/HeelerNotificationCore/AgentNotificationIdentity.swift
@@ -36,6 +36,7 @@ enum AgentNotificationIdentity {
         case "qodercli": "Qoder CLI"
         case "maki": "Maki"
         case "qwen": "Qwen Code"
+        case "muse": "Muse"
         case "unknown": "Unknown"
         default: rawValue
         }

--- a/Tests/HeelerTests/StartAgentStoreTests.swift
+++ b/Tests/HeelerTests/StartAgentStoreTests.swift
@@ -177,11 +177,13 @@ struct StartAgentStoreTests {
             "pi", "claude", "codex", "gemini", "cursor", "devin", "agy",
             "cline", "omp", "mastracode", "opencode", "copilot", "kimi",
             "kiro", "droid", "amp", "grok", "hermes", "kilo", "qodercli",
-            "maki", "qwen",
+            "maki", "qwen", "muse",
         ])
         #expect(SupportedAgentKind.qwen.rawValue == "qwen")
         #expect(SupportedAgentKind.qwen.displayName == "Qwen Code")
         #expect(SupportedAgentKind.qwen.executable == "qwen")
+        #expect(SupportedAgentKind.muse.displayName == "Muse")
+        #expect(SupportedAgentKind.muse.executable == "muse")
         #expect(SupportedAgentKind.cursor.executable == "cursor-agent")
         #expect(SupportedAgentKind.kiro.executable == "kiro-cli")
         #expect(


### PR DESCRIPTION
Closes #289.

Adds Muse to the supported agent catalog after verifying herdr 0.9.0:

- `herdr agent start --kind` possible-values include `muse`; the flag help reads "Supported agent kind and canonical executable", so the canonical executable is `muse`.
- Embedded detection manifest reports `id = "muse"` with aliases `["muse-code", "muse-cli"]`.
- herdr 0.9.0 release notes list "Added Muse agent detection".

Changes:
- `SupportedAgentKind.muse` (raw `muse`, display `Muse`, default executable `muse`) appended after `qwen`.
- Notification `kindLabel` maps `muse` to `Muse`.
- Catalog test extended with muse displayName/executable asserts; discovery auto-covers muse via `allCases`.
- CHANGELOG Unreleased Added entry refs #289.
- No skill catalog entry: Muse skill paths unverified, falls to default empty (SkillProbe expectations unchanged).

Verification:
- `swiftc -parse` passes on both edited Sources files.
- `git diff --check` clean.
- Full `xcodebuild test` not run locally (no Xcode iOS SDK here); CI covers app tests.
- Note: `scripts/generate-wire-types.py --check` already reports stale Generated types on clean main (protocol drift, out of scope for #289 / tracked by #288).