### PR TITLE
feat: add search to the Agents list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Entries reference the issue that motivated them.
 - Direct Input's shortcut row gains a Paste key after ⇧Enter, so pasting into
   an Agent no longer needs a hardware keyboard. The text goes through the
   same paste review as ⌘V. (#307)
+- The Agents list has a search field. Typing filters Agents by working
+  directory or title text, combines with the Host filter, and hides empty
+  Host sections in grouped mode only while their Host is nominal; a
+  reconnecting or failed Host keeps its section. (#292)
 
 ### Fixed
 

--- a/Heeler.xcodeproj/project.pbxproj
+++ b/Heeler.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		8254C70BCD2334725D5F3ED2 /* AgentNotificationIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401F5B396F9F00568A4FFF88 /* AgentNotificationIdentity.swift */; };
 		82600FB64A99ADAD1C60D451 /* PairingCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D419158B027AF5F38B73AD8B /* PairingCodeTests.swift */; };
 		836C6CE781A0FE57FBA87727 /* JSONValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F261A0911D08819AFC013F1E /* JSONValueTests.swift */; };
+		83A5CACF8A302E149975E284 /* ConsoleAgentSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443200EE85ADB91172DCFA90 /* ConsoleAgentSearchTests.swift */; };
 		83AAFC996DF32402681F38AB /* HostDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A63EFEB7D00E59949CF331 /* HostDraft.swift */; };
 		84107CE13DF5FB29C1D05AA0 /* TerminalScrollControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5AC4A835B6FCE7731E251E /* TerminalScrollControl.swift */; };
 		845B6E45C06C55CCC011D6F0 /* TerminalGridReportPhaseRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747773ABBBA6ECEDAD7786DE /* TerminalGridReportPhaseRecorder.swift */; };
@@ -495,6 +496,7 @@
 		427512344847A84699F819A0 /* TerminalFontSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalFontSettingsTests.swift; sourceTree = "<group>"; };
 		431389855EAA66004BCCB5B9 /* AgentRowLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRowLayoutTests.swift; sourceTree = "<group>"; };
 		442A5127B47FF6FF8840B0B9 /* WorktreeDetailStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeDetailStoreTests.swift; sourceTree = "<group>"; };
+		443200EE85ADB91172DCFA90 /* ConsoleAgentSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleAgentSearchTests.swift; sourceTree = "<group>"; };
 		444F11A4450A3CA904B26658 /* SkillsPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillsPickerView.swift; sourceTree = "<group>"; };
 		4582B5EA42CFA9C8878E6207 /* HeelerSSH */ = {isa = PBXFileReference; lastKnownFileType = folder; name = HeelerSSH; path = Packages/HeelerSSH; sourceTree = SOURCE_ROOT; };
 		45DB60007029322902FD1AFF /* PairingScanStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingScanStore.swift; sourceTree = "<group>"; };
@@ -827,6 +829,7 @@
 				414B652A16576BEDEE9AE000 /* ClosePaneStoreTests.swift */,
 				F4616CECA2722086A6B8B490 /* ComposerAttachmentTests.swift */,
 				239FD696B72E804AE3D85D72 /* ComposerStagingStoreTests.swift */,
+				443200EE85ADB91172DCFA90 /* ConsoleAgentSearchTests.swift */,
 				86F44B0C95580FC88ED880FD /* ConsoleDetailPresentationTests.swift */,
 				107722DE7ECD0406951E6B74 /* ConsoleHostSectionHeaderPresentationTests.swift */,
 				512561E4D83FFB6575A1A8A5 /* ConsoleHostStatusPresentationTests.swift */,
@@ -1801,6 +1804,7 @@
 				61F58007C6B81F14D2F6B58B /* ClosePaneStoreTests.swift in Sources */,
 				179292D9C3E605BC46282FE0 /* ComposerAttachmentTests.swift in Sources */,
 				847FCB04EA7913ACB390C978 /* ComposerStagingStoreTests.swift in Sources */,
+				83A5CACF8A302E149975E284 /* ConsoleAgentSearchTests.swift in Sources */,
 				7A73A34256C7B55060AAE9DE /* ConsoleDetailPresentationTests.swift in Sources */,
 				6E9F5427AEA4BF21EA3C9353 /* ConsoleHostSectionHeaderPresentationTests.swift in Sources */,
 				F61261FF8A17C9C754B99ED9 /* ConsoleHostStatusPresentationTests.swift in Sources */,

