### PR TITLE
fix(console): keep herdr's machine field in agent rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Entries reference the issue that motivated them.
 
 ### Fixed
 
+- Agent List Fields keep herdr's machine field. A layout synced from herdr
+  dropped the built-in while decoding, so the row no longer matched herdr's
+  sidebar row for the same Agent. Like herdr, the field shows the machine
+  only when the Console spans more than one Host. (#310)
 - New Agent now discovers agents installed through mise. The discovery PATH
   includes mise's shims directory, resolved from `MISE_DATA_DIR` or
   `XDG_DATA_HOME` when either reaches the non-interactive SSH environment,

--- a/Sources/Heeler/Console/AgentRowLayout.swift
+++ b/Sources/Heeler/Console/AgentRowLayout.swift
@@ -8,14 +8,14 @@ import Foundation
 /// decoding, but Console layouts drop it (`normalizedForConsole`) and the
 /// Field Editor never offers it: the status badge at the end of Row 1 owns it.
 enum AgentRowToken: RawRepresentable, Codable, Hashable, Sendable {
-    case stateIcon, stateText, workspace, tab, pane, agent
+    case stateIcon, stateText, machine, workspace, tab, pane, agent
     case terminalTitle, terminalTitleStripped
     case host, status, directory
     case custom(String)
 
     /// herdr fields the Field Editor offers. Excludes `state_icon`.
     static let herdrBuiltins: [Self] = [
-        .stateText, .workspace, .tab, .pane, .agent,
+        .stateText, .machine, .workspace, .tab, .pane, .agent,
         .terminalTitle, .terminalTitleStripped,
     ]
 
@@ -29,6 +29,7 @@ enum AgentRowToken: RawRepresentable, Codable, Hashable, Sendable {
         switch rawValue {
         case "state_icon": self = .stateIcon
         case "state_text": self = .stateText
+        case "machine": self = .machine
         case "workspace": self = .workspace
         case "tab": self = .tab
         case "pane": self = .pane
@@ -53,6 +54,7 @@ enum AgentRowToken: RawRepresentable, Codable, Hashable, Sendable {
         switch self {
         case .stateIcon: "state_icon"
         case .stateText: "state_text"
+        case .machine: "machine"
         case .workspace: "workspace"
         case .tab: "tab"
         case .pane: "pane"

--- a/Sources/Heeler/Console/AgentRowRenderer.swift
+++ b/Sources/Heeler/Console/AgentRowRenderer.swift
@@ -41,6 +41,9 @@ enum AgentRowRenderer {
         case .terminalTitle: row.agent.terminalTitle
         case .terminalTitleStripped: row.agent.terminalTitleStripped
         case .host: nonempty(row.hostName)
+        // herdr prints the machine label only when more than one machine is
+        // present, so a Console listing a single Host shows no machine text.
+        case .machine: row.showsMachine ? nonempty(row.hostName) : nil
         case .status: nonempty(row.agent.status.rawValue.capitalized)
         case .directory: nonempty(row.agent.cwd)
         case .custom(let name): row.agent.tokens[name]

--- a/Sources/Heeler/Console/ConsoleAgent.swift
+++ b/Sources/Heeler/Console/ConsoleAgent.swift
@@ -26,6 +26,12 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
     /// automatic label uses position, not TabInfo.number's stable identity.
     let tabPosition: Int?
     let workspaceTabCount: Int
+    /// herdr labels the machine only when the client spans more than one
+    /// machine, so the Console sets this when it lists Agents from more than
+    /// one Host. Mirrors `showsTabLabel`: it is presentation context, not
+    /// snapshot data — one Host's snapshot cannot say how many Hosts are on
+    /// screen, and the flattened Console list is the only place that can.
+    var showsMachine: Bool
     /// Collection order from session.snapshot.agents for the `spaces` sort.
     let snapshotOrder: Int?
     /// Snapshot git metadata when the workspace reported any. Presence does
@@ -49,6 +55,7 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
         tabLabel: String? = nil,
         tabPosition: Int? = nil,
         workspaceTabCount: Int = 0,
+        showsMachine: Bool = false,
         snapshotOrder: Int? = nil,
         paneLabel: String? = nil
     ) {
@@ -61,6 +68,7 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
         self.paneLabel = paneLabel
         self.tabPosition = tabPosition
         self.workspaceTabCount = workspaceTabCount
+        self.showsMachine = showsMachine
         self.snapshotOrder = snapshotOrder
         self.repositoryCheckout = repositoryCheckout
         self.lastOutputSnippet = lastOutputSnippet

--- a/Sources/Heeler/Console/ConsoleStore.swift
+++ b/Sources/Heeler/Console/ConsoleStore.swift
@@ -551,6 +551,14 @@ final class ConsoleStore {
 
     private func rebuildAgentOrder() {
         let unsorted = projections.values.flatMap { $0.agentsByPane.values }
+        // herdr labels the machine only while the client spans more than one
+        // machine, so only a Console listing more than one Host shows it.
+        let showsMachine = Set(unsorted.map(\.hostID)).count > 1
+        let rows = unsorted.map { row in
+            var row = row
+            row.showsMachine = showsMachine
+            return row
+        }
         let sorts = Dictionary(uniqueKeysWithValues: projections.keys.compactMap { id in
             sidebarSnapshots.snapshot(for: id).map { (id, $0.agentPanelSort) }
         })
@@ -558,7 +566,7 @@ final class ConsoleStore {
             pins.pinRank(hostID: agent.hostID, paneID: agent.agent.paneID)
                 .map { (agent.id, $0) }
         })
-        agents = unsorted.consoleSorted(sortByHost: sorts) { pinRanks[$0.id] }
+        agents = rows.consoleSorted(sortByHost: sorts) { pinRanks[$0.id] }
     }
 
     private func publishAgentStatuses() {

--- a/Sources/Heeler/LiveActivities/HostLiveActivityCoordinator.swift
+++ b/Sources/Heeler/LiveActivities/HostLiveActivityCoordinator.swift
@@ -118,7 +118,19 @@ final class HostLiveActivityCoordinator {
     /// launch with already-working Agents should start an activity once the
     /// settle elapses. Newer input cancels an in-flight settle.
     func agentsDidChange(_ agents: [ConsoleAgent]) {
-        let grouped = Dictionary(grouping: agents, by: \.hostID)
+        // The Console sets herdr's machine label once it lists more than one
+        // Host, and the flag rides along on every row it hands us. Each
+        // activity below is one Host's card, though, and its header already
+        // names that Host, so the label would only repeat it and eat the row
+        // budget (#281). This is the one surface that departs from herdr's
+        // host-count rule; the Console and the switcher chips keep it.
+        let grouped = Dictionary(grouping: agents, by: \.hostID).mapValues { rows in
+            rows.map { row in
+                var perHostRow = row
+                perHostRow.showsMachine = false
+                return perHostRow
+            }
+        }
         var hosts = Set(latestAgents.keys)
         hosts.formUnion(grouped.keys)
         hosts.formUnion(sessions.keys)

--- a/Sources/Heeler/Settings/AgentLayoutTokensEditing.swift
+++ b/Sources/Heeler/Settings/AgentLayoutTokensEditing.swift
@@ -94,6 +94,8 @@ enum AgentLayoutTokensEditing {
             "Terminal title without the Agent prefix"
         case .host:
             "Host name"
+        case .machine:
+            "Machine the Agent runs on, which Heeler names the Host"
         case .status:
             "Agent Status as text"
         case .directory:

--- a/Sources/Heeler/Settings/AgentListFieldsPreview.swift
+++ b/Sources/Heeler/Settings/AgentListFieldsPreview.swift
@@ -23,6 +23,8 @@ struct AgentListFieldsPreview: View {
     }
 
     /// Deterministic sample values for built-in and custom tokens; not a live Agent.
+    /// It stands in for a Console spanning more than one Host, so a field
+    /// being added previews as it renders: the machine label is conditional.
     static func sampleAgent(hostName: String) -> ConsoleAgent {
         ConsoleAgent(
             hostID: sampleHostID,
@@ -46,7 +48,8 @@ struct AgentListFieldsPreview: View {
             repositoryCheckout: nil,
             tabLabel: "1",
             tabPosition: 1,
-            workspaceTabCount: 2)
+            workspaceTabCount: 2,
+            showsMachine: true)
     }
 
     private static let sampleHostID = UUID(uuid: (

--- a/Tests/HeelerTests/AgentRowLayoutTests.swift
+++ b/Tests/HeelerTests/AgentRowLayoutTests.swift
@@ -16,6 +16,21 @@ struct AgentRowLayoutTests {
                 == [[.stateIcon, .workspace, .tab], [.agent]])
     }
 
+    @Test func herdrMachineFieldDecodesFromSnapshotsAndRoundTrips() throws {
+        let snapshot = try #require(AgentRowLayoutSnapshot.decode(Data(#"""
+            {"v":1,"sidebar":{"agents":{"rows":[[{"token":"machine"},
+              {"token":"agent","bold":true}]]}}}
+            """#.utf8)))
+        #expect(snapshot.layout.rows == [[.init(.machine), .init(.agent, bold: true)]])
+        #expect(AgentRowToken(rawValue: "machine") == .machine)
+        #expect(AgentRowToken.machine.rawValue == "machine")
+        #expect(AgentRowToken(rawValue: AgentRowToken.machine.rawValue) == .machine)
+        #expect(AgentRowToken.herdrBuiltins.contains(.machine))
+        let encoded = try JSONEncoder().encode(snapshot.layout)
+        #expect(try JSONDecoder().decode(AgentRowLayout.self, from: encoded) == snapshot.layout)
+        #expect(String(decoding: encoded, as: UTF8.self).contains("\"machine\""))
+    }
+
     @Test func consoleShapeDropsStateIconAndKeepsThreeRowSlots() throws {
         #expect(AgentRowLayout.maximumConsoleRows == 3)
         #expect(AgentRowLayout.consoleDefault.rows.map { $0.map(\.token) } == [[.workspace, .tab], [.agent], [.directory]])

--- a/Tests/HeelerTests/AgentRowRendererTests.swift
+++ b/Tests/HeelerTests/AgentRowRendererTests.swift
@@ -5,9 +5,12 @@ import Testing
 
 @Suite("Agent row renderer")
 struct AgentRowRendererTests {
-    private func agent(tabLabel: String? = "1", tabPosition: Int? = 1, tabCount: Int = 1) -> ConsoleAgent {
+    private func agent(
+        hostName: String = "Host", tabLabel: String? = "1", tabPosition: Int? = 1, tabCount: Int = 1,
+        showsMachine: Bool = false
+    ) -> ConsoleAgent {
         ConsoleAgent(
-            hostID: UUID(), hostName: "Host",
+            hostID: UUID(), hostName: hostName,
             agent: Agent(AgentInfo(
                 agentStatus: .working, focused: false, paneID: "opaque-pane", revision: 1,
                 tabID: "opaque-tab", terminalID: "term", workspaceID: "workspace",
@@ -16,7 +19,8 @@ struct AgentRowRendererTests {
                 terminalTitleStripped: "Fix the build", title: "Manual pane",
                 tokens: ["pin_icon": "📌", "markup": "**literal**", "empty": "", "spaces": " \n"])),
             workspaceLabel: "Heeler", repositoryCheckout: nil,
-            tabLabel: tabLabel, tabPosition: tabPosition, workspaceTabCount: tabCount)
+            tabLabel: tabLabel, tabPosition: tabPosition, workspaceTabCount: tabCount,
+            showsMachine: showsMachine)
     }
 
     @Test func defaultElidesAutomaticSingleTabAndStatusFields() {
@@ -93,6 +97,21 @@ struct AgentRowRendererTests {
             workspaceLabel: nil, repositoryCheckout: nil)
         #expect(AgentRowRenderer.render(layout: layout, agent: empty).map { $0.map(\.text).joined() }
                 == ["Working"])
+    }
+
+    @Test func herdrMachineFieldRendersOnlyWhenTheConsoleSpansMultipleHosts() {
+        let layout = AgentRowLayout(rows: [[.init(.machine)]])
+        // One Host: herdr prints no machine label, so nothing renders.
+        #expect(AgentRowRenderer.render(layout: layout, agent: agent()).isEmpty)
+        let rendered = AgentRowRenderer.render(layout: layout, agent: agent(showsMachine: true))
+        #expect(rendered.map { $0.map(\.text).joined() } == ["Host"])
+        #expect(rendered.flatMap { $0.compactMap(\.token) } == [.machine])
+    }
+
+    @Test func herdrMachineFieldRendersNothingForABlankHostName() {
+        let layout = AgentRowLayout(rows: [[.init(.machine), .init(.workspace)]])
+        #expect(AgentRowRenderer.render(layout: layout, agent: agent(hostName: " \n", showsMachine: true))
+                .map { $0.map(\.text).joined() } == ["Heeler"])
     }
 
     @Test func missingTitlesAndWorkspaceNeverRenderOpaqueIDs() {

--- a/Tests/HeelerTests/HostLiveActivityCoordinatorTests.swift
+++ b/Tests/HeelerTests/HostLiveActivityCoordinatorTests.swift
@@ -84,12 +84,13 @@ struct HostLiveActivityCoordinatorTests {
     }
 
     private func agent(
-        _ paneID: String, _ status: AgentStatus, title: String = "Task"
+        _ paneID: String, _ status: AgentStatus, title: String = "Task",
+        hostID: Host.ID? = nil, hostName: String = "mbp", showsMachine: Bool = false
     ) -> ConsoleAgent {
         ConsoleAgent(
-            hostID: host.id, hostName: "mbp",
+            hostID: hostID ?? host.id, hostName: hostName,
             agent: Agent(.fixture(paneID: paneID, status: status, title: title)),
-            workspaceLabel: nil, repositoryCheckout: nil)
+            workspaceLabel: nil, repositoryCheckout: nil, showsMachine: showsMachine)
     }
 
     private func waitUntil(
@@ -122,11 +123,16 @@ struct HostLiveActivityCoordinatorTests {
         try #require(try NotificationKeyStore(secrets: secrets).record(forHost: host.id)?.key)
     }
 
-    private func openedPaneIDs(_ state: AgentActivityAttributes.ContentState) throws -> [String] {
+    private func openedDetails(
+        _ state: AgentActivityAttributes.ContentState
+    ) throws -> AgentActivityDetails {
         let envelope = try #require(state.envelope)
-        let details = try AgentActivityEnvelope.open(
+        return try AgentActivityEnvelope.open(
             try JSONEncoder().encode(envelope), using: notificationKey())
-        return details.agents.map(\.paneID)
+    }
+
+    private func openedPaneIDs(_ state: AgentActivityAttributes.ContentState) throws -> [String] {
+        try openedDetails(state).agents.map(\.paneID)
     }
 
     // MARK: Start / settle / flap
@@ -510,6 +516,43 @@ struct HostLiveActivityCoordinatorTests {
             return fields.first?["token"] == .string("status")
         }
         #expect(try await liveActivityToken() == "ab")
+    }
+
+    /// The Console turns herdr's machine label on once it lists Agents from
+    /// more than one Host, and that flag arrives here on every row. One card
+    /// is one Host, so a card must not print a Host name its own header
+    /// already carries.
+    @Test func aPerHostCardDoesNotRepeatItsHostAsAMachineLabel() async throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        try await registerDevice()
+        armWorld()
+        // The machine row is the one the Console turns on for this card; the
+        // title row under it proves the payload still carries its other rows.
+        world.layout = AgentRowLayout(rows: [[.init(.machine)], [.init(.terminalTitleStripped)]])
+        let coordinator = makeCoordinator(defaults: defaults)
+        coordinator.start()
+
+        let otherHostID = UUID()
+        coordinator.agentsDidChange([
+            agent(observedPaneID, .working, showsMachine: true),
+            agent("wS:p1", .working, hostID: otherHostID, hostName: "studio", showsMachine: true),
+        ])
+        try await waitUntil("the first Host's activity should start") {
+            !controller.requestedHandles.isEmpty
+        }
+
+        let details = try openedDetails(try #require(controller.requested.first))
+        #expect(details.hostName == "mbp", "the card's header names the Host")
+        #expect(
+            details.agents.map(\.paneID) == [observedPaneID],
+            "the card under test belongs to the Host that owns the pane")
+        let rows = try #require(
+            details.agents.first?.rows,
+            "the configured rows should still reach the card's payload")
+        #expect(
+            rows.map { $0.map(\.text).joined() } == ["Task"],
+            "a per-Host card already names its Host: the machine row is blank while its other rows render")
     }
 
     // MARK: Pins

--- a/Tests/HeelerTests/SidebarConsoleIntegrationTests.swift
+++ b/Tests/HeelerTests/SidebarConsoleIntegrationTests.swift
@@ -183,6 +183,15 @@ struct SidebarConsoleIntegrationTests {
         try await waitForSnapshots(store, hosts: [alpha.id, beta.id])
         #expect(store.agents.map(\.agent.paneID) == ["a0", "a1", "b1", "b0"])
         #expect(connects.withLock { $0 } == 2)
+        // herdr's `machine` token is host-count dependent, and only the
+        // flattened Console list knows the count, so the flag is read off the
+        // store's rows rather than set by hand.
+        let machineRow = AgentRowLayout(rows: [[.init(.machine)]])
+        #expect(!store.agents.isEmpty)
+        #expect(store.agents.allSatisfy { row in
+            AgentRowRenderer.render(layout: machineRow, agent: row).map { $0.map(\.text).joined() }
+                == [row.hostName]
+        }, "A Console listing more than one Host shows each row's machine name")
         let plugin = store.rowLayout(for: alpha.id)
         // herdr's rows_by_agent is decoded but never applied in the Console.
         #expect(plugin.rows == [[.init(.terminalTitleStripped)], [], [.init(.directory)]])
@@ -214,6 +223,29 @@ struct SidebarConsoleIntegrationTests {
         #expect(store.agents.map(\.agent.paneID) == ["b0", "a1", "b1", "a0"])
         #expect(connects.withLock { $0 } == 2)
         #expect(store.rowLayout(for: alpha.id).rows.isEmpty)
+    }
+
+    @Test func machineLabelStaysUnrenderedForASingleHost() async throws {
+        let suite = "sidebar-machine-\(UUID())"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let host = Host.fixture(name: "alpha")
+        let transport = ScriptedTransport(snapshot: .fixture(agents: [
+            .fixture(paneID: "a0", status: .idle), .fixture(paneID: "a1", status: .blocked),
+        ]))
+        await transport.setSidebarLayout(try snapshot(sort: "spaces"))
+        let store = liveStore(defaults: defaults, connect: { transport })
+        defer { store.setHosts([]) }
+        store.setHosts([host])
+        await store.resume()
+        try await waitForSnapshots(store, hosts: [host.id])
+        // One Host is one machine, so the flattened rows carry no machine
+        // text even though the Host has a name to show.
+        #expect(!store.agents.isEmpty)
+        let machineRow = AgentRowLayout(rows: [[.init(.machine)]])
+        #expect(store.agents.allSatisfy { row in
+            AgentRowRenderer.render(layout: machineRow, agent: row).isEmpty
+        }, "A Console listing a single Host renders no machine row")
     }
 
     @Test func consoleSuspensionRejectsAnInFlightSnapshot() async throws {


### PR DESCRIPTION
Fixes #310.

herdr documents its built-in agent row fields as `state_icon, state_text, machine, workspace, tab, pane, agent, terminal_title, and terminal_title_stripped`, and its docs pin the machine label's condition (`connecting-machines.mdx`):

> Default agent rows show a `machine` token when multiple machines are present. Existing custom rows are preserved; add `machine` explicitly if you want that label in your layout.

Heeler knew every one of those fields except `machine`: `AgentRowToken.init?(rawValue:)` returns `nil` for a name it does not recognise and `WireLayout.convert` drops those with `compactMap`, so a layout synced from herdr lost the field with no diagnostic.

The condition also explains a row that looked wrong. This real Host config:

```toml
[ui.sidebar.agents]
rows = [["state_icon", "machine", "workspace", "tab"], ["$quota_error"], ["$quota_5h_normal", …]]
```

lists `machine` in its first row and shows no machine text in herdr's sidebar, because that client has a single machine. Listing the field is not enough; there has to be more than one machine. Heeler's machine is the Host, so the same rule reads: label the machine only when the Console lists Agents from more than one Host.

## What changed

- `AgentRowToken` gains a `machine` case: parsed in `init?(rawValue:)`, serialized by `rawValue`, and listed in `herdrBuiltins` so the Field Editor offers herdr's own field name rather than an alias.
- `ConsoleAgent.showsMachine` carries the condition, which is presentation context rather than snapshot data — one Host's snapshot cannot say how many Hosts are on screen. `ConsoleStore.rebuildAgentOrder` sets it, since flattening every projection is the only place that knows the count.
- `AgentRowRenderer` renders `row.showsMachine ? nonempty(row.hostName) : nil`. The Host is the machine Heeler connects to, and a blank Host name still contributes no text.
- `AgentLayoutTokensEditing` describes the field in the Field Editor, and `AgentListFieldsPreview` passes `showsMachine: true` so a field being added previews as it renders.
- `HostLiveActivityCoordinator` clears the flag on the per-Host slices it groups. This is the one surface that departs from herdr's rule, deliberately: each Live Activity card is a single Host and its header already names that Host, so the label would repeat it inside a row budget that #281 documents as tight. The Console and the keyboard switcher chips both span Hosts and keep the label.
- CHANGELOG entry under `[Unreleased]`.

## Verification

There is no iOS SDK on this machine, so the test target runs in CI. Locally:

- A probe compiled these three real sources against stub app types and decoded a herdr-shaped sidebar snapshot whose rows list `"machine"`. It asserts: a one-Host Console renders no machine label (the reported behaviour), a two-Host Console renders `aliefe@100.64.1.3`, the workspace row and plugin tokens after it are untouched, and a whitespace Host name renders nothing. A mutant with the `showsMachine` guard removed fails that first assertion, so the condition is load-bearing rather than incidentally satisfied.
- `swiftc -parse` clean for every changed file; `git diff --check` clean.

Tests:

- `AgentRowRendererTests.herdrMachineFieldRendersOnlyWhenTheConsoleSpansMultipleHosts` and `herdrMachineFieldRendersNothingForABlankHostName`.
- `AgentRowLayoutTests.herdrMachineFieldDecodesFromSnapshotsAndRoundTrips` for the parsing and round-trip side.
- `SidebarConsoleIntegrationTests`: the two-Host test asserts every flattened row renders its own Host name for a `machine` layout, and a new single-Host test asserts no row renders one. These read `store.agents`, so they cover the host-count computation itself rather than the flag being set by hand.
- `HostLiveActivityCoordinatorTests.aPerHostCardDoesNotRepeatItsHostAsAMachineLabel` drives two Hosts with `showsMachine: true` and asserts the card's payload is exactly its other row, so removing the clearing fails it.

## Merge note

A companion PR fixes the `~` shorthand in the same `.directory` row (#313). Both touch neighbouring lines of `AgentRowRenderer.swift` — this one inserts the `.machine` case above `case .status`, #313 rewrites the `case .directory` line just below it — so whichever lands second needs a trivial rebase. The CHANGELOG entries were placed at opposite ends of the `[Unreleased]` list for the same reason.
