### PR TITLE
fix(console): shorten a standard home in the directory row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ Entries reference the issue that motivated them.
   height and its test measured only frame minimums, not the rendered text.
   Four three-row cards exceed ActivityKit's 160 pt limit, so four rows remain
   only for two-row layouts. (#281)
+- Console rows show a standard home directory as `~` again: an Agent launched
+  in `/Users/aliefe/Code/bitbucket/opinnate-python` prints
+  `~/Code/bitbucket/opinnate-python`. Only the SSH account's own `/root`,
+  `/Users/<user>`, and `/home/<user>` homes are shortened, so a path that
+  merely shares a prefix with a longer account name is left alone. (#311)
 
 ## [0.1.6] - 2026-09-09
 

--- a/Sources/Heeler/Console/AgentRowRenderer.swift
+++ b/Sources/Heeler/Console/AgentRowRenderer.swift
@@ -42,7 +42,7 @@ enum AgentRowRenderer {
         case .terminalTitleStripped: row.agent.terminalTitleStripped
         case .host: nonempty(row.hostName)
         case .status: nonempty(row.agent.status.rawValue.capitalized)
-        case .directory: nonempty(row.agent.cwd)
+        case .directory: nonempty(row.displayCwd)
         case .custom(let name): row.agent.tokens[name]
         }
     }

--- a/Sources/Heeler/Console/ConsoleAgent.swift
+++ b/Sources/Heeler/Console/ConsoleAgent.swift
@@ -123,6 +123,21 @@ struct ConsoleAgent: Identifiable, Sendable, Equatable {
             return field.range(of: needle, options: .caseInsensitive) != nil
         }
     }
+
+    /// The launch directory as a Console row should print it. The snapshot
+    /// carries the expanded remote path but not `$HOME`, so only the
+    /// account's conventional macOS/Linux homes are shortened to `~`; every
+    /// other path stays exactly as the Agent reported it.
+    var displayCwd: String {
+        guard let hostUsername, !hostUsername.isEmpty else { return agent.cwd }
+        let homes =
+            hostUsername == "root"
+            ? ["/root"]
+            : ["/Users/\(hostUsername)", "/home/\(hostUsername)"]
+        guard let home = homes.first(where: { agent.cwd == $0 || agent.cwd.hasPrefix("\($0)/") })
+        else { return agent.cwd }
+        return agent.cwd == home ? "~" : "~\(agent.cwd.dropFirst(home.count))"
+    }
 }
 
 /// The snapshot's exact git checkout identity for one workspace. Workspace

--- a/Tests/HeelerTests/AgentRowRendererTests.swift
+++ b/Tests/HeelerTests/AgentRowRendererTests.swift
@@ -37,6 +37,51 @@ struct AgentRowRendererTests {
         #expect(AgentRowRenderer.render(layout: layout, agent: agent(tabLabel: nil, tabCount: 2)).isEmpty)
     }
 
