### PR TITLE
fix(settings): keep Agent List Fields editable and recoverable when the saved catalog is unreadable

### DIFF
--- a/.testloop/reports/2026-09-13-issue-320-agent-list-fields.md
+++ b/.testloop/reports/2026-09-13-issue-320-agent-list-fields.md
@@ -1,0 +1,54 @@
+# testloop — 2026-09-13 — issue-320-agent-list-fields
+
+**Verdict:** pass · **Rounds:** 4
+
+## Covered
+
+- Agent List Fields on the iPhone Simulator with a saved catalog written by
+  another build (herdr's `machine` field from the unmerged PR #312): the
+  screens open without an error, the unknown field is dropped, and adding,
+  restyling, moving, and removing fields save and survive re-navigation and
+  the on-disk catalog.
+- The same screens with a saved catalog that is not JSON: the red
+  explanation and Reset Saved Fields on both the list and the Host page,
+  editing controls disabled, the reset confirmation and its dismissal, and
+  editing after the reset.
+- Sync from plugin while the catalog is unreadable (no dialog, dimmed) and
+  after the reset (its confirmation opens).
+
+## Found & fixed
+
+- **An unknown field name locked every edit.** The persisted catalog used the
+  strict decoder, so one name this build did not know made the whole catalog
+  unreadable and every write was refused with "could not be read", with
+  nothing on screen explaining why. The catalog now loads through the same
+  lenient decoder plugin snapshots use, dropping unknown names and invalid
+  colors individually; structural damage still keeps the bytes and refuses
+  writes, and both screens announce that state with a Reset Saved Fields
+  action (`Sources/Heeler/Console/AgentRowLayout.swift`,
+  `Sources/Heeler/Console/AgentRowLayoutStore.swift`,
+  `Sources/Heeler/Settings/AgentLayoutErrorView.swift`).
+- **A refused add left a phantom chip on the row.** Adding a field against an
+  unreadable catalog reused the draft-session rule that a failed save keeps
+  its drafts, so Row 3 showed the unsaved field as if saved and the add sheet
+  stayed open. An inline commit now discards its draft on a refused save, the
+  sheet closes so the message is visible, and while the catalog is unreadable
+  the chips, add chips, and Sync from plugin are disabled
+  (`Sources/Heeler/Settings/AgentListFieldsEditor.swift`,
+  `Sources/Heeler/Settings/AgentListFieldsSettingsView.swift`,
+  `Sources/Heeler/Settings/AgentListFieldsAddFieldSheet.swift`).
+- **Disabled Sync from plugin still looked enabled.** Its label forced the
+  tint color over the disabled dimming; it now picks the tertiary style while
+  the catalog is unreadable (`AgentListFieldsSettingsView.swift`).
+
+## Still open
+
+- Persistence across an app relaunch was checked by the driver reading the
+  on-disk catalog, not through the GUI.
+- On this iOS version an anchored confirmation dialog renders as a popover
+  without a Cancel button; tapping outside cancels. Plans should not expect a
+  Cancel button.
+- Driving this Simulator while another testloop drives a second one only
+  works with device-scoped `simctl`/`idb` commands, which the Codex sandbox
+  blocks; the authorization has to be stated in the chat pointer, not only in
+  the prompt file. `project.md` records the seeding and driving lessons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Entries reference the issue that motivated them.
 
 ## [Unreleased]
 
+### Fixed
+
+- Agent List Fields no longer refuses every edit after a build with a
+  different field set saved on the same device: field names this build does
+  not know are dropped on load instead of making the whole saved catalog
+  unreadable. When the saved fields truly cannot be read, both Agent List
+  Fields screens say so before any edit and offer Reset Saved Fields. (#320)
+
 ## [0.1.7] - 2026-09-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ Entries reference the issue that motivated them.
   different field set saved on the same device: field names this build does
   not know are dropped on load instead of making the whole saved catalog
   unreadable. When the saved fields truly cannot be read, both Agent List
-  Fields screens say so before any edit and offer Reset Saved Fields. (#320)
+  Fields screens say so before any edit, keep the fields read-only, and offer
+  Reset Saved Fields. (#320)
 
 ## [0.1.7] - 2026-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Entries reference the issue that motivated them.
   not know are dropped on load instead of making the whole saved catalog
   unreadable. When the saved fields truly cannot be read, both Agent List
   Fields screens say so before any edit, keep the fields read-only, and offer
-  Reset Saved Fields. (#320)
+  Reset Saved Fields. (#320; PR #321)
 
 ## [0.1.7] - 2026-09-12
 

--- a/Sources/Heeler/Console/AgentRowLayout.swift
+++ b/Sources/Heeler/Console/AgentRowLayout.swift
@@ -271,8 +271,8 @@ enum AgentPanelSort: String, Codable, Sendable {
 }
 
 /// Read-only normalized plugin snapshot. Unknown token names are removed
-/// individually; malformed structure or an unsupported version is absent.
-/// Local persisted layouts use stricter Codable decoding to protect edits.
+/// individually (`AgentRowLayout.Lenient`); malformed structure or an
+/// unsupported version is absent.
 struct AgentRowLayoutSnapshot: Equatable, Sendable {
     let layout: AgentRowLayout
     let agentPanelSort: AgentPanelSort
@@ -287,11 +287,11 @@ struct AgentRowLayoutSnapshot: Equatable, Sendable {
     static func decode(_ data: Data?) -> Self? {
         guard let data,
             let snapshot = try? JSONDecoder().decode(WireSnapshot.self, from: data),
-            snapshot.v == 1,
-            let layout = try? (snapshot.sidebar?.agents?.layout() ?? AgentRowLayout.heelerDefault)
+            snapshot.v == 1
         else { return nil }
         return Self(
-            layout: layout, agentPanelSort: snapshot.agentPanelSort ?? .spaces,
+            layout: snapshot.sidebar?.agents?.layout ?? AgentRowLayout.heelerDefault,
+            agentPanelSort: snapshot.agentPanelSort ?? .spaces,
             diagnostics: snapshot.diagnostics ?? [])
     }
 
@@ -308,22 +308,36 @@ struct AgentRowLayoutSnapshot: Equatable, Sendable {
     }
 
     private struct Sidebar: Decodable {
-        let agents: WireLayout?
+        let agents: AgentRowLayout.Lenient?
     }
+}
 
-    private struct WireLayout: Decodable {
-        let rowGap: Int?
-        let rows: [[WireToken]]?
-        let rowsByAgent: [String: [[WireToken]]]?
+extension AgentRowLayout {
+    /// Tolerant decoding for layouts written by something other than this
+    /// build: herdr plugin snapshots and the persisted catalog after a build
+    /// with a different field set ran on the same device. Unknown token
+    /// names and invalid colors are dropped individually so one unfamiliar
+    /// field never discards a whole layout. Structure and limits stay
+    /// strict: wrong types, too many rows, or too many fields still fail.
+    struct Lenient: Decodable {
+        let layout: AgentRowLayout
 
-        enum CodingKeys: String, CodingKey {
+        private struct Token: Decodable {
+            let token: String
+            let fg: String?
+            let bold: Bool?
+            let dim: Bool?
+        }
+
+        private enum CodingKeys: String, CodingKey {
             case rowGap = "row_gap"
             case rows
             case rowsByAgent = "rows_by_agent"
         }
 
-        func layout() throws -> AgentRowLayout {
-            func convert(_ rows: [[WireToken]]) throws -> [AgentRow] {
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            func convert(_ rows: [[Token]]) throws -> [AgentRow] {
                 guard rows.count <= AgentRowLayout.maximumRows else { throw AgentRowLayoutError.tooManyRows }
                 return try rows.map { row in
                     guard row.count <= AgentRowLayout.maximumTokensPerRow else {
@@ -338,18 +352,13 @@ struct AgentRowLayoutSnapshot: Equatable, Sendable {
                 }
             }
             let layout = AgentRowLayout(
-                rows: try rows.map(convert) ?? AgentRowLayout.heelerDefault.rows,
-                rowGap: rowGap ?? 0,
-                rowsByAgent: try (rowsByAgent ?? [:]).mapValues(convert))
+                rows: try container.decodeIfPresent([[Token]].self, forKey: .rows).map(convert)
+                    ?? AgentRowLayout.heelerDefault.rows,
+                rowGap: try container.decodeIfPresent(Int.self, forKey: .rowGap) ?? 0,
+                rowsByAgent: try (container.decodeIfPresent([String: [[Token]]].self, forKey: .rowsByAgent) ?? [:])
+                    .mapValues(convert))
             try layout.validate()
-            return layout
+            self.layout = layout
         }
-    }
-
-    private struct WireToken: Decodable {
-        let token: String
-        let fg: String?
-        let bold: Bool?
-        let dim: Bool?
     }
 }

--- a/Sources/Heeler/Console/AgentRowLayoutStore.swift
+++ b/Sources/Heeler/Console/AgentRowLayoutStore.swift
@@ -16,9 +16,18 @@ final class AgentRowLayoutStore {
     /// Earlier version-1 catalogs also carried a `globalLayout`. It is
     /// ignored on load and dropped by the next write, so a hidden legacy
     /// choice can never override a Host's herdr fields.
-    private struct PersistedCatalog: Codable {
+    private struct PersistedCatalog: Encodable {
         let version: Int
         let hostLayouts: [Host.ID: AgentRowLayout]
+    }
+
+    /// Field names come from whichever build last saved on this device, so a
+    /// name this build does not know is dropped on load and by the next
+    /// write rather than making the catalog unreadable (#320). Structural
+    /// problems still do: they keep the original bytes and refuse writes.
+    private struct LoadedCatalog: Decodable {
+        let version: Int
+        let hostLayouts: [Host.ID: AgentRowLayout.Lenient]
     }
 
     private(set) var hostLayouts: [Host.ID: AgentRowLayout] = [:]
@@ -29,14 +38,24 @@ final class AgentRowLayoutStore {
         self.defaults = defaults
         guard let data = defaults.data(forKey: Self.defaultsKey) else { return }
         do {
-            let catalog = try JSONDecoder().decode(PersistedCatalog.self, from: data)
+            let catalog = try JSONDecoder().decode(LoadedCatalog.self, from: data)
             guard catalog.version == Self.catalogVersion else {
                 throw AgentRowLayoutStoreError.catalogUnreadable
             }
-            hostLayouts = catalog.hostLayouts
+            hostLayouts = catalog.hostLayouts.mapValues(\.layout)
         } catch {
             catalogLoadError = .catalogUnreadable
         }
+    }
+
+    /// Discards an unreadable catalog so every Host follows its herdr fields
+    /// again and writes are accepted. The only way out of `catalogLoadError`;
+    /// a readable catalog is left alone.
+    func resetUnreadableCatalog() {
+        guard catalogLoadError != nil else { return }
+        defaults.removeObject(forKey: Self.defaultsKey)
+        hostLayouts = [:]
+        catalogLoadError = nil
     }
 
     /// nil removes this Host's choice so its herdr fields apply again.

--- a/Sources/Heeler/Settings/AgentLayoutErrorView.swift
+++ b/Sources/Heeler/Settings/AgentLayoutErrorView.swift
@@ -1,13 +1,42 @@
 import SwiftUI
 
+/// Problems with saving, shown at the end of both Agent List Fields screens.
+/// An unreadable catalog is announced before any edit, with the one way out:
+/// Reset Saved Fields discards it after confirmation.
 struct AgentLayoutErrorView: View {
     let editor: AgentListFieldsEditor
+    @State private var confirmingReset = false
 
     var body: some View {
+        if editor.isCatalogUnreadable {
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(AgentListFieldsCopy.unreadableCatalog)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("settings.agentList.unreadable")
+                    Button("Reset Saved Fields", role: .destructive) {
+                        confirmingReset = true
+                    }
+                    .buttonStyle(.borderless)
+                    .accessibilityIdentifier("settings.agentList.reset")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .confirmationDialog(
+                "Reset saved Agent List Fields?", isPresented: $confirmingReset, titleVisibility: .visible
+            ) {
+                Button("Reset Saved Fields", role: .destructive) { editor.resetSavedFields() }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text(AgentListFieldsCopy.resetConfirmation)
+            }
+        }
         if let message = editor.errorMessage {
             Section {
                 Text(verbatim: message)
                     .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
                     .accessibilityIdentifier("settings.agentList.error")
             }
         }

--- a/Sources/Heeler/Settings/AgentLayoutErrorView.swift
+++ b/Sources/Heeler/Settings/AgentLayoutErrorView.swift
@@ -1,8 +1,10 @@
 import SwiftUI
 
-/// Problems with saving, shown at the end of both Agent List Fields screens.
-/// An unreadable catalog is announced before any edit, with the one way out:
-/// Reset Saved Fields discards it after confirmation.
+/// Problems with saving, shown at the end of both Agent List Fields screens
+/// as cards on the page's own surface. An unreadable catalog is announced
+/// before any edit, with the one way out: Reset Saved Fields discards it
+/// after confirmation. Color carries the severity in the icon and the
+/// button, not in the copy, so the notice reads as a calm explanation.
 struct AgentLayoutErrorView: View {
     let editor: AgentListFieldsEditor
     @State private var confirmingReset = false
@@ -11,18 +13,33 @@ struct AgentLayoutErrorView: View {
         if editor.isCatalogUnreadable {
             Section {
                 VStack(alignment: .leading, spacing: 8) {
+                    HStack(alignment: .firstTextBaseline, spacing: 7) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                            .accessibilityHidden(true)
+                        Text(AgentListFieldsCopy.unreadableCatalogTitle)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.primary)
+                    }
                     Text(AgentListFieldsCopy.unreadableCatalog)
-                        .foregroundStyle(.red)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                         .accessibilityIdentifier("settings.agentList.unreadable")
                     Button("Reset Saved Fields", role: .destructive) {
                         confirmingReset = true
                     }
-                    .buttonStyle(.borderless)
+                    .buttonStyle(.bordered)
+                    .font(.subheadline.weight(.medium))
+                    .padding(.top, 4)
                     .accessibilityIdentifier("settings.agentList.reset")
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .listRowInsets(AgentListFieldsChrome.noticeInsets)
+                .listRowSeparator(.hidden)
+                .agentListHostSurface(isFirst: true, isLast: true)
             }
+            .listSectionSeparator(.hidden)
             .confirmationDialog(
                 "Reset saved Agent List Fields?", isPresented: $confirmingReset, titleVisibility: .visible
             ) {
@@ -34,11 +51,22 @@ struct AgentLayoutErrorView: View {
         }
         if let message = editor.errorMessage {
             Section {
-                Text(verbatim: message)
-                    .foregroundStyle(.red)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .accessibilityIdentifier("settings.agentList.error")
+                HStack(alignment: .firstTextBaseline, spacing: 7) {
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .foregroundStyle(.red)
+                        .accessibilityHidden(true)
+                    Text(verbatim: message)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("settings.agentList.error")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .listRowInsets(AgentListFieldsChrome.noticeInsets)
+                .listRowSeparator(.hidden)
+                .agentListHostSurface(isFirst: true, isLast: true)
             }
+            .listSectionSeparator(.hidden)
         }
     }
 }

--- a/Sources/Heeler/Settings/AgentListFieldsAddFieldSheet.swift
+++ b/Sources/Heeler/Settings/AgentListFieldsAddFieldSheet.swift
@@ -135,10 +135,12 @@ struct AgentListFieldsAddFieldSheet: View {
         .accessibilityAddTraits(.isButton)
     }
 
+    /// Closes after a saved change and after a refused one, whose message
+    /// waits on the page behind the sheet; a no-op keeps the sheet open.
     private func add(_ token: AgentRowToken) {
-        if AgentLayoutTokensEditing.add(
+        let added = AgentLayoutTokensEditing.add(
             token, editor: editor, hostID: destination.hostID, rowIndex: destination.rowIndex)
-        {
+        if added || editor.errorMessage != nil {
             dismiss()
         }
     }

--- a/Sources/Heeler/Settings/AgentListFieldsEditor.swift
+++ b/Sources/Heeler/Settings/AgentListFieldsEditor.swift
@@ -131,10 +131,12 @@ final class AgentListFieldsEditor {
         }
     }
 
-    /// One inline change, validated and persisted at once. A no-op or invalid
-    /// change writes nothing and returns false; an invalid one keeps its
-    /// message in `errorMessage`. Inside an open draft session the change
-    /// joins that session and `save` writes every dirty Host.
+    /// One inline change, validated and persisted at once. A no-op, invalid,
+    /// or unsaveable change writes nothing and returns false, keeping its
+    /// message in `errorMessage` and no draft behind: the screens show what
+    /// is persisted, never a change that failed to save. Inside an open draft
+    /// session the change joins that session and `save` writes every dirty
+    /// Host; a failed save then keeps the session, as `save` documents.
     @discardableResult
     func commit(_ hostID: Host.ID, _ edit: (inout AgentRowLayout) -> Void) -> Bool {
         let wasEditing = isEditing
@@ -150,6 +152,10 @@ final class AgentListFieldsEditor {
             return false
         }
         save()
+        if isEditing, !wasEditing {
+            discardKeepingError()
+            return false
+        }
         return !isEditing
     }
 

--- a/Sources/Heeler/Settings/AgentListFieldsEditor.swift
+++ b/Sources/Heeler/Settings/AgentListFieldsEditor.swift
@@ -208,6 +208,19 @@ final class AgentListFieldsEditor {
         errorMessage = nil
     }
 
+    /// True while the saved catalog cannot be read: edits are refused until
+    /// `resetSavedFields` discards it.
+    var isCatalogUnreadable: Bool {
+        layouts.catalogLoadError != nil
+    }
+
+    /// Discards the unreadable catalog together with any draft session, so
+    /// the screens return to each Host's herdr fields.
+    func resetSavedFields() {
+        layouts.resetUnreadableCatalog()
+        cancel()
+    }
+
     private func discardKeepingError() {
         let message = errorMessage
         cancel()
@@ -223,7 +236,7 @@ final class AgentListFieldsEditor {
 
     private func report(_ error: any Error) {
         errorMessage = error is AgentRowLayoutStoreError
-            ? "The saved Agent List Fields could not be read. Nothing was changed."
+            ? AgentListFieldsCopy.unreadableCatalogEdit
             : "This layout could not be saved. Use at most 3 rows and 16 fields per row, with valid field names."
     }
 }

--- a/Sources/Heeler/Settings/AgentListFieldsSettingsView.swift
+++ b/Sources/Heeler/Settings/AgentListFieldsSettingsView.swift
@@ -451,7 +451,7 @@ private struct AgentListFieldsChipWrap: Layout {
     }
 }
 
-private struct AgentListFieldsHostSurface: View {
+struct AgentListFieldsHostSurface: View {
     var isFirst: Bool
     var isLast: Bool
     var fill: Color
@@ -468,7 +468,7 @@ private struct AgentListFieldsHostSurface: View {
     }
 }
 
-private extension View {
+extension View {
     func agentListHostSurface(
         isFirst: Bool, isLast: Bool, fill: Color = AgentListFieldsChrome.cardFill
     ) -> some View {
@@ -476,7 +476,7 @@ private extension View {
     }
 }
 
-private enum AgentListFieldsChrome {
+enum AgentListFieldsChrome {
     static let pageInset: CGFloat = 16
     static let hostSpacing: CGFloat = 18
     static let hostCornerRadius: CGFloat = 12
@@ -501,6 +501,7 @@ private enum AgentListFieldsChrome {
     static let rowInsets = EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16)
     static let slotsNoteInsets = EdgeInsets(top: 10, leading: 16, bottom: 6, trailing: 16)
     static let syncInsets = EdgeInsets(top: 8, leading: 16, bottom: 14, trailing: 16)
+    static let noticeInsets = EdgeInsets(top: 14, leading: 16, bottom: 14, trailing: 16)
 }
 
 /// Identity for an Add Field sheet. Row slots are fixed, so the slot index
@@ -535,9 +536,10 @@ enum AgentListFieldsCopy {
         "Tap a field to change its style, move it, or remove it. Tap + to add one. Changes save right away."
     static let syncConfirmation =
         "This Host's rows are replaced with its herdr fields and saved right away."
+    static let unreadableCatalogTitle = "Saved fields can’t be read"
     static let unreadableCatalog =
-        "The saved Agent List Fields could not be read, so every Host shows its herdr fields and "
-        + "changes are not saved. The original data has been kept. Reset Saved Fields discards it."
+        "Heeler kept the saved data untouched. Every Host follows its herdr fields, and editing "
+        + "is paused until you reset."
     static let unreadableCatalogEdit =
         "The saved Agent List Fields could not be read. Nothing was changed. Reset Saved Fields to start over."
     static let resetConfirmation =

--- a/Sources/Heeler/Settings/AgentListFieldsSettingsView.swift
+++ b/Sources/Heeler/Settings/AgentListFieldsSettingsView.swift
@@ -531,6 +531,13 @@ enum AgentListFieldsCopy {
         "Tap a field to change its style, move it, or remove it. Tap + to add one. Changes save right away."
     static let syncConfirmation =
         "This Host's rows are replaced with its herdr fields and saved right away."
+    static let unreadableCatalog =
+        "The saved Agent List Fields could not be read, so every Host shows its herdr fields and "
+        + "changes are not saved. The original data has been kept. Reset Saved Fields discards it."
+    static let unreadableCatalogEdit =
+        "The saved Agent List Fields could not be read. Nothing was changed. Reset Saved Fields to start over."
+    static let resetConfirmation =
+        "The unreadable saved fields are deleted. Every Host returns to its herdr fields and can be edited again."
     static let rowSlots =
         "Row 1 and Row 2 start from herdr's sidebar fields; Sync from plugin refills them. "
         + "Row 3 is Heeler's own row. Any row can use herdr and Heeler fields. "

--- a/Sources/Heeler/Settings/AgentListFieldsSettingsView.swift
+++ b/Sources/Heeler/Settings/AgentListFieldsSettingsView.swift
@@ -178,7 +178,7 @@ struct AgentListFieldsHostDetailView: View {
         let slotRows = AgentRowSlot.slotRows(layout.rows)
         ForEach(Array(slotRows.enumerated()), id: \.offset) { index, row in
             AgentListFieldsRowEditor(
-                index: index, row: row, isEnabled: !isSyncing,
+                index: index, row: row, isEnabled: !isSyncing && !editor.isCatalogUnreadable,
                 onAdd: {
                     addingField = AgentListFieldsEditorDestination(hostID: host.id, rowIndex: index)
                 },
@@ -244,6 +244,7 @@ struct AgentListFieldsHostDetailView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .disabled(editor.isCatalogUnreadable)
         .listRowInsets(AgentListFieldsChrome.syncInsets)
         .listRowSeparator(.hidden)
         .agentListHostSurface(isFirst: false, isLast: true)

--- a/Sources/Heeler/Settings/AgentListFieldsSettingsView.swift
+++ b/Sources/Heeler/Settings/AgentListFieldsSettingsView.swift
@@ -261,10 +261,13 @@ struct AgentListFieldsHostDetailView: View {
                     .font(.subheadline.weight(.medium))
                 Text("Sync from plugin")
             }
-            .foregroundStyle(.tint)
+            // An explicit tint would override the dimming a disabled button
+            // gets, so the unreadable-catalog state picks the style itself.
+            .foregroundStyle(
+                editor.isCatalogUnreadable ? AnyShapeStyle(.tertiary) : AnyShapeStyle(.tint))
         }
         .buttonStyle(.borderless)
-        .disabled(isSyncing)
+        .disabled(isSyncing || editor.isCatalogUnreadable)
         .accessibilityIdentifier(identifier)
     }
 

--- a/Tests/HeelerTests/AgentListFieldsEditorTests.swift
+++ b/Tests/HeelerTests/AgentListFieldsEditorTests.swift
@@ -424,6 +424,8 @@ struct AgentListFieldsEditorTests {
         let refused = editor.commit(hostID) { $0.rows = rows }
         #expect(refused == false)
         #expect(editor.errorMessage == AgentListFieldsCopy.unreadableCatalogEdit)
+        #expect(editor.isEditing == false && editor.drafts.isEmpty)
+        #expect(editor.layout(for: hostID) == .consoleDefault)
         #expect(defaults.data(forKey: "agent-row-layouts") == Data("not json".utf8))
 
         editor.resetSavedFields()
@@ -464,6 +466,26 @@ struct AgentListFieldsInlineEditingTests {
         let suite = "fields-inline-\(UUID())"
         let defaults = try #require(UserDefaults(suiteName: suite))
         return (defaults, { defaults.removePersistentDomain(forName: suite) })
+    }
+
+    /// A field added through the sheet against an unreadable catalog must
+    /// not linger as a draft that the rows then display as if saved (#320).
+    @Test func inlineEditAgainstAnUnreadableCatalogLeavesNoDraftBehind() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        defaults.set(Data("not json".utf8), forKey: "agent-row-layouts")
+        let layouts = AgentRowLayoutStore(defaults: defaults)
+        let editor = AgentListFieldsEditor(
+            layouts: layouts, snapshots: HerdrSidebarSnapshotStore(), fetch: { _ in nil })
+        let hostID = UUID()
+        #expect(editor.isCatalogUnreadable)
+        let added = AgentLayoutTokensEditing.add(.host, editor: editor, hostID: hostID, rowIndex: 2)
+        #expect(added == false)
+        #expect(editor.errorMessage == AgentListFieldsCopy.unreadableCatalogEdit)
+        #expect(editor.isEditing == false && editor.drafts.isEmpty)
+        #expect(editor.layout(for: hostID) == .consoleDefault)
+        #expect(AgentLayoutTokensEditing.availableHeelerFields(in: editor.layout(for: hostID).rows[2]) == [.host, .status])
+        #expect(defaults.data(forKey: "agent-row-layouts") == Data("not json".utf8))
     }
 
     @Test func commitValidatesAndPersistsOneChangeWithoutLeavingASessionOpen() throws {

--- a/Tests/HeelerTests/AgentListFieldsEditorTests.swift
+++ b/Tests/HeelerTests/AgentListFieldsEditorTests.swift
@@ -386,6 +386,54 @@ struct AgentListFieldsEditorTests {
             self.value = value
         }
     }
+
+    /// Catalog captured from a device that had run the unmerged PR #312
+    /// build, which knew herdr's `machine` field (#320). The control case
+    /// isolates that token.
+    private nonisolated static let savedCatalogs: [(label: String, json: String)] = [
+        ("simulator catalog", ##"{"hostLayouts":["F75B1706-8EAC-4641-AC08-1F9FF038A1F1",{"rows":[[{"token":"terminal_title_stripped","fg":"#6c7086","dim":false}],[{"token":"$pin_icon"},{"token":"workspace","fg":"#45475a","dim":false},{"token":"agent"}],[{"token":"machine"}]],"row_gap":0,"rows_by_agent":{}}],"version":1}"##),
+        ("machine only", ##"{"hostLayouts":["F75B1706-8EAC-4641-AC08-1F9FF038A1F1",{"rows":[[{"token":"machine"}]]}],"version":1}"##),
+        ("control: host instead of machine", ##"{"hostLayouts":["F75B1706-8EAC-4641-AC08-1F9FF038A1F1",{"rows":[[{"token":"terminal_title_stripped","fg":"#6c7086","dim":false}],[{"token":"$pin_icon"},{"token":"workspace","fg":"#45475a","dim":false},{"token":"agent"}],[{"token":"host"}]],"row_gap":0,"rows_by_agent":{}}],"version":1}"##),
+    ]
+
+    @Test(arguments: savedCatalogs)
+    func savedCatalogFromAnotherBuildDoesNotBlockEdits(label: String, json: String) throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        defaults.set(Data(json.utf8), forKey: "agent-row-layouts")
+        let layouts = AgentRowLayoutStore(defaults: defaults)
+        let editor = AgentListFieldsEditor(
+            layouts: layouts, snapshots: HerdrSidebarSnapshotStore(), fetch: { _ in nil })
+        let hostID = try #require(UUID(uuidString: "F75B1706-8EAC-4641-AC08-1F9FF038A1F1"))
+        let rows: [AgentRow] = [[.init(.agent)], [], [.init(.directory)]]
+        let committed = editor.commit(hostID) { $0.rows = rows }
+        #expect(editor.errorMessage == nil, "\(label): \(editor.errorMessage ?? "")")
+        #expect(committed, "\(label)")
+    }
+
+    @Test func resetSavedFieldsClearsAnUnreadableCatalogAndEndsTheSession() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        defaults.set(Data("not json".utf8), forKey: "agent-row-layouts")
+        let layouts = AgentRowLayoutStore(defaults: defaults)
+        let editor = AgentListFieldsEditor(
+            layouts: layouts, snapshots: HerdrSidebarSnapshotStore(), fetch: { _ in nil })
+        let hostID = UUID()
+        let rows: [AgentRow] = [[.init(.agent)]]
+        #expect(editor.isCatalogUnreadable)
+        let refused = editor.commit(hostID) { $0.rows = rows }
+        #expect(refused == false)
+        #expect(editor.errorMessage == AgentListFieldsCopy.unreadableCatalogEdit)
+        #expect(defaults.data(forKey: "agent-row-layouts") == Data("not json".utf8))
+
+        editor.resetSavedFields()
+        #expect(editor.isCatalogUnreadable == false)
+        #expect(editor.errorMessage == nil && editor.isEditing == false && editor.drafts.isEmpty)
+        #expect(editor.layout(for: hostID) == .consoleDefault)
+        let committed = editor.commit(hostID) { $0.rows = rows }
+        #expect(committed)
+        #expect(layouts.hostLayouts[hostID]?.rows == rows)
+    }
 }
 
 @MainActor

--- a/Tests/HeelerTests/AgentRowLayoutStoreTests.swift
+++ b/Tests/HeelerTests/AgentRowLayoutStoreTests.swift
@@ -78,7 +78,8 @@ struct AgentRowLayoutStoreTests {
         let (defaults, cleanup) = try makeDefaults()
         defer { cleanup() }
         for json in ["not json", #"{"version":2,"hostLayouts":[]}"#,
-                     #"{"version":1,"hostLayouts":["\#(UUID().uuidString)",{"rows":[[{"token":"future"}]],"rowGap":0,"rowsByAgent":{}}]}"#] {
+                     #"{"version":1,"hostLayouts":["\#(UUID().uuidString)",{"rows":"nope"}]}"#,
+                     #"{"version":1,"hostLayouts":["\#(UUID().uuidString)",{"rows":[],"row_gap":-1}]}"#] {
             let corrupt = Data(json.utf8)
             defaults.set(corrupt, forKey: "agent-row-layouts")
             let store = AgentRowLayoutStore(defaults: defaults)
@@ -108,5 +109,49 @@ struct AgentRowLayoutStoreTests {
         }
         #expect(store.hostLayouts == [host: .heelerDefault])
         #expect(defaults.data(forKey: "agent-row-layouts") == before)
+    }
+    /// Captured from a device that had run the unmerged PR #312 build, which
+    /// knew herdr's `machine` field (#320). Names this build does not know
+    /// and invalid colors drop individually; everything else survives.
+    @Test func unknownFieldNamesDropOnLoadAndByTheNextWrite() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let host = try #require(UUID(uuidString: "F75B1706-8EAC-4641-AC08-1F9FF038A1F1"))
+        let captured = ##"{"hostLayouts":["F75B1706-8EAC-4641-AC08-1F9FF038A1F1",{"rows":[[{"token":"terminal_title_stripped","fg":"#6c7086","dim":false}],[{"token":"$pin_icon"},{"token":"workspace","fg":"#45475a","dim":false},{"token":"agent"}],[{"token":"machine"},{"token":"tab","fg":"nothex"}]],"row_gap":0,"rows_by_agent":{"claude":[[{"token":"future"},{"token":"pane"}]]}}],"version":1}"##
+        defaults.set(Data(captured.utf8), forKey: "agent-row-layouts")
+        let store = AgentRowLayoutStore(defaults: defaults)
+        #expect(store.catalogLoadError == nil)
+        let expected = AgentRowLayout(rows: [
+            [.init(.terminalTitleStripped, fg: HexColor("#6c7086"), dim: false)],
+            [.init(.custom("pin_icon")), .init(.workspace, fg: HexColor("#45475a"), dim: false), .init(.agent)],
+            [.init(.tab)],
+        ], rowsByAgent: ["claude": [[.init(.pane)]]])
+        #expect(store.hostLayouts == [host: expected])
+
+        let other = UUID()
+        try store.setLayout(.heelerDefault, for: other)
+        let written = try #require(defaults.data(forKey: "agent-row-layouts"))
+        #expect(String(decoding: written, as: UTF8.self).contains("machine") == false)
+        #expect(AgentRowLayoutStore(defaults: defaults).hostLayouts == [host: expected, other: .heelerDefault])
+    }
+
+    @Test func resetDiscardsOnlyAnUnreadableCatalog() throws {
+        let (defaults, cleanup) = try makeDefaults()
+        defer { cleanup() }
+        let host = UUID()
+        let readable = AgentRowLayoutStore(defaults: defaults)
+        try readable.setLayout(.heelerDefault, for: host)
+        readable.resetUnreadableCatalog()
+        #expect(readable.hostLayouts == [host: .heelerDefault])
+        #expect(defaults.data(forKey: "agent-row-layouts") != nil)
+
+        defaults.set(Data("not json".utf8), forKey: "agent-row-layouts")
+        let store = AgentRowLayoutStore(defaults: defaults)
+        #expect(store.catalogLoadError == .catalogUnreadable)
+        store.resetUnreadableCatalog()
+        #expect(store.catalogLoadError == nil && store.hostLayouts.isEmpty)
+        #expect(defaults.data(forKey: "agent-row-layouts") == nil)
+        try store.setLayout(.heelerDefault, for: host)
+        #expect(AgentRowLayoutStore(defaults: defaults).hostLayouts == [host: .heelerDefault])
     }
 }


### PR DESCRIPTION
Closes #320.

## Problem

A build with a different field set (the unmerged PR #312 knew herdr's `machine` field) saved a layout on the same device. The strict Codable path then failed the whole catalog on load, every edit was refused with "The saved Agent List Fields could not be read. Nothing was changed.", and nothing on screen explained why or offered a way out.

## Changes

- The persisted catalog loads through `AgentRowLayout.Lenient`, the decoder plugin snapshots already use: unknown field names and invalid colors drop individually and the next write persists the cleaned layout. Structural problems (not JSON, unsupported version, limits exceeded) still keep the original bytes and refuse writes.
- When the catalog truly cannot be read, both Agent List Fields screens show a card explaining it, the field chips, add chips, and Sync from plugin are disabled, and a Reset Saved Fields button (with confirmation) discards the catalog.
- An inline commit that fails to save no longer leaves a phantom draft on the row; the add sheet closes on a refused add so the message is visible.

Released builds share one token set and never removed a name, so App Store users are not affected today; the gap would have surfaced the first time a release drops or renames a field, or a TestFlight tester installs an older build.

## Verification

- Unit tests: `AgentRowLayoutStoreTests`, `AgentListFieldsEditorTests`, `AgentListFieldsInlineEditingTests`, `AgentListFieldsPreviewTests`, `AgentRowLayoutTests`, `AgentRowLayoutResolverTests`, `SidebarConsoleIntegrationTests` pass. New tests seed the catalog captured from the affected device.
- GUI acceptance on the iPhone 17 Pro Simulator (four testloop rounds, report in `.testloop/reports/2026-09-13-issue-320-agent-list-fields.md`): the captured catalog is editable again, the unreadable state is announced and read-only, Reset recovers, and edits persist on disk.