--- a/Sources/Heeler/Console/ConsoleAgent.swift
+++ b/Sources/Heeler/Console/ConsoleAgent.swift
@@ -100,6 +100,29 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
         if let checkoutPath, !checkoutPath.isEmpty { return checkoutPath }
         return agent.cwd.isEmpty ? nil : agent.cwd
     }
+
+    /// Client-side Agents search (#292): a trimmed, case-insensitive
+    /// substring match over the working directory and the title/visible
+    /// text. An empty query matches every agent.
+    func matchesAgentSearch(_ query: String) -> Bool {
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !needle.isEmpty else { return true }
+        let candidates: [String?] = [
+            agent.cwd,
+            workspaceLabel,
+            tabLabel,
+            paneLabel,
+            agent.title,
+            agent.paneTitle,
+            agent.displayName,
+            agent.terminalTitle,
+            agent.terminalTitleStripped,
+        ]
+        return candidates.contains {
+            guard let field = $0, !field.isEmpty else { return false }
+            return field.range(of: needle, options: .caseInsensitive) != nil
+        }
+    }
 }
 
 /// The snapshot's exact git checkout identity for one workspace. Workspace

--- a/Sources/Heeler/Console/ConsoleHostStatusPresentation.swift
+++ b/Sources/Heeler/Console/ConsoleHostStatusPresentation.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// One Console list row for a Host's connection or snapshot condition.
 ///
 /// Quiet rows (Paused, Connecting, Loading Agents) are informational and