+    /// A CLI Agent whose launch directory and SSH account are the only things
+    /// a directory row depends on.
+    private func directoryAgent(cwd: String, hostUsername: String?) -> ConsoleAgent {
+        ConsoleAgent(
+            hostID: UUID(), hostName: "Host",
+            agent: Agent(AgentInfo(
+                agentStatus: .working, focused: false, paneID: "opaque-pane", revision: 1,
+                tabID: "opaque-tab", terminalID: "term", workspaceID: "workspace",
+                agent: "claude", cwd: cwd)),
+            workspaceLabel: "Heeler", repositoryCheckout: nil, hostUsername: hostUsername)
+    }
+
+    @Test func directoryShortensOnlyTheAccountsStandardHome() {
+        let layout = AgentRowLayout(rows: [[.init(.directory)]])
+        for (cwd, username, expected) in [
+            ("/Users/aliefe/Code/bitbucket/opinnate-python", "aliefe",
+             "~/Code/bitbucket/opinnate-python"),
+            ("/home/dev/app", "dev", "~/app"),
+            ("/root/work", "root", "~/work"),
+            ("/Users/aliefe", "aliefe", "~"),
+            ("/Users/aliefesh/Code", "aliefe", "/Users/aliefesh/Code"),
+            ("/Users/someone/Code", "aliefe", "/Users/someone/Code"),
+            ("/private/tmp", "aliefe", "/private/tmp"),
+            ("/private/tmp", nil, "/private/tmp"),
+        ] as [(String, String?, String)] {
+            let rows = AgentRowRenderer.render(
+                layout: layout, agent: directoryAgent(cwd: cwd, hostUsername: username))
+            #expect(
+                rows.map { $0.map(\.text).joined() } == [expected],
+                "\(cwd) for user \(username ?? "none")")
+        }
+    }
+
+    @Test func directoryStaysAbsentWhenTheLaunchPathIsBlank() {
+        let layout = AgentRowLayout(rows: [[.init(.directory)]])
+        #expect(
+            AgentRowRenderer.render(
+                layout: layout, agent: directoryAgent(cwd: "", hostUsername: "aliefe")
+            ).isEmpty)
+        #expect(
+            AgentRowRenderer.render(
+                layout: layout, agent: directoryAgent(cwd: " \n", hostUsername: "aliefe")
+            ).isEmpty)
+    }
+
     @Test func allTitleTokensStayDistinctAndPluginTextIsLiteral() {
         let layout = AgentRowLayout(rows: [[
             .init(.stateIcon), .init(.pane), .init(.terminalTitle), .init(.terminalTitleStripped),


### PR DESCRIPTION
Fixes #311.

0.1.5 shortened a standard home in the launch-directory line — `AgentCardPresentation.abbreviatingStandardHome` rendered `/Users/example/Code/example/example-project` as `~/Code/example/example-project`. When the card moved to herdr's sidebar fields, `ConsoleAgent.hostUsername` kept being written by `HostConsoleProjection` but nothing read it any more, and the `.directory` token rendered `agent.cwd` verbatim — so the row now prints the full absolute path, which on a phone is most of the second line.

## What changed

- `ConsoleAgent.displayCwd`: the launch directory with the SSH account's own home shortened to `~`. Root only ever gets `/root`; every other account gets `/Users/<user>` and `/home/<user>`. A path equal to the home renders `~`, a path under it renders `~/…`, and anything else is returned exactly as reported — `/Users/exampleish/Code` is not shortened for user `example`, and neither is another account's home. A nil or blank account name leaves the path alone.
- `AgentRowRenderer`'s `.directory` renders `displayCwd` instead of `agent.cwd`, keeping the existing `nonempty` behaviour so a blank path still emits no token text.
- `Agent.cwd` and `ConsoleAgent.skillsProjectRoot` keep the raw path, so worktree actions, attach, and skill resolution are unaffected. Only the rendered field changes.
- CHANGELOG entry under `[Unreleased]`.

## Verification

There is no iOS SDK on this machine, so the test target runs in CI. Locally:

- A probe compiled the three real sources against stub app types and rendered a `.directory` row: pre-change every home path printed in full; post-change `/Users/example/Code/example/example-project` renders `~/Code/example/example-project`, `/home/dev/app` renders `~/app`, `/root/work` renders `~/work`, the home itself renders `~`, and `/private/tmp`, `/Users/someone/Code`, `/Users/exampleish/Code`, and every path without an account name are unchanged.
- `swiftc -parse` clean for every changed file, `git diff --check` clean.
- New tests in `AgentRowRendererTests`: `directoryShortensOnlyTheAccountsStandardHome` (the table above) and `directoryStaysAbsentWhenTheLaunchPathIsBlank`.


## Merge note

The companion PR that changed the adjacent `case .status`/`.machine` area (#312) was closed, so `AgentRowRenderer.swift` is no longer contested; this branch is rebased onto current `main` and merges cleanly.