@@ -111,6 +113,7 @@ enum ConsoleAgentsSurface: Equatable {
     case noHosts
     case noAgents
     case noAgentsOnHost(String)
+    case noSearchResults
     case rows
 
     init(
@@ -119,14 +122,24 @@ enum ConsoleAgentsSurface: Equatable {
         filteredAgentCount: Int,
         visibleIssueCount: Int,
         presentationMode: ConsoleListPresentationMode = .flat,
-        projectedSectionCount: Int = 0
+        projectedSectionCount: Int = 0,
+        searchQuery: String = ""
     ) {
+        let isSearching = !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         if hostCount == 0 {
             self = .noHosts
         } else if presentationMode == .grouped {
-            self = projectedSectionCount > 0 ? .rows : .noHosts
+            if projectedSectionCount > 0 {
+                self = .rows
+            } else if isSearching {
+                self = .noSearchResults
+            } else {
+                self = .noHosts
+            }
         } else if filteredAgentCount == 0 && visibleIssueCount == 0 {
-            if let filteredHostName {
+            if isSearching {
+                self = .noSearchResults
+            } else if let filteredHostName {
                 self = .noAgentsOnHost(filteredHostName)
             } else {
                 self = .noAgents

--- a/Sources/Heeler/Console/ConsoleListPresentationStore.swift
+++ b/Sources/Heeler/Console/ConsoleListPresentationStore.swift
@@ -127,7 +127,8 @@ final class ConsoleListPresentationStore {
     func sections(
         hosts: [Host],
         console: ConsoleStore,
-        filteredHostID: Host.ID? = nil
+        filteredHostID: Host.ID? = nil,
+        searchQuery: String = ""
     ) -> [ConsoleHostSection] {
         sections(
             hosts: hosts,
@@ -136,7 +137,8 @@ final class ConsoleListPresentationStore {
             hostStandingFailures: console.hostStandingFailures,
             hostsAwaitingSnapshot: console.hostsAwaitingSnapshot,
             hostSyncErrors: console.hostSyncErrors,
-            filteredHostID: filteredHostID)
+            filteredHostID: filteredHostID,
+            searchQuery: searchQuery)
     }
 
     /// Projects one section per catalog Host, in catalog order. `agents` is
@@ -149,9 +151,12 @@ final class ConsoleListPresentationStore {
         hostStandingFailures: [Host.ID: TransportError] = [:],
         hostsAwaitingSnapshot: Set<Host.ID> = [],
         hostSyncErrors: [Host.ID: String] = [:],
-        filteredHostID: Host.ID? = nil
+        filteredHostID: Host.ID? = nil,
+        searchQuery: String = ""
     ) -> [ConsoleHostSection] {
-        let agentsByHost = Dictionary(grouping: agents, by: \.hostID)
+        let trimmedQuery = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        let searchedAgents = trimmedQuery.isEmpty ? agents : agents.filter { $0.matchesAgentSearch(trimmedQuery) }
+        let agentsByHost = Dictionary(grouping: searchedAgents, by: \.hostID)
         var projectedHostIDs: Set<Host.ID> = []
 
         return hosts.compactMap { host in
@@ -160,17 +165,29 @@ final class ConsoleListPresentationStore {
 
             let hostAgents = agentsByHost[host.id] ?? []
             let isAwaitingSnapshot = hostsAwaitingSnapshot.contains(host.id)
+            let statusPresentation = ConsoleHostStatusPresentation(
+                host: host,
+                status: hostStatuses[host.id],
+                standingFailure: hostStandingFailures[host.id],
+                isAwaitingSnapshot: isAwaitingSnapshot,
+                syncError: hostSyncErrors[host.id])
+            // While searching, an empty section leaves the list only while its
+            // Host is nominal (#292). A reconnecting or failed Host reports
+            // itself through its status row alone, so that row outranks the
+            // empty-section tidy-up and holds the section open; an absent
+            // presentation, or one carrying informational text only (paused,
+            // connecting, loading Agents), still leaves. Without a query every
+            // catalog Host stays visible, including empty ones.
+            if !trimmedQuery.isEmpty && hostAgents.isEmpty {
+                guard let severity = statusPresentation?.severity, severity != .informational
+                else { return nil }
+            }
             return ConsoleHostSection(
                 hostID: host.id,
                 hostDisplayName: host.displayName,
                 connectionStatus: hostStatuses[host.id],
                 isAwaitingSnapshot: isAwaitingSnapshot,
-                statusPresentation: ConsoleHostStatusPresentation(
-                    host: host,
-                    status: hostStatuses[host.id],
-                    standingFailure: hostStandingFailures[host.id],
-                    isAwaitingSnapshot: isAwaitingSnapshot,
-                    syncError: hostSyncErrors[host.id]),
+                statusPresentation: statusPresentation,
                 agents: hostAgents,
                 isCollapsed: isCollapsed(host.id),
                 statusCounts: ConsoleHostAgentStatusCounts(agents: hostAgents))

--- a/Sources/Heeler/Console/ConsoleView.swift
+++ b/Sources/Heeler/Console/ConsoleView.swift
@@ -32,6 +32,9 @@ struct ConsoleView: View {
     /// Narrows the Agent list to one Host; nil shows every Host. This is a
     /// filter in both presentations, not a second grouping mechanism.
     @State private var hostFilter: Host.ID?
+    /// Client-side Agents search text (#292). Applied after `hostFilter` in
+    /// both presentations; the Host filter is untouched.
+    @State private var searchText = ""
     /// Owns flat/grouped mode and per-Host collapsed state (#245).
     @State private var listPresentation = ConsoleListPresentationStore()
     /// Outlives the detail column's rebuilds, which is the whole point: it
@@ -56,6 +59,7 @@ struct ConsoleView: View {
         NavigationSplitView {
             content
                 .navigationTitle("Agents")
+                .searchable(text: $searchText, prompt: "Search Agents")
                 .navigationSplitViewColumnWidth(min: 320, ideal: 380)
                 .toolbar {
                     // A filter is meaningless with a single Host.
@@ -330,6 +334,15 @@ struct ConsoleView: View {
             } actions: {
                 Button("Show All Hosts") { hostFilter = nil }
             }
+        case .noSearchResults:
+            ContentUnavailableView {
+                Label("No Results", systemImage: "magnifyingglass")
+            } description: {
+                Text("No agents match \"\(searchText)\".")
+            } actions: {
+                Button("Clear Search") { searchText = "" }
+                    .buttonStyle(.borderedProminent)
+            }
         case .rows:
             List(selection: selectedAgent) {
                 if listPresentation.mode == .flat {
@@ -408,14 +421,16 @@ struct ConsoleView: View {
             filteredAgentCount: filteredAgents.count,
             visibleIssueCount: visibleHostIssues.count,
             presentationMode: listPresentation.mode,
-            projectedSectionCount: hostSections.count)
+            projectedSectionCount: hostSections.count,
+            searchQuery: searchText)
     }
 
     private var hostSections: [ConsoleHostSection] {
         listPresentation.sections(
             hosts: hosts.hosts,
             console: console,
-            filteredHostID: hostFilter)
+            filteredHostID: hostFilter,
+            searchQuery: searchText)
     }
 
     private var presentationModeBinding: Binding<ConsoleListPresentationMode> {
@@ -435,8 +450,15 @@ struct ConsoleView: View {
     }
 
     private var filteredAgents: [ConsoleAgent] {
-        guard let hostFilter else { return console.agents }
-        return console.agents.filter { $0.hostID == hostFilter }
+        let hostFiltered: [ConsoleAgent]
+        if let hostFilter {
+            hostFiltered = console.agents.filter { $0.hostID == hostFilter }
+        } else {
+            hostFiltered = console.agents
+        }
+        let needle = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !needle.isEmpty else { return hostFiltered }
+        return hostFiltered.filter { $0.matchesAgentSearch(needle) }
     }
 
     /// Host issues shown in the list: all of them, or the filtered Host's

--- a/Tests/HeelerTests/ConsoleAgentSearchTests.swift
+++ b/Tests/HeelerTests/ConsoleAgentSearchTests.swift
@@ -1,0 +1,251 @@
+import Foundation
+import Testing
+
+@testable import Heeler
+
+@MainActor
+@Suite("Console agent search")
+struct ConsoleAgentSearchTests {
+    private func makeAgent(
+        host: Host,
+        paneID: String,
+        cwd: String = "/work/w1",
+        title: String = "Task",
+        name: String? = nil,
+        terminalTitle: String? = nil,
+        terminalTitleStripped: String? = nil,
+        paneTitle: String? = nil,
+        workspaceLabel: String? = nil,
+        tabLabel: String? = nil,
+        paneLabel: String? = nil
+    ) -> ConsoleAgent {
+        let agent = Agent(
+            terminalID: "term_\(paneID)", kind: "codex", title: title, status: .idle,
+            workspaceID: "w1", tabID: "w1:t1", paneID: paneID, cwd: cwd, revision: 1,
+            name: name, terminalTitle: terminalTitle,
+            terminalTitleStripped: terminalTitleStripped, paneTitle: paneTitle)
+        return ConsoleAgent(
+            hostID: host.id,
+            hostName: host.displayName,
+            agent: agent,
+            workspaceLabel: workspaceLabel,
+            repositoryCheckout: nil,
+            tabLabel: tabLabel,
+            paneLabel: paneLabel)
+    }
+
+    private func makeDefaults() throws -> (UserDefaults, cleanup: () -> Void) {
+        let suiteName = "hm-console-agent-search-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        return (defaults, { defaults.removePersistentDomain(forName: suiteName) })
+    }
+
+    @Test func emptyQueryMatchesEveryAgent() {
+        let host = Host.fixture(name: "studio")
+        let agent = makeAgent(host: host, paneID: "w1:p1")
+        #expect(agent.matchesAgentSearch(""))
+        #expect(agent.matchesAgentSearch("   "))
+    }
+
+    @Test func matchesWorkingDirectorySubstringCaseInsensitively() {
+        let host = Host.fixture(name: "studio")
+        let agent = makeAgent(host: host, paneID: "w1:p1", cwd: "/work/Heeler-Checkout")
+        #expect(agent.matchesAgentSearch("heeler"))
+        #expect(agent.matchesAgentSearch("HEELER-CHECK"))
+        #expect(!agent.matchesAgentSearch("definitely-absent"))
+    }
+
+    @Test func matchesEachTitleAndVisibleTextField() {
+        let host = Host.fixture(name: "studio")
+        let marker = "QuarryQuartz"
+        let agents = [
+            makeAgent(host: host, paneID: "w1:p1", workspaceLabel: "ws-\(marker)"),
+            makeAgent(host: host, paneID: "w1:p2", tabLabel: "tab-\(marker)"),
+            makeAgent(host: host, paneID: "w1:p3", paneLabel: "pane-\(marker)"),
+            makeAgent(host: host, paneID: "w1:p4", title: "title-\(marker)"),
+            makeAgent(host: host, paneID: "w1:p5", paneTitle: "ptitle-\(marker)"),
+            makeAgent(host: host, paneID: "w1:p6", name: "name-\(marker)"),
+            makeAgent(host: host, paneID: "w1:p7", terminalTitle: "term-\(marker)"),
+            makeAgent(
+                host: host, paneID: "w1:p8", terminalTitleStripped: "stripped-\(marker)"),
+        ]
+        for agent in agents {
+            #expect(agent.matchesAgentSearch(marker.lowercased()))
+        }
+    }
+    @Test func skipsNilAndEmptyFieldsWithoutMatching() {
+        let host = Host.fixture(name: "studio")
+        let agent = makeAgent(
+            host: host, paneID: "w1:p1", cwd: "", title: "",
+            terminalTitle: "", terminalTitleStripped: "", paneTitle: "")
+        #expect(!agent.matchesAgentSearch("definitely-absent"))
+        #expect(agent.matchesAgentSearch(""))
+    }
+
+    @Test func searchComposesWithHostFilter() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let store = ConsoleListPresentationStore(defaults: defaults)
+        let hostA = Host.fixture(name: "studio")
+        let hostB = Host.fixture(name: "laptop")
+        let agents = [
+            makeAgent(host: hostA, paneID: "w1:p1", title: "Alpha work"),
+            makeAgent(host: hostB, paneID: "w1:p2", title: "Beta work"),
+        ]
+
+        let filteredToMatchingHost = store.sections(
+            hosts: [hostA, hostB], agents: agents,
+            filteredHostID: hostA.id, searchQuery: "alpha")
+        #expect(filteredToMatchingHost.count == 1)
+        #expect(filteredToMatchingHost.first?.agents.count == 1)
+
+        let filteredToOtherHost = store.sections(
+            hosts: [hostA, hostB], agents: agents,
+            filteredHostID: hostA.id, searchQuery: "beta")
+        #expect(filteredToOtherHost.isEmpty)
+
+        let unfiltered = store.sections(
+            hosts: [hostA, hostB], agents: agents, searchQuery: "beta")
+        #expect(unfiltered.count == 1)
+        #expect(unfiltered.first?.hostID == hostB.id)
+    }
+
+    @Test func groupedModeHidesEmptySectionsOnlyWhileSearching() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let store = ConsoleListPresentationStore(defaults: defaults)
+        let hostA = Host.fixture(name: "studio")
+        let hostB = Host.fixture(name: "laptop")
+        let agents = [makeAgent(host: hostA, paneID: "w1:p1", title: "Alpha work")]
+
+        let withoutQuery = store.sections(hosts: [hostA, hostB], agents: agents)
+        #expect(withoutQuery.count == 2)
+
+        let whileSearching = store.sections(
+            hosts: [hostA, hostB], agents: agents, searchQuery: "alpha")
+        #expect(whileSearching.count == 1)
+        #expect(whileSearching.first?.hostID == hostA.id)
+
+        // Empty or not, a query-free projection never drops a catalog Host.
+        let unqueried = store.sections(
+            hosts: [hostA, hostB], agents: agents,
+            hostStatuses: [
+                hostB.id: .reconnecting(attempt: 1, delay: .seconds(1), failure: .timedOut)
+            ])
+        #expect(unqueried.map(\.hostID) == [hostA.id, hostB.id])
+    }
+
+    /// An empty section survives a search only because its Host is
+    /// reconnecting: the section's status row is where the Console reports
+    /// that, so it must not be tidied away with the other empty sections.
+    @Test func reconnectingHostKeepsItsSectionWhileSearching() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let store = ConsoleListPresentationStore(defaults: defaults)
+        let hostA = Host.fixture(name: "studio")
+        let hostB = Host.fixture(name: "laptop")
+        let agents = [makeAgent(host: hostA, paneID: "w1:p1", title: "Alpha work")]
+
+        let whileSearching = store.sections(
+            hosts: [hostA, hostB], agents: agents,
+            hostStatuses: [
+                hostB.id: .reconnecting(attempt: 1, delay: .seconds(1), failure: .timedOut)
+            ],
+            searchQuery: "alpha")
+
+        #expect(whileSearching.map(\.hostID) == [hostA.id, hostB.id])
+        #expect(whileSearching.last?.agents.isEmpty == true)
+        #expect(whileSearching.last?.statusPresentation?.severity == .warning)
+    }
+
+    @Test func failedHostKeepsItsSectionWhileSearching() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let store = ConsoleListPresentationStore(defaults: defaults)
+        let hostA = Host.fixture(name: "studio")
+        let hostB = Host.fixture(name: "laptop")
+        let hostC = Host.fixture(name: "tablet")
+        let agents = [makeAgent(host: hostA, paneID: "w1:p1", title: "Alpha work")]
+
+        let whileSearching = store.sections(
+            hosts: [hostA, hostB, hostC], agents: agents,
+            hostStatuses: [
+                hostB.id: .failed(.authenticationFailed),
+                hostC.id: .failed(
+                    .hostKeyMismatch(
+                        known: HostKeyFingerprint(digest: Data(repeating: 1, count: 32)),
+                        presented: HostKeyFingerprint(digest: Data(repeating: 2, count: 32)))),
+            ],
+            searchQuery: "alpha")
+
+        #expect(whileSearching.map(\.hostID) == [hostA.id, hostB.id, hostC.id])
+        let warned = try #require(whileSearching.first { $0.hostID == hostB.id })
+        let critical = try #require(whileSearching.first { $0.hostID == hostC.id })
+        #expect(warned.statusPresentation?.severity == .warning)
+        #expect(critical.statusPresentation?.severity == .critical)
+    }
+
+    /// Nominal Hosts — no status row at all, or one that only reports a
+    /// pause, a connection attempt, or a snapshot load — still leave the
+    /// list while searching, so an idle catalog does not fill with empty
+    /// sections.
+    @Test func nominalHostSectionsLeaveWhileSearching() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let store = ConsoleListPresentationStore(defaults: defaults)
+        let hostA = Host.fixture(name: "studio")
+        let hostB = Host.fixture(name: "laptop")
+        let hostC = Host.fixture(name: "tablet")
+        let agents = [makeAgent(host: hostA, paneID: "w1:p1", title: "Alpha work")]
+
+        let whileSearching = store.sections(
+            hosts: [hostA, hostB, hostC], agents: agents,
+            hostStatuses: [hostB.id: .connected, hostC.id: .suspended],
+            searchQuery: "alpha")
+
+        #expect(whileSearching.map(\.hostID) == [hostA.id])
+    }
+
+    @Test func flatSurfaceSelectsNoSearchResultsWhileSearching() {
+        let searching = ConsoleAgentsSurface(
+            hostCount: 2, filteredHostName: nil, filteredAgentCount: 0,
+            visibleIssueCount: 0, searchQuery: "alpha")
+        #expect(searching == .noSearchResults)
+        #expect(searching != .noAgents)
+
+        let idle = ConsoleAgentsSurface(
+            hostCount: 2, filteredHostName: nil, filteredAgentCount: 0,
+            visibleIssueCount: 0)
+        #expect(idle == .noAgents)
+
+        let searchingOnFilteredHost = ConsoleAgentsSurface(
+            hostCount: 2, filteredHostName: "studio", filteredAgentCount: 0,
+            visibleIssueCount: 0, searchQuery: "alpha")
+        #expect(searchingOnFilteredHost == .noSearchResults)
+
+        let searchingWithVisibleIssues = ConsoleAgentsSurface(
+            hostCount: 2, filteredHostName: nil, filteredAgentCount: 0,
+            visibleIssueCount: 1, searchQuery: "alpha")
+        #expect(searchingWithVisibleIssues == .rows)
+    }
+
+    @Test func groupedSurfaceSelectsNoSearchResultsWhileSearching() {
+        let searching = ConsoleAgentsSurface(
+            hostCount: 2, filteredHostName: nil, filteredAgentCount: 0,
+            visibleIssueCount: 0, presentationMode: .grouped,
+            projectedSectionCount: 0, searchQuery: "alpha")
+        #expect(searching == .noSearchResults)
+
+        let idle = ConsoleAgentsSurface(
+            hostCount: 2, filteredHostName: nil, filteredAgentCount: 0,
+            visibleIssueCount: 0, presentationMode: .grouped,
+            projectedSectionCount: 0)
+        #expect(idle == .noHosts)
+
+        let withSections = ConsoleAgentsSurface(
+            hostCount: 2, filteredHostName: nil, filteredAgentCount: 1,
+            visibleIssueCount: 0, presentationMode: .grouped,
+            projectedSectionCount: 1, searchQuery: "alpha")
+        #expect(withSections == .rows)
+    }
+}


### PR DESCRIPTION
Implements #292. Closes #292.

Client-side only, using data already in agent.list snapshots; no server/RPC/wire changes.

- ConsoleAgent.matchesAgentSearch: trimmed case-insensitive substring over cwd + workspace/tab/pane labels + title/paneTitle/displayName/terminalTitle(_Stripped); empty matches all.
- ConsoleView: .searchable on the Agents sidebar (precedent: Skills/Snippets pickers); applies after hostFilter in flat and grouped.
- Sections: defaulted searchQuery param; empty-section hosts drop out only while searching.
- New ConsoleAgentsSurface.noSearchResults with distinct copy (No Results / No agents match + Clear Search).

Verification: swiftc -parse on all touched Sources files + new tests, git diff --check (verify_work PASS). xcodebuild not available locally (CLT only); CI runs the suite, including new ConsoleAgentSearchTests